### PR TITLE
feat(web): SSE bridge — forward kernel events to browser SSE clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3303,6 +3303,7 @@ dependencies = [
  "voom-sqlite-store",
  "voom-tool-detector",
  "voom-web-server",
+ "voom-web-sse-bridge",
 ]
 
 [[package]]
@@ -3565,6 +3566,19 @@ dependencies = [
  "voom-domain",
  "voom-dsl",
  "voom-report",
+]
+
+[[package]]
+name = "voom-web-sse-bridge"
+version = "0.1.0"
+dependencies = [
+ "serde_json",
+ "tokio",
+ "tracing",
+ "uuid",
+ "voom-domain",
+ "voom-kernel",
+ "voom-web-server",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "plugins/ffmpeg-executor",
     "plugins/job-manager",
     "plugins/web-server",
+    "plugins/web-sse-bridge",
     "plugins/health-checker",
     "plugins/bus-tracer",
     "plugins/report",
@@ -65,6 +66,7 @@ voom-ffmpeg-executor = { path = "plugins/ffmpeg-executor" }
 voom-backup-manager = { path = "plugins/backup-manager" }
 voom-job-manager = { path = "plugins/job-manager" }
 voom-web-server = { path = "plugins/web-server" }
+voom-web-sse-bridge = { path = "plugins/web-sse-bridge" }
 voom-health-checker = { path = "plugins/health-checker" }
 voom-bus-tracer = { path = "plugins/bus-tracer" }
 voom-report = { path = "plugins/report" }

--- a/crates/voom-cli/Cargo.toml
+++ b/crates/voom-cli/Cargo.toml
@@ -30,6 +30,7 @@ voom-ffmpeg-executor.workspace = true
 voom-backup-manager.workspace = true
 voom-job-manager.workspace = true
 voom-web-server.workspace = true
+voom-web-sse-bridge.workspace = true
 voom-health-checker.workspace = true
 voom-bus-tracer.workspace = true
 voom-report.workspace = true

--- a/crates/voom-cli/src/commands/serve.rs
+++ b/crates/voom-cli/src/commands/serve.rs
@@ -27,8 +27,10 @@ pub async fn run(args: ServeArgs, token: CancellationToken) -> Result<()> {
     // to the web server so connected clients receive the broadcasts.
     let (sse_tx, _) = tokio::sync::broadcast::channel::<SseEvent>(SSE_CHANNEL_CAPACITY);
     let bridge = voom_web_sse_bridge::WebSseBridgePlugin::new(sse_tx.clone());
+    let bridge_ctx =
+        voom_kernel::PluginContext::new(serde_json::json!({}), config.data_dir.clone());
     kernel
-        .register_plugin(Arc::new(bridge), PRIORITY_WEB_SSE_BRIDGE)
+        .init_and_register(Arc::new(bridge), PRIORITY_WEB_SSE_BRIDGE, &bridge_ctx)
         .context("Failed to register web-sse-bridge plugin")?;
 
     // Snapshot plugin info from the kernel registry

--- a/crates/voom-cli/src/commands/serve.rs
+++ b/crates/voom-cli/src/commands/serve.rs
@@ -14,9 +14,11 @@ use crate::cli::ServeArgs;
 /// events without lagging slow clients.
 const SSE_CHANNEL_CAPACITY: usize = 256;
 
-/// Priority for the web-sse-bridge plugin. Placed after job-manager (20)
-/// and after sqlite-store (100) so it observes job lifecycle events that
-/// have already been logged and persisted.
+/// Priority for the web-sse-bridge plugin. In the VOOM event bus, lower
+/// priority numbers dispatch first; 200 is the highest registered value
+/// in the system, so the bridge runs last and observes events only after
+/// job-manager (20) and sqlite-store (100) have already logged and
+/// persisted them.
 const PRIORITY_WEB_SSE_BRIDGE: i32 = 200;
 
 pub async fn run(args: ServeArgs, token: CancellationToken) -> Result<()> {

--- a/crates/voom-cli/src/commands/serve.rs
+++ b/crates/voom-cli/src/commands/serve.rs
@@ -27,10 +27,8 @@ pub async fn run(args: ServeArgs, token: CancellationToken) -> Result<()> {
     // to the web server so connected clients receive the broadcasts.
     let (sse_tx, _) = tokio::sync::broadcast::channel::<SseEvent>(SSE_CHANNEL_CAPACITY);
     let bridge = voom_web_sse_bridge::WebSseBridgePlugin::new(sse_tx.clone());
-    let bridge_ctx =
-        voom_kernel::PluginContext::new(serde_json::json!({}), config.data_dir.clone());
     kernel
-        .init_and_register(Arc::new(bridge), PRIORITY_WEB_SSE_BRIDGE, &bridge_ctx)
+        .register_plugin(Arc::new(bridge), PRIORITY_WEB_SSE_BRIDGE)
         .context("Failed to register web-sse-bridge plugin")?;
 
     // Snapshot plugin info from the kernel registry

--- a/crates/voom-cli/src/commands/serve.rs
+++ b/crates/voom-cli/src/commands/serve.rs
@@ -122,11 +122,10 @@ pub async fn run(args: ServeArgs, token: CancellationToken) -> Result<()> {
     );
     println!("  {} http://{}:{}", style("→").bold(), args.host, args.port);
 
-    let mut server_config = ServerConfig::new(args.host, args.port);
+    let mut server_config = ServerConfig::new(args.host, args.port, sse_tx);
     server_config.auth_token = config.auth_token;
     server_config.plugin_info = plugin_info;
     server_config.data_dir = Some(config.data_dir.clone());
-    server_config.sse_tx = Some(sse_tx);
 
     let shutdown = async move { token.cancelled().await };
     start_server(server_config, store, shutdown).await?;
@@ -142,11 +141,14 @@ mod tests {
 
     #[test]
     fn test_server_config_from_default_args() {
+        use tokio::sync::broadcast;
+        use voom_web_server::state::SseEvent;
         let args = ServeArgs {
             port: 8080,
             host: "127.0.0.1".to_string(),
         };
-        let server_config = ServerConfig::new(args.host.clone(), args.port);
+        let (sse_tx, _) = broadcast::channel::<SseEvent>(1);
+        let server_config = ServerConfig::new(args.host.clone(), args.port, sse_tx);
         assert_eq!(server_config.port, 8080);
         assert_eq!(server_config.host, "127.0.0.1");
         assert!(server_config.auth_token.is_none());
@@ -154,11 +156,14 @@ mod tests {
 
     #[test]
     fn test_server_config_with_auth_token() {
+        use tokio::sync::broadcast;
+        use voom_web_server::state::SseEvent;
         let config = crate::config::AppConfig {
             auth_token: Some("secret".to_string()),
             ..Default::default()
         };
-        let mut server_config = ServerConfig::new("0.0.0.0".to_string(), 3000);
+        let (sse_tx, _) = broadcast::channel::<SseEvent>(1);
+        let mut server_config = ServerConfig::new("0.0.0.0".to_string(), 3000, sse_tx);
         server_config.auth_token = config.auth_token.clone();
         assert_eq!(server_config.auth_token.as_deref(), Some("secret"));
         assert_eq!(server_config.port, 3000);

--- a/crates/voom-cli/src/commands/serve.rs
+++ b/crates/voom-cli/src/commands/serve.rs
@@ -1,17 +1,40 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use console::style;
 use tokio_util::sync::CancellationToken;
 use voom_web_server::server::{start_server, ServerConfig};
+use voom_web_server::state::SseEvent;
 
 use crate::cli::ServeArgs;
 
+/// Capacity of the SSE broadcast channel shared between the web server and
+/// the kernel-side bridge plugin. Sized to absorb short bursts of job-progress
+/// events without lagging slow clients.
+const SSE_CHANNEL_CAPACITY: usize = 256;
+
+/// Priority for the web-sse-bridge plugin. Placed after job-manager (20)
+/// and after sqlite-store (100) so it observes job lifecycle events that
+/// have already been logged and persisted.
+const PRIORITY_WEB_SSE_BRIDGE: i32 = 200;
+
 pub async fn run(args: ServeArgs, token: CancellationToken) -> Result<()> {
     let config = crate::config::load_config()?;
-    let crate::app::BootstrapResult { kernel, store, .. } =
-        crate::app::bootstrap_kernel_with_store(&config)?;
+    let crate::app::BootstrapResult {
+        mut kernel, store, ..
+    } = crate::app::bootstrap_kernel_with_store(&config)?;
+
+    // Create the SSE broadcast channel and register a kernel-side bridge plugin
+    // that forwards relevant bus events into it. The same sender is then handed
+    // to the web server so connected clients receive the broadcasts.
+    let (sse_tx, _) = tokio::sync::broadcast::channel::<SseEvent>(SSE_CHANNEL_CAPACITY);
+    let bridge = voom_web_sse_bridge::WebSseBridgePlugin::new(sse_tx.clone());
+    let bridge_ctx =
+        voom_kernel::PluginContext::new(serde_json::json!({}), config.data_dir.clone());
+    kernel
+        .init_and_register(Arc::new(bridge), PRIORITY_WEB_SSE_BRIDGE, &bridge_ctx)
+        .context("Failed to register web-sse-bridge plugin")?;
 
     // Snapshot plugin info from the kernel registry
     let plugin_info: Vec<voom_web_server::api::plugins::PluginInfoResponse> = kernel
@@ -106,6 +129,7 @@ pub async fn run(args: ServeArgs, token: CancellationToken) -> Result<()> {
     server_config.auth_token = config.auth_token;
     server_config.plugin_info = plugin_info;
     server_config.data_dir = Some(config.data_dir.clone());
+    server_config.sse_tx = Some(sse_tx);
 
     let shutdown = async move { token.cancelled().await };
     start_server(server_config, store, shutdown).await?;

--- a/crates/voom-cli/src/commands/serve.rs
+++ b/crates/voom-cli/src/commands/serve.rs
@@ -5,14 +5,9 @@ use anyhow::{Context, Result};
 use console::style;
 use tokio_util::sync::CancellationToken;
 use voom_web_server::server::{start_server, ServerConfig};
-use voom_web_server::state::SseEvent;
+use voom_web_server::state::{SseEvent, SSE_CHANNEL_CAPACITY};
 
 use crate::cli::ServeArgs;
-
-/// Capacity of the SSE broadcast channel shared between the web server and
-/// the kernel-side bridge plugin. Sized to absorb short bursts of job-progress
-/// events without lagging slow clients.
-const SSE_CHANNEL_CAPACITY: usize = 256;
 
 /// Priority for the web-sse-bridge plugin. In the VOOM event bus, lower
 /// priority numbers dispatch first; 200 is the highest registered value

--- a/plugins/web-server/src/server.rs
+++ b/plugins/web-server/src/server.rs
@@ -21,16 +21,15 @@ pub struct ServerConfig {
     pub auth_token: Option<String>,
     pub plugin_info: Vec<crate::api::plugins::PluginInfoResponse>,
     pub data_dir: Option<std::path::PathBuf>,
-    /// Externally-provided SSE broadcast sender. When `Some`, this sender is
-    /// installed on the `AppState` instead of the default one created by
-    /// `AppState::new`. This lets callers share the channel with a kernel-side
-    /// bridge plugin that forwards bus events to SSE clients.
-    pub sse_tx: Option<broadcast::Sender<SseEvent>>,
+    /// SSE broadcast sender supplied by the caller. All channel creation is
+    /// the caller's responsibility; the server uses this sender directly so
+    /// that it shares the same channel as any kernel-side bridge plugin.
+    pub sse_tx: broadcast::Sender<SseEvent>,
 }
 
 impl ServerConfig {
     #[must_use]
-    pub fn new(host: String, port: u16) -> Self {
+    pub fn new(host: String, port: u16, sse_tx: broadcast::Sender<SseEvent>) -> Self {
         Self {
             host,
             port,
@@ -38,7 +37,7 @@ impl ServerConfig {
             auth_token: None,
             plugin_info: Vec::new(),
             data_dir: None,
-            sse_tx: None,
+            sse_tx,
         }
     }
 }
@@ -69,11 +68,14 @@ pub async fn start_server(
     }
 
     let templates = load_templates(config.template_dir.as_deref())?;
-    let sse_tx = config
-        .sse_tx
-        .unwrap_or_else(|| broadcast::channel(crate::state::SSE_CHANNEL_CAPACITY).0);
-    let state = AppState::new(store, sse_tx, templates, config.auth_token, config.data_dir)
-        .with_plugin_info(config.plugin_info);
+    let state = AppState::new(
+        store,
+        config.sse_tx,
+        templates,
+        config.auth_token,
+        config.data_dir,
+    )
+    .with_plugin_info(config.plugin_info);
     let router = build_router(state).layer(DefaultBodyLimit::max(2 * 1024 * 1024)); // 2 MiB
 
     let address = format!("{}:{}", config.host, config.port);
@@ -166,6 +168,7 @@ mod tests {
 
     #[test]
     fn test_server_config_fields() {
+        let (sse_tx, _rx) = broadcast::channel::<SseEvent>(1);
         let config = ServerConfig {
             host: "127.0.0.1".into(),
             port: 8080,
@@ -173,17 +176,17 @@ mod tests {
             auth_token: Some("secret".into()),
             plugin_info: vec![],
             data_dir: None,
-            sse_tx: None,
+            sse_tx,
         };
         assert_eq!(config.host, "127.0.0.1");
         assert_eq!(config.port, 8080);
         assert!(config.template_dir.is_none());
         assert_eq!(config.auth_token, Some("secret".to_string()));
-        assert!(config.sse_tx.is_none());
     }
 
     #[test]
     fn test_server_config_clone() {
+        let (sse_tx, _rx) = broadcast::channel::<SseEvent>(1);
         let config = ServerConfig {
             host: "0.0.0.0".into(),
             port: 3000,
@@ -191,7 +194,7 @@ mod tests {
             auth_token: None,
             plugin_info: vec![],
             data_dir: None,
-            sse_tx: None,
+            sse_tx,
         };
         let cloned = config.clone();
         assert_eq!(cloned.host, "0.0.0.0");
@@ -201,11 +204,11 @@ mod tests {
     }
 
     #[test]
-    fn test_server_config_with_external_sse_sender() {
+    fn test_server_config_stores_sse_sender() {
         let (tx, _rx) = broadcast::channel::<SseEvent>(8);
-        let mut config = ServerConfig::new("127.0.0.1".into(), 8080);
-        config.sse_tx = Some(tx);
-        assert!(config.sse_tx.is_some());
+        let config = ServerConfig::new("127.0.0.1".into(), 8080, tx);
+        // Verify the sender is wired by confirming a receiver can be created from it
+        let _rx2 = config.sse_tx.subscribe();
     }
 
     #[test]

--- a/plugins/web-server/src/server.rs
+++ b/plugins/web-server/src/server.rs
@@ -69,11 +69,11 @@ pub async fn start_server(
     }
 
     let templates = load_templates(config.template_dir.as_deref())?;
-    let mut state = AppState::new(store, templates, config.auth_token, config.data_dir)
+    let sse_tx = config
+        .sse_tx
+        .unwrap_or_else(|| broadcast::channel(crate::state::SSE_CHANNEL_CAPACITY).0);
+    let state = AppState::new(store, sse_tx, templates, config.auth_token, config.data_dir)
         .with_plugin_info(config.plugin_info);
-    if let Some(sse_tx) = config.sse_tx {
-        state = state.with_sse_sender(sse_tx);
-    }
     let router = build_router(state).layer(DefaultBodyLimit::max(2 * 1024 * 1024)); // 2 MiB
 
     let address = format!("{}:{}", config.host, config.port);

--- a/plugins/web-server/src/server.rs
+++ b/plugins/web-server/src/server.rs
@@ -205,10 +205,25 @@ mod tests {
 
     #[test]
     fn test_server_config_stores_sse_sender() {
-        let (tx, _rx) = broadcast::channel::<SseEvent>(8);
+        let (tx, mut rx) = broadcast::channel::<SseEvent>(8);
         let config = ServerConfig::new("127.0.0.1".into(), 8080, tx);
-        // Verify the sender is wired by confirming a receiver can be created from it
-        let _rx2 = config.sse_tx.subscribe();
+        config
+            .sse_tx
+            .send(SseEvent::JobStarted {
+                job_id: "test".into(),
+                description: "test".into(),
+            })
+            .expect("send should succeed with a live receiver");
+        match rx.try_recv() {
+            Ok(SseEvent::JobStarted {
+                job_id,
+                description,
+            }) => {
+                assert_eq!(job_id, "test");
+                assert_eq!(description, "test");
+            }
+            other => panic!("expected JobStarted, got {other:?}"),
+        }
     }
 
     #[test]

--- a/plugins/web-server/src/server.rs
+++ b/plugins/web-server/src/server.rs
@@ -4,11 +4,12 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use axum::extract::DefaultBodyLimit;
+use tokio::sync::broadcast;
 use voom_domain::storage::StorageTrait;
 
 use crate::errors::ServerError;
 use crate::router::build_router;
-use crate::state::AppState;
+use crate::state::{AppState, SseEvent};
 
 /// Configuration for the web server.
 #[non_exhaustive]
@@ -20,6 +21,11 @@ pub struct ServerConfig {
     pub auth_token: Option<String>,
     pub plugin_info: Vec<crate::api::plugins::PluginInfoResponse>,
     pub data_dir: Option<std::path::PathBuf>,
+    /// Externally-provided SSE broadcast sender. When `Some`, this sender is
+    /// installed on the `AppState` instead of the default one created by
+    /// `AppState::new`. This lets callers share the channel with a kernel-side
+    /// bridge plugin that forwards bus events to SSE clients.
+    pub sse_tx: Option<broadcast::Sender<SseEvent>>,
 }
 
 impl ServerConfig {
@@ -32,6 +38,7 @@ impl ServerConfig {
             auth_token: None,
             plugin_info: Vec::new(),
             data_dir: None,
+            sse_tx: None,
         }
     }
 }
@@ -62,8 +69,11 @@ pub async fn start_server(
     }
 
     let templates = load_templates(config.template_dir.as_deref())?;
-    let state = AppState::new(store, templates, config.auth_token, config.data_dir)
+    let mut state = AppState::new(store, templates, config.auth_token, config.data_dir)
         .with_plugin_info(config.plugin_info);
+    if let Some(sse_tx) = config.sse_tx {
+        state = state.with_sse_sender(sse_tx);
+    }
     let router = build_router(state).layer(DefaultBodyLimit::max(2 * 1024 * 1024)); // 2 MiB
 
     let address = format!("{}:{}", config.host, config.port);
@@ -163,11 +173,13 @@ mod tests {
             auth_token: Some("secret".into()),
             plugin_info: vec![],
             data_dir: None,
+            sse_tx: None,
         };
         assert_eq!(config.host, "127.0.0.1");
         assert_eq!(config.port, 8080);
         assert!(config.template_dir.is_none());
         assert_eq!(config.auth_token, Some("secret".to_string()));
+        assert!(config.sse_tx.is_none());
     }
 
     #[test]
@@ -179,12 +191,21 @@ mod tests {
             auth_token: None,
             plugin_info: vec![],
             data_dir: None,
+            sse_tx: None,
         };
         let cloned = config.clone();
         assert_eq!(cloned.host, "0.0.0.0");
         assert_eq!(cloned.port, 3000);
         assert_eq!(cloned.template_dir, Some("/tmp/templates".to_string()));
         assert!(cloned.auth_token.is_none());
+    }
+
+    #[test]
+    fn test_server_config_with_external_sse_sender() {
+        let (tx, _rx) = broadcast::channel::<SseEvent>(8);
+        let mut config = ServerConfig::new("127.0.0.1".into(), 8080);
+        config.sse_tx = Some(tx);
+        assert!(config.sse_tx.is_some());
     }
 
     #[test]

--- a/plugins/web-server/src/state.rs
+++ b/plugins/web-server/src/state.rs
@@ -273,6 +273,57 @@ mod tests {
     }
 
     #[test]
+    fn test_sse_event_plan_completed_serialization() {
+        let event = SseEvent::PlanCompleted {
+            plan_id: "p-2".into(),
+            file: "movie.mkv".into(),
+            phase: "remux".into(),
+            actions_applied: 5,
+        };
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "PlanCompleted");
+        assert_eq!(json["data"]["plan_id"], "p-2");
+        assert_eq!(json["data"]["file"], "movie.mkv");
+        assert_eq!(json["data"]["phase"], "remux");
+        assert_eq!(json["data"]["actions_applied"], 5);
+    }
+
+    #[test]
+    fn test_sse_event_plan_skipped_serialization() {
+        let event = SseEvent::PlanSkipped {
+            plan_id: "p-3".into(),
+            file: "movie.mkv".into(),
+            phase: "transcode".into(),
+            skip_reason: "no matching tracks".into(),
+        };
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "PlanSkipped");
+        assert_eq!(json["data"]["plan_id"], "p-3");
+        assert_eq!(json["data"]["file"], "movie.mkv");
+        assert_eq!(json["data"]["phase"], "transcode");
+        assert_eq!(json["data"]["skip_reason"], "no matching tracks");
+    }
+
+    #[test]
+    fn test_sse_event_plan_failed_serialization() {
+        let event = SseEvent::PlanFailed {
+            plan_id: "p-4".into(),
+            file: "movie.mkv".into(),
+            phase: "transcode".into(),
+            error: "ffmpeg returned non-zero".into(),
+        };
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "PlanFailed");
+        assert_eq!(json["data"]["plan_id"], "p-4");
+        assert_eq!(json["data"]["file"], "movie.mkv");
+        assert_eq!(json["data"]["phase"], "transcode");
+        assert_eq!(json["data"]["error"], "ffmpeg returned non-zero");
+        // Confirm no leak-prone fields appear in the serialized envelope.
+        assert!(json["data"].get("error_chain").is_none());
+        assert!(json["data"].get("execution_detail").is_none());
+    }
+
+    #[test]
     fn test_sse_event_job_completed_serialization() {
         let event = SseEvent::JobCompleted {
             job_id: "j2".into(),

--- a/plugins/web-server/src/state.rs
+++ b/plugins/web-server/src/state.rs
@@ -6,6 +6,10 @@ use std::sync::Arc;
 use tokio::sync::broadcast;
 use voom_domain::storage::StorageTrait;
 
+/// Capacity of the SSE broadcast channel. Sized to absorb short bursts of
+/// job-progress events without lagging slow clients.
+pub const SSE_CHANNEL_CAPACITY: usize = 256;
+
 /// Events broadcast via SSE to connected clients.
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(tag = "type", content = "data")]
@@ -43,13 +47,18 @@ pub struct AppState {
 }
 
 impl AppState {
+    /// Create a new `AppState`.
+    ///
+    /// The caller must supply a `broadcast::Sender<SseEvent>`. Use
+    /// [`AppState::new_with_default_sse`] for tests or other callers that
+    /// do not need to share the sender with another component.
     pub fn new(
         store: Arc<dyn StorageTrait>,
+        sse_tx: broadcast::Sender<SseEvent>,
         templates: tera::Tera,
         auth_token: Option<String>,
         data_dir: Option<std::path::PathBuf>,
     ) -> Self {
-        let (sse_tx, _) = broadcast::channel(256);
         Self {
             store,
             sse_tx,
@@ -61,21 +70,24 @@ impl AppState {
         }
     }
 
+    /// Create a new `AppState` with an internally-allocated SSE broadcast
+    /// channel of the default capacity. Convenience constructor for tests
+    /// and callers that do not need to share the sender.
+    #[must_use]
+    pub fn new_with_default_sse(
+        store: Arc<dyn StorageTrait>,
+        templates: tera::Tera,
+        auth_token: Option<String>,
+        data_dir: Option<std::path::PathBuf>,
+    ) -> Self {
+        let (sse_tx, _) = broadcast::channel(SSE_CHANNEL_CAPACITY);
+        Self::new(store, sse_tx, templates, auth_token, data_dir)
+    }
+
     /// Set the plugin info snapshot (typically populated from kernel registry at startup).
     #[must_use]
     pub fn with_plugin_info(mut self, info: Vec<crate::api::plugins::PluginInfoResponse>) -> Self {
         self.plugin_info = Arc::new(info);
-        self
-    }
-
-    /// Replace the SSE broadcast sender with an externally-provided one.
-    ///
-    /// Used by callers (e.g. the `serve` command) that need to share the same
-    /// channel between this `AppState` and a separate kernel-side bridge plugin
-    /// so that bus events forwarded by the bridge reach connected SSE clients.
-    #[must_use]
-    pub fn with_sse_sender(mut self, sse_tx: broadcast::Sender<SseEvent>) -> Self {
-        self.sse_tx = sse_tx;
         self
     }
 
@@ -108,7 +120,7 @@ pub(crate) fn make_test_state(auth_token: Option<String>) -> AppState {
     use voom_domain::test_support::InMemoryStore;
     let store = Arc::new(InMemoryStore::new());
     let templates = tera::Tera::default();
-    AppState::new(store, templates, auth_token, None)
+    AppState::new_with_default_sse(store, templates, auth_token, None)
 }
 
 #[cfg(test)]

--- a/plugins/web-server/src/state.rs
+++ b/plugins/web-server/src/state.rs
@@ -72,6 +72,17 @@ impl AppState {
         self
     }
 
+    /// Replace the SSE broadcast sender with an externally-provided one.
+    ///
+    /// Used by callers (e.g. the `serve` command) that need to share the same
+    /// channel between this `AppState` and a separate kernel-side bridge plugin
+    /// so that bus events forwarded by the bridge reach connected SSE clients.
+    #[must_use]
+    pub fn with_sse_sender(mut self, sse_tx: broadcast::Sender<SseEvent>) -> Self {
+        self.sse_tx = sse_tx;
+        self
+    }
+
     /// Returns true if an auth token is configured.
     #[must_use]
     pub fn has_auth(&self) -> bool {

--- a/plugins/web-server/src/state.rs
+++ b/plugins/web-server/src/state.rs
@@ -24,10 +24,6 @@ pub enum SseEvent {
         success: bool,
         message: Option<String>,
     },
-    ScanProgress {
-        files_found: u64,
-        files_processed: u64,
-    },
     FileIntrospected {
         path: String,
     },
@@ -217,18 +213,6 @@ mod tests {
         assert_eq!(json["type"], "JobStarted");
         assert_eq!(json["data"]["job_id"], "j1");
         assert_eq!(json["data"]["description"], "test job");
-    }
-
-    #[test]
-    fn test_sse_event_scan_progress_serialization() {
-        let event = SseEvent::ScanProgress {
-            files_found: 42,
-            files_processed: 10,
-        };
-        let json = serde_json::to_value(&event).unwrap();
-        assert_eq!(json["type"], "ScanProgress");
-        assert_eq!(json["data"]["files_found"], 42);
-        assert_eq!(json["data"]["files_processed"], 10);
     }
 
     #[test]

--- a/plugins/web-server/src/state.rs
+++ b/plugins/web-server/src/state.rs
@@ -31,6 +31,35 @@ pub enum SseEvent {
     FileIntrospected {
         path: String,
     },
+    PlanExecuting {
+        plan_id: String,
+        /// Basename of the media file the plan is being applied to.
+        file: String,
+        phase: String,
+        action_count: usize,
+    },
+    PlanCompleted {
+        plan_id: String,
+        file: String,
+        phase: String,
+        actions_applied: usize,
+    },
+    PlanSkipped {
+        plan_id: String,
+        file: String,
+        phase: String,
+        skip_reason: String,
+    },
+    PlanFailed {
+        plan_id: String,
+        file: String,
+        phase: String,
+        /// Single error message. Detailed error chains and subprocess
+        /// output are intentionally NOT forwarded over SSE — they need a
+        /// separate disclosure review before exposing subprocess output to web
+        /// clients.
+        error: String,
+    },
 }
 
 /// Application state shared across all handlers.
@@ -225,6 +254,22 @@ mod tests {
         assert_eq!(json["type"], "JobStarted");
         assert_eq!(json["data"]["job_id"], "j1");
         assert_eq!(json["data"]["description"], "test job");
+    }
+
+    #[test]
+    fn test_sse_event_plan_executing_serialization() {
+        let event = SseEvent::PlanExecuting {
+            plan_id: "p-1".into(),
+            file: "movie.mkv".into(),
+            phase: "transcode".into(),
+            action_count: 3,
+        };
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "PlanExecuting");
+        assert_eq!(json["data"]["plan_id"], "p-1");
+        assert_eq!(json["data"]["file"], "movie.mkv");
+        assert_eq!(json["data"]["phase"], "transcode");
+        assert_eq!(json["data"]["action_count"], 3);
     }
 
     #[test]

--- a/plugins/web-server/tests/api_tests.rs
+++ b/plugins/web-server/tests/api_tests.rs
@@ -26,7 +26,8 @@ fn make_server(store: InMemoryStore) -> TestServer {
 fn make_server_with_auth(store: InMemoryStore, auth_token: Option<String>) -> TestServer {
     let store = Arc::new(store);
     let templates = voom_web_server::server::embedded_templates().unwrap();
-    let state = voom_web_server::state::AppState::new(store, templates, auth_token, None);
+    let state =
+        voom_web_server::state::AppState::new_with_default_sse(store, templates, auth_token, None);
     let router = voom_web_server::router::build_router(state);
     TestServer::new(router).unwrap()
 }
@@ -183,8 +184,9 @@ async fn test_list_plugins_with_data() {
         String::new(),
         vec!["test".into()],
     )];
-    let state = voom_web_server::state::AppState::new(store, templates, None, None)
-        .with_plugin_info(plugin_info);
+    let state =
+        voom_web_server::state::AppState::new_with_default_sse(store, templates, None, None)
+            .with_plugin_info(plugin_info);
     let router = voom_web_server::router::build_router(state);
     let server = TestServer::new(router).unwrap();
 
@@ -464,7 +466,8 @@ async fn test_sse_client_limit_enforced() {
     use std::sync::atomic::Ordering;
     let store = Arc::new(InMemoryStore::new());
     let templates = voom_web_server::server::embedded_templates().unwrap();
-    let state = voom_web_server::state::AppState::new(store, templates, None, None);
+    let state =
+        voom_web_server::state::AppState::new_with_default_sse(store, templates, None, None);
     // Simulate 64 clients already connected
     state.sse_client_count.store(64, Ordering::Relaxed);
     let router = voom_web_server::router::build_router(state);
@@ -478,7 +481,8 @@ async fn test_sse_client_limit_enforced() {
 async fn test_request_id_header_present() {
     let store = Arc::new(InMemoryStore::new());
     let templates = voom_web_server::server::embedded_templates().unwrap();
-    let state = voom_web_server::state::AppState::new(store, templates, None, None);
+    let state =
+        voom_web_server::state::AppState::new_with_default_sse(store, templates, None, None);
     let router = voom_web_server::router::build_router(state);
     let server = TestServer::new(router).unwrap();
 
@@ -499,7 +503,8 @@ async fn test_request_id_header_present() {
 async fn test_request_id_unique_per_request() {
     let store = Arc::new(InMemoryStore::new());
     let templates = voom_web_server::server::embedded_templates().unwrap();
-    let state = voom_web_server::state::AppState::new(store, templates, None, None);
+    let state =
+        voom_web_server::state::AppState::new_with_default_sse(store, templates, None, None);
     let router = voom_web_server::router::build_router(state);
     let server = TestServer::new(router).unwrap();
 

--- a/plugins/web-sse-bridge/Cargo.toml
+++ b/plugins/web-sse-bridge/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "voom-web-sse-bridge"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Bridge plugin that forwards kernel job/file events to the web server's SSE broadcast channel"
+
+[dependencies]
+voom-domain = { workspace = true }
+voom-kernel = { workspace = true }
+voom-web-server = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+
+[lints]
+workspace = true
+
+[dev-dependencies]
+serde_json = { workspace = true }
+uuid = { workspace = true }

--- a/plugins/web-sse-bridge/src/lib.rs
+++ b/plugins/web-sse-bridge/src/lib.rs
@@ -27,6 +27,14 @@ impl WebSseBridgePlugin {
         Self { sse_tx }
     }
 
+    /// Extract the basename of a path as a `String`. Returns an empty
+    /// string if the path has no file-name component (e.g. `/`).
+    fn basename(path: &std::path::Path) -> String {
+        path.file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_default()
+    }
+
     /// Map a kernel event to its SSE counterpart, if one exists.
     ///
     /// Returns `None` for event types the bridge does not forward.
@@ -47,12 +55,31 @@ impl WebSseBridgePlugin {
                 message: e.message.clone(),
             }),
             Event::FileIntrospected(e) => Some(SseEvent::FileIntrospected {
-                path: e
-                    .file
-                    .path
-                    .file_name()
-                    .map(|n| n.to_string_lossy().into_owned())
-                    .unwrap_or_default(),
+                path: Self::basename(&e.file.path),
+            }),
+            Event::PlanExecuting(e) => Some(SseEvent::PlanExecuting {
+                plan_id: e.plan_id.to_string(),
+                file: Self::basename(&e.path),
+                phase: e.phase_name.clone(),
+                action_count: e.action_count,
+            }),
+            Event::PlanCompleted(e) => Some(SseEvent::PlanCompleted {
+                plan_id: e.plan_id.to_string(),
+                file: Self::basename(&e.path),
+                phase: e.phase_name.clone(),
+                actions_applied: e.actions_applied,
+            }),
+            Event::PlanSkipped(e) => Some(SseEvent::PlanSkipped {
+                plan_id: e.plan_id.to_string(),
+                file: Self::basename(&e.path),
+                phase: e.phase_name.clone(),
+                skip_reason: e.skip_reason.clone(),
+            }),
+            Event::PlanFailed(e) => Some(SseEvent::PlanFailed {
+                plan_id: e.plan_id.to_string(),
+                file: Self::basename(&e.path),
+                phase: e.phase_name.clone(),
+                error: e.error.clone(),
             }),
             _ => None,
         }
@@ -81,6 +108,10 @@ impl Plugin for WebSseBridgePlugin {
                 | Event::JOB_PROGRESS
                 | Event::JOB_COMPLETED
                 | Event::FILE_INTROSPECTED
+                | Event::PLAN_EXECUTING
+                | Event::PLAN_COMPLETED
+                | Event::PLAN_SKIPPED
+                | Event::PLAN_FAILED
         )
     }
 
@@ -259,6 +290,136 @@ mod tests {
 
     /// End-to-end: register the bridge with a real Kernel and dispatch a job
     /// event through the bus. The SSE receiver should observe the broadcast.
+    #[test]
+    fn forwards_plan_executing_with_basename_only() {
+        use voom_domain::events::PlanExecutingEvent;
+        let (bridge, mut rx) = bridge_with_rx();
+        let plan_id = Uuid::new_v4();
+        let event = Event::PlanExecuting(PlanExecutingEvent::new(
+            plan_id,
+            PathBuf::from("/media/movies/MyMovie.mkv"),
+            "transcode",
+            3,
+        ));
+
+        bridge.on_event(&event).unwrap();
+
+        let sse = rx.try_recv().expect("event should be broadcast");
+        match sse {
+            SseEvent::PlanExecuting {
+                plan_id: pid,
+                file,
+                phase,
+                action_count,
+            } => {
+                assert_eq!(pid, plan_id.to_string());
+                assert_eq!(file, "MyMovie.mkv");
+                assert_eq!(phase, "transcode");
+                assert_eq!(action_count, 3);
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn forwards_plan_completed() {
+        use voom_domain::events::PlanCompletedEvent;
+        let (bridge, mut rx) = bridge_with_rx();
+        let plan_id = Uuid::new_v4();
+        let event = Event::PlanCompleted(PlanCompletedEvent::new(
+            plan_id,
+            PathBuf::from("/m/x.mkv"),
+            "remux",
+            5,
+            false,
+        ));
+        bridge.on_event(&event).unwrap();
+        match rx.try_recv().unwrap() {
+            SseEvent::PlanCompleted {
+                plan_id: pid,
+                file,
+                phase,
+                actions_applied,
+            } => {
+                assert_eq!(pid, plan_id.to_string());
+                assert_eq!(file, "x.mkv");
+                assert_eq!(phase, "remux");
+                assert_eq!(actions_applied, 5);
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn forwards_plan_skipped() {
+        use voom_domain::events::PlanSkippedEvent;
+        let (bridge, mut rx) = bridge_with_rx();
+        let plan_id = Uuid::new_v4();
+        let event = Event::PlanSkipped(PlanSkippedEvent::new(
+            plan_id,
+            PathBuf::from("/m/x.mkv"),
+            "transcode",
+            "no matching tracks",
+        ));
+        bridge.on_event(&event).unwrap();
+        match rx.try_recv().unwrap() {
+            SseEvent::PlanSkipped {
+                plan_id: pid,
+                file,
+                phase,
+                skip_reason,
+            } => {
+                assert_eq!(pid, plan_id.to_string());
+                assert_eq!(file, "x.mkv");
+                assert_eq!(phase, "transcode");
+                assert_eq!(skip_reason, "no matching tracks");
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn forwards_plan_failed_without_leaking_chain_or_detail() {
+        use voom_domain::events::PlanFailedEvent;
+        let (bridge, mut rx) = bridge_with_rx();
+        let plan_id = Uuid::new_v4();
+        let mut payload = PlanFailedEvent::new(
+            plan_id,
+            PathBuf::from("/m/x.mkv"),
+            "transcode",
+            "ffmpeg returned non-zero",
+        );
+        // These fields exist but must NOT appear in the SSE payload —
+        // they may contain stack traces or absolute paths.
+        payload.error_chain = vec!["root cause".into()];
+        let event = Event::PlanFailed(payload);
+
+        bridge.on_event(&event).unwrap();
+        match rx.try_recv().unwrap() {
+            SseEvent::PlanFailed {
+                plan_id: pid,
+                file,
+                phase,
+                error,
+            } => {
+                assert_eq!(pid, plan_id.to_string());
+                assert_eq!(file, "x.mkv");
+                assert_eq!(phase, "transcode");
+                assert_eq!(error, "ffmpeg returned non-zero");
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn handles_returns_true_for_all_plan_lifecycle_events() {
+        let (bridge, _rx) = bridge_with_rx();
+        assert!(bridge.handles(Event::PLAN_EXECUTING));
+        assert!(bridge.handles(Event::PLAN_COMPLETED));
+        assert!(bridge.handles(Event::PLAN_SKIPPED));
+        assert!(bridge.handles(Event::PLAN_FAILED));
+    }
+
     #[test]
     fn integrates_with_kernel_dispatch() {
         use std::path::PathBuf;

--- a/plugins/web-sse-bridge/src/lib.rs
+++ b/plugins/web-sse-bridge/src/lib.rs
@@ -3,8 +3,35 @@
 //! The web server is library-only and cannot subscribe to the kernel bus
 //! directly. This plugin holds a clone of the web server's
 //! [`broadcast::Sender<SseEvent>`] and forwards relevant kernel events
-//! (job lifecycle, file introspection) to it so that browser SSE clients
-//! receive live updates.
+//! (job lifecycle, file introspection, plan lifecycle) to it so that
+//! browser SSE clients receive live updates.
+//!
+//! # Disclosure surface
+//!
+//! All forwarded events go to any authenticated SSE client. Two rules
+//! govern what we put on the wire:
+//!
+//! 1. **Filesystem paths are reduced to basenames** before forwarding,
+//!    to avoid leaking the internal media library layout. See
+//!    `WebSseBridgePlugin::basename` and every path-carrying arm of
+//!    `WebSseBridgePlugin::to_sse_event`.
+//! 2. **Subprocess output and error chains** from `PlanFailedEvent` are
+//!    intentionally NOT forwarded. They may contain absolute paths,
+//!    environment values, or partial command lines that need a separate
+//!    disclosure review before exposure. Only the top-level `error`
+//!    string is forwarded.
+//!
+//! Operator-supplied strings (job descriptions, progress messages, error
+//! messages, phase names, skip reasons) ARE forwarded. The web frontend
+//! templates in `plugins/web-server/templates/` bind every dynamic
+//! string with Alpine's `x-text` directive, which sets `textContent`
+//! (not `innerHTML`), so these strings cannot be used as an XSS vector
+//! against the current UI. The `base.html` SSE handler parses event
+//! data via `JSON.parse` and dispatches it as a `CustomEvent` — no
+//! string concatenation into HTML. Any future template that consumes
+//! these fields MUST continue to use `x-text` or an equivalent safe
+//! binding; reviewers should audit `innerHTML`/`x-html` usage when
+//! adding new consumers.
 
 use tokio::sync::broadcast;
 use tracing::{debug, trace};

--- a/plugins/web-sse-bridge/src/lib.rs
+++ b/plugins/web-sse-bridge/src/lib.rs
@@ -16,8 +16,10 @@
 //!    `WebSseBridgePlugin::basename` and every path-carrying arm of
 //!    `WebSseBridgePlugin::to_sse_event`.
 //! 2. **Subprocess output and error chains** from `PlanFailedEvent` are
-//!    intentionally NOT forwarded. They may contain absolute paths,
-//!    environment values, or partial command lines that need a separate
+//!    intentionally NOT forwarded. This rule applies specifically to
+//!    `PlanFailedEvent`, which carries `error_chain` and
+//!    `execution_detail` fields that may contain absolute paths,
+//!    environment values, or partial command lines and need a separate
 //!    disclosure review before exposure. Only the top-level `error`
 //!    string is forwarded.
 //!
@@ -473,6 +475,7 @@ mod tests {
     fn integrates_with_kernel_dispatch() {
         use std::path::PathBuf;
         use std::sync::Arc;
+        use voom_domain::events::PlanFailedEvent;
         use voom_kernel::{Kernel, PluginContext};
 
         let (tx, mut rx) = broadcast::channel(8);
@@ -484,20 +487,48 @@ mod tests {
             .init_and_register(Arc::new(bridge), 200, &ctx)
             .expect("register bridge");
 
+        // Dispatch a JobStarted through the real kernel and confirm the
+        // bridge forwards it to the SSE channel.
         let job_id = Uuid::new_v4();
         kernel.dispatch(Event::JobStarted(JobStartedEvent::new(
             job_id,
             "kernel test",
         )));
 
-        let sse = rx.try_recv().expect("event should be broadcast");
-        match sse {
+        match rx.try_recv().expect("JobStarted should be broadcast") {
             SseEvent::JobStarted {
                 job_id: id,
                 description,
             } => {
                 assert_eq!(id, job_id.to_string());
                 assert_eq!(description, "kernel test");
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+
+        // Dispatch a PlanFailed through the real kernel. This proves the
+        // kernel actually routes plan lifecycle events to a bridge whose
+        // handles() returns true for PLAN_FAILED — a concern orthogonal
+        // to the pure unit tests of to_sse_event.
+        let plan_id = Uuid::new_v4();
+        kernel.dispatch(Event::PlanFailed(PlanFailedEvent::new(
+            plan_id,
+            PathBuf::from("/media/movies/broken.mkv"),
+            "transcode",
+            "ffmpeg exited with code 1",
+        )));
+
+        match rx.try_recv().expect("PlanFailed should be broadcast") {
+            SseEvent::PlanFailed {
+                plan_id: pid,
+                file,
+                phase,
+                error,
+            } => {
+                assert_eq!(pid, plan_id.to_string());
+                assert_eq!(file, "broken.mkv");
+                assert_eq!(phase, "transcode");
+                assert_eq!(error, "ffmpeg exited with code 1");
             }
             other => panic!("unexpected variant: {other:?}"),
         }

--- a/plugins/web-sse-bridge/src/lib.rs
+++ b/plugins/web-sse-bridge/src/lib.rs
@@ -46,7 +46,12 @@ impl WebSseBridgePlugin {
                 message: e.message.clone(),
             }),
             Event::FileIntrospected(e) => Some(SseEvent::FileIntrospected {
-                path: e.file.path.display().to_string(),
+                path: e
+                    .file
+                    .path
+                    .file_name()
+                    .map(|n| n.to_string_lossy().into_owned())
+                    .unwrap_or_default(),
             }),
             _ => None,
         }
@@ -188,9 +193,9 @@ mod tests {
     }
 
     #[test]
-    fn forwards_file_introspected() {
+    fn forwards_file_introspected_basename_only() {
         let (bridge, mut rx) = bridge_with_rx();
-        let media = MediaFile::new(PathBuf::from("/media/movie.mkv"));
+        let media = MediaFile::new(PathBuf::from("/media/movies/MyMovie.mkv"));
         let event = Event::FileIntrospected(FileIntrospectedEvent::new(media));
 
         bridge.on_event(&event).unwrap();
@@ -198,8 +203,27 @@ mod tests {
         let sse = rx.try_recv().unwrap();
         match sse {
             SseEvent::FileIntrospected { path } => {
-                assert_eq!(path, "/media/movie.mkv");
+                assert_eq!(
+                    path, "MyMovie.mkv",
+                    "absolute filesystem path must not be exposed to SSE clients"
+                );
             }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn file_introspected_with_no_basename_yields_empty_string() {
+        // PathBuf::from("/") has no `file_name()` — make sure we don't panic
+        // and don't accidentally fall back to the full path.
+        let (bridge, mut rx) = bridge_with_rx();
+        let media = MediaFile::new(PathBuf::from("/"));
+        bridge
+            .on_event(&Event::FileIntrospected(FileIntrospectedEvent::new(media)))
+            .unwrap();
+        let sse = rx.try_recv().unwrap();
+        match sse {
+            SseEvent::FileIntrospected { path } => assert_eq!(path, ""),
             other => panic!("unexpected variant: {other:?}"),
         }
     }

--- a/plugins/web-sse-bridge/src/lib.rs
+++ b/plugins/web-sse-bridge/src/lib.rs
@@ -7,6 +7,7 @@
 //! receive live updates.
 
 use tokio::sync::broadcast;
+use tracing::{debug, trace};
 
 use voom_domain::capabilities::Capability;
 use voom_domain::errors::Result;
@@ -88,9 +89,15 @@ impl Plugin for WebSseBridgePlugin {
             return Ok(None);
         };
 
+        let event_kind = event.event_type();
+        trace!(event_kind, "forwarding kernel event to SSE channel");
+
         // `send` returns Err only when there are zero receivers, which is the
-        // normal case while no SSE clients are connected. Drop the result.
-        let _ = self.sse_tx.send(sse_event);
+        // normal case while no SSE clients are connected. Log at debug level
+        // so operators can correlate "no events delivered" with "no clients".
+        if self.sse_tx.send(sse_event).is_err() {
+            debug!(event_kind, "SSE send dropped: no active subscribers");
+        }
         Ok(None)
     }
 }

--- a/plugins/web-sse-bridge/src/lib.rs
+++ b/plugins/web-sse-bridge/src/lib.rs
@@ -1,0 +1,264 @@
+//! Bridges kernel event-bus events to the web server's SSE broadcast channel.
+//!
+//! The web server is library-only and cannot subscribe to the kernel bus
+//! directly. This plugin holds a clone of the web server's
+//! [`broadcast::Sender<SseEvent>`] and forwards relevant kernel events
+//! (job lifecycle, file introspection) to it so that browser SSE clients
+//! receive live updates.
+
+use tokio::sync::broadcast;
+
+use voom_domain::capabilities::Capability;
+use voom_domain::errors::Result;
+use voom_domain::events::{Event, EventResult};
+use voom_kernel::Plugin;
+use voom_web_server::state::SseEvent;
+
+/// Plugin that forwards kernel events to the web server's SSE broadcast channel.
+pub struct WebSseBridgePlugin {
+    sse_tx: broadcast::Sender<SseEvent>,
+}
+
+impl WebSseBridgePlugin {
+    /// Construct a bridge that forwards events to the given SSE sender.
+    #[must_use]
+    pub fn new(sse_tx: broadcast::Sender<SseEvent>) -> Self {
+        Self { sse_tx }
+    }
+
+    /// Map a kernel event to its SSE counterpart, if one exists.
+    ///
+    /// Returns `None` for event types the bridge does not forward.
+    fn to_sse_event(event: &Event) -> Option<SseEvent> {
+        match event {
+            Event::JobStarted(e) => Some(SseEvent::JobStarted {
+                job_id: e.job_id.to_string(),
+                description: e.description.clone(),
+            }),
+            Event::JobProgress(e) => Some(SseEvent::JobProgress {
+                job_id: e.job_id.to_string(),
+                progress: e.progress,
+                message: e.message.clone(),
+            }),
+            Event::JobCompleted(e) => Some(SseEvent::JobCompleted {
+                job_id: e.job_id.to_string(),
+                success: e.success,
+                message: e.message.clone(),
+            }),
+            Event::FileIntrospected(e) => Some(SseEvent::FileIntrospected {
+                path: e.file.path.display().to_string(),
+            }),
+            _ => None,
+        }
+    }
+}
+
+impl Plugin for WebSseBridgePlugin {
+    fn name(&self) -> &str {
+        "web-sse-bridge"
+    }
+
+    fn version(&self) -> &str {
+        env!("CARGO_PKG_VERSION")
+    }
+
+    voom_kernel::plugin_cargo_metadata!();
+
+    fn capabilities(&self) -> &[Capability] {
+        &[]
+    }
+
+    fn handles(&self, event_type: &str) -> bool {
+        matches!(
+            event_type,
+            Event::JOB_STARTED
+                | Event::JOB_PROGRESS
+                | Event::JOB_COMPLETED
+                | Event::FILE_INTROSPECTED
+        )
+    }
+
+    fn on_event(&self, event: &Event) -> Result<Option<EventResult>> {
+        let Some(sse_event) = Self::to_sse_event(event) else {
+            return Ok(None);
+        };
+
+        // `send` returns Err only when there are zero receivers, which is the
+        // normal case while no SSE clients are connected. Drop the result.
+        let _ = self.sse_tx.send(sse_event);
+        Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use uuid::Uuid;
+    use voom_domain::events::{
+        FileIntrospectedEvent, JobCompletedEvent, JobProgressEvent, JobStartedEvent,
+    };
+    use voom_domain::media::MediaFile;
+
+    fn bridge_with_rx() -> (WebSseBridgePlugin, broadcast::Receiver<SseEvent>) {
+        let (tx, rx) = broadcast::channel(16);
+        (WebSseBridgePlugin::new(tx), rx)
+    }
+
+    #[test]
+    fn handles_only_forwarded_event_types() {
+        let (bridge, _rx) = bridge_with_rx();
+        assert!(bridge.handles(Event::JOB_STARTED));
+        assert!(bridge.handles(Event::JOB_PROGRESS));
+        assert!(bridge.handles(Event::JOB_COMPLETED));
+        assert!(bridge.handles(Event::FILE_INTROSPECTED));
+
+        assert!(!bridge.handles(Event::FILE_DISCOVERED));
+        assert!(!bridge.handles(Event::PLAN_CREATED));
+        assert!(!bridge.handles(Event::TOOL_DETECTED));
+    }
+
+    #[test]
+    fn forwards_job_started() {
+        let (bridge, mut rx) = bridge_with_rx();
+        let job_id = Uuid::new_v4();
+        let event = Event::JobStarted(JobStartedEvent::new(job_id, "scan /media"));
+
+        bridge.on_event(&event).unwrap();
+
+        let sse = rx.try_recv().expect("event should be broadcast");
+        match sse {
+            SseEvent::JobStarted {
+                job_id: id,
+                description,
+            } => {
+                assert_eq!(id, job_id.to_string());
+                assert_eq!(description, "scan /media");
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn forwards_job_progress_with_message() {
+        let (bridge, mut rx) = bridge_with_rx();
+        let job_id = Uuid::new_v4();
+        let mut payload = JobProgressEvent::new(job_id, 0.42);
+        payload.message = Some("transcoding".into());
+        let event = Event::JobProgress(payload);
+
+        bridge.on_event(&event).unwrap();
+
+        let sse = rx.try_recv().unwrap();
+        match sse {
+            SseEvent::JobProgress {
+                job_id: id,
+                progress,
+                message,
+            } => {
+                assert_eq!(id, job_id.to_string());
+                assert!((progress - 0.42).abs() < f64::EPSILON);
+                assert_eq!(message.as_deref(), Some("transcoding"));
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn forwards_job_completed() {
+        let (bridge, mut rx) = bridge_with_rx();
+        let job_id = Uuid::new_v4();
+        let event = Event::JobCompleted(JobCompletedEvent::new(job_id, true));
+
+        bridge.on_event(&event).unwrap();
+
+        let sse = rx.try_recv().unwrap();
+        match sse {
+            SseEvent::JobCompleted {
+                job_id: id,
+                success,
+                message,
+            } => {
+                assert_eq!(id, job_id.to_string());
+                assert!(success);
+                assert!(message.is_none());
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn forwards_file_introspected() {
+        let (bridge, mut rx) = bridge_with_rx();
+        let media = MediaFile::new(PathBuf::from("/media/movie.mkv"));
+        let event = Event::FileIntrospected(FileIntrospectedEvent::new(media));
+
+        bridge.on_event(&event).unwrap();
+
+        let sse = rx.try_recv().unwrap();
+        match sse {
+            SseEvent::FileIntrospected { path } => {
+                assert_eq!(path, "/media/movie.mkv");
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ignores_non_forwarded_events() {
+        let (bridge, mut rx) = bridge_with_rx();
+        let event = Event::FileDiscovered(voom_domain::events::FileDiscoveredEvent::new(
+            PathBuf::from("/media/x.mkv"),
+            42,
+            None,
+        ));
+
+        bridge.on_event(&event).unwrap();
+        assert!(rx.try_recv().is_err(), "no event should be broadcast");
+    }
+
+    #[test]
+    fn send_with_no_receivers_does_not_panic() {
+        let (tx, rx) = broadcast::channel(4);
+        drop(rx); // no subscribers
+        let bridge = WebSseBridgePlugin::new(tx);
+        let event = Event::JobStarted(JobStartedEvent::new(Uuid::new_v4(), "x"));
+        bridge.on_event(&event).expect("must not error");
+    }
+
+    /// End-to-end: register the bridge with a real Kernel and dispatch a job
+    /// event through the bus. The SSE receiver should observe the broadcast.
+    #[test]
+    fn integrates_with_kernel_dispatch() {
+        use std::path::PathBuf;
+        use std::sync::Arc;
+        use voom_kernel::{Kernel, PluginContext};
+
+        let (tx, mut rx) = broadcast::channel(8);
+        let bridge = WebSseBridgePlugin::new(tx);
+
+        let mut kernel = Kernel::new();
+        let ctx = PluginContext::new(serde_json::json!({}), PathBuf::from("/tmp"));
+        kernel
+            .init_and_register(Arc::new(bridge), 200, &ctx)
+            .expect("register bridge");
+
+        let job_id = Uuid::new_v4();
+        kernel.dispatch(Event::JobStarted(JobStartedEvent::new(
+            job_id,
+            "kernel test",
+        )));
+
+        let sse = rx.try_recv().expect("event should be broadcast");
+        match sse {
+            SseEvent::JobStarted {
+                job_id: id,
+                description,
+            } => {
+                assert_eq!(id, job_id.to_string());
+                assert_eq!(description, "kernel test");
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+}

--- a/plugins/web-sse-bridge/src/lib.rs
+++ b/plugins/web-sse-bridge/src/lib.rs
@@ -391,24 +391,46 @@ mod tests {
         );
         // These fields exist but must NOT appear in the SSE payload —
         // they may contain stack traces or absolute paths.
-        payload.error_chain = vec!["root cause".into()];
+        payload.error_chain = vec!["secret root cause".into()];
         let event = Event::PlanFailed(payload);
 
         bridge.on_event(&event).unwrap();
-        match rx.try_recv().unwrap() {
+        let sse = rx.try_recv().unwrap();
+
+        // Structural check: the destructure only binds the 4 allowed fields.
+        match &sse {
             SseEvent::PlanFailed {
                 plan_id: pid,
                 file,
                 phase,
                 error,
             } => {
-                assert_eq!(pid, plan_id.to_string());
+                assert_eq!(pid, &plan_id.to_string());
                 assert_eq!(file, "x.mkv");
                 assert_eq!(phase, "transcode");
                 assert_eq!(error, "ffmpeg returned non-zero");
             }
             other => panic!("unexpected variant: {other:?}"),
         }
+
+        // Runtime check: defense-in-depth. If a future refactor adds
+        // error_chain/execution_detail back to SseEvent::PlanFailed and
+        // populates it from the bridge, this assertion catches the
+        // serialized JSON leak even if the destructure above still
+        // compiles and passes.
+        let json = serde_json::to_string(&sse).expect("SSE event must serialize");
+        assert!(
+            !json.contains("error_chain"),
+            "PlanFailed SSE payload must not contain error_chain: {json}"
+        );
+        assert!(
+            !json.contains("execution_detail"),
+            "PlanFailed SSE payload must not contain execution_detail: {json}"
+        );
+        assert!(
+            !json.contains("secret root cause"),
+            "PlanFailed SSE payload must not leak error_chain contents: {json}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds a new native plugin `web-sse-bridge` that forwards kernel event-bus events (job lifecycle, file introspection, plan lifecycle) to the web server's SSE broadcast channel so browser clients can receive live updates. The web server plugin is library-only and cannot subscribe to the kernel bus directly, so this bridge is the only route.

This branch is the original feature plus 13 commits addressing every finding from a five-agent pre-merge review (plugin-contract, event-bus, concurrency, error-handling, security).

## What the bridge does

- Subscribes to 8 event types: `JobStarted`, `JobProgress`, `JobCompleted`, `FileIntrospected`, `PlanExecuting`, `PlanCompleted`, `PlanSkipped`, `PlanFailed`.
- Maps each to an `SseEvent` variant and pushes it onto a `tokio::sync::broadcast::Sender<SseEvent>` shared with the web server's `AppState`.
- Runs at priority 200 so it observes events only after `job-manager` (20) and `sqlite-store` (100) have logged and persisted them.
- Emits `trace!` per forwarded event and `debug!` when there are no active SSE subscribers, with `event_kind` as a structured tracing field.

## Disclosure surface (two enforced rules)

1. **Filesystem paths are reduced to basenames** before forwarding. All path-carrying arms go through a single `WebSseBridgePlugin::basename` helper.
2. **Subprocess output and error chains** from `PlanFailedEvent` are NOT forwarded. Only the top-level `error` string is. `error_chain`, `execution_detail`, `error_code`, and `plugin_name` may contain absolute paths, environment values, or partial command lines and need a separate disclosure review before exposure.

Both rules are documented in the bridge module doc comment and enforced by tests — including a defense-in-depth runtime JSON-absence assertion (`forwards_plan_failed_without_leaking_chain_or_detail`) that uses a distinct sentinel string so a future refactor reintroducing the fields would trip the assertion.

## Review findings addressed

| Finding | Severity | Commits |
|---|---|---|
| Absolute paths leaked in `FileIntrospected` SSE event | Medium | `b3bd3b8` |
| Priority comment in `serve.rs` described ordering backwards | Warning | `06e9636` |
| Dead `SseEvent::ScanProgress` variant | Warning | `0e51d2b` |
| Throwaway channel allocation + duplicated `SSE_CHANNEL_CAPACITY` constant | Info | `ec7c79d`, `9454c40`, `11f6300` |
| Bridge emitted zero tracing output | Info | `3caf605` |
| `init_and_register` vs `register_plugin` | Info | `cbdaa9a` → `9e349dc` (investigated, reverted: kernel docs explicitly recommend `init_and_register`, which also enforces `Arc::get_mut` refcount==1 safety) |
| Plan lifecycle events not forwarded | Info | `48dbf17`, `ed21ed6` |
| Template escape audit | Info | `e2bd055`, `4d95f63` |

## Notable API changes from the refactor

- `AppState::new` now requires an explicit `broadcast::Sender<SseEvent>` as its second parameter. Tests that don't need to share the sender use the new `AppState::new_with_default_sse` convenience constructor.
- `ServerConfig::sse_tx` is no longer `Option` — it's a required field on `ServerConfig::new(host, port, sse_tx)`. The serve command supplies the same sender clone to both the web server and the bridge plugin.
- `SSE_CHANNEL_CAPACITY` is now exported from `voom-web-server` (previously duplicated in `voom-cli`).

## Tests

- 14 bridge unit tests covering every forwarded variant, basename edge cases, no-subscribers case, `handles()` coverage, and an end-to-end integration test (`integrates_with_kernel_dispatch`) that drives both a `JobStarted` and a `PlanFailed` through a real `Kernel`.
- 4 new `state.rs` serialization tests for `PlanExecuting`, `PlanCompleted`, `PlanSkipped`, `PlanFailed` including leak-field absence for `PlanFailed`.
- `ServerConfig::sse_tx` round-trip test (`test_server_config_stores_sse_sender`) — verified via mutation testing that it actually guards against a constructor that ignores its argument.

Full suite: **1589 tests pass, 0 failures.** `cargo clippy --workspace --all-targets -- -D warnings` clean. `cargo fmt --all -- --check` clean. `cargo test -p voom-cli --features functional` — 103 functional tests pass.

## Known pre-existing issue (not in scope)

Filed as randomparity/voom#135: `sse.rs` currently emits SSE events without explicit event names, while `base.html` listens for named `job-update`/`file-update` events — so no event actually reaches the browser yet. This branch makes the server-side plumbing correct and test-covered, but the frontend wire fix is tracked separately. The new `Plan*` events also need a matching listener added to `base.html`. See #135 for the suggested fix and a regression-test recommendation.

## Test plan

- [ ] CI runs `cargo test`, `cargo clippy --workspace -- -D warnings`, `cargo fmt -- --check` — all should pass
- [ ] CI runs `cargo test -p voom-cli --features functional`
- [ ] Manual: `cargo run -- serve` starts without the bridge-related warning/error paths
- [ ] Manual: `tracing` output at `debug` level shows "SSE send dropped: no active subscribers" lines when no browser is connected (confirms the forwarding is happening)
- [ ] Follow-up issue #135 is filed before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)