### PR TITLE
fix(web): refresh dashboard on voom:plan-update SSE events

### DIFF
--- a/plugins/web-server/templates/dashboard.html
+++ b/plugins/web-server/templates/dashboard.html
@@ -8,7 +8,7 @@
     <p>Overview of your media library and processing status</p>
 </div>
 
-<div class="card-grid" hx-get="/" hx-trigger="every 10s, voom:file-update from:body throttle:2s, voom:job-update from:body throttle:2s" hx-select=".card-grid" hx-target=".card-grid" hx-swap="outerHTML">
+<div class="card-grid" hx-get="/" hx-trigger="every 10s, voom:file-update from:body throttle:2s, voom:job-update from:body throttle:2s, voom:plan-update from:body throttle:2s" hx-select=".card-grid" hx-target=".card-grid" hx-swap="outerHTML">
     <a href="/library" class="stat-card accent" style="text-decoration: none; color: inherit;">
         <div class="stat-value">{{ total_files | default(value=0) }}</div>
         <div class="stat-label">Total Files</div>

--- a/plugins/web-server/tests/template_triggers.rs
+++ b/plugins/web-server/tests/template_triggers.rs
@@ -33,6 +33,16 @@ fn dashboard_listens_for_job_update_events() {
 }
 
 #[test]
+fn dashboard_listens_for_plan_update_events() {
+    assert!(
+        DASHBOARD_HTML.contains("voom:plan-update from:body"),
+        "dashboard.html must register an htmx trigger on `voom:plan-update from:body` \
+         so job counters refresh when Plan* lifecycle events arrive via the \
+         web-sse-bridge (issue #138)"
+    );
+}
+
+#[test]
 fn jobs_page_listens_for_job_update_events() {
     assert!(
         JOBS_HTML.contains("voom:job-update from:body"),


### PR DESCRIPTION
## Summary
- Add `voom:plan-update from:body throttle:2s` to the dashboard `.card-grid` hx-trigger so Plan lifecycle events coming through the web-sse-bridge actually refresh the job counters.
- Add a regression test in `template_triggers.rs` mirroring the existing file/job-update assertions.

Prior to this change the full pipeline (kernel → web-sse-bridge → SSE channel → EventSource → `voom:plan-update` CustomEvent on `document.body`) ran end-to-end and the event was then dropped because no template listened for it.

Closes #138

## Test plan
- [x] `cargo test -p voom-web-server` — new `dashboard_listens_for_plan_update_events` test passes alongside existing trigger tests
- [x] `cargo clippy -p voom-web-server --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)