### PR TITLE
feat: capture executor output and add `voom report errors`

### DIFF
--- a/crates/voom-cli/src/cli.rs
+++ b/crates/voom-cli/src/cli.rs
@@ -345,6 +345,18 @@ pub struct ReportArgs {
     /// List files (was previously the default)
     #[arg(long)]
     pub files: bool,
+
+    /// Show errors from a processing session (default: most recent)
+    #[arg(long)]
+    pub errors: bool,
+
+    /// Show errors from a specific session (use with --errors)
+    #[arg(long, requires = "errors")]
+    pub session: Option<String>,
+
+    /// List available sessions with error counts (use with --errors)
+    #[arg(long, requires = "errors")]
+    pub list_sessions: bool,
 }
 
 // === Serve ===

--- a/crates/voom-cli/src/commands/process.rs
+++ b/crates/voom-cli/src/commands/process.rs
@@ -341,15 +341,6 @@ fn print_run_results(ctx: &RunResultsContext<'_>) -> Result<()> {
         }
         print_phase_breakdown(&ctx.counters.phase_stats.lock(), ctx.all_phase_names);
 
-        let total_errors = ctx.pool.failed_count()
-            + ctx
-                .counters
-                .phase_stats
-                .lock()
-                .values()
-                .map(|ps| ps.failed)
-                .sum::<u64>();
-        // Deduplicate: pool counts files, phase_stats counts phases. Use phase errors.
         let phase_errors: u64 = ctx
             .counters
             .phase_stats
@@ -365,8 +356,6 @@ fn print_run_results(ctx: &RunResultsContext<'_>) -> Result<()> {
                 style(format!("voom report errors --session {short_session}")).bold(),
             );
         }
-        // Suppress unused binding warning
-        let _ = total_errors;
     }
 
     Ok(())
@@ -856,7 +845,7 @@ async fn process_single_file_execute(
             break;
         }
 
