### PR TITLE
feat(web): refresh dashboard live on file/job SSE events

### DIFF
--- a/plugins/web-server/templates/base.html
+++ b/plugins/web-server/templates/base.html
@@ -399,19 +399,25 @@
     <script nonce="{{ csp_nonce }}">
         const evtSource = new EventSource('/events');
 
+        // htmx's `from:body` trigger modifier listens on <body> and relies on
+        // events bubbling up to it from a descendant. CustomEvent defaults to
+        // bubbles:false, and dispatching on `document` puts the event above
+        // <body> in the DOM hierarchy, so we must dispatch on document.body
+        // with bubbles:true for hx-trigger="... from:body" to fire (#134).
+        function dispatchVoomEvent(name, data) {
+            document.body.dispatchEvent(new CustomEvent(name, { detail: data, bubbles: true }));
+        }
+
         evtSource.addEventListener('job-update', function(e) {
-            const data = JSON.parse(e.data);
-            document.dispatchEvent(new CustomEvent('voom:job-update', { detail: data }));
+            dispatchVoomEvent('voom:job-update', JSON.parse(e.data));
         });
 
         evtSource.addEventListener('file-update', function(e) {
-            const data = JSON.parse(e.data);
-            document.dispatchEvent(new CustomEvent('voom:file-update', { detail: data }));
+            dispatchVoomEvent('voom:file-update', JSON.parse(e.data));
         });
 
         evtSource.addEventListener('plan-update', function(e) {
-            const data = JSON.parse(e.data);
-            document.dispatchEvent(new CustomEvent('voom:plan-update', { detail: data }));
+            dispatchVoomEvent('voom:plan-update', JSON.parse(e.data));
         });
 
         evtSource.onerror = function() {

--- a/plugins/web-server/templates/dashboard.html
+++ b/plugins/web-server/templates/dashboard.html
@@ -8,7 +8,7 @@
     <p>Overview of your media library and processing status</p>
 </div>
 
-<div class="card-grid" hx-get="/" hx-trigger="every 10s" hx-select=".card-grid" hx-target=".card-grid" hx-swap="outerHTML">
+<div class="card-grid" hx-get="/" hx-trigger="every 10s, voom:file-update from:body throttle:2s, voom:job-update from:body throttle:2s" hx-select=".card-grid" hx-target=".card-grid" hx-swap="outerHTML">
     <a href="/library" class="stat-card accent" style="text-decoration: none; color: inherit;">
         <div class="stat-value">{{ total_files | default(value=0) }}</div>
         <div class="stat-label">Total Files</div>

--- a/plugins/web-server/tests/template_triggers.rs
+++ b/plugins/web-server/tests/template_triggers.rs
@@ -1,0 +1,87 @@
+//! Static regression tests asserting that templates declare the htmx
+//! triggers required to consume SSE-driven custom events.
+//!
+//! Issue #134: the dashboard must refresh when `voom:file-update` (and
+//! `voom:job-update`) custom events are dispatched, so the live file count
+//! advances as `FileIntrospected` events flow through the bridge.
+//!
+//! These tests intentionally grep the embedded template strings rather than
+//! rendering them, because the triggers are static markup that must survive
+//! template edits — they have no runtime branching to test.
+
+const DASHBOARD_HTML: &str = include_str!("../templates/dashboard.html");
+const JOBS_HTML: &str = include_str!("../templates/jobs.html");
+const BASE_HTML: &str = include_str!("../templates/base.html");
+
+#[test]
+fn dashboard_listens_for_file_update_events() {
+    assert!(
+        DASHBOARD_HTML.contains("voom:file-update from:body"),
+        "dashboard.html must register an htmx trigger on `voom:file-update from:body` \
+         so the total-files stat card refreshes when FileIntrospected events arrive \
+         (issue #134)"
+    );
+}
+
+#[test]
+fn dashboard_listens_for_job_update_events() {
+    assert!(
+        DASHBOARD_HTML.contains("voom:job-update from:body"),
+        "dashboard.html must register an htmx trigger on `voom:job-update from:body` \
+         so the job counter cards refresh when job lifecycle events arrive (issue #134)"
+    );
+}
+
+#[test]
+fn jobs_page_listens_for_job_update_events() {
+    assert!(
+        JOBS_HTML.contains("voom:job-update from:body"),
+        "jobs.html must register an htmx trigger on `voom:job-update from:body` \
+         so the jobs table refreshes when job lifecycle events arrive (issue #134)"
+    );
+}
+
+#[test]
+fn base_dispatches_named_sse_events_as_custom_events() {
+    // Sanity check the bridge between the EventSource listeners and the
+    // htmx triggers above. If either half is renamed without updating the
+    // other, the dashboard goes silent.
+    for needle in [
+        "addEventListener('job-update'",
+        "addEventListener('file-update'",
+        "voom:job-update",
+        "voom:file-update",
+    ] {
+        assert!(
+            BASE_HTML.contains(needle),
+            "base.html missing required SSE wiring: {needle}"
+        );
+    }
+}
+
+#[test]
+fn base_dispatches_voom_events_so_htmx_from_body_can_catch_them() {
+    // htmx's `from:body` trigger modifier requires the event to bubble up to
+    // <body>. CustomEvent defaults to bubbles:false, and dispatching on
+    // `document` puts the event above <body> in the DOM hierarchy. The fix
+    // for #134 is to dispatch on `document.body` with `bubbles: true`. This
+    // test pins those two requirements so a future refactor cannot silently
+    // break the live-update path again.
+    assert!(
+        BASE_HTML.contains("document.body.dispatchEvent"),
+        "base.html must dispatch SSE-derived custom events on `document.body`, \
+         not `document` — htmx `from:body` only fires on bubbled events that \
+         reach the <body> element (issue #134)"
+    );
+    assert!(
+        BASE_HTML.contains("bubbles: true"),
+        "base.html must set `bubbles: true` on the SSE-derived CustomEvents so \
+         they propagate to the <body> listener registered by htmx (issue #134)"
+    );
+    assert!(
+        !BASE_HTML.contains("document.dispatchEvent(new CustomEvent('voom:"),
+        "base.html still dispatches a `voom:*` event on `document` instead of \
+         `document.body` — these will never reach htmx `from:body` triggers \
+         (issue #134)"
+    );
+}


### PR DESCRIPTION
## Summary

- Wire dashboard stat cards to refresh on `voom:file-update` / `voom:job-update` so Total Files and job counters advance live without a page reload, throttled to 2s
- Fix dead-on-arrival event wiring from 89cc956: `base.html` dispatched `voom:*` CustomEvents on `document` with default `bubbles:false`, so all htmx `from:body` triggers (including the existing jobs.html one) never fired. Dispatch on `document.body` with `bubbles:true` instead
- Add static regression tests pinning the trigger strings and the dispatch contract

Closes #134.
Follow-up #138 tracks the still-unconsumed `voom:plan-update` event.

## Why two fixes in one PR

The htmx-trigger bug from 89cc956 was discovered while implementing #134's dashboard wiring — without the fix, the dashboard refresh (and the jobs page refresh from #135) literally cannot work, so #134's acceptance criteria are unsatisfiable until base.html dispatches events that bubble. Both reviewer agents (event-bus and security) confirmed the diagnosis.

## Test plan

- [x] `cargo test -p voom-web-server` — 5 new template-trigger regression tests pass alongside existing SSE stream tests
- [x] `cargo test` workspace — 1597 passed, 0 failed
- [x] `cargo test -p voom-cli --features functional -- --test-threads=4` — 490 passed, 0 failed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [ ] Manual: `cargo run -- serve`, open `/`, run `cargo run -- scan <dir>` in another shell, confirm Total Files increments live within ~2s without reload
- [ ] Manual: open `/jobs` during a transcode, confirm progress bar and status pill update live

🤖 Generated with [Claude Code](https://claude.com/claude-code)