### PR TITLE
fix: phase outcomes tracking for safeguards and execution failures (#124)

### DIFF
--- a/crates/voom-cli/src/commands/process.rs
+++ b/crates/voom-cli/src/commands/process.rs
@@ -857,6 +857,10 @@ async fn process_single_file_execute(
 
         // Pre-execution safeguard: check disk space
         if check_disk_space(&plan, &current_file, ctx) {
+            phase_outcomes.insert(
+                phase_name.clone(),
+                voom_policy_evaluator::EvaluationOutcome::SafeguardFailed,
+            );
             continue;
         }
 
@@ -883,6 +887,10 @@ async fn process_single_file_execute(
             PlanOutcome::Success { executor } => {
                 any_executed = true;
                 if check_size_increase(&plan, &current_file, ctx) {
+                    phase_outcomes.insert(
+                        phase_name.clone(),
+                        voom_policy_evaluator::EvaluationOutcome::SafeguardFailed,
+                    );
                     continue;
                 }
                 current_file = handle_plan_success(

--- a/crates/voom-cli/src/commands/process.rs
+++ b/crates/voom-cli/src/commands/process.rs
@@ -812,6 +812,7 @@ async fn process_single_file_execute(
     let mut phase_outcomes: HashMap<String, voom_policy_evaluator::EvaluationOutcome> =
         HashMap::new();
     let mut any_executed = false;
+    let mut modified_counted = false;
     let mut plans_evaluated: usize = 0;
 
     for phase_name in &compiled.phase_order {
@@ -832,43 +833,37 @@ async fn process_single_file_execute(
 
         plans_evaluated += 1;
 
-        // Track the evaluation outcome for dependency resolution
-        let outcome = if plan.is_skipped() {
-            voom_policy_evaluator::EvaluationOutcome::Skipped
-        } else {
-            voom_policy_evaluator::EvaluationOutcome::Executed {
-                modified: !plan.is_empty(),
-            }
-        };
-        phase_outcomes.insert(phase_name.clone(), outcome);
-
         dispatch_safeguard_violations(&plan, &current_file, ctx);
 
         // Handle skipped plans
         if let Some(reason) = &plan.skip_reason {
+            phase_outcomes.insert(
+                phase_name.clone(),
+                voom_policy_evaluator::EvaluationOutcome::Skipped,
+            );
             dispatch_skipped_plan(&plan, &current_file, reason, ctx);
             continue;
         }
 
         // Empty plans need no execution
         if plan.is_empty() {
+            phase_outcomes.insert(
+                phase_name.clone(),
+                voom_policy_evaluator::EvaluationOutcome::Executed { modified: false },
+            );
             continue;
         }
 
         // Pre-execution safeguard: check disk space
+        // Note: check_disk_space already dispatches PlanFailed and records
+        // PhaseOutcomeKind::Failed for stats. This insert updates the
+        // dependency-resolution map to block downstream run_if gates.
         if check_disk_space(&plan, &current_file, ctx) {
             phase_outcomes.insert(
                 phase_name.clone(),
                 voom_policy_evaluator::EvaluationOutcome::SafeguardFailed,
             );
             continue;
-        }
-
-        // Count as modified on first real plan
-        if !any_executed {
-            ctx.counters
-                .modified_count
-                .fetch_add(1, AtomicOrdering::Relaxed);
         }
 
         // Execute this plan
@@ -885,7 +880,10 @@ async fn process_single_file_execute(
 
         match exec_outcome {
             PlanOutcome::Success { executor } => {
-                any_executed = true;
+                // Post-execution safeguard: check size increase
+                // Note: check_size_increase already dispatches PlanFailed and
+                // records PhaseOutcomeKind::Failed for stats. This insert
+                // updates the dependency-resolution map.
                 if check_size_increase(&plan, &current_file, ctx) {
                     phase_outcomes.insert(
                         phase_name.clone(),
@@ -893,6 +891,17 @@ async fn process_single_file_execute(
                     );
                     continue;
                 }
+                any_executed = true;
+                if !modified_counted {
+                    ctx.counters
+                        .modified_count
+                        .fetch_add(1, AtomicOrdering::Relaxed);
+                    modified_counted = true;
+                }
+                phase_outcomes.insert(
+                    phase_name.clone(),
+                    voom_policy_evaluator::EvaluationOutcome::Executed { modified: true },
+                );
                 current_file = handle_plan_success(
                     plan,
                     &current_file,
@@ -906,17 +915,23 @@ async fn process_single_file_execute(
             PlanOutcome::Failed(failed) => {
                 let plan_id = plan.id;
                 let policy_name = plan.policy_name.clone();
-                let phase_name = plan.phase_name.clone();
+                let phase_name_owned = plan.phase_name.clone();
                 let executor = failed.plugin_name.clone().unwrap_or_default();
-                dispatch_plan_failure(failed, &phase_name, ctx);
+                dispatch_plan_failure(failed, &phase_name_owned, ctx);
                 record_failure_transition(
                     &current_file,
                     plan_id,
                     &executor,
                     &policy_name,
-                    &phase_name,
+                    &phase_name_owned,
                     ctx,
                 );
+                phase_outcomes.insert(
+                    phase_name_owned.clone(),
+                    voom_policy_evaluator::EvaluationOutcome::ExecutionFailed,
+                );
+                // Downstream phases still evaluate; run_if gates block
+                // them via ExecutionFailed in phase_outcomes.
             }
         }
     }

--- a/crates/voom-cli/src/lock.rs
+++ b/crates/voom-cli/src/lock.rs
@@ -54,8 +54,14 @@ impl ProcessLock {
 mod tests {
     use super::*;
 
+    // flock(2) is per open-file-description, but within a single process
+    // concurrent threads can interfere when multiple tests acquire/release
+    // locks simultaneously. Serialize all lock tests to prevent flakes.
+    static LOCK_TEST: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
     fn test_acquire_succeeds_in_fresh_dir() {
+        let _guard = LOCK_TEST.lock().expect("test mutex");
         let dir = tempfile::tempdir().expect("tempdir");
         let _lock = ProcessLock::acquire(dir.path()).expect("acquire");
         assert!(dir.path().join("voom.lock").exists());
@@ -63,6 +69,7 @@ mod tests {
 
     #[test]
     fn test_second_acquire_fails() {
+        let _guard = LOCK_TEST.lock().expect("test mutex");
         let dir = tempfile::tempdir().expect("tempdir");
         let _first = ProcessLock::acquire(dir.path()).expect("first acquire");
         let result = ProcessLock::acquire(dir.path());
@@ -83,6 +90,7 @@ mod tests {
 
     #[test]
     fn test_lock_released_on_drop() {
+        let _guard = LOCK_TEST.lock().expect("test mutex");
         let dir = tempfile::tempdir().expect("tempdir");
         {
             let _lock = ProcessLock::acquire(dir.path()).expect("first acquire");
@@ -93,6 +101,7 @@ mod tests {
 
     #[test]
     fn test_creates_nested_dirs() {
+        let _guard = LOCK_TEST.lock().expect("test mutex");
         let dir = tempfile::tempdir().expect("tempdir");
         let nested = dir.path().join("a").join("b").join("c");
         assert!(!nested.exists());
@@ -102,6 +111,7 @@ mod tests {
 
     #[test]
     fn test_lock_file_is_named_voom_lock() {
+        let _guard = LOCK_TEST.lock().expect("test mutex");
         let dir = tempfile::tempdir().expect("tempdir");
         let _lock = ProcessLock::acquire(dir.path()).expect("acquire");
         assert!(dir.path().join("voom.lock").exists());

--- a/plugins/policy-evaluator/src/evaluator.rs
+++ b/plugins/policy-evaluator/src/evaluator.rs
@@ -46,6 +46,7 @@ pub struct EvaluationResult {
 pub enum EvaluationOutcome {
     Executed { modified: bool },
     Skipped,
+    SafeguardFailed,
 }
 
 /// Evaluate a compiled policy against a media file, producing plans for all phases.
@@ -2520,5 +2521,101 @@ mod tests {
             assert!(indices.contains(&2), "jpn audio should be removed");
             assert!(indices.contains(&5), "commentary sub should be removed");
         }
+    }
+
+    #[test]
+    fn test_safeguard_failed_blocks_run_if_completed() {
+        let policy = voom_dsl::compile_policy(
+            r#"policy "test" {
+                phase containerize {
+                    container mkv
+                }
+                phase post_tc {
+                    depends_on: [containerize]
+                    run_if containerize.completed
+                    container mkv
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let file = MediaFile::new(PathBuf::from("/tmp/test.mkv"));
+        let mut outcomes = HashMap::new();
+        outcomes.insert(
+            "containerize".to_string(),
+            EvaluationOutcome::SafeguardFailed,
+        );
+
+        let plan = evaluate_single_phase("post_tc", &policy, &file, &outcomes, None);
+        let plan = plan.expect("phase should be evaluated");
+        assert!(plan.is_skipped());
+        assert!(plan
+            .skip_reason
+            .as_ref()
+            .expect("should have skip reason")
+            .contains("run_if"));
+    }
+
+    #[test]
+    fn test_safeguard_failed_blocks_run_if_modified() {
+        let policy = voom_dsl::compile_policy(
+            r#"policy "test" {
+                phase containerize {
+                    container mkv
+                }
+                phase post_tc {
+                    depends_on: [containerize]
+                    run_if containerize.modified
+                    container mkv
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let file = MediaFile::new(PathBuf::from("/tmp/test.mkv"));
+        let mut outcomes = HashMap::new();
+        outcomes.insert(
+            "containerize".to_string(),
+            EvaluationOutcome::SafeguardFailed,
+        );
+
+        let plan = evaluate_single_phase("post_tc", &policy, &file, &outcomes, None);
+        let plan = plan.expect("phase should be evaluated");
+        assert!(plan.is_skipped());
+        assert!(plan
+            .skip_reason
+            .as_ref()
+            .expect("should have skip reason")
+            .contains("run_if"));
+    }
+
+    #[test]
+    fn test_safeguard_failed_satisfies_depends_on() {
+        let policy = voom_dsl::compile_policy(
+            r#"policy "test" {
+                phase containerize {
+                    container mkv
+                }
+                phase cleanup {
+                    depends_on: [containerize]
+                    container mkv
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let file = MediaFile::new(PathBuf::from("/tmp/test.mkv"));
+        let mut outcomes = HashMap::new();
+        outcomes.insert(
+            "containerize".to_string(),
+            EvaluationOutcome::SafeguardFailed,
+        );
+
+        let plan = evaluate_single_phase("cleanup", &policy, &file, &outcomes, None);
+        let plan = plan.expect("phase should be evaluated");
+        assert!(
+            !plan.is_skipped(),
+            "depends_on should be satisfied by SafeguardFailed"
+        );
     }
 }

--- a/plugins/policy-evaluator/src/evaluator.rs
+++ b/plugins/policy-evaluator/src/evaluator.rs
@@ -47,6 +47,7 @@ pub enum EvaluationOutcome {
     Executed { modified: bool },
     Skipped,
     SafeguardFailed,
+    ExecutionFailed,
 }
 
 /// Evaluate a compiled policy against a media file, producing plans for all phases.
@@ -2616,6 +2617,102 @@ mod tests {
         assert!(
             !plan.is_skipped(),
             "depends_on should be satisfied by SafeguardFailed"
+        );
+    }
+
+    #[test]
+    fn test_execution_failed_blocks_run_if_completed() {
+        let policy = voom_dsl::compile_policy(
+            r#"policy "test" {
+                phase containerize {
+                    container mkv
+                }
+                phase post_tc {
+                    depends_on: [containerize]
+                    run_if containerize.completed
+                    container mkv
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let file = MediaFile::new(PathBuf::from("/tmp/test.mkv"));
+        let mut outcomes = HashMap::new();
+        outcomes.insert(
+            "containerize".to_string(),
+            EvaluationOutcome::ExecutionFailed,
+        );
+
+        let plan = evaluate_single_phase("post_tc", &policy, &file, &outcomes, None);
+        let plan = plan.expect("phase should be evaluated");
+        assert!(plan.is_skipped());
+        assert!(plan
+            .skip_reason
+            .as_ref()
+            .expect("should have skip reason")
+            .contains("run_if"));
+    }
+
+    #[test]
+    fn test_execution_failed_blocks_run_if_modified() {
+        let policy = voom_dsl::compile_policy(
+            r#"policy "test" {
+                phase containerize {
+                    container mkv
+                }
+                phase post_tc {
+                    depends_on: [containerize]
+                    run_if containerize.modified
+                    container mkv
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let file = MediaFile::new(PathBuf::from("/tmp/test.mkv"));
+        let mut outcomes = HashMap::new();
+        outcomes.insert(
+            "containerize".to_string(),
+            EvaluationOutcome::ExecutionFailed,
+        );
+
+        let plan = evaluate_single_phase("post_tc", &policy, &file, &outcomes, None);
+        let plan = plan.expect("phase should be evaluated");
+        assert!(plan.is_skipped());
+        assert!(plan
+            .skip_reason
+            .as_ref()
+            .expect("should have skip reason")
+            .contains("run_if"));
+    }
+
+    #[test]
+    fn test_execution_failed_satisfies_depends_on() {
+        let policy = voom_dsl::compile_policy(
+            r#"policy "test" {
+                phase containerize {
+                    container mkv
+                }
+                phase cleanup {
+                    depends_on: [containerize]
+                    container mkv
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let file = MediaFile::new(PathBuf::from("/tmp/test.mkv"));
+        let mut outcomes = HashMap::new();
+        outcomes.insert(
+            "containerize".to_string(),
+            EvaluationOutcome::ExecutionFailed,
+        );
+
+        let plan = evaluate_single_phase("cleanup", &policy, &file, &outcomes, None);
+        let plan = plan.expect("phase should be evaluated");
+        assert!(
+            !plan.is_skipped(),
+            "depends_on should be satisfied by ExecutionFailed"
         );
     }
 }

--- a/plugins/policy-evaluator/src/evaluator.rs
+++ b/plugins/policy-evaluator/src/evaluator.rs
@@ -152,12 +152,18 @@ fn check_skip_conditions(
     if let Some(ref run_if) = phase.run_if {
         let should_run = match phase_outcomes.get(&run_if.phase) {
             Some(outcome) => match run_if.trigger {
-                RunIfTrigger::Modified => {
-                    matches!(outcome, EvaluationOutcome::Executed { modified: true })
-                }
-                RunIfTrigger::Completed => {
-                    matches!(outcome, EvaluationOutcome::Executed { .. })
-                }
+                RunIfTrigger::Modified => match outcome {
+                    EvaluationOutcome::Executed { modified } => *modified,
+                    EvaluationOutcome::Skipped
+                    | EvaluationOutcome::SafeguardFailed
+                    | EvaluationOutcome::ExecutionFailed => false,
+                },
+                RunIfTrigger::Completed => match outcome {
+                    EvaluationOutcome::Executed { .. } => true,
+                    EvaluationOutcome::Skipped
+                    | EvaluationOutcome::SafeguardFailed
+                    | EvaluationOutcome::ExecutionFailed => false,
+                },
             },
             None => false,
         };


### PR DESCRIPTION
## Summary

- Add `SafeguardFailed` and `ExecutionFailed` variants to `EvaluationOutcome` so the phase dependency-resolution map correctly reflects when a phase was blocked by a safeguard or failed during execution
- Eliminate the optimistic `phase_outcomes` write that briefly stored `Executed` before safeguards ran, replacing it with definitive writes at each exit point (skipped, empty, safeguard-failed, success, execution-failed)
- Fix `modified_count` over-increment by deferring the counter until after all post-execution safeguards pass
- Convert `check_skip_conditions` to exhaustive `match` so the compiler enforces handling of future `EvaluationOutcome` variants
- Serialize flock-based lock tests with a shared mutex to prevent parallel test flakiness

## Test plan

- [x] 6 new unit tests verify `SafeguardFailed` and `ExecutionFailed` semantics: blocks `run_if completed`, blocks `run_if modified`, satisfies `depends_on`
- [x] All 488 workspace tests pass
- [x] Functional tests pass (`cargo test -p voom-cli --features functional -- --test-threads=4`)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --all` clean
- [x] Lock tests verified stable over 10 consecutive runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)