### PR TITLE
test(policy-evaluator): broaden ffmpeg capabilities fixture

### DIFF
--- a/plugins/policy-evaluator/src/evaluator.rs
+++ b/plugins/policy-evaluator/src/evaluator.rs
@@ -2192,14 +2192,46 @@ mod tests {
         use voom_domain::capability_map::CapabilityMap;
         use voom_domain::events::{CodecCapabilities, ExecutorCapabilitiesEvent};
 
+        fn ffmpeg_codecs() -> CodecCapabilities {
+            CodecCapabilities::new(
+                vec!["h264".into(), "hevc".into(), "aac".into()],
+                vec!["h264".into(), "hevc".into(), "aac".into()],
+            )
+        }
+
+        /// Realistic ffmpeg muxer set covering every reachable `Container`
+        /// variant via `Container::ffmpeg_format_name()`. Update this list
+        /// whenever a new `Container` variant is added so the fixture
+        /// stays in sync with the domain enum.
         fn ffmpeg_capabilities() -> CapabilityMap {
             let mut map = CapabilityMap::new();
             map.register(ExecutorCapabilitiesEvent::new(
                 "ffmpeg-executor",
-                CodecCapabilities::new(
-                    vec!["h264".into(), "hevc".into(), "aac".into()],
-                    vec!["h264".into(), "hevc".into(), "aac".into()],
-                ),
+                ffmpeg_codecs(),
+                vec![
+                    "matroska".into(),
+                    "mp4".into(),
+                    "webm".into(),
+                    "avi".into(),
+                    "mov".into(),
+                    "mpegts".into(),
+                    "asf".into(),
+                    "flv".into(),
+                ],
+                vec![],
+            ));
+            map
+        }
+
+        /// Deliberately narrow fixture used only by tests that need to
+        /// exercise the "format not supported" warning path. Keep this
+        /// list limited; real ffmpeg supports many more muxers — see
+        /// `ffmpeg_capabilities()` for the realistic set.
+        fn limited_ffmpeg_capabilities() -> CapabilityMap {
+            let mut map = CapabilityMap::new();
+            map.register(ExecutorCapabilitiesEvent::new(
+                "ffmpeg-executor",
+                ffmpeg_codecs(),
                 vec!["matroska".into(), "mp4".into()],
                 vec![],
             ));
@@ -2252,7 +2284,10 @@ mod tests {
             // Tracks are all WebM-compatible so the ContainerIncompatible
             // safeguard leaves the ConvertContainer in place; the
             // capability-hints layer is what should surface the warning
-            // here, since ffmpeg_capabilities() doesn't list webm.
+            // here. Use the deliberately narrow `limited_ffmpeg_capabilities`
+            // fixture, which intentionally omits webm so we can exercise
+            // the "format not supported" warning path. Real ffmpeg
+            // absolutely supports webm — see `ffmpeg_capabilities()`.
             let mut file = test_file();
             file.tracks = vec![
                 Track::new(0, TrackType::Video, "vp9".into()),
@@ -2260,7 +2295,7 @@ mod tests {
             ];
             let policy = test_policy(r#"policy "test" { phase init { container webm } }"#);
             let mut result = evaluate(&policy, &file);
-            let caps = ffmpeg_capabilities();
+            let caps = limited_ffmpeg_capabilities();
             apply_capability_hints(&mut result.plans, &caps);
 
             assert!(


### PR DESCRIPTION
## Summary

Fixes #143. The `ffmpeg_capabilities()` test fixture in `plugins/policy-evaluator/src/evaluator.rs` advertised only `matroska` and `mp4`, which misrepresented what real ffmpeg supports and made `test_warns_on_unsupported_container_format` pass by virtue of webm being absent from the fixture rather than by exercising a genuine capability gap.

- Broaden `ffmpeg_capabilities()` to cover every reachable `Container` variant via `Container::ffmpeg_format_name()` (matroska, mp4, webm, avi, mov, mpegts, asf, flv).
- Add `limited_ffmpeg_capabilities()` — a separately-named, deliberately narrow fixture used only by the "format not supported" warning-path test, with a doc comment stating real ffmpeg supports more muxers.
- Extract a shared `ffmpeg_codecs()` helper so the two fixtures don't drift.
- Document the invariant that `ffmpeg_capabilities()` must mirror the `Container` enum.
- Update the test comment to no longer imply ffmpeg lacks webm support.

No production code changes.

## Test plan

- [x] `cargo test -p voom-policy-evaluator` (118 passed)
- [x] `cargo test` (full workspace)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all`

Closes #143