-        let plan = match evaluator.evaluate_single_phase(
+        let mut plan = match evaluator.evaluate_single_phase(
             phase_name,
             compiled,
             &current_file,
@@ -866,6 +855,7 @@ async fn process_single_file_execute(
             Some(p) => p,
             None => continue,
         };
+        plan.session_id = Some(ctx.counters.session_id);
 
         plans_evaluated += 1;
 
@@ -1046,6 +1036,10 @@ fn dispatch_plan_failure(failed: PlanFailedEvent, phase_name: &str, ctx: &Proces
 /// The file is unchanged on failure, so `to_size = from_size` and `to_hash =
 /// from_hash`. The `executor` argument should be the executor plugin name, or
 /// an empty string when no executor was involved (e.g. size-increase abort).
+///
+/// Dual-write: `file_transitions.error_message` is used for session-based
+/// queries (`voom report errors`), while `plans.result` stores the structured
+/// `ExecutionDetail` JSON for plan-based queries with full subprocess output.
 fn record_failure_transition(
     file: &voom_domain::media::MediaFile,
     plan_id: uuid::Uuid,
@@ -1663,6 +1657,7 @@ fn execute_single_plan(
 
     let claimed = results.iter().any(|r| r.claimed);
     let exec_error = results.iter().find_map(|r| r.execution_error.clone());
+    let exec_detail = results.iter().find_map(|r| r.execution_detail.clone());
 
     if claimed && exec_error.is_none() {
         let executor = results
@@ -1678,6 +1673,7 @@ fn execute_single_plan(
             .iter()
             .find(|r| r.claimed)
             .map(|r| r.plugin_name.clone());
+        failed.execution_detail = exec_detail;
         PlanOutcome::Failed(failed)
     } else {
         PlanOutcome::Failed(PlanFailedEvent::new(

--- a/crates/voom-cli/src/commands/process.rs
+++ b/crates/voom-cli/src/commands/process.rs
@@ -83,11 +83,17 @@ pub async fn run(args: ProcessArgs, quiet: bool, token: CancellationToken) -> Re
     };
 
     let resolver = build_policy_resolver(&args, &config, &root)?;
+    let counters = RunCounters::new();
 
     if !plan_only && !quiet {
         let path_list: Vec<_> = paths.iter().map(|p| p.display().to_string()).collect();
         let display_paths = path_list.join(", ");
-        print_run_header(&resolver.summary(), &display_paths, dry_run);
+        print_run_header(
+            &resolver.summary(),
+            &display_paths,
+            dry_run,
+            counters.session_id,
+        );
     }
 
     // Auto-prune stale file entries under the target directories
@@ -189,7 +195,6 @@ pub async fn run(args: ProcessArgs, quiet: bool, token: CancellationToken) -> Re
     let all_phase_names = resolver.all_phase_names();
     let resolver = Arc::new(resolver);
     let flag_size_increase = args.flag_size_increase;
-    let counters = RunCounters::new();
 
     let token_for_workers = token.clone();
     let ffprobe_path: Option<String> = config.ffprobe_path().map(String::from);
@@ -335,6 +340,33 @@ fn print_run_results(ctx: &RunResultsContext<'_>) -> Result<()> {
             });
         }
         print_phase_breakdown(&ctx.counters.phase_stats.lock(), ctx.all_phase_names);
+
+        let total_errors = ctx.pool.failed_count()
+            + ctx
+                .counters
+                .phase_stats
+                .lock()
+                .values()
+                .map(|ps| ps.failed)
+                .sum::<u64>();
+        // Deduplicate: pool counts files, phase_stats counts phases. Use phase errors.
+        let phase_errors: u64 = ctx
+            .counters
+            .phase_stats
+            .lock()
+            .values()
+            .map(|ps| ps.failed)
+            .sum();
+        if phase_errors > 0 && !ctx.dry_run {
+            let short_session = &ctx.counters.session_id.to_string()[..8];
+            eprintln!(
+                "\n  {} Run `{}` to see details.",
+                style(format!("{phase_errors} files had errors.")).yellow(),
+                style(format!("voom report errors --session {short_session}")).bold(),
+            );
+        }
+        // Suppress unused binding warning
+        let _ = total_errors;
     }
 
     Ok(())
@@ -365,9 +397,10 @@ fn build_policy_resolver(
 }
 
 /// Print the header line describing what we are about to do.
-fn print_run_header(policy_name: &str, path_display: &str, dry_run: bool) {
+fn print_run_header(policy_name: &str, path_display: &str, dry_run: bool, session_id: uuid::Uuid) {
+    let short_session = &session_id.to_string()[..8];
     eprintln!(
-        "{} policy {} to {}{}",
+        "{} policy {} to {} (session {}){}",
         if dry_run {
             style("Dry-running").bold()
         } else {
@@ -375,6 +408,7 @@ fn print_run_header(policy_name: &str, path_display: &str, dry_run: bool) {
         },
         style(policy_name).cyan(),
         style(path_display).cyan(),
+        style(short_session).dim(),
         if dry_run {
             " (no changes will be made)"
         } else {
@@ -631,6 +665,7 @@ struct RunCounters {
     backup_bytes: Arc<AtomicU64>,
     phase_stats: PhaseStatsMap,
     plan_collector: Arc<Mutex<Vec<serde_json::Value>>>,
+    session_id: uuid::Uuid,
 }
 
 impl RunCounters {
@@ -640,6 +675,7 @@ impl RunCounters {
             backup_bytes: Arc::new(AtomicU64::new(0)),
             phase_stats: Arc::new(Mutex::new(HashMap::new())),
             plan_collector: Arc::new(Mutex::new(Vec::new())),
+            session_id: uuid::Uuid::new_v4(),
         }
     }
 }
@@ -919,6 +955,7 @@ async fn process_single_file_execute(
                 let policy_name = plan.policy_name.clone();
                 let phase_name_owned = plan.phase_name.clone();
                 let executor = failed.plugin_name.clone().unwrap_or_default();
+                let error_msg = failed.error.clone();
                 dispatch_plan_failure(failed, &phase_name_owned, ctx);
                 record_failure_transition(
                     &current_file,
@@ -926,6 +963,7 @@ async fn process_single_file_execute(
                     &executor,
                     &policy_name,
                     &phase_name_owned,
+                    Some(&error_msg),
                     ctx,
                 );
                 phase_outcomes.insert(
@@ -1014,10 +1052,11 @@ fn record_failure_transition(
     executor: &str,
     policy_name: &str,
     phase_name: &str,
+    error_message: Option<&str>,
     ctx: &ProcessContext<'_>,
 ) {
     let to_hash = file.content_hash.clone().unwrap_or_default();
-    let transition = voom_domain::FileTransition::new(
+    let mut transition = voom_domain::FileTransition::new(
         file.id,
         file.path.clone(),
         to_hash,
@@ -1034,7 +1073,12 @@ fn record_failure_transition(
         voom_domain::ProcessingOutcome::Failure,
         policy_name,
         phase_name,
-    );
+    )
+    .with_session_id(ctx.counters.session_id);
+
+    if let Some(msg) = error_message {
+        transition = transition.with_error_message(msg);
+    }
 
     if let Err(e) = ctx.store.record_transition(&transition) {
         tracing::warn!(error = %e, "failed to record failure transition");
@@ -1093,7 +1137,16 @@ fn check_size_increase(
         &plan.phase_name,
         PhaseOutcomeKind::Failed,
     );
-    record_failure_transition(file, plan.id, "", &plan.policy_name, &plan.phase_name, ctx);
+    let err_msg = format!("output grew from {} to {} bytes", file.size, new_size);
+    record_failure_transition(
+        file,
+        plan.id,
+        "",
+        &plan.policy_name,
+        &plan.phase_name,
+        Some(&err_msg),
+        ctx,
+    );
     true
 }
 
@@ -1160,7 +1213,15 @@ fn check_disk_space(
         &plan.phase_name,
         PhaseOutcomeKind::Failed,
     );
-    record_failure_transition(file, plan.id, "", &plan.policy_name, &plan.phase_name, ctx);
+    record_failure_transition(
+        file,
+        plan.id,
+        "",
+        &plan.policy_name,
+        &plan.phase_name,
+        Some(&message),
+        ctx,
+    );
     true
 }
 
@@ -1307,7 +1368,8 @@ fn record_file_transition(
         policy_name,
         phase_name,
     )
-    .with_metadata_snapshot(voom_domain::MetadataSnapshot::from_media_file(new_file));
+    .with_metadata_snapshot(voom_domain::MetadataSnapshot::from_media_file(new_file))
+    .with_session_id(ctx.counters.session_id);
 
     if let Err(e) = ctx.store.record_transition(&transition) {
         tracing::warn!(error = %e, "failed to record transition");

--- a/crates/voom-cli/src/commands/report.rs
+++ b/crates/voom-cli/src/commands/report.rs
@@ -1142,17 +1142,15 @@ fn run_errors(store: &dyn voom_domain::storage::StorageTrait, args: &ReportArgs)
     }
 
     let session_id = if let Some(ref s) = args.session {
-        uuid::Uuid::parse_str(s)
-            .or_else(|_| {
-                // Allow short prefix matching
-                let sessions = store.failure_sessions()?;
-                sessions
-                    .iter()
-                    .find(|sess| sess.session_id.to_string().starts_with(s))
-                    .map(|sess| sess.session_id)
-                    .ok_or_else(|| anyhow::anyhow!("no session matching '{s}'"))
-            })
-            .context("invalid session UUID")?
+        uuid::Uuid::parse_str(s).or_else(|_| {
+            // Allow short prefix matching
+            let sessions = store.failure_sessions()?;
+            sessions
+                .iter()
+                .find(|sess| sess.session_id.to_string().starts_with(s))
+                .map(|sess| sess.session_id)
+                .ok_or_else(|| anyhow::anyhow!("no session matching prefix '{s}'"))
+        })?
     } else {
         store
             .latest_failure_session()
@@ -1195,6 +1193,7 @@ fn run_errors(store: &dyn voom_domain::storage::StorageTrait, args: &ReportArgs)
                 }
 
                 // Try to extract ExecutionDetail from plan_result JSON
+                let mut detail_rendered = false;
                 if let Some(ref result_json) = f.plan_result {
                     if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(result_json) {
                         if let Some(detail) = parsed.get("detail") {
@@ -1203,15 +1202,20 @@ fn run_errors(store: &dyn voom_domain::storage::StorageTrait, args: &ReportArgs)
                             {
                                 if let Some(code) = ed.exit_code {
                                     println!("    Exit:  {code}");
+                                    detail_rendered = true;
                                 }
                                 if !ed.command.is_empty() {
-                                    println!("    Cmd:   {}", ed.command);
+                                    let cmd = console::strip_ansi_codes(&ed.command);
+                                    println!("    Cmd:   {cmd}");
+                                    detail_rendered = true;
                                 }
                                 if !ed.stderr_tail.is_empty() {
+                                    let stderr = console::strip_ansi_codes(&ed.stderr_tail);
                                     println!("    Error:");
-                                    for line in ed.stderr_tail.lines() {
+                                    for line in stderr.lines() {
                                         println!("      {line}");
                                     }
+                                    detail_rendered = true;
                                 }
                             }
                         }
@@ -1219,8 +1223,7 @@ fn run_errors(store: &dyn voom_domain::storage::StorageTrait, args: &ReportArgs)
                 }
 
                 if let Some(ref msg) = f.error_message {
-                    // Only print if we didn't already print detail
-                    if f.plan_result.is_none() {
+                    if !detail_rendered {
                         println!("    Error: {msg}");
                     }
                 }

--- a/crates/voom-cli/src/commands/report.rs
+++ b/crates/voom-cli/src/commands/report.rs
@@ -19,6 +19,10 @@ pub fn run(args: ReportArgs) -> Result<()> {
     let config = config::load_config()?;
     let store = app::open_store(&config)?;
 
+    if args.errors {
+        return run_errors(&*store, &args);
+    }
+
     if args.snapshot {
         let snapshot =
             ReportPlugin::capture_snapshot(&*store, voom_domain::stats::SnapshotTrigger::Manual)?;
@@ -101,6 +105,7 @@ fn is_summary_request(args: &ReportArgs) -> bool {
         && !args.savings
         && !args.issues
         && !args.database
+        && !args.errors
         && args.history.is_none()
 }
 
@@ -1101,6 +1106,132 @@ fn codec_counts(files: &[voom_domain::MediaFile]) -> Vec<(String, usize)> {
     })
 }
 
+// ── Error reporting ────────────────────────────────────────
+
+fn run_errors(store: &dyn voom_domain::storage::StorageTrait, args: &ReportArgs) -> Result<()> {
+    use voom_domain::plan::ExecutionDetail;
+
+    if args.list_sessions {
+        let sessions = store.failure_sessions()?;
+        if sessions.is_empty() {
+            eprintln!("{}", style("No sessions with errors found.").dim());
+            return Ok(());
+        }
+        match args.format {
+            OutputFormat::Json => {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&sessions).context("serialize sessions")?
+                );
+            }
+            _ => {
+                println!("{}", style("Sessions with errors:").bold().underlined());
+                println!();
+                for s in &sessions {
+                    let short = &s.session_id.to_string()[..8];
+                    println!(
+                        "  {} {} ({} failures)",
+                        style(short).cyan(),
+                        style(s.started_at.format("%Y-%m-%d %H:%M:%S")).dim(),
+                        style(s.failure_count).yellow(),
+                    );
+                }
+            }
+        }
+        return Ok(());
+    }
+
+    let session_id = if let Some(ref s) = args.session {
+        uuid::Uuid::parse_str(s)
+            .or_else(|_| {
+                // Allow short prefix matching
+                let sessions = store.failure_sessions()?;
+                sessions
+                    .iter()
+                    .find(|sess| sess.session_id.to_string().starts_with(s))
+                    .map(|sess| sess.session_id)
+                    .ok_or_else(|| anyhow::anyhow!("no session matching '{s}'"))
+            })
+            .context("invalid session UUID")?
+    } else {
+        store
+            .latest_failure_session()
+            .context("failed to query latest session")?
+            .ok_or_else(|| anyhow::anyhow!("no sessions with errors found"))?
+    };
+
+    let failures = store
+        .failed_transitions_for_session(&session_id)
+        .context("failed to query session errors")?;
+
+    if failures.is_empty() {
+        eprintln!("{}", style("No errors in the most recent session.").green());
+        return Ok(());
+    }
+
+    match args.format {
+        OutputFormat::Json => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&failures).context("serialize failures")?
+            );
+        }
+        _ => {
+            let short_session = &session_id.to_string()[..8];
+            println!(
+                "Errors from session {} ({} failures)\n",
+                style(short_session).cyan(),
+                failures.len(),
+            );
+            for f in &failures {
+                let filename = f
+                    .path
+                    .file_name()
+                    .map(|n| n.to_string_lossy().to_string())
+                    .unwrap_or_else(|| f.path.display().to_string());
+                println!("  {}", style(&filename).bold());
+                if let Some(ref phase) = f.phase_name {
+                    println!("    Phase: {phase}");
+                }
+
+                // Try to extract ExecutionDetail from plan_result JSON
+                if let Some(ref result_json) = f.plan_result {
+                    if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(result_json) {
+                        if let Some(detail) = parsed.get("detail") {
+                            if let Ok(ed) =
+                                serde_json::from_value::<ExecutionDetail>(detail.clone())
+                            {
+                                if let Some(code) = ed.exit_code {
+                                    println!("    Exit:  {code}");
+                                }
+                                if !ed.command.is_empty() {
+                                    println!("    Cmd:   {}", ed.command);
+                                }
+                                if !ed.stderr_tail.is_empty() {
+                                    println!("    Error:");
+                                    for line in ed.stderr_tail.lines() {
+                                        println!("      {line}");
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if let Some(ref msg) = f.error_message {
+                    // Only print if we didn't already print detail
+                    if f.plan_result.is_none() {
+                        println!("    Error: {msg}");
+                    }
+                }
+                println!();
+            }
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1165,6 +1296,9 @@ mod tests {
             all: false,
             snapshot: false,
             files: false,
+            errors: false,
+            session: None,
+            list_sessions: false,
         };
         let req = build_request(&args).unwrap();
         assert!(req.includes(ReportSection::Library));
@@ -1185,6 +1319,9 @@ mod tests {
             all: true,
             snapshot: false,
             files: false,
+            errors: false,
+            session: None,
+            list_sessions: false,
         };
         let req = build_request(&args).unwrap();
         assert!(req.includes(ReportSection::Library));
@@ -1206,6 +1343,9 @@ mod tests {
             all: false,
             snapshot: false,
             files: false,
+            errors: false,
+            session: None,
+            list_sessions: false,
         };
         let req = build_request(&args).unwrap();
         assert!(req.includes(ReportSection::Plans));
@@ -1228,6 +1368,9 @@ mod tests {
             all: false,
             snapshot: false,
             files: false,
+            errors: false,
+            session: None,
+            list_sessions: false,
         };
         assert!(is_summary_request(&default_args));
 

--- a/crates/voom-domain/src/events.rs
+++ b/crates/voom-domain/src/events.rs
@@ -5,7 +5,7 @@ use uuid::Uuid;
 use crate::bad_file::BadFileSource;
 use crate::job::JobType;
 use crate::media::MediaFile;
-use crate::plan::{ActionResult, Plan};
+use crate::plan::{ActionResult, ExecutionDetail, Plan};
 
 /// All event types that flow through the event bus.
 #[non_exhaustive]
@@ -239,6 +239,9 @@ pub struct EventResult {
     /// without parsing the `data` JSON.
     #[serde(default)]
     pub execution_error: Option<String>,
+    /// Subprocess output captured by the executor, if available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub execution_detail: Option<ExecutionDetail>,
 }
 
 impl EventResult {
@@ -250,6 +253,7 @@ impl EventResult {
             data: None,
             claimed: false,
             execution_error: None,
+            execution_detail: None,
         }
     }
 }
@@ -268,6 +272,7 @@ impl EventResult {
             data,
             claimed: true,
             execution_error: None,
+            execution_detail: None,
         }
     }
 
@@ -284,6 +289,7 @@ impl EventResult {
             data: None,
             claimed: true,
             execution_error: Some(error.into()),
+            execution_detail: None,
         }
     }
 
@@ -300,13 +306,16 @@ impl EventResult {
         match outcome {
             Ok(results) => {
                 let actions_applied = results.iter().filter(|r| r.success).count();
-                Self::plan_succeeded(
+                let detail = results.iter().find_map(|r| r.execution_detail.clone());
+                let mut result = Self::plan_succeeded(
                     plugin_name,
                     Some(serde_json::json!({
                         "actions_applied": actions_applied,
                         "results": serde_json::to_value(&results).unwrap_or_default(),
                     })),
-                )
+                );
+                result.execution_detail = detail;
+                result
             }
             Err(e) => Self::plan_failed(plugin_name, e.to_string()),
         }
@@ -536,6 +545,9 @@ pub struct PlanFailedEvent {
     /// Populated when structured error information is available.
     #[serde(default)]
     pub error_chain: Vec<String>,
+    /// Subprocess output captured by the executor, if available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub execution_detail: Option<ExecutionDetail>,
 }
 
 impl PlanFailedEvent {
@@ -554,6 +566,7 @@ impl PlanFailedEvent {
             error_code: None,
             plugin_name: None,
             error_chain: Vec::new(),
+            execution_detail: None,
         }
     }
 }

--- a/crates/voom-domain/src/events.rs
+++ b/crates/voom-domain/src/events.rs
@@ -259,6 +259,13 @@ impl EventResult {
 }
 
 impl EventResult {
+    /// Attach subprocess execution detail to this result.
+    #[must_use]
+    pub fn with_execution_detail(mut self, detail: ExecutionDetail) -> Self {
+        self.execution_detail = Some(detail);
+        self
+    }
+
     /// Build a result for executor plugins when a plan execution succeeds.
     ///
     /// Lifecycle events (`PlanExecuting`, `PlanCompleted`) are dispatched by the
@@ -296,8 +303,10 @@ impl EventResult {
     /// Wrap the outcome of an executor's plan execution into an `EventResult`.
     ///
     /// On success the result carries the action results as JSON data and is
-    /// marked as claimed.  On failure a failed result is returned (callers
-    /// should log the error if needed).
+    /// marked as claimed. When all action results are failures (subprocess
+    /// exited non-zero), a *failed* result is returned with the execution
+    /// detail attached so it can be persisted. On `Err` (spawn/timeout with
+    /// no detail) a failed result without detail is returned.
     #[must_use]
     pub fn from_plan_execution(
         plugin_name: &str,
@@ -307,6 +316,21 @@ impl EventResult {
             Ok(results) => {
                 let actions_applied = results.iter().filter(|r| r.success).count();
                 let detail = results.iter().find_map(|r| r.execution_detail.clone());
+
+                // All actions failed — treat as execution failure so the
+                // detail propagates to PlanFailedEvent and gets persisted.
+                if actions_applied == 0 && !results.is_empty() {
+                    let error_msg = results
+                        .iter()
+                        .find_map(|r| r.error.clone())
+                        .unwrap_or_else(|| "all actions failed".into());
+                    let mut result = Self::plan_failed(plugin_name, error_msg);
+                    if let Some(d) = detail {
+                        result = result.with_execution_detail(d);
+                    }
+                    return result;
+                }
+
                 let mut result = Self::plan_succeeded(
                     plugin_name,
                     Some(serde_json::json!({
@@ -888,6 +912,33 @@ mod tests {
         let event: PlanFailedEvent = serde_json::from_str(json).unwrap();
         assert!(event.error_code.is_none());
         assert!(event.plugin_name.is_none());
+        assert!(event.execution_detail.is_none());
+    }
+
+    #[test]
+    fn test_plan_failed_with_execution_detail_roundtrip() {
+        use crate::plan::ExecutionDetail;
+
+        let mut event = PlanFailedEvent::new(
+            Uuid::nil(),
+            PathBuf::from("/test.mkv"),
+            "normalize",
+            "ffmpeg exited with 1",
+        );
+        event.execution_detail = Some(ExecutionDetail {
+            command: "ffmpeg -i /test.mkv out.mkv".into(),
+            exit_code: Some(1),
+            stderr_tail: "Error opening input".into(),
+            duration_ms: 1234,
+        });
+
+        let json = serde_json::to_string(&event).unwrap();
+        let restored: PlanFailedEvent = serde_json::from_str(&json).unwrap();
+        assert!(restored.execution_detail.is_some());
+        let detail = restored.execution_detail.unwrap();
+        assert_eq!(detail.exit_code, Some(1));
+        assert_eq!(detail.stderr_tail, "Error opening input");
+        assert_eq!(detail.duration_ms, 1234);
     }
 
     #[test]

--- a/crates/voom-domain/src/plan.rs
+++ b/crates/voom-domain/src/plan.rs
@@ -691,6 +691,19 @@ pub enum PhaseOutcome {
     Failed,
 }
 
+/// Captured subprocess output from an executor invocation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecutionDetail {
+    /// Shell-quoted command line.
+    pub command: String,
+    /// Process exit code.
+    pub exit_code: Option<i32>,
+    /// Last N non-empty lines of stderr.
+    pub stderr_tail: String,
+    /// Wall-clock execution time in milliseconds.
+    pub duration_ms: u64,
+}
+
 /// The result of executing a single action within a phase.
 #[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -699,6 +712,8 @@ pub struct ActionResult {
     pub success: bool,
     pub description: String,
     pub error: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub execution_detail: Option<ExecutionDetail>,
 }
 
 impl ActionResult {
@@ -709,6 +724,7 @@ impl ActionResult {
             success: true,
             description: description.into(),
             error: None,
+            execution_detail: None,
         }
     }
 
@@ -723,7 +739,15 @@ impl ActionResult {
             success: false,
             description: description.into(),
             error: Some(error.into()),
+            execution_detail: None,
         }
+    }
+
+    /// Attach execution detail to this result.
+    #[must_use]
+    pub fn with_execution_detail(mut self, detail: ExecutionDetail) -> Self {
+        self.execution_detail = Some(detail);
+        self
     }
 }
 

--- a/crates/voom-domain/src/plan.rs
+++ b/crates/voom-domain/src/plan.rs
@@ -33,6 +33,10 @@ pub struct Plan {
     /// set by capability-aware validation when a single executor matches.
     #[serde(default)]
     pub executor_hint: Option<String>,
+    /// Processing session that produced this plan. Set by the CLI before
+    /// dispatching `PlanCreated`, used for session-level queries.
+    #[serde(default)]
+    pub session_id: Option<uuid::Uuid>,
 }
 
 impl Plan {
@@ -80,6 +84,7 @@ impl Plan {
             policy_hash: None,
             evaluated_at: Utc::now(),
             executor_hint: None,
+            session_id: None,
         }
     }
 
@@ -698,7 +703,8 @@ pub struct ExecutionDetail {
     pub command: String,
     /// Process exit code.
     pub exit_code: Option<i32>,
-    /// Last N non-empty lines of stderr.
+    /// Last N non-empty lines of stderr. Populated on failure and on
+    /// mkvmerge warnings (exit code 1). Empty on clean success.
     pub stderr_tail: String,
     /// Wall-clock execution time in milliseconds.
     pub duration_ms: u64,
@@ -775,6 +781,7 @@ mod tests {
             policy_hash: None,
             evaluated_at: Utc::now(),
             executor_hint: None,
+            session_id: None,
         }
     }
 

--- a/crates/voom-domain/src/storage.rs
+++ b/crates/voom-domain/src/storage.rs
@@ -119,6 +119,13 @@ pub trait PlanStorage: Send + Sync {
     fn update_plan_status(&self, plan_id: &Uuid, status: PlanStatus) -> Result<()>;
     /// Aggregate plan counts grouped by phase name, status, and skip reason.
     fn plan_stats_by_phase(&self) -> Result<Vec<PlanPhaseStat>>;
+    /// Write error info and optional execution detail to the plan's `result` column.
+    fn update_plan_error(
+        &self,
+        plan_id: &Uuid,
+        error: &str,
+        detail: Option<&crate::plan::ExecutionDetail>,
+    ) -> Result<()>;
 }
 
 /// File lifecycle transition recording.
@@ -140,6 +147,32 @@ pub trait FileTransitionStorage: Send + Sync {
     /// executor (`source_detail`), phase (`phase_name`), and optionally by
     /// time period.
     fn savings_by_provenance(&self, period: Option<TimePeriod>) -> Result<SavingsReport>;
+    /// Retrieve failed transitions for a specific session.
+    fn failed_transitions_for_session(&self, session_id: &Uuid) -> Result<Vec<FailedTransition>>;
+    /// Find the most recent session that has failures.
+    fn latest_failure_session(&self) -> Result<Option<Uuid>>;
+    /// List sessions that have failures, most recent first.
+    fn failure_sessions(&self) -> Result<Vec<SessionSummary>>;
+}
+
+/// A failed transition with plan result details for error reporting.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FailedTransition {
+    pub path: PathBuf,
+    pub phase_name: Option<String>,
+    pub error_message: Option<String>,
+    pub session_id: Option<Uuid>,
+    pub created_at: DateTime<Utc>,
+    /// JSON from plans.result containing ExecutionDetail.
+    pub plan_result: Option<String>,
+}
+
+/// Summary of a processing session with failure counts.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionSummary {
+    pub session_id: Uuid,
+    pub started_at: DateTime<Utc>,
+    pub failure_count: u64,
 }
 
 /// Plugin key-value data storage.

--- a/crates/voom-domain/src/test_support.rs
+++ b/crates/voom-domain/src/test_support.rs
@@ -413,6 +413,15 @@ impl PlanStorage for InMemoryStore {
     fn plan_stats_by_phase(&self) -> Result<Vec<crate::storage::PlanPhaseStat>> {
         Ok(Vec::new())
     }
+
+    fn update_plan_error(
+        &self,
+        _plan_id: &Uuid,
+        _error: &str,
+        _detail: Option<&crate::plan::ExecutionDetail>,
+    ) -> Result<()> {
+        Ok(())
+    }
 }
 
 impl FileTransitionStorage for InMemoryStore {
@@ -444,6 +453,21 @@ impl FileTransitionStorage for InMemoryStore {
         _period: Option<crate::stats::TimePeriod>,
     ) -> Result<crate::stats::SavingsReport> {
         Ok(crate::stats::SavingsReport::default())
+    }
+
+    fn failed_transitions_for_session(
+        &self,
+        _session_id: &Uuid,
+    ) -> Result<Vec<crate::storage::FailedTransition>> {
+        Ok(Vec::new())
+    }
+
+    fn latest_failure_session(&self) -> Result<Option<Uuid>> {
+        Ok(None)
+    }
+
+    fn failure_sessions(&self) -> Result<Vec<crate::storage::SessionSummary>> {
+        Ok(Vec::new())
     }
 }
 

--- a/crates/voom-domain/src/transition.rs
+++ b/crates/voom-domain/src/transition.rs
@@ -125,6 +125,10 @@ pub struct FileTransition {
     /// To determine the pre-processing state, read the snapshot from the
     /// preceding transition in the file's history chain.
     pub metadata_snapshot: Option<MetadataSnapshot>,
+    /// Error message when outcome is failure.
+    pub error_message: Option<String>,
+    /// Session UUID linking transitions to a single `voom process` run.
+    pub session_id: Option<Uuid>,
 }
 
 impl FileTransition {
@@ -160,7 +164,23 @@ impl FileTransition {
             policy_name: None,
             phase_name: None,
             metadata_snapshot: None,
+            error_message: None,
+            session_id: None,
         }
+    }
+
+    /// Set the error message for a failed transition.
+    #[must_use]
+    pub fn with_error_message(mut self, message: impl Into<String>) -> Self {
+        self.error_message = Some(message.into());
+        self
+    }
+
+    /// Set the session ID linking this transition to a `voom process` run.
+    #[must_use]
+    pub fn with_session_id(mut self, session_id: Uuid) -> Self {
+        self.session_id = Some(session_id);
+        self
     }
 
     /// Set the prior hash and size (pre-change state).

--- a/crates/voom-process/src/lib.rs
+++ b/crates/voom-process/src/lib.rs
@@ -140,7 +140,13 @@ pub fn run_with_timeout_env(
 /// single-quoted. Simple args pass through unquoted.
 pub fn shell_quote_args(tool: &str, args: &[impl AsRef<str>]) -> String {
     let mut parts = Vec::with_capacity(args.len() + 1);
-    parts.push(tool.to_string());
+    // Quote the tool name if it contains shell metacharacters (e.g. spaces in path)
+    if tool.contains(|c: char| c.is_whitespace() || "\"'\\$`!#&|;(){}[]<>?*~".contains(c)) {
+        let escaped = tool.replace('\'', "'\\''");
+        parts.push(format!("'{escaped}'"));
+    } else {
+        parts.push(tool.to_string());
+    }
     for arg in args {
         let s = arg.as_ref();
         if s.is_empty()

--- a/crates/voom-process/src/lib.rs
+++ b/crates/voom-process/src/lib.rs
@@ -134,6 +134,35 @@ pub fn run_with_timeout_env(
     }
 }
 
+/// Format a tool invocation as a shell-reproducible command string.
+///
+/// Args containing spaces, quotes, or shell metacharacters are
+/// single-quoted. Simple args pass through unquoted.
+pub fn shell_quote_args(tool: &str, args: &[impl AsRef<str>]) -> String {
+    let mut parts = Vec::with_capacity(args.len() + 1);
+    parts.push(tool.to_string());
+    for arg in args {
+        let s = arg.as_ref();
+        if s.is_empty()
+            || s.contains(|c: char| c.is_whitespace() || "\"'\\$`!#&|;(){}[]<>?*~".contains(c))
+        {
+            let escaped = s.replace('\'', "'\\''");
+            parts.push(format!("'{escaped}'"));
+        } else {
+            parts.push(s.to_string());
+        }
+    }
+    parts.join(" ")
+}
+
+/// Extract the last N non-empty lines from a byte buffer (stderr output).
+pub fn stderr_tail(bytes: &[u8], max_lines: usize) -> String {
+    let text = String::from_utf8_lossy(bytes);
+    let lines: Vec<&str> = text.lines().filter(|l| !l.is_empty()).collect();
+    let start = lines.len().saturating_sub(max_lines);
+    lines[start..].join("\n")
+}
+
 /// Read all bytes from an optional tokio `ChildStdout`/`ChildStderr`.
 async fn read_child_pipe<R>(pipe: Option<R>) -> Vec<u8>
 where

--- a/plugins/backup-manager/src/lib.rs
+++ b/plugins/backup-manager/src/lib.rs
@@ -298,6 +298,10 @@ impl Plugin for BackupManagerPlugin {
             }
             Event::PlanFailed(evt) => {
                 if self.has_backup(&evt.path)? {
+                    // debug!, not warn!: restore-from-backup is expected
+                    // failure-handling behavior and is not surfaced in
+                    // `voom report errors` — the plan failure itself is
+                    // the user-facing signal.
                     tracing::debug!(
                         path = %evt.path.display(),
                         phase = %evt.phase_name,

--- a/plugins/backup-manager/src/lib.rs
+++ b/plugins/backup-manager/src/lib.rs
@@ -298,7 +298,7 @@ impl Plugin for BackupManagerPlugin {
             }
             Event::PlanFailed(evt) => {
                 if self.has_backup(&evt.path)? {
-                    tracing::warn!(
+                    tracing::debug!(
                         path = %evt.path.display(),
                         phase = %evt.phase_name,
                         error = %evt.error,

--- a/plugins/ffmpeg-executor/src/executor.rs
+++ b/plugins/ffmpeg-executor/src/executor.rs
@@ -85,18 +85,27 @@ pub fn execute_plan(plan: &Plan, hw_accel: &HwAccelConfig) -> Result<Vec<ActionR
                 "ffmpeg failed"
             );
             let tail = voom_process::stderr_tail(&output.stderr, STDERR_TAIL_LINES);
-            let detail = if tail.is_empty() {
-                "(no output)".to_string()
+            let display_tail = if tail.is_empty() {
+                "(no output)"
             } else {
-                tail.clone()
+                &tail
             };
-            Err(VoomError::ToolExecution {
-                tool: "ffmpeg".into(),
-                message: format!(
-                    "ffmpeg exited with {}:\n{}\ncmd: {}",
-                    output.status, detail, command_str
-                ),
-            })
+            let error_msg = format!(
+                "ffmpeg exited with {}:\n{}\ncmd: {}",
+                output.status, display_tail, command_str
+            );
+            let detail = ExecutionDetail {
+                command: command_str,
+                exit_code: output.status.code(),
+                stderr_tail: tail,
+                duration_ms,
+            };
+            Ok(vec![ActionResult::failure(
+                actions[0].operation,
+                &actions[0].description,
+                &error_msg,
+            )
+            .with_execution_detail(detail)])
         }
         Err(e) => {
             let _ = std::fs::remove_file(&output_path);

--- a/plugins/ffmpeg-executor/src/executor.rs
+++ b/plugins/ffmpeg-executor/src/executor.rs
@@ -1,9 +1,9 @@
 //! FFmpeg plan execution: build commands, run subprocess, manage temp files.
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use voom_domain::errors::{Result, VoomError};
-use voom_domain::plan::{ActionResult, Plan, PlannedAction};
+use voom_domain::plan::{ActionResult, ExecutionDetail, Plan, PlannedAction};
 use voom_process::run_with_timeout_env;
 
 use voom_domain::temp_file::temp_path_with_ext;
@@ -13,6 +13,9 @@ use crate::hwaccel::HwAccelConfig;
 
 /// Default timeout for `FFmpeg` operations (4 hours — transcode can be slow).
 const FFMPEG_TIMEOUT: Duration = Duration::from_secs(4 * 60 * 60);
+
+/// Maximum number of stderr lines to capture in `ExecutionDetail`.
+const STDERR_TAIL_LINES: usize = 20;
 
 /// Execute a plan by spawning an `FFmpeg` subprocess.
 ///
@@ -45,8 +48,11 @@ pub fn execute_plan(plan: &Plan, hw_accel: &HwAccelConfig) -> Result<Vec<ActionR
     );
     tracing::debug!(args = ?ffmpeg_args, "ffmpeg command");
 
+    let command_str = voom_process::shell_quote_args("ffmpeg", &ffmpeg_args);
     let env_vars: Vec<(&str, &str)> = hw_accel.device_env().into_iter().collect();
+    let start = Instant::now();
     let output = run_with_timeout_env("ffmpeg", &ffmpeg_args, FFMPEG_TIMEOUT, &env_vars);
+    let duration_ms = start.elapsed().as_millis() as u64;
 
     match output {
         Ok(output) if output.status.success() => {
@@ -58,25 +64,37 @@ pub fn execute_plan(plan: &Plan, hw_accel: &HwAccelConfig) -> Result<Vec<ActionR
                 "ffmpeg execution complete"
             );
 
+            let detail = ExecutionDetail {
+                command: command_str,
+                exit_code: Some(0),
+                stderr_tail: String::new(),
+                duration_ms,
+            };
             Ok(actions
                 .iter()
-                .map(|a| ActionResult::success(a.operation, a.description.clone()))
+                .map(|a| {
+                    ActionResult::success(a.operation, a.description.clone())
+                        .with_execution_detail(detail.clone())
+                })
                 .collect())
         }
         Ok(output) => {
             let _ = std::fs::remove_file(&output_path);
-            let stderr = String::from_utf8_lossy(&output.stderr);
             tracing::debug!(
-                stderr = %stderr,
                 args = ?ffmpeg_args,
                 "ffmpeg failed"
             );
+            let tail = voom_process::stderr_tail(&output.stderr, STDERR_TAIL_LINES);
+            let detail = if tail.is_empty() {
+                "(no output)".to_string()
+            } else {
+                tail.clone()
+            };
             Err(VoomError::ToolExecution {
                 tool: "ffmpeg".into(),
                 message: format!(
-                    "ffmpeg exited with {}: {}",
-                    output.status,
-                    stderr.lines().last().unwrap_or("(no output)")
+                    "ffmpeg exited with {}:\n{}\ncmd: {}",
+                    output.status, detail, command_str
                 ),
             })
         }

--- a/plugins/ffmpeg-executor/src/lib.rs
+++ b/plugins/ffmpeg-executor/src/lib.rs
@@ -327,8 +327,11 @@ impl FfmpegExecutorPlugin {
         args.push("-y".to_string());
         args.push(temp_path.to_string_lossy().into_owned());
 
+        let command_str = voom_process::shell_quote_args("ffmpeg", &args);
         const SUBTITLE_MUX_TIMEOUT: Duration = Duration::from_secs(120);
+        let start = std::time::Instant::now();
         let output = voom_process::run_with_timeout_env("ffmpeg", &args, SUBTITLE_MUX_TIMEOUT, &[]);
+        let duration_ms = start.elapsed().as_millis() as u64;
 
         match output {
             Ok(o) if o.status.success() => {
@@ -336,17 +339,30 @@ impl FfmpegExecutorPlugin {
                     let _ = std::fs::remove_file(&temp_path);
                     plugin_err(format!("failed to rename temp file: {e}"))
                 })?;
+                let detail = voom_domain::plan::ExecutionDetail {
+                    command: command_str,
+                    exit_code: Some(0),
+                    stderr_tail: String::new(),
+                    duration_ms,
+                };
                 Ok(vec![voom_domain::plan::ActionResult::success(
                     action.operation,
                     &action.description,
-                )])
+                )
+                .with_execution_detail(detail)])
             }
             Ok(o) => {
                 let _ = std::fs::remove_file(&temp_path);
+                let tail = voom_process::stderr_tail(&o.stderr, 20);
                 Err(plugin_err(format!(
-                    "ffmpeg failed (exit {}): {}",
+                    "ffmpeg failed (exit {}):\n{}\ncmd: {}",
                     o.status.code().unwrap_or(-1),
-                    String::from_utf8_lossy(&o.stderr)
+                    if tail.is_empty() {
+                        "(no output)"
+                    } else {
+                        &tail
+                    },
+                    command_str
                 )))
             }
             Err(e) => {

--- a/plugins/ffmpeg-executor/src/lib.rs
+++ b/plugins/ffmpeg-executor/src/lib.rs
@@ -354,16 +354,29 @@ impl FfmpegExecutorPlugin {
             Ok(o) => {
                 let _ = std::fs::remove_file(&temp_path);
                 let tail = voom_process::stderr_tail(&o.stderr, 20);
-                Err(plugin_err(format!(
+                let display_tail = if tail.is_empty() {
+                    "(no output)"
+                } else {
+                    &tail
+                };
+                let error_msg = format!(
                     "ffmpeg failed (exit {}):\n{}\ncmd: {}",
                     o.status.code().unwrap_or(-1),
-                    if tail.is_empty() {
-                        "(no output)"
-                    } else {
-                        &tail
-                    },
+                    display_tail,
                     command_str
-                )))
+                );
+                let detail = voom_domain::plan::ExecutionDetail {
+                    command: command_str,
+                    exit_code: o.status.code(),
+                    stderr_tail: tail,
+                    duration_ms,
+                };
+                Ok(vec![voom_domain::plan::ActionResult::failure(
+                    action.operation,
+                    &action.description,
+                    &error_msg,
+                )
+                .with_execution_detail(detail)])
             }
             Err(e) => {
                 let _ = std::fs::remove_file(&temp_path);

--- a/plugins/mkvtoolnix-executor/src/lib.rs
+++ b/plugins/mkvtoolnix-executor/src/lib.rs
@@ -326,7 +326,8 @@ impl MkvtoolnixExecutorPlugin {
                 let detail = voom_domain::plan::ExecutionDetail {
                     command: command_str,
                     exit_code: o.status.code(),
-                    stderr_tail: String::new(),
+                    // exit code 1 = mkvmerge warnings; capture stderr for diagnostics
+                    stderr_tail: voom_process::stderr_tail(&o.stderr, 20),
                     duration_ms,
                 };
                 Ok(vec![ActionResult::success(
@@ -337,19 +338,29 @@ impl MkvtoolnixExecutorPlugin {
             }
             Ok(o) => {
                 let tail = voom_process::stderr_tail(&o.stderr, 20);
-                Err(VoomError::ToolExecution {
-                    tool: "mkvmerge".into(),
-                    message: format!(
-                        "mkvmerge failed (exit {}):\n{}\ncmd: {}",
-                        o.status.code().unwrap_or(-1),
-                        if tail.is_empty() {
-                            "(no output)"
-                        } else {
-                            &tail
-                        },
-                        command_str
-                    ),
-                })
+                let display_tail = if tail.is_empty() {
+                    "(no output)"
+                } else {
+                    &tail
+                };
+                let error_msg = format!(
+                    "mkvmerge failed (exit {}):\n{}\ncmd: {}",
+                    o.status.code().unwrap_or(-1),
+                    display_tail,
+                    command_str
+                );
+                let detail = voom_domain::plan::ExecutionDetail {
+                    command: command_str,
+                    exit_code: o.status.code(),
+                    stderr_tail: tail,
+                    duration_ms,
+                };
+                Ok(vec![ActionResult::failure(
+                    action.operation,
+                    &action.description,
+                    &error_msg,
+                )
+                .with_execution_detail(detail)])
             }
             Err(e) => Err(VoomError::ToolExecution {
                 tool: "mkvmerge".into(),

--- a/plugins/mkvtoolnix-executor/src/lib.rs
+++ b/plugins/mkvtoolnix-executor/src/lib.rs
@@ -308,9 +308,12 @@ impl MkvtoolnixExecutorPlugin {
         args.push(path.to_string_lossy().into_owned());
         args.push(subtitle_path.to_string_lossy().into_owned());
 
+        let command_str = voom_process::shell_quote_args("mkvmerge", &args);
         const SUBTITLE_MUX_TIMEOUT: Duration = Duration::from_secs(120);
+        let start = std::time::Instant::now();
         let output =
             voom_process::run_with_timeout_env("mkvmerge", &args, SUBTITLE_MUX_TIMEOUT, &[]);
+        let duration_ms = start.elapsed().as_millis() as u64;
 
         match output {
             Ok(o) if o.status.success() || o.status.code() == Some(1) => {
@@ -320,19 +323,34 @@ impl MkvtoolnixExecutorPlugin {
                 })?;
                 // Defuse guard — temp file was successfully renamed
                 scopeguard::ScopeGuard::into_inner(_guard);
+                let detail = voom_domain::plan::ExecutionDetail {
+                    command: command_str,
+                    exit_code: o.status.code(),
+                    stderr_tail: String::new(),
+                    duration_ms,
+                };
                 Ok(vec![ActionResult::success(
                     action.operation,
                     &action.description,
-                )])
+                )
+                .with_execution_detail(detail)])
             }
-            Ok(o) => Err(VoomError::ToolExecution {
-                tool: "mkvmerge".into(),
-                message: format!(
-                    "mkvmerge failed (exit {}): {}",
-                    o.status.code().unwrap_or(-1),
-                    String::from_utf8_lossy(&o.stderr)
-                ),
-            }),
+            Ok(o) => {
+                let tail = voom_process::stderr_tail(&o.stderr, 20);
+                Err(VoomError::ToolExecution {
+                    tool: "mkvmerge".into(),
+                    message: format!(
+                        "mkvmerge failed (exit {}):\n{}\ncmd: {}",
+                        o.status.code().unwrap_or(-1),
+                        if tail.is_empty() {
+                            "(no output)"
+                        } else {
+                            &tail
+                        },
+                        command_str
+                    ),
+                })
+            }
             Err(e) => Err(VoomError::ToolExecution {
                 tool: "mkvmerge".into(),
                 message: format!("mkvmerge subtitle mux failed: {e}"),

--- a/plugins/mkvtoolnix-executor/src/merge.rs
+++ b/plugins/mkvtoolnix-executor/src/merge.rs
@@ -81,7 +81,8 @@ pub fn execute_merge_actions(path: &Path, actions: &[&PlannedAction]) -> Result<
         let detail = ExecutionDetail {
             command: command_str,
             exit_code: output.status.code(),
-            stderr_tail: String::new(),
+            // exit code 1 = mkvmerge warnings; capture stderr for diagnostics
+            stderr_tail: voom_process::stderr_tail(&output.stderr, 20),
             duration_ms,
         };
         Ok(actions
@@ -100,13 +101,22 @@ pub fn execute_merge_actions(path: &Path, actions: &[&PlannedAction]) -> Result<
             stderr = %tail,
             "mkvmerge failed"
         );
-        Err(VoomError::ToolExecution {
-            tool: "mkvmerge".into(),
-            message: format!(
-                "mkvmerge exited with status {}:\n{}\ncmd: {}",
-                output.status, tail, command_str
-            ),
-        })
+        let error_msg = format!(
+            "mkvmerge exited with status {}:\n{}\ncmd: {}",
+            output.status, tail, command_str
+        );
+        let detail = ExecutionDetail {
+            command: command_str,
+            exit_code: output.status.code(),
+            stderr_tail: tail,
+            duration_ms,
+        };
+        Ok(vec![ActionResult::failure(
+            actions[0].operation,
+            &actions[0].description,
+            &error_msg,
+        )
+        .with_execution_detail(detail)])
     }
 }
 

--- a/plugins/mkvtoolnix-executor/src/merge.rs
+++ b/plugins/mkvtoolnix-executor/src/merge.rs
@@ -1,10 +1,12 @@
 use std::fs;
 use std::path::Path;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use scopeguard::ScopeGuard;
 use voom_domain::errors::{Result, VoomError};
-use voom_domain::plan::{ActionParams, ActionResult, OperationType, PlannedAction};
+use voom_domain::plan::{
+    ActionParams, ActionResult, ExecutionDetail, OperationType, PlannedAction,
+};
 use voom_domain::temp_file::temp_path_with_ext;
 use voom_process::run_with_timeout;
 
@@ -45,7 +47,10 @@ pub fn execute_merge_actions(path: &Path, actions: &[&PlannedAction]) -> Result<
     );
     tracing::debug!(args = ?args, "mkvmerge arguments");
 
+    let command_str = voom_process::shell_quote_args("mkvmerge", &args);
+    let start = Instant::now();
     let output = run_with_timeout("mkvmerge", &args, Duration::from_secs(1800))?;
+    let duration_ms = start.elapsed().as_millis() as u64;
 
     // mkvmerge returns 0 for success, 1 for warnings (still successful), 2 for errors
     if output.status.code().unwrap_or(2) <= 1 {
@@ -73,22 +78,34 @@ pub fn execute_merge_actions(path: &Path, actions: &[&PlannedAction]) -> Result<
             let _ = fs::remove_file(path);
         }
 
+        let detail = ExecutionDetail {
+            command: command_str,
+            exit_code: output.status.code(),
+            stderr_tail: String::new(),
+            duration_ms,
+        };
         Ok(actions
             .iter()
-            .map(|a| ActionResult::success(a.operation, a.description.clone()))
+            .map(|a| {
+                ActionResult::success(a.operation, a.description.clone())
+                    .with_execution_detail(detail.clone())
+            })
             .collect())
     } else {
         // Guard will clean up temp file when it drops
 
-        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        let tail = voom_process::stderr_tail(&output.stderr, 20);
         tracing::error!(
             input = %path.display(),
-            stderr = %stderr,
+            stderr = %tail,
             "mkvmerge failed"
         );
         Err(VoomError::ToolExecution {
             tool: "mkvmerge".into(),
-            message: format!("mkvmerge exited with status {}: {}", output.status, stderr),
+            message: format!(
+                "mkvmerge exited with status {}:\n{}\ncmd: {}",
+                output.status, tail, command_str
+            ),
         })
     }
 }

--- a/plugins/sqlite-store/src/lib.rs
+++ b/plugins/sqlite-store/src/lib.rs
@@ -222,6 +222,7 @@ fn handle_plan_skipped(
 fn handle_plan_failed(store: &SqliteStore, e: &voom_domain::events::PlanFailedEvent) -> Result<()> {
     tracing::info!(path = %e.path.display(), phase = %e.phase_name, error = %e.error, "plan failed");
     store.update_plan_status(&e.plan_id, voom_domain::storage::PlanStatus::Failed)?;
+    store.update_plan_error(&e.plan_id, &e.error, e.execution_detail.as_ref())?;
     if let Err(err) = store.delete_pending_op(&e.plan_id) {
         tracing::warn!(
             error = %err,

--- a/plugins/sqlite-store/src/schema.rs
+++ b/plugins/sqlite-store/src/schema.rs
@@ -75,7 +75,8 @@ CREATE TABLE IF NOT EXISTS plans (
     evaluated_at TEXT,
     created_at TEXT NOT NULL,
     executed_at TEXT,
-    result TEXT
+    result TEXT,
+    session_id TEXT
 );
 
 CREATE TABLE IF NOT EXISTS file_transitions (
@@ -96,6 +97,8 @@ CREATE TABLE IF NOT EXISTS file_transitions (
     policy_name TEXT,
     phase_name TEXT,
     metadata_snapshot TEXT,
+    error_message TEXT,
+    session_id TEXT,
     created_at TEXT NOT NULL
 );
 
@@ -244,6 +247,7 @@ pub(crate) fn migrate(conn: &Connection) -> rusqlite::Result<()> {
     migrate_indexes_and_constraints(conn)?;
     migrate_processing_stats_into_transitions(conn, &has_column)?;
     migrate_metadata_snapshot_column(conn, &has_column)?;
+    migrate_execution_capture_columns(conn, &has_column)?;
 
     Ok(())
 }
@@ -519,6 +523,47 @@ fn migrate_metadata_snapshot_column(
     if !has_column("file_transitions", "metadata_snapshot")? {
         conn.execute_batch("ALTER TABLE file_transitions ADD COLUMN metadata_snapshot TEXT;")?;
     }
+    Ok(())
+}
+
+/// Add error_message and session_id columns to file_transitions, and
+/// session_id to plans, for execution output capture.
+fn migrate_execution_capture_columns(
+    conn: &Connection,
+    has_column: &dyn Fn(&str, &str) -> rusqlite::Result<bool>,
+) -> rusqlite::Result<()> {
+    let table_exists = |name: &str| -> rusqlite::Result<bool> {
+        conn.query_row(
+            "SELECT COUNT(*) > 0 FROM sqlite_master \
+             WHERE type='table' AND name=?1",
+            [name],
+            |row| row.get(0),
+        )
+    };
+
+    if table_exists("file_transitions")? {
+        if !has_column("file_transitions", "error_message")? {
+            conn.execute_batch("ALTER TABLE file_transitions ADD COLUMN error_message TEXT;")?;
+        }
+        if !has_column("file_transitions", "session_id")? {
+            conn.execute_batch("ALTER TABLE file_transitions ADD COLUMN session_id TEXT;")?;
+        }
+        conn.execute_batch(
+            "CREATE INDEX IF NOT EXISTS idx_transitions_session \
+             ON file_transitions(session_id);",
+        )?;
+    }
+
+    if table_exists("plans")? {
+        if !has_column("plans", "session_id")? {
+            conn.execute_batch("ALTER TABLE plans ADD COLUMN session_id TEXT;")?;
+        }
+        conn.execute_batch(
+            "CREATE INDEX IF NOT EXISTS idx_plans_session \
+             ON plans(session_id);",
+        )?;
+    }
+
     Ok(())
 }
 

--- a/plugins/sqlite-store/src/store/file_transition_storage.rs
+++ b/plugins/sqlite-store/src/store/file_transition_storage.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use rusqlite::params;
+use rusqlite::OptionalExtension;
 use uuid::Uuid;
 
 use voom_domain::errors::Result;
@@ -18,9 +19,10 @@ impl FileTransitionStorage for SqliteStore {
              (id, file_id, path, from_hash, to_hash, from_size, to_size, \
               source, source_detail, plan_id, \
               duration_ms, actions_taken, tracks_modified, outcome, \
-              policy_name, phase_name, metadata_snapshot, created_at) \
+              policy_name, phase_name, metadata_snapshot, \
+              error_message, session_id, created_at) \
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, \
-                     ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)",
+                     ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20)",
             params![
                 t.id.to_string(),
                 t.file_id.to_string(),
@@ -45,6 +47,8 @@ impl FileTransitionStorage for SqliteStore {
                         )
                         .ok()
                 }),
+                t.error_message.as_deref(),
+                t.session_id.map(|id| id.to_string()),
                 format_datetime(&t.created_at),
             ],
         )
@@ -173,6 +177,120 @@ impl FileTransitionStorage for SqliteStore {
             .map_err(storage_err("failed to query transitions for path"))?
             .collect::<rusqlite::Result<Vec<_>>>()
             .map_err(storage_err("failed to collect transitions for path"))?;
+
+        Ok(rows)
+    }
+
+    fn failed_transitions_for_session(
+        &self,
+        session_id: &Uuid,
+    ) -> Result<Vec<voom_domain::storage::FailedTransition>> {
+        let conn = self.conn()?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT ft.path, ft.phase_name, ft.error_message, \
+                 ft.session_id, ft.created_at, p.result \
+                 FROM file_transitions ft \
+                 LEFT JOIN plans p ON ft.plan_id = p.id \
+                 WHERE ft.outcome = 'failure' \
+                   AND ft.session_id = ?1 \
+                 ORDER BY ft.created_at",
+            )
+            .map_err(storage_err("failed to prepare failed_transitions query"))?;
+
+        let rows = stmt
+            .query_map(params![session_id.to_string()], |row| {
+                let path_str: String = row.get("path")?;
+                let phase_name: Option<String> = row.get("phase_name")?;
+                let error_message: Option<String> = row.get("error_message")?;
+                let session_str: Option<String> = row.get("session_id")?;
+                let created_at_str: String = row.get("created_at")?;
+                let plan_result: Option<String> = row.get("result")?;
+
+                let session_id = session_str
+                    .filter(|s| !s.is_empty())
+                    .and_then(|s| Uuid::parse_str(&s).ok());
+                let created_at = created_at_str.parse().map_err(|e| {
+                    rusqlite::Error::FromSqlConversionFailure(
+                        0,
+                        rusqlite::types::Type::Text,
+                        format!("corrupt datetime: {e}").into(),
+                    )
+                })?;
+
+                Ok(voom_domain::storage::FailedTransition {
+                    path: PathBuf::from(path_str),
+                    phase_name,
+                    error_message,
+                    session_id,
+                    created_at,
+                    plan_result,
+                })
+            })
+            .map_err(storage_err("failed to query failed transitions"))?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(storage_err("failed to collect failed transitions"))?;
+
+        Ok(rows)
+    }
+
+    fn latest_failure_session(&self) -> Result<Option<Uuid>> {
+        let conn = self.conn()?;
+        let result: Option<String> = conn
+            .query_row(
+                "SELECT session_id FROM file_transitions \
+                 WHERE outcome = 'failure' AND session_id IS NOT NULL \
+                 ORDER BY created_at DESC LIMIT 1",
+                [],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(storage_err("failed to query latest failure session"))?;
+
+        Ok(result.and_then(|s| Uuid::parse_str(&s).ok()))
+    }
+
+    fn failure_sessions(&self) -> Result<Vec<voom_domain::storage::SessionSummary>> {
+        let conn = self.conn()?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT session_id, MIN(created_at) as started, COUNT(*) as cnt \
+                 FROM file_transitions \
+                 WHERE outcome = 'failure' AND session_id IS NOT NULL \
+                 GROUP BY session_id \
+                 ORDER BY MIN(created_at) DESC \
+                 LIMIT 20",
+            )
+            .map_err(storage_err("failed to prepare failure_sessions query"))?;
+
+        let rows = stmt
+            .query_map([], |row| {
+                let session_str: String = row.get("session_id")?;
+                let started_str: String = row.get("started")?;
+                let count: i64 = row.get("cnt")?;
+                let session_id = Uuid::parse_str(&session_str).map_err(|e| {
+                    rusqlite::Error::FromSqlConversionFailure(
+                        0,
+                        rusqlite::types::Type::Text,
+                        format!("invalid UUID: {e}").into(),
+                    )
+                })?;
+                let started_at = started_str.parse().map_err(|e| {
+                    rusqlite::Error::FromSqlConversionFailure(
+                        0,
+                        rusqlite::types::Type::Text,
+                        format!("corrupt datetime: {e}").into(),
+                    )
+                })?;
+                Ok(voom_domain::storage::SessionSummary {
+                    session_id,
+                    started_at,
+                    failure_count: count as u64,
+                })
+            })
+            .map_err(storage_err("failed to query failure sessions"))?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(storage_err("failed to collect failure sessions"))?;
 
         Ok(rows)
     }

--- a/plugins/sqlite-store/src/store/plan_storage.rs
+++ b/plugins/sqlite-store/src/store/plan_storage.rs
@@ -226,6 +226,27 @@ impl PlanStorage for SqliteStore {
 
         Ok(stats)
     }
+
+    fn update_plan_error(
+        &self,
+        plan_id: &Uuid,
+        error: &str,
+        detail: Option<&voom_domain::plan::ExecutionDetail>,
+    ) -> Result<()> {
+        let conn = self.conn()?;
+        let result_json = serde_json::json!({
+            "error": error,
+            "detail": detail,
+        });
+        let result_str = serde_json::to_string(&result_json)
+            .map_err(other_storage_err("failed to serialize plan error result"))?;
+        conn.execute(
+            "UPDATE plans SET result = ?1 WHERE id = ?2",
+            params![result_str, plan_id.to_string()],
+        )
+        .map_err(storage_err("failed to update plan error result"))?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/plugins/sqlite-store/src/store/plan_storage.rs
+++ b/plugins/sqlite-store/src/store/plan_storage.rs
@@ -92,8 +92,8 @@ impl PlanStorage for SqliteStore {
             });
 
         conn.execute(
-            "INSERT INTO plans (id, file_id, policy_name, phase_name, status, actions, warnings, skip_reason, policy_hash, evaluated_at, created_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+            "INSERT INTO plans (id, file_id, policy_name, phase_name, status, actions, warnings, skip_reason, policy_hash, evaluated_at, created_at, session_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
             params![
                 plan.id.to_string(),
                 effective_file_id,
@@ -106,6 +106,7 @@ impl PlanStorage for SqliteStore {
                 plan.policy_hash,
                 format_datetime(&plan.evaluated_at),
                 format_datetime(&Utc::now()),
+                plan.session_id.map(|id| id.to_string()),
             ],
         )
         .map_err(storage_err("failed to save plan"))?;


### PR DESCRIPTION
## Summary

- Capture subprocess output (`ExecutionDetail`: command, exit code, stderr tail, duration) from ffmpeg and mkvtoolnix executors and persist it to the database on both success and failure
- Add `voom report errors` CLI subcommand to display failed transitions with full subprocess diagnostics, supporting `--session <id>` lookup and `--list-sessions`
- Thread `ExecutionDetail` through the failure path by returning `Ok(ActionResult::failure(...).with_execution_detail(detail))` from executors instead of `Err(VoomError)`, so the detail propagates through `from_plan_execution` → `PlanFailedEvent` → `plans.result`

## Details

Executors now build `ExecutionDetail` on subprocess failure and attach it to a failed `ActionResult`. `EventResult::from_plan_execution` detects all-failed results and produces a failed `EventResult` with the detail attached. `execute_single_plan` extracts it into `PlanFailedEvent.execution_detail`, which sqlite-store persists in `plans.result` as structured JSON. `voom report errors` reads it back and displays command, exit code, and stderr tail.

Additional fixes from review:
- Wire `plans.session_id` in `save_plan` INSERT (column already existed)
- Capture mkvmerge stderr on exit code 1 (warnings) for diagnostics
- Fix `error_message` suppression in report display — only suppress when detail was actually rendered
- Strip ANSI escapes from command/stderr before printing
- Remove misleading `.context("invalid session UUID")` wrapper on prefix-match path
- Quote tool name in `shell_quote_args` when it contains shell metacharacters
- Add serde backward-compat test for `PlanFailedEvent.execution_detail`
- Remove dead `total_errors` computation in process summary

## Test plan

- [x] `cargo build` — clean
- [x] `cargo clippy --workspace` — zero warnings
- [x] `cargo test` — all tests pass, including new `test_plan_failed_with_execution_detail_roundtrip`
- [ ] Manual: run `voom process` on a file that will fail (corrupt input) and verify `voom report errors` shows exit code, command, and stderr tail