### PR TITLE
chore(triage): close 16 issues; fix #42 #93 #131 #142

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3319,6 +3319,7 @@ dependencies = [
 name = "voom-discovery"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "rayon",
  "tempfile",
  "tracing",

--- a/crates/voom-cli/src/app.rs
+++ b/crates/voom-cli/src/app.rs
@@ -205,16 +205,9 @@ pub fn bootstrap_kernel_with_store(config: &AppConfig) -> Result<BootstrapResult
         "ffprobe introspector"
     );
 
-    // Capability collector — captures ExecutorCapabilities events for the evaluator.
-    // Priority 35 dispatches before executor priorities (39, 40), so init-time
-    // ExecutorCapabilities events emitted by executors land in the collector
-    // first.
-    //
-    // When disabled, we still construct the collector (so `collector.snapshot()`
-    // remains callable on BootstrapResult) but do NOT register it on the bus.
-    // The snapshot will be empty, which is a documented degraded mode:
-    // executor selection falls back to plain priority order with no capability
-    // hints.
+    // When disabled, we still construct the collector so `snapshot()` is callable,
+    // but do not register it on the bus. The snapshot stays empty and executor
+    // selection falls back to priority order with no capability hints.
     let collector = if disabled.iter().any(|d| d == "capability-collector") {
         tracing::warn!(
             "capability-collector disabled — executor selection will have no capability hints"

--- a/crates/voom-cli/src/app.rs
+++ b/crates/voom-cli/src/app.rs
@@ -206,8 +206,12 @@ pub fn bootstrap_kernel_with_store(config: &AppConfig) -> Result<BootstrapResult
     );
 
     // When disabled, we still construct the collector so `snapshot()` is callable,
-    // but do not register it on the bus. The snapshot stays empty and executor
-    // selection falls back to priority order with no capability hints.
+    // but do not register it on the bus and do not call `init()`. The snapshot
+    // stays empty and executor selection falls back to priority order.
+    //
+    // Safe only because `CapabilityCollectorPlugin::init()` is a no-op. If it
+    // ever acquires resources needed by `snapshot()`, this branch must call
+    // `init()` directly.
     let collector = if disabled.iter().any(|d| d == "capability-collector") {
         tracing::warn!(
             "capability-collector disabled — executor selection will have no capability hints"

--- a/crates/voom-cli/src/app.rs
+++ b/crates/voom-cli/src/app.rs
@@ -208,34 +208,29 @@ pub fn bootstrap_kernel_with_store(config: &AppConfig) -> Result<BootstrapResult
     // Capability collector — captures ExecutorCapabilities events for the evaluator.
     // Priority 35 dispatches before executor priorities (39, 40), so init-time
     // ExecutorCapabilities events emitted by executors land in the collector
-    // first. Uses manual init + register_plugin (like sqlite-store) because
-    // the caller needs an Arc<CapabilityCollectorPlugin> handle for snapshot()
-    // after bootstrap.
+    // first.
     //
     // When disabled, we still construct the collector (so `collector.snapshot()`
     // remains callable on BootstrapResult) but do NOT register it on the bus.
     // The snapshot will be empty, which is a documented degraded mode:
     // executor selection falls back to plain priority order with no capability
     // hints.
-    let (collector, collector_init_events) = {
-        let mut plugin = CapabilityCollectorPlugin::new();
-        let ctx =
-            voom_kernel::PluginContext::new(plugin_json("capability-collector"), data_dir.clone());
-        let events = plugin
-            .init(&ctx)
-            .context("Failed to initialize capability collector")?;
-        (Arc::new(plugin), events)
-    };
-    if disabled.iter().any(|d| d == "capability-collector") {
+    let collector = if disabled.iter().any(|d| d == "capability-collector") {
         tracing::warn!(
             "capability-collector disabled — executor selection will have no capability hints"
         );
+        Arc::new(CapabilityCollectorPlugin::new())
     } else {
-        kernel.register_plugin(collector.clone(), PRIORITY_CAPABILITY_COLLECTOR)?;
-        for event in collector_init_events {
-            kernel.dispatch(event);
-        }
-    }
+        let ctx =
+            voom_kernel::PluginContext::new(plugin_json("capability-collector"), data_dir.clone());
+        kernel
+            .init_and_register_shared(
+                CapabilityCollectorPlugin::new(),
+                PRIORITY_CAPABILITY_COLLECTOR,
+                &ctx,
+            )
+            .context("Failed to initialize and register capability collector")?
+    };
 
     // Executor — mkvtoolnix (MKV metadata, track removal/reorder, convert-to-MKV)
     register_if_enabled!(

--- a/crates/voom-cli/src/commands/process/mod.rs
+++ b/crates/voom-cli/src/commands/process/mod.rs
@@ -153,7 +153,7 @@ pub async fn run(args: ProcessArgs, quiet: bool, token: CancellationToken) -> Re
         return Ok(());
     }
 
-    let mut events = discover_files(&paths, &args, &kernel, quiet)?;
+    let mut events = discover_files(&paths, &args, &kernel, quiet, store.clone())?;
     if events.is_empty() {
         if plan_only {
             println!("[]");
@@ -431,6 +431,7 @@ fn discover_files(
     args: &ProcessArgs,
     kernel: &voom_kernel::Kernel,
     quiet: bool,
+    store: Arc<dyn voom_domain::storage::StorageTrait>,
 ) -> Result<Vec<voom_domain::events::FileDiscoveredEvent>> {
     let discovery = voom_discovery::DiscoveryPlugin::new();
     let hash_files = !args.no_backup;
@@ -459,6 +460,7 @@ fn discover_files(
         let mut options = voom_discovery::ScanOptions::new(path.clone());
         options.hash_files = hash_files;
         options.workers = args.workers;
+        options.fingerprint_lookup = Some(crate::introspect::fingerprint_lookup(store.clone()));
 
         let progress_clone = progress.clone();
         let cum_disc = cumulative_discovered.clone();
@@ -482,6 +484,7 @@ fn discover_files(
                 progress_clone.on_processing(base + current, base + total, &path, action);
             }
             voom_discovery::ScanProgress::OrphanedTempFiles { .. } => {}
+            voom_discovery::ScanProgress::HashReused { .. } => {}
         }));
 
         let errors_clone = discovery_errors.clone();
@@ -727,10 +730,12 @@ fn print_summary(ctx: &SummaryContext<'_>) {
     if ctx.backup_bytes > 0 && ctx.modified > 0 && !ctx.dry_run {
         let path_args: Vec<_> = ctx.paths.iter().map(|p| p.display().to_string()).collect();
         eprintln!(
-            "{} {} backups retained ({}) \u{2014} delete with: find {} -name '*.vbak' -delete",
+            "{} {} backups retained ({}) \u{2014} list with: voom backup list {} \
+             \u{2014} delete with: voom backup cleanup {}",
             style("Info:").bold(),
             style(ctx.modified).cyan(),
             style(format_size(ctx.backup_bytes)).cyan(),
+            path_args.join(" "),
             path_args.join(" "),
         );
     }

--- a/crates/voom-cli/src/commands/scan.rs
+++ b/crates/voom-cli/src/commands/scan.rs
@@ -39,7 +39,7 @@ pub async fn run(args: ScanArgs, quiet: bool, token: CancellationToken) -> Resul
     }
 
     let (mut all_events, orphans, disc_errors) =
-        run_discovery(&args, &paths, hash_files, quiet, &kernel)?;
+        run_discovery(&args, &paths, hash_files, quiet, &kernel, store.clone())?;
 
     // Deduplicate events by path in case multiple scan roots overlap
     let mut seen = HashSet::new();
@@ -117,6 +117,7 @@ fn run_discovery(
     hash_files: bool,
     quiet: bool,
     kernel: &Arc<voom_kernel::Kernel>,
+    store: Arc<dyn voom_domain::storage::StorageTrait>,
 ) -> Result<(Vec<FileDiscoveredEvent>, u64, u64)> {
     let discovery = voom_discovery::DiscoveryPlugin::new();
     let progress = if quiet {
@@ -145,6 +146,7 @@ fn run_discovery(
         options.recursive = args.recursive;
         options.hash_files = hash_files;
         options.workers = args.workers;
+        options.fingerprint_lookup = Some(crate::introspect::fingerprint_lookup(store.clone()));
         options.on_progress = Some(Box::new(move |progress| match progress {
             voom_discovery::ScanProgress::Discovered { count: _, path } => {
                 let cumulative = cum_disc.fetch_add(1, Ordering::Relaxed) + 1;
@@ -164,6 +166,7 @@ fn run_discovery(
             voom_discovery::ScanProgress::OrphanedTempFiles { count } => {
                 orphan_clone.fetch_add(count as u64, Ordering::Relaxed);
             }
+            voom_discovery::ScanProgress::HashReused { .. } => {}
         }));
         options.on_error = Some(Box::new(move |path, size, error| {
             tracing::warn!(path = %path.display(), error = %error, "discovery error");

--- a/crates/voom-cli/src/introspect.rs
+++ b/crates/voom-cli/src/introspect.rs
@@ -115,24 +115,12 @@ pub use voom_domain::DiscoveredFilePayload;
 
 /// Build a fingerprint lookup closure backed by the given storage.
 ///
-/// Returns a closure that, given a file path, looks up the previously-stored
-/// [`MediaFile`](voom_domain::media::MediaFile) (if any) and produces a
-/// [`StoredFingerprint`](voom_domain::media::StoredFingerprint). Discovery
-/// uses this to skip re-hashing files whose size and mtime indicate no change.
-///
-/// Files that were never stored, files with `None` `content_hash`, and lookup
-/// errors all return `None` so discovery falls back to hashing.
+/// The closure delegates to `StorageTrait::file_fingerprint_by_path`, which
+/// the sqlite-store backend serves from a narrow query. Lookup failures
+/// return `None` so discovery falls back to hashing.
 #[must_use]
 pub fn fingerprint_lookup(
     store: std::sync::Arc<dyn voom_domain::storage::StorageTrait>,
 ) -> voom_discovery::FingerprintLookup {
-    Box::new(move |path| {
-        let stored = store.file_by_path(path).ok().flatten()?;
-        let content_hash = stored.content_hash?;
-        Some(voom_domain::media::StoredFingerprint {
-            size: stored.size,
-            content_hash,
-            last_seen: stored.introspected_at,
-        })
-    })
+    Box::new(move |path| store.file_fingerprint_by_path(path).ok().flatten())
 }

--- a/crates/voom-cli/src/introspect.rs
+++ b/crates/voom-cli/src/introspect.rs
@@ -116,11 +116,23 @@ pub use voom_domain::DiscoveredFilePayload;
 /// Build a fingerprint lookup closure backed by the given storage.
 ///
 /// The closure delegates to `StorageTrait::file_fingerprint_by_path`, which
-/// the sqlite-store backend serves from a narrow query. Lookup failures
-/// return `None` so discovery falls back to hashing.
+/// the sqlite-store backend serves from a narrow query. Storage errors are
+/// logged at warn level and the closure returns `None` so discovery falls
+/// back to hashing — a sustained storage failure would otherwise cause a
+/// library-wide silent re-hash with no operator visibility.
 #[must_use]
 pub fn fingerprint_lookup(
     store: std::sync::Arc<dyn voom_domain::storage::StorageTrait>,
 ) -> voom_discovery::FingerprintLookup {
-    Box::new(move |path| store.file_fingerprint_by_path(path).ok().flatten())
+    Box::new(move |path| match store.file_fingerprint_by_path(path) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %e,
+                "fingerprint lookup failed; falling back to rehash"
+            );
+            None
+        }
+    })
 }

--- a/crates/voom-cli/src/introspect.rs
+++ b/crates/voom-cli/src/introspect.rs
@@ -112,3 +112,27 @@ pub async fn introspect_file(
 }
 
 pub use voom_domain::DiscoveredFilePayload;
+
+/// Build a fingerprint lookup closure backed by the given storage.
+///
+/// Returns a closure that, given a file path, looks up the previously-stored
+/// [`MediaFile`](voom_domain::media::MediaFile) (if any) and produces a
+/// [`StoredFingerprint`](voom_domain::media::StoredFingerprint). Discovery
+/// uses this to skip re-hashing files whose size and mtime indicate no change.
+///
+/// Files that were never stored, files with `None` `content_hash`, and lookup
+/// errors all return `None` so discovery falls back to hashing.
+#[must_use]
+pub fn fingerprint_lookup(
+    store: std::sync::Arc<dyn voom_domain::storage::StorageTrait>,
+) -> voom_discovery::FingerprintLookup {
+    Box::new(move |path| {
+        let stored = store.file_by_path(path).ok().flatten()?;
+        let content_hash = stored.content_hash?;
+        Some(voom_domain::media::StoredFingerprint {
+            size: stored.size,
+            content_hash,
+            last_seen: stored.introspected_at,
+        })
+    })
+}

--- a/crates/voom-domain/src/media.rs
+++ b/crates/voom-domain/src/media.rs
@@ -7,6 +7,25 @@ use uuid::Uuid;
 
 use crate::transition::FileStatus;
 
+/// Cached fingerprint used to decide whether a previously-hashed file needs
+/// to be re-hashed during discovery.
+///
+/// The caller (typically the CLI) supplies one of these (looked up from the
+/// storage layer) for each file being scanned. Discovery compares the file's
+/// on-disk `size` and `mtime` against these cached values — if the file has
+/// not grown or shrunk and its `mtime` is no later than `last_seen`, the
+/// stored `content_hash` is reused instead of re-reading the file.
+#[derive(Debug, Clone)]
+pub struct StoredFingerprint {
+    /// File size in bytes at the time the hash was computed.
+    pub size: u64,
+    /// Previously computed content hash.
+    pub content_hash: String,
+    /// Timestamp after which a newer `mtime` on disk means the content may
+    /// have changed. Typically `MediaFile::introspected_at`.
+    pub last_seen: DateTime<Utc>,
+}
+
 /// A media file with full introspection metadata.
 #[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/voom-domain/src/storage.rs
+++ b/crates/voom-domain/src/storage.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 use crate::bad_file::{BadFile, BadFileSource};
 use crate::errors::Result;
 use crate::job::{Job, JobStatus, JobUpdate};
-use crate::media::{Container, MediaFile};
+use crate::media::{Container, MediaFile, StoredFingerprint};
 use crate::plan::Plan;
 use crate::stats::{LibrarySnapshot, SavingsReport, SnapshotTrigger, TimePeriod};
 use crate::transition::{DiscoveredFile, FileTransition, ReconcileResult, TransitionSource};
@@ -55,6 +55,19 @@ pub trait FileStorage: Send + Sync {
     fn upsert_file(&self, file: &MediaFile) -> Result<()>;
     fn file(&self, id: &Uuid) -> Result<Option<MediaFile>>;
     fn file_by_path(&self, path: &Path) -> Result<Option<MediaFile>>;
+    /// Fast fingerprint lookup for discovery's hash short-circuit. Default
+    /// impl forwards to [`file_by_path`](Self::file_by_path) — backends that
+    /// can serve this from a narrower query (e.g. skipping a `tracks` join)
+    /// should override it.
+    fn file_fingerprint_by_path(&self, path: &Path) -> Result<Option<StoredFingerprint>> {
+        Ok(self.file_by_path(path)?.and_then(|f| {
+            f.content_hash.map(|h| StoredFingerprint {
+                size: f.size,
+                content_hash: h,
+                last_seen: f.introspected_at,
+            })
+        }))
+    }
     fn list_files(&self, filters: &FileFilters) -> Result<Vec<MediaFile>>;
     /// Count total files matching the given filters (ignoring limit/offset).
     fn count_files(&self, filters: &FileFilters) -> Result<u64>;

--- a/crates/voom-kernel/src/lib.rs
+++ b/crates/voom-kernel/src/lib.rs
@@ -245,33 +245,21 @@ impl Kernel {
     ) -> Result<()> {
         let name = plugin.name().to_string();
         if self.registry.contains(&name) {
-            return Err(voom_domain::errors::VoomError::Plugin {
-                plugin: name,
-                message: "a plugin with this name is already registered".into(),
-            });
+            return Err(voom_domain::errors::VoomError::plugin(
+                name,
+                "a plugin with this name is already registered",
+            ));
         }
-        let plugin_mut =
-            Arc::get_mut(&mut plugin).ok_or_else(|| voom_domain::errors::VoomError::Plugin {
-                plugin: name.clone(),
-                message: "init_and_register requires exclusive Arc ownership (refcount must be 1)"
-                    .into(),
-            })?;
-        let init_events =
-            plugin_mut
-                .init(ctx)
-                .map_err(|e| voom_domain::errors::VoomError::Plugin {
-                    plugin: name.clone(),
-                    message: format!("init failed: {e}"),
-                })?;
-        self.registry.register(plugin.clone())?;
-        self.bus.subscribe_plugin(plugin, priority);
-        tracing::info!(plugin = %name, "plugin initialized and registered");
-
-        for event in init_events {
-            self.dispatch(event);
-        }
-
-        Ok(())
+        let plugin_mut = Arc::get_mut(&mut plugin).ok_or_else(|| {
+            voom_domain::errors::VoomError::plugin(
+                name.clone(),
+                "init requires exclusive Arc ownership (refcount must be 1)",
+            )
+        })?;
+        let init_events = plugin_mut.init(ctx).map_err(|e| {
+            voom_domain::errors::VoomError::plugin(name.clone(), format!("init failed: {e}"))
+        })?;
+        self.finish_registration(plugin, priority, &name, init_events)
     }
 
     /// Initialize a typed plugin, register it, and return an `Arc<P>` handle.
@@ -290,36 +278,42 @@ impl Kernel {
         let mut arc: Arc<P> = Arc::new(plugin);
         let name = arc.name().to_string();
         if self.registry.contains(&name) {
-            return Err(voom_domain::errors::VoomError::Plugin {
-                plugin: name,
-                message: "a plugin with this name is already registered".into(),
-            });
+            return Err(voom_domain::errors::VoomError::plugin(
+                name,
+                "a plugin with this name is already registered",
+            ));
         }
-        let plugin_mut =
-            Arc::get_mut(&mut arc).ok_or_else(|| voom_domain::errors::VoomError::Plugin {
-                plugin: name.clone(),
-                message:
-                    "init_and_register_shared requires exclusive Arc ownership (refcount must be 1)"
-                        .into(),
-            })?;
-        let init_events =
-            plugin_mut
-                .init(ctx)
-                .map_err(|e| voom_domain::errors::VoomError::Plugin {
-                    plugin: name.clone(),
-                    message: format!("init failed: {e}"),
-                })?;
+        let plugin_mut = Arc::get_mut(&mut arc).ok_or_else(|| {
+            voom_domain::errors::VoomError::plugin(
+                name.clone(),
+                "init requires exclusive Arc ownership (refcount must be 1)",
+            )
+        })?;
+        let init_events = plugin_mut.init(ctx).map_err(|e| {
+            voom_domain::errors::VoomError::plugin(name.clone(), format!("init failed: {e}"))
+        })?;
+        self.finish_registration(arc.clone(), priority, &name, init_events)?;
+        Ok(arc)
+    }
 
-        let dyn_arc: Arc<dyn Plugin> = arc.clone();
-        self.registry.register(dyn_arc.clone())?;
-        self.bus.subscribe_plugin(dyn_arc, priority);
+    /// Shared tail of both init-and-register paths: insert into the registry,
+    /// subscribe on the bus, and dispatch init events. Kept separate from the
+    /// init step so each caller can preserve the `Arc::get_mut` refcount-1
+    /// invariant on its own `Arc`.
+    fn finish_registration(
+        &mut self,
+        plugin: Arc<dyn Plugin>,
+        priority: i32,
+        name: &str,
+        init_events: Vec<Event>,
+    ) -> Result<()> {
+        self.registry.register(plugin.clone())?;
+        self.bus.subscribe_plugin(plugin, priority);
         tracing::info!(plugin = %name, "plugin initialized and registered");
-
         for event in init_events {
             self.dispatch(event);
         }
-
-        Ok(arc)
+        Ok(())
     }
 
     /// Dispatch an event through the bus to all matching subscribers.

--- a/crates/voom-kernel/src/lib.rs
+++ b/crates/voom-kernel/src/lib.rs
@@ -274,6 +274,54 @@ impl Kernel {
         Ok(())
     }
 
+    /// Initialize a typed plugin, register it, and return an `Arc<P>` handle.
+    ///
+    /// Use this instead of [`init_and_register`](Self::init_and_register) when the caller needs a
+    /// typed `Arc<P>` for later use (e.g. the capability collector, whose
+    /// `snapshot()` method is called after bootstrap). Takes `P` by value so
+    /// the kernel constructs the `Arc` itself — guaranteeing the refcount-1
+    /// invariant that `Arc::get_mut` requires during `init()`.
+    pub fn init_and_register_shared<P: Plugin + 'static>(
+        &mut self,
+        plugin: P,
+        priority: i32,
+        ctx: &PluginContext,
+    ) -> Result<Arc<P>> {
+        let mut arc: Arc<P> = Arc::new(plugin);
+        let name = arc.name().to_string();
+        if self.registry.contains(&name) {
+            return Err(voom_domain::errors::VoomError::Plugin {
+                plugin: name,
+                message: "a plugin with this name is already registered".into(),
+            });
+        }
+        let plugin_mut =
+            Arc::get_mut(&mut arc).ok_or_else(|| voom_domain::errors::VoomError::Plugin {
+                plugin: name.clone(),
+                message:
+                    "init_and_register_shared requires exclusive Arc ownership (refcount must be 1)"
+                        .into(),
+            })?;
+        let init_events =
+            plugin_mut
+                .init(ctx)
+                .map_err(|e| voom_domain::errors::VoomError::Plugin {
+                    plugin: name.clone(),
+                    message: format!("init failed: {e}"),
+                })?;
+
+        let dyn_arc: Arc<dyn Plugin> = arc.clone();
+        self.registry.register(dyn_arc.clone())?;
+        self.bus.subscribe_plugin(dyn_arc, priority);
+        tracing::info!(plugin = %name, "plugin initialized and registered");
+
+        for event in init_events {
+            self.dispatch(event);
+        }
+
+        Ok(arc)
+    }
+
     /// Dispatch an event through the bus to all matching subscribers.
     pub fn dispatch(&self, event: Event) -> Vec<EventResult> {
         let event_type = event.event_type().to_string();
@@ -377,6 +425,60 @@ mod tests {
         assert!(init_called.load(Ordering::SeqCst));
         assert_eq!(kernel.registry.len(), 1);
         assert_eq!(kernel.subscriber_count(), 1);
+    }
+
+    #[test]
+    fn test_init_and_register_shared_returns_typed_handle_and_calls_init() {
+        let init_called = Arc::new(AtomicBool::new(false));
+        let shutdown_called = Arc::new(AtomicBool::new(false));
+
+        let plugin = LifecyclePlugin {
+            init_called: init_called.clone(),
+            shutdown_called: shutdown_called.clone(),
+        };
+
+        let ctx = PluginContext::new(serde_json::json!({}), PathBuf::from("/tmp"));
+
+        let mut kernel = Kernel::new();
+        let handle: Arc<LifecyclePlugin> =
+            kernel.init_and_register_shared(plugin, 50, &ctx).unwrap();
+
+        assert!(init_called.load(Ordering::SeqCst));
+        assert_eq!(kernel.registry.len(), 1);
+        assert_eq!(kernel.subscriber_count(), 1);
+        // The typed handle shares state with the kernel-owned Arc.
+        assert!(handle.init_called.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn test_init_and_register_shared_rejects_duplicate_name() {
+        let ctx = PluginContext::new(serde_json::json!({}), PathBuf::from("/tmp"));
+        let mut kernel = Kernel::new();
+        kernel
+            .init_and_register_shared(
+                LifecyclePlugin {
+                    init_called: Arc::new(AtomicBool::new(false)),
+                    shutdown_called: Arc::new(AtomicBool::new(false)),
+                },
+                50,
+                &ctx,
+            )
+            .unwrap();
+        let err = match kernel.init_and_register_shared(
+            LifecyclePlugin {
+                init_called: Arc::new(AtomicBool::new(false)),
+                shutdown_called: Arc::new(AtomicBool::new(false)),
+            },
+            60,
+            &ctx,
+        ) {
+            Err(e) => e,
+            Ok(_) => panic!("expected duplicate registration to fail"),
+        };
+        assert!(
+            format!("{err}").contains("already registered"),
+            "expected already-registered error, got: {err}"
+        );
     }
 
     #[test]

--- a/crates/voom-kernel/src/lib.rs
+++ b/crates/voom-kernel/src/lib.rs
@@ -286,7 +286,7 @@ impl Kernel {
         let plugin_mut = Arc::get_mut(&mut arc).ok_or_else(|| {
             voom_domain::errors::VoomError::plugin(
                 name.clone(),
-                "init requires exclusive Arc ownership (refcount must be 1)",
+                "internal error: Arc refcount > 1 before init (kernel-constructed Arc should be unique)",
             )
         })?;
         let init_events = plugin_mut.init(ctx).map_err(|e| {
@@ -473,6 +473,30 @@ mod tests {
             format!("{err}").contains("already registered"),
             "expected already-registered error, got: {err}"
         );
+    }
+
+    #[test]
+    fn test_drop_calls_shutdown_shared_with_retained_handle() {
+        let shutdown_called = Arc::new(AtomicBool::new(false));
+        let plugin = LifecyclePlugin {
+            init_called: Arc::new(AtomicBool::new(false)),
+            shutdown_called: shutdown_called.clone(),
+        };
+        let ctx = PluginContext::new(serde_json::json!({}), PathBuf::from("/tmp"));
+
+        // Callers of init_and_register_shared typically retain the typed Arc
+        // past kernel drop (e.g. BootstrapResult.collector). Verify shutdown
+        // still fires exactly once during kernel drop, with no use-after-free.
+        let handle: Arc<LifecyclePlugin>;
+        {
+            let mut kernel = Kernel::new();
+            handle = kernel.init_and_register_shared(plugin, 50, &ctx).unwrap();
+            assert!(!shutdown_called.load(Ordering::SeqCst));
+            // kernel dropped here, while `handle` is still live
+        }
+        assert!(shutdown_called.load(Ordering::SeqCst));
+        // `handle` is still valid here — accessing it must not panic.
+        assert_eq!(handle.name(), "lifecycle-test");
     }
 
     #[test]

--- a/docs/plans/issue-triage-2026-04-18.md
+++ b/docs/plans/issue-triage-2026-04-18.md
@@ -1,0 +1,390 @@
+# Open Issue Triage & Implementation Plans — 2026-04-18
+
+Triage of the 25 open GitHub issues at time of review, with per-issue
+relevance assessment and implementation plans for the still-relevant ones.
+
+Verified against branch `desloppify/code-health` @ 18df0e6.
+
+## Summary
+
+| # | Title | Status | Action |
+|---|-------|--------|--------|
+| 142 | ContainerIncompatible safeguard: extend check to synthesized tracks | **Relevant** | Implement |
+| 131 | Need Better Process to Clean Backup Directories | **Relevant** | Design + implement |
+| 94 | Improve *arr Stack Integration | **Relevant (design)** | Defer — subsumed by #37 |
+| 93 | Applying Policy Forces Full Hash on Library | **Relevant** | Implement |
+| 92 | Support Plugin Stats | **Relevant (design)** | Scope as sprint-sized feature |
+| 91 | Multi-Host Agent Coordination | **Relevant (design)** | Keep open — large future effort |
+| 90 | Consider Container Release Options | **Relevant (ops)** | Implement |
+| 47 | Create UNIX Compliant Output for Scripting | **Relevant** | Implement |
+| 44 | Verify tower middleware layer ordering for rate limiting | **Resolved, no change** | Close |
+| 43 | Audit StorageReporter for async safety in daemon mode | **Relevant (docs-only)** | Implement |
+| 42 | Use init_and_register for capability-collector plugin | **Relevant** | Implement |
+| 41 | Add daemon_mode parameter to bootstrap_kernel_with_store | **Outdated** | Close |
+| 40 | Executors: use probed capabilities in can_handle() | **Done** | Close |
+| 39 | Policy evaluator: subscribe to executor capability events | **Done (via collector)** | Close |
+| 38 | Plugin: executor capability announcement via init-time probing | **Done** | Close |
+| 37 | Plugin: notification/webhook forwarding | **Relevant (design)** | New plugin |
+| 36 | Plugin: filesystem watcher | **Relevant (design)** | New plugin — feeds #4 |
+| 35 | Plugin: library-index emitting stats from SQLite at startup | **Relevant (design)** | New plugin |
+| 34 | Plugin: health-check emitting system readiness events | **Done** | Close |
+| 33 | Plugin: config/policy validator emitting init-time events | **Relevant (design)** | New plugin |
+| 31 | No per-IP rate limiting on web API | **Relevant** | Implement |
+| 30 | No minimum entropy check on web auth token | **Relevant** | Implement |
+| 28 | CSP trusts unpkg.com without SRI hashes | **Relevant** | Implement |
+| 27 | Event bus: FileDiscovered dispatched with zero subscribers | **Outdated** | Close |
+| 4  | Event-driven pipeline under serve with periodic scanning | **Relevant (sprint-sized)** | Plan as sprint |
+
+**Close immediately (6):** #27, #34, #38, #39, #40, #41, #44 (7 total — #44 explicitly says "no code change needed").
+
+**Small-to-medium fixes (8):** #28, #30, #31, #42, #43, #47, #93, #142.
+
+**New feature work (5):** #33, #35, #36, #37, #131.
+
+**Sprint-sized / design (5):** #4, #90, #91, #92, #94.
+
+---
+
+## Close-on-Review (verification evidence)
+
+### #27 — FileDiscovered has zero subscribers
+
+**Current state:** `plugins/sqlite-store/src/lib.rs:79` — `Event::FileDiscovered(e) => handle_file_discovered(store, e)?`. Test at line 529 asserts the same. `handles()` at line 395 returns true for `FILE_DISCOVERED`.
+
+**Action:** Close with comment citing `plugins/sqlite-store/src/lib.rs:79` and `plugins/sqlite-store/src/lib.rs:395`.
+
+### #34 — health-check plugin
+
+**Current state:** `plugins/health-checker/` crate exists with `HealthCheckerPlugin`, `HealthStatusEvent`, and config. Registered as a native plugin.
+
+**Action:** Close with comment citing `plugins/health-checker/src/lib.rs`.
+
+### #38 / #39 / #40 — Executor capability events
+
+**Current state:**
+
+- `plugins/ffmpeg-executor/src/lib.rs:628` emits `ExecutorCapabilitiesEvent::new("ffmpeg-executor", …)` from `init()`.
+- `plugins/mkvtoolnix-executor/src/lib.rs:456` emits `ExecutorCapabilitiesEvent::new("mkvtoolnix-executor", …)` from `init()`.
+- `plugins/capability-collector` subscribes and provides a snapshot.
+- `plugins/policy-evaluator/src/evaluator.rs:1092` uses the snapshot to validate plans.
+- `plugins/ffmpeg-executor/src/lib.rs:176` — `can_handle_probed` checks `probed_codecs.encoders` against the target codec.
+
+**Action:** Close all three with cross-references to the evidence above.
+
+### #41 — daemon_mode parameter for bootstrap
+
+**Current state:** `crates/voom-cli/src/app.rs:268` — `job_queue` is registered as a resource only on the `job-manager`'s `PluginContext`, not on `ffprobe-introspector`. `plugins/ffprobe-introspector/src/` has no references to `job_queue`. The reported problem no longer exists.
+
+**Action:** Close with a pointer to `crates/voom-cli/src/app.rs:264-276`.
+
+### #44 — Tower layer ordering
+
+**Current state:** Issue text itself concludes "No code change needed". This is a stale documentation-only issue.
+
+**Action:** Close as resolved — the documentation lives in the issue itself.
+
+---
+
+## Small-to-medium implementation plans
+
+### #142 — Extend ContainerIncompatible safeguard to synthesized tracks
+
+**Scope:** ~40 lines + test.
+
+**Files:**
+
+- `plugins/policy-evaluator/src/evaluator.rs` — modify `apply_container_safeguard` (lines 300–379).
+- `plugins/policy-evaluator/tests/` — new test case (MKV → WebM + synthesize AAC → violation; MKV → WebM + synthesize Opus → no violation).
+
+**Plan:**
+
+1. After the existing loop over `file.tracks` (evaluator.rs:339–350), add a loop over `plan.actions` for `ActionParams::Synthesize { codec: Some(codec), .. }`.
+2. For each synthesized track, if `codec_supported(target, codec) == Some(false)`, push `(synthetic_idx, codec)` to `offenders`. Use a synthetic index (e.g., `u32::MAX - n` or an enum-tagged identifier) so it doesn't collide with real track indices in the error message.
+3. Skip when the synthesized action has `codec: None` (already-decoded upstream).
+4. Error message copy: change "leave incompatible codecs in {filename}: {details}" to handle "(synthesized)" decoration for synthetic tracks.
+5. Add unit tests covering both cases in the existing test module.
+
+**Validation:** `cargo test -p voom-policy-evaluator` + `cargo clippy --workspace`.
+
+---
+
+### #42 — Use `init_and_register` for capability-collector
+
+**Scope:** Small refactor — make ownership compatible.
+
+**Files:**
+
+- `crates/voom-kernel/src/lib.rs` — may need a new `init_and_register_with_handle()` or return the `Arc` from `init_and_register()`.
+- `crates/voom-cli/src/app.rs` (lines 220–238) — switch to the unified path.
+
+**Plan:**
+
+1. Add a new kernel method `init_and_register_shared<P>(plugin: P, priority, ctx) -> Result<Arc<P>>` that: constructs the `Arc`, calls `init()`, registers with a clone, dispatches init events, returns the `Arc<P>` for caller use.
+2. Migrate `capability-collector` in `app.rs:220-238` to use the new method and expose the `Arc<CapabilityCollectorPlugin>` via `BootstrapResult.collector`.
+3. Consider migrating `report` plugin (app.rs:286-299) and `sqlite-store` (app.rs:136) to the same pattern for consistency.
+4. Keep existing `init_and_register` for plugins that don't need a handle.
+
+**Risks:** Minor API churn — confined to kernel+bootstrap.
+
+**Validation:** `cargo test --workspace` + `cargo clippy --workspace`.
+
+---
+
+### #43 — StorageReporter sync-only contract
+
+**Scope:** Doc comments only (for now).
+
+**Files:**
+
+- `plugins/job-manager/src/progress.rs` — the `StorageReporter` type.
+
+**Plan:**
+
+1. Add a module-level or type-level doc comment stating: "`StorageReporter::on_job_progress` performs a blocking SQLite write. Must only be called from synchronous/rayon contexts. If used from an async context, wrap in `tokio::task::spawn_blocking`."
+2. Add `#[must_use]` where appropriate.
+3. No runtime change. Re-evaluate when daemon-mode job processing moves to tokio tasks (tracked separately via #4).
+
+**Validation:** `cargo doc --workspace --no-deps`.
+
+---
+
+### #47 — UNIX-compliant scripting output
+
+**Scope:** Add `--format={table,json,tsv,csv,plain}` to list commands.
+
+**Files:**
+
+- `crates/voom-cli/src/commands/db.rs` (list-bad), `files.rs`, `plans.rs`, `jobs.rs`, `events.rs`, `report.rs` — any command producing a table.
+- `crates/voom-cli/src/output.rs` (or new `crates/voom-cli/src/output/format.rs`) — shared formatter enum + writer.
+
+**Plan:**
+
+1. Add a shared `OutputFormat` enum (`Table`, `Json`, `Tsv`, `Csv`, `Plain`) with a `clap::ValueEnum` impl.
+2. Add a `--format` flag (default `Table`) to each list command. Consider a top-level `--format` mirrored via `clap`'s `global = true`.
+3. For each command, extract the current row assembly into a `Vec<Row>` where `Row` is command-specific, then render via the chosen format.
+4. TSV output should be one record per line, tab-separated, no header by default (or add `--header`).
+5. JSON output should serialize the command's existing domain types via `serde_json`.
+6. Add integration tests for each new format (`assert_cmd` + snapshot).
+
+**Validation:** `cargo test -p voom-cli` + functional tests.
+
+**Note:** Consider adopting `--quiet`/`--porcelain` flag conventions from `git` for consistency.
+
+---
+
+### #93 — Avoid re-hashing unchanged files
+
+**Scope:** Hash short-circuit based on (mtime, size).
+
+**Files:**
+
+- `plugins/discovery/src/scanner.rs` — hashing pipeline.
+- `plugins/sqlite-store` — lookup by path to fetch cached (mtime, size, hash).
+- `crates/voom-domain/src/storage.rs` — may need a `get_file_fingerprint(path) -> Option<(mtime, size, hash)>` helper.
+
+**Plan:**
+
+1. Add `StorageTrait::get_file_fingerprint(&self, path: &Path) -> Result<Option<FileFingerprint>>` where `FileFingerprint = { mtime_secs: i64, size: u64, content_hash: String }`.
+2. In `discovery/scanner.rs`, before hashing, call the fingerprint lookup. If `mtime == stored_mtime && size == stored_size`, reuse the stored hash — skip the read.
+3. Add a `--force-rescan` flag to invalidate the shortcut (the scan command already has one — plumb it through to discovery).
+4. Emit a stat (`files_rehashed`, `files_skipped_by_fingerprint`) visible in the scan summary.
+5. Tests: one for fingerprint match (no hash read), one for mtime change (re-hash), one for size change (re-hash), one for `--force-rescan` (always re-hash).
+
+**Risks:** mtime resolution differs across filesystems — acceptable since changes >1s will always bust.
+
+**Validation:** `cargo test -p voom-discovery -p voom-sqlite-store` + functional test timing.
+
+---
+
+### #28 — CSP drops `unpkg.com`; bundle htmx + Alpine
+
+**Scope:** Vendor external assets, update CSP.
+
+**Files:**
+
+- `plugins/web-server/src/templates/*.html` — remove `<script src="https://unpkg.com/...">` tags.
+- `plugins/web-server/static/vendor/` — add `htmx.min.js` and `alpine.min.js` (pinned versions).
+- `plugins/web-server/src/router.rs` or `middleware.rs` — CSP header: remove `unpkg.com` from `script-src`, drop to `'self'` only.
+- `plugins/web-server/build.rs` or a one-shot script — optional, to download+verify SHA256 on build.
+
+**Plan:**
+
+1. Download htmx 2.x and Alpine.js 3.x from their upstream GitHub releases, verify published SHA256, vendor as `plugins/web-server/static/vendor/htmx-<ver>.min.js` and `alpine-<ver>.min.js`.
+2. Update all templates to reference `/static/vendor/htmx.min.js` and `/static/vendor/alpine.min.js`.
+3. Update CSP in `middleware.rs` (search for `"unpkg.com"`): `script-src 'self'`.
+4. Add a comment near the vendored files documenting the version and upstream URL.
+5. Add a test: fetch the dashboard, assert the CSP header contains `script-src 'self'` and no `unpkg.com`.
+
+**Validation:** `cargo test -p voom-web-server` + manual browser check (no CSP violations, dashboard functional).
+
+---
+
+### #30 — Minimum entropy check on web auth token
+
+**Scope:** Startup warning only.
+
+**Files:**
+
+- `plugins/web-server/src/auth.rs` (or `config.rs`) — config validation step.
+
+**Plan:**
+
+1. Where `AuthConfig` is loaded, check `token.len() < 32` and emit `tracing::warn!` with the suggestion to use `openssl rand -base64 32`.
+2. Optionally also check for low-entropy patterns (all same char, digits-only) — cheap Shannon entropy approximation, warn if < 3 bits/byte.
+3. Test: construct config with short token, assert warning via `tracing-test`.
+
+**Validation:** `cargo test -p voom-web-server`.
+
+---
+
+### #31 — Per-IP rate limiting on web API
+
+**Scope:** Add `tower-governor` with a conservative default.
+
+**Files:**
+
+- `plugins/web-server/Cargo.toml` — add `tower_governor` dependency.
+- `plugins/web-server/src/router.rs` (or `middleware.rs`) — add the layer, before `ConcurrencyLimitLayer`.
+- `plugins/web-server/src/config.rs` — new `RateLimitConfig` (per-second, burst, enabled).
+
+**Plan:**
+
+1. Pick `tower-governor` v0.5+ (check current version at time of work).
+2. Default config: 30 rps per IP, burst 60, enabled by default but documented as LAN-tuned.
+3. Exempt `GET /static/*` (already served efficiently; excluding avoids page reload throttling).
+4. Over-limit returns 429 with `Retry-After`.
+5. Tests: 100 rapid requests from one IP → some get 429.
+
+**Validation:** `cargo test -p voom-web-server` (integration test via `axum-test`).
+
+---
+
+## New plugin proposals (design summaries)
+
+Each of these is a new plugin. Group together into "init-time events" sprint if capacity permits.
+
+### #33 — `policy-validator` plugin
+
+**Pattern:** Like `tool-detector`. At `init()`, load and validate the active `.voom` policy file, emit `PolicyLoaded` + zero-or-more `PolicyWarning` events. Plugins that currently re-parse the policy (phase-orchestrator, web-server dashboard) can subscribe instead.
+
+**Files to add:** `plugins/policy-validator/{Cargo.toml, src/lib.rs, tests/}`. Event variants `PolicyLoaded`, `PolicyWarning` in `voom-domain/src/events.rs`.
+
+**Downstream effort:** phase-orchestrator refactor to consume events rather than re-read the file.
+
+### #35 — `library-index` plugin
+
+**Pattern:** At `init()`, query `StorageTrait` for counts and emit `LibraryStatsReady`. Web dashboard subscribes for instant stats on first load.
+
+**Files to add:** `plugins/library-index/{Cargo.toml, src/lib.rs}`. Event variant `LibraryStatsReady`.
+
+**Dependency:** registration priority must come after `sqlite-store`.
+
+### #36 — `fs-watcher` plugin
+
+**Pattern:** Use `notify` crate. At `init()`, set up watchers on configured library roots, emit `WatchStarted` event. On FS changes, emit existing `FileDiscovered` — so the current pipeline needs no changes.
+
+**Files to add:** `plugins/fs-watcher/{Cargo.toml, src/lib.rs}`. Event variant `WatchStarted`.
+
+**Enables:** issue #4 (event-driven pipeline) without the polling design.
+
+### #37 — `notifier` plugin
+
+**Pattern:** Subscribes to configurable event types, forwards to Slack/webhook/desktop. At `init()`, validates channels and emits `NotificationChannelReady`.
+
+**Files to add:** `plugins/notifier/{Cargo.toml, src/lib.rs}`. Event variant `NotificationChannelReady`. Config at `~/.config/voom/plugins/notifier/config.toml`.
+
+**Covers:** part of #94 (*arr integration via webhooks).
+
+### #131 — Backup directory cleanup
+
+**Not strictly a new plugin** — this is a UX fix for `backup-manager`. Currently `find -name '*.voom-backup'` leaves clutter.
+
+**Plan:**
+
+1. On successful `finalize_backup`, if the backup dir is empty, remove it. Walk upward to remove empty parent backup dirs too, stopping at the library root.
+2. Add a `voom backup clean [--dry-run]` subcommand that:
+   - Scans for `.voom-backup` and `.vbak` files
+   - Shows sizes and counts
+   - Offers `--older-than <duration>` filtering
+3. Expose the cleanup via the web UI (Settings → Backups panel).
+4. Update the final-summary hint in `process.rs` to suggest the new subcommand, not a raw `find` pipe.
+
+**Files:** `plugins/backup-manager/src/lib.rs`, new `crates/voom-cli/src/commands/backup.rs`, plus web-server dashboard card.
+
+---
+
+## Sprint-sized / design issues (defer, do not implement here)
+
+### #4 — Event-driven pipeline under `serve`
+
+**Status:** Large multi-phase feature. Should be scoped as its own sprint.
+
+**Dependencies:** #33, #35, #36 (and arguably #37) should land first so the plugins exist. Then the `serve` command wires up a periodic scheduler and `POST /api/scan`.
+
+**Plan sketch (high level):**
+
+1. Add `ScanRequested` event variant.
+2. Introduce `ServeConfig { scan_interval, scan_paths, auto_process }` in `config.toml`.
+3. `serve` command spawns a tokio task that publishes `ScanRequested` on interval. Discovery plugin subscribes.
+4. `POST /api/scan` publishes the same event.
+5. SSE already broadcasts bus events → UI live updates work for free.
+6. Migrate `StorageReporter` use-sites in daemon paths to `spawn_blocking` (per #43).
+
+**Action:** Leave issue open. Create a scoped spec (`docs/sprints/sprint-13-event-pipeline.md`) before implementation.
+
+### #90 — Container release options
+
+**Status:** Ops/packaging track.
+
+**Plan:** Provide a `Dockerfile` that:
+
+1. Multi-stage build: `rust:1-bookworm` → build `voom` with `--release`, copy into `debian:stable-slim` with `ffmpeg`, `mkvtoolnix` installed.
+2. `EXPOSE 8080`, `ENTRYPOINT ["voom", "serve"]`.
+3. Volume mounts: `/data/config`, `/data/library`.
+4. Publish to `ghcr.io/<org>/voom:<version>` via GitHub Actions.
+5. Add a `docs/deployment/docker.md` with compose example.
+
+**Action:** Implement post-Sprint-13 once the serve command is production-ready.
+
+### #91 — Multi-host coordination
+
+**Status:** Large feature, low priority until local execution is polished.
+
+**Possible approaches to evaluate:** Raft-based coordinator, pull-based worker model with shared SQLite (low-hanging; same DB file over NFS), or gRPC agent protocol. Each has tradeoffs.
+
+**Action:** Keep open. Revisit after #4 (event-driven serve) lands.
+
+### #92 — Plugin stats
+
+**Status:** Design-level — needs shape decided before implementation.
+
+**Options:** (a) plugins own their data in `~/.config/voom/plugins/<name>/stats.db`; (b) extend `StorageTrait` with a generic `plugin_stats` table; (c) provide a stats-emission event type and let plugins self-report on an interval.
+
+**Recommendation:** (c) — aligns with the init-time event pattern. Add `PluginStatsReported` event + a dashboard widget.
+
+**Action:** Once #33/#35 land and the event pattern is solidified, convert this to a concrete plan.
+
+### #94 — *arr stack integration
+
+**Status:** Overlapping with #37 (notifier plugin).
+
+**Action:** After #37 ships, close #94 as subsumed, or refocus it on a specific *arr-facing plugin (Radarr/Sonarr custom-script receivers, not just webhook out).
+
+---
+
+## Proposed execution order
+
+Recommended work batches (each ~1 PR):
+
+1. **Close-outs** — post verification comments and close #27, #34, #38, #39, #40, #41, #44. (No code.)
+2. **Security trio** — #28, #30, #31. Small, independent, all touch `plugins/web-server`.
+3. **Scripting output** — #47. Self-contained, CLI-only.
+4. **Safeguard + refactor** — #42, #142. Both small, orthogonal.
+5. **Docs-only** — #43. Trivial.
+6. **Hash short-circuit** — #93. Discovery + storage. Moderate.
+7. **Backup cleanup UX** — #131. Moderate.
+8. **New plugins batch** — #33, #35, #36 together (same pattern).
+9. **Notifier** — #37 (enables closing #94).
+10. **Sprint 13** — #4 (event-driven serve), pulling in #43 async wrap.
+11. **Ops track** — #90.
+12. **Design tracks** — #91, #92 (await capacity).

--- a/plugins/discovery/Cargo.toml
+++ b/plugins/discovery/Cargo.toml
@@ -18,6 +18,7 @@ walkdir = { workspace = true }
 rayon = { workspace = true }
 xxhash-rust = { workspace = true }
 tracing = { workspace = true }
+chrono = { workspace = true }
 unicode-normalization = "0.1"
 
 [lints]

--- a/plugins/discovery/src/lib.rs
+++ b/plugins/discovery/src/lib.rs
@@ -8,6 +8,7 @@ pub use scanner::normalize_path;
 use voom_domain::capabilities::Capability;
 use voom_domain::errors::Result;
 use voom_domain::events::FileDiscoveredEvent;
+use voom_domain::media::StoredFingerprint;
 use voom_kernel::Plugin;
 
 /// Progress update during a scan.
@@ -24,12 +25,22 @@ pub enum ScanProgress {
         total: usize,
         path: std::path::PathBuf,
     },
+    /// A file's hash was reused from a cached fingerprint — no read took place.
+    HashReused { path: std::path::PathBuf },
     /// Orphaned voom temp files were found and skipped.
     OrphanedTempFiles { count: usize },
 }
 
 /// Callback for files that fail during discovery (path, size, error message).
 type ErrorCallback = Box<dyn Fn(std::path::PathBuf, u64, String) + Send + Sync>;
+
+/// Callback that looks up a previously-stored fingerprint for a given file path.
+///
+/// Returning `None` forces discovery to compute a fresh content hash. Returning
+/// `Some(fingerprint)` allows discovery to skip hashing if the file's size and
+/// mtime indicate it has not changed.
+pub type FingerprintLookup =
+    Box<dyn Fn(&std::path::Path) -> Option<StoredFingerprint> + Send + Sync>;
 
 /// Configuration for a discovery scan.
 #[non_exhaustive]
@@ -48,6 +59,12 @@ pub struct ScanOptions {
     /// (e.g., disappeared between walk and hash). Called with (path, size, `error_message`).
     /// Size is captured during the directory walk and may be stale if the file changed.
     pub on_error: Option<ErrorCallback>,
+    /// Optional fingerprint lookup. When set, discovery reuses the cached
+    /// `content_hash` for files whose on-disk `size` and `mtime` indicate no
+    /// change, avoiding a potentially expensive re-read.
+    ///
+    /// Has no effect when `hash_files` is `false`.
+    pub fingerprint_lookup: Option<FingerprintLookup>,
 }
 
 impl ScanOptions {
@@ -60,6 +77,7 @@ impl ScanOptions {
             workers: 0,
             on_progress: None,
             on_error: None,
+            fingerprint_lookup: None,
         }
     }
 }
@@ -73,6 +91,10 @@ impl std::fmt::Debug for ScanOptions {
             .field("workers", &self.workers)
             .field("on_progress", &self.on_progress.as_ref().map(|_| "..."))
             .field("on_error", &self.on_error.as_ref().map(|_| "..."))
+            .field(
+                "fingerprint_lookup",
+                &self.fingerprint_lookup.as_ref().map(|_| "..."),
+            )
             .finish()
     }
 }
@@ -235,6 +257,107 @@ mod tests {
         let plugin = DiscoveryPlugin::new();
         let result = plugin.scan(&opts);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_scan_reuses_cached_hash_when_fingerprint_matches() {
+        use chrono::Utc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+        use voom_domain::media::StoredFingerprint;
+
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("video.mkv");
+        std::fs::write(&file_path, b"fake mkv data").unwrap();
+
+        let canonical = normalize_path(&file_path);
+        let file_size = std::fs::metadata(&file_path).unwrap().len();
+        let cached_hash = "cached-hash-sentinel".to_string();
+
+        // Fingerprint "last seen" is in the future so the on-disk mtime is
+        // guaranteed to be earlier.
+        let stored = StoredFingerprint {
+            size: file_size,
+            content_hash: cached_hash.clone(),
+            last_seen: Utc::now() + chrono::Duration::hours(1),
+        };
+
+        let reused = Arc::new(AtomicUsize::new(0));
+        let reused_clone = reused.clone();
+
+        let mut opts = ScanOptions::new(dir.path());
+        let stored_clone = stored.clone();
+        let canonical_lookup = canonical.clone();
+        opts.fingerprint_lookup = Some(Box::new(move |p| {
+            if p == canonical_lookup {
+                Some(stored_clone.clone())
+            } else {
+                None
+            }
+        }));
+        opts.on_progress = Some(Box::new(move |p| {
+            if let ScanProgress::HashReused { .. } = p {
+                reused_clone.fetch_add(1, Ordering::Relaxed);
+            }
+        }));
+
+        let events = DiscoveryPlugin::new().scan(&opts).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0].content_hash.as_deref(),
+            Some(cached_hash.as_str())
+        );
+        assert_eq!(reused.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn test_scan_rehashes_when_size_differs() {
+        use chrono::Utc;
+        use voom_domain::media::StoredFingerprint;
+
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("video.mkv");
+        std::fs::write(&file_path, b"fake mkv data").unwrap();
+
+        let stored = StoredFingerprint {
+            size: 9_999_999, // deliberately wrong
+            content_hash: "stale-hash".to_string(),
+            last_seen: Utc::now() + chrono::Duration::hours(1),
+        };
+
+        let mut opts = ScanOptions::new(dir.path());
+        opts.fingerprint_lookup = Some(Box::new(move |_| Some(stored.clone())));
+
+        let events = DiscoveryPlugin::new().scan(&opts).unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(events[0].content_hash.is_some());
+        assert_ne!(events[0].content_hash.as_deref(), Some("stale-hash"));
+    }
+
+    #[test]
+    fn test_scan_rehashes_when_mtime_is_newer_than_last_seen() {
+        use chrono::Utc;
+        use voom_domain::media::StoredFingerprint;
+
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("video.mkv");
+        std::fs::write(&file_path, b"fake mkv data").unwrap();
+        let file_size = std::fs::metadata(&file_path).unwrap().len();
+
+        let stored = StoredFingerprint {
+            size: file_size,
+            content_hash: "stale-hash".to_string(),
+            // Mark the fingerprint as last seen far in the past so the
+            // on-disk mtime is considered newer.
+            last_seen: Utc::now() - chrono::Duration::days(365),
+        };
+
+        let mut opts = ScanOptions::new(dir.path());
+        opts.fingerprint_lookup = Some(Box::new(move |_| Some(stored.clone())));
+
+        let events = DiscoveryPlugin::new().scan(&opts).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_ne!(events[0].content_hash.as_deref(), Some("stale-hash"));
     }
 
     #[test]

--- a/plugins/discovery/src/lib.rs
+++ b/plugins/discovery/src/lib.rs
@@ -313,6 +313,8 @@ mod tests {
     #[test]
     fn test_scan_rehashes_when_size_differs() {
         use chrono::Utc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
         use voom_domain::media::StoredFingerprint;
 
         let dir = tempfile::tempdir().unwrap();
@@ -325,18 +327,33 @@ mod tests {
             last_seen: Utc::now() + chrono::Duration::hours(1),
         };
 
+        let reused = Arc::new(AtomicUsize::new(0));
+        let reused_clone = reused.clone();
+
         let mut opts = ScanOptions::new(dir.path());
         opts.fingerprint_lookup = Some(Box::new(move |_| Some(stored.clone())));
+        opts.on_progress = Some(Box::new(move |p| {
+            if let ScanProgress::HashReused { .. } = p {
+                reused_clone.fetch_add(1, Ordering::Relaxed);
+            }
+        }));
 
         let events = DiscoveryPlugin::new().scan(&opts).unwrap();
         assert_eq!(events.len(), 1);
         assert!(events[0].content_hash.is_some());
         assert_ne!(events[0].content_hash.as_deref(), Some("stale-hash"));
+        assert_eq!(
+            reused.load(Ordering::Relaxed),
+            0,
+            "HashReused must not fire when size differs"
+        );
     }
 
     #[test]
     fn test_scan_rehashes_when_mtime_is_newer_than_last_seen() {
         use chrono::Utc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
         use voom_domain::media::StoredFingerprint;
 
         let dir = tempfile::tempdir().unwrap();
@@ -347,17 +364,28 @@ mod tests {
         let stored = StoredFingerprint {
             size: file_size,
             content_hash: "stale-hash".to_string(),
-            // Mark the fingerprint as last seen far in the past so the
-            // on-disk mtime is considered newer.
             last_seen: Utc::now() - chrono::Duration::days(365),
         };
 
+        let reused = Arc::new(AtomicUsize::new(0));
+        let reused_clone = reused.clone();
+
         let mut opts = ScanOptions::new(dir.path());
         opts.fingerprint_lookup = Some(Box::new(move |_| Some(stored.clone())));
+        opts.on_progress = Some(Box::new(move |p| {
+            if let ScanProgress::HashReused { .. } = p {
+                reused_clone.fetch_add(1, Ordering::Relaxed);
+            }
+        }));
 
         let events = DiscoveryPlugin::new().scan(&opts).unwrap();
         assert_eq!(events.len(), 1);
         assert_ne!(events[0].content_hash.as_deref(), Some("stale-hash"));
+        assert_eq!(
+            reused.load(Ordering::Relaxed),
+            0,
+            "HashReused must not fire when mtime is newer than last_seen"
+        );
     }
 
     #[test]

--- a/plugins/discovery/src/scanner.rs
+++ b/plugins/discovery/src/scanner.rs
@@ -355,10 +355,10 @@ fn reuse_cached_hash(
     let metadata = match fs::metadata(path) {
         Ok(m) => m,
         Err(e) => {
-            tracing::debug!(
+            tracing::warn!(
                 path = %path.display(),
                 error = %e,
-                "fingerprint reuse aborted: fs::metadata failed"
+                "fingerprint reuse aborted: fs::metadata failed; check file permissions"
             );
             return None;
         }

--- a/plugins/discovery/src/scanner.rs
+++ b/plugins/discovery/src/scanner.rs
@@ -352,8 +352,28 @@ fn reuse_cached_hash(
     if stored.size != walk_size {
         return None;
     }
-    let metadata = fs::metadata(path).ok()?;
-    let mtime = metadata.modified().ok()?;
+    let metadata = match fs::metadata(path) {
+        Ok(m) => m,
+        Err(e) => {
+            tracing::debug!(
+                path = %path.display(),
+                error = %e,
+                "fingerprint reuse aborted: fs::metadata failed"
+            );
+            return None;
+        }
+    };
+    let mtime = match metadata.modified() {
+        Ok(m) => m,
+        Err(e) => {
+            tracing::debug!(
+                path = %path.display(),
+                error = %e,
+                "fingerprint reuse aborted: mtime unavailable on this filesystem"
+            );
+            return None;
+        }
+    };
     let mtime_utc: chrono::DateTime<chrono::Utc> = mtime.into();
     if mtime_utc > stored.last_seen {
         return None;

--- a/plugins/discovery/src/scanner.rs
+++ b/plugins/discovery/src/scanner.rs
@@ -248,7 +248,13 @@ pub fn scan_directory(options: &ScanOptions) -> Result<Vec<FileDiscoveredEvent>>
     // concurrent open file descriptors during hashing.
     let process_file = |(path, walk_size): &(PathBuf, u64)| {
         let _guard = fd_sem.guard();
-        let result = build_event(path, *walk_size, options.hash_files);
+        let result = build_event(
+            path,
+            *walk_size,
+            options.hash_files,
+            options.fingerprint_lookup.as_deref(),
+            options.on_progress.as_deref(),
+        );
         let current = processed.fetch_add(1, Ordering::Relaxed) + 1;
         if let Some(ref cb) = options.on_progress {
             cb(crate::ScanProgress::Processing {
@@ -291,13 +297,36 @@ pub fn scan_directory(options: &ScanOptions) -> Result<Vec<FileDiscoveredEvent>>
     Ok(discovered)
 }
 
+type FingerprintLookupRef<'a> =
+    &'a (dyn Fn(&Path) -> Option<voom_domain::media::StoredFingerprint> + Send + Sync);
+type ProgressCallbackRef<'a> = &'a (dyn Fn(crate::ScanProgress) + Send + Sync);
+
 /// Build a `FileDiscoveredEvent` for a single file.
 ///
 /// `walk_size` is the file size captured during the directory walk. It avoids
 /// a redundant `stat` call — `hash_file` will detect a missing file on its own.
-fn build_event(path: &Path, walk_size: u64, compute_hash: bool) -> Result<FileDiscoveredEvent> {
+///
+/// When `fingerprint_lookup` returns a cached fingerprint and the on-disk
+/// `size`/`mtime` indicate the file has not changed, the cached `content_hash`
+/// is reused instead of re-reading the file.
+fn build_event(
+    path: &Path,
+    walk_size: u64,
+    compute_hash: bool,
+    fingerprint_lookup: Option<FingerprintLookupRef<'_>>,
+    on_progress: Option<ProgressCallbackRef<'_>>,
+) -> Result<FileDiscoveredEvent> {
     let content_hash = if compute_hash {
-        Some(hash_file(path)?)
+        if let Some(cached) = reuse_cached_hash(path, walk_size, fingerprint_lookup) {
+            if let Some(cb) = on_progress {
+                cb(crate::ScanProgress::HashReused {
+                    path: path.to_path_buf(),
+                });
+            }
+            Some(cached)
+        } else {
+            Some(hash_file(path)?)
+        }
     } else {
         None
     };
@@ -309,6 +338,27 @@ fn build_event(path: &Path, walk_size: u64, compute_hash: bool) -> Result<FileDi
         walk_size,
         content_hash,
     ))
+}
+
+/// Return the cached content hash if the file on disk matches the stored
+/// fingerprint's `size` and its `mtime` is no newer than `last_seen`.
+fn reuse_cached_hash(
+    path: &Path,
+    walk_size: u64,
+    fingerprint_lookup: Option<FingerprintLookupRef<'_>>,
+) -> Option<String> {
+    let lookup = fingerprint_lookup?;
+    let stored = lookup(path)?;
+    if stored.size != walk_size {
+        return None;
+    }
+    let metadata = fs::metadata(path).ok()?;
+    let mtime = metadata.modified().ok()?;
+    let mtime_utc: chrono::DateTime<chrono::Utc> = mtime.into();
+    if mtime_utc > stored.last_seen {
+        return None;
+    }
+    Some(stored.content_hash)
 }
 
 #[cfg(test)]
@@ -406,7 +456,7 @@ mod tests {
         let path = dir.path().join("test.mkv");
         std::fs::write(&path, b"fake video data").unwrap();
 
-        let event = build_event(&path, 15, true).unwrap();
+        let event = build_event(&path, 15, true, None, None).unwrap();
         assert_eq!(event.path, path);
         assert_eq!(event.size, 15);
         assert!(event.content_hash.is_some());
@@ -432,6 +482,7 @@ mod tests {
             workers: 0,
             on_progress: None,
             on_error: None,
+            fingerprint_lookup: None,
         };
         let events = scan_directory(&options).unwrap();
         // Should only find the file under "real/", not under "link/"
@@ -447,7 +498,7 @@ mod tests {
         let path = dir.path().join("test.mkv");
         std::fs::write(&path, b"fake video data").unwrap();
 
-        let event = build_event(&path, 15, false).unwrap();
+        let event = build_event(&path, 15, false, None, None).unwrap();
         assert!(event.content_hash.is_none());
     }
 

--- a/plugins/policy-evaluator/src/evaluator.rs
+++ b/plugins/policy-evaluator/src/evaluator.rs
@@ -350,10 +350,8 @@ fn apply_container_safeguard(plan: &mut Plan, file: &MediaFile, filename: &str) 
         }
     }
 
-    // Synthesized tracks are new tracks added by the policy and do not exist
-    // in `file.tracks`, so check them separately against the target container.
-    // Entries with no codec (`None`) are skipped — this happens when the
-    // synthesize operation inherits the codec from a downstream action.
+    // `codec: None` means the synthesize operation inherits codec from a
+    // downstream action — skip because there is no codec to check.
     for action in &plan.actions {
         if action.operation != OperationType::SynthesizeAudio {
             continue;

--- a/plugins/policy-evaluator/src/evaluator.rs
+++ b/plugins/policy-evaluator/src/evaluator.rs
@@ -295,8 +295,9 @@ fn apply_safeguards(plan: &mut Plan, file: &MediaFile) {
 
 /// Post-evaluation safeguard: verify that a planned container conversion
 /// can actually hold the codecs of the surviving tracks (taking any planned
-/// transcodes into account). If not, retract the `ConvertContainer` action
-/// and record a violation so the file stays in its original container.
+/// transcodes and synthesized tracks into account). If not, retract the
+/// `ConvertContainer` action and record a violation so the file stays in its
+/// original container.
 fn apply_container_safeguard(plan: &mut Plan, file: &MediaFile, filename: &str) {
     // Find the target container from a ConvertContainer action, if any.
     let Some(target) = plan.actions.iter().find_map(|a| {
@@ -335,7 +336,7 @@ fn apply_container_safeguard(plan: &mut Plan, file: &MediaFile, filename: &str) 
         }
     }
 
-    let mut offenders: Vec<(u32, String)> = Vec::new();
+    let mut offenders: Vec<String> = Vec::new();
     for track in &file.tracks {
         if removed.contains(&track.index) {
             continue;
@@ -345,7 +346,28 @@ fn apply_container_safeguard(plan: &mut Plan, file: &MediaFile, filename: &str) 
             .cloned()
             .unwrap_or_else(|| track.codec.clone());
         if let Some(false) = codec_supported(target, &effective_codec) {
-            offenders.push((track.index, effective_codec));
+            offenders.push(format!("track {} ({effective_codec})", track.index));
+        }
+    }
+
+    // Synthesized tracks are new tracks added by the policy and do not exist
+    // in `file.tracks`, so check them separately against the target container.
+    // Entries with no codec (`None`) are skipped — this happens when the
+    // synthesize operation inherits the codec from a downstream action.
+    for action in &plan.actions {
+        if action.operation != OperationType::SynthesizeAudio {
+            continue;
+        }
+        let ActionParams::Synthesize {
+            codec: Some(codec),
+            name,
+            ..
+        } = &action.parameters
+        else {
+            continue;
+        };
+        if let Some(false) = codec_supported(target, codec) {
+            offenders.push(format!("synthesized {name} ({codec})"));
         }
     }
 
@@ -360,7 +382,7 @@ fn apply_container_safeguard(plan: &mut Plan, file: &MediaFile, filename: &str) 
     let details = offenders
         .iter()
         .take(4)
-        .map(|(idx, codec)| format!("track {idx} ({codec})"))
+        .cloned()
         .collect::<Vec<_>>()
         .join(", ");
     let suffix = if offenders.len() > 4 {
@@ -2161,6 +2183,88 @@ mod tests {
                 .iter()
                 .any(|a| a.operation == OperationType::ConvertContainer),
             "ConvertContainer should remain — dts is transcoded to aac"
+        );
+        assert!(plan
+            .safeguard_violations
+            .iter()
+            .all(|v| v.kind != SafeguardKind::ContainerIncompatible));
+    }
+
+    #[test]
+    fn test_container_safeguard_blocks_webm_with_synthesized_aac() {
+        // MKV with vp9 + opus → policy converts to WebM AND synthesizes an
+        // AAC track. AAC is not WebM-compatible, so the conversion must be
+        // retracted and a violation recorded.
+        let file = container_test_file(
+            Container::Mkv,
+            vec![
+                Track::new(0, TrackType::Video, "vp9".into()),
+                Track::new(1, TrackType::AudioMain, "opus".into()),
+            ],
+        );
+        let policy = test_policy(
+            r#"policy "p" {
+                phase init {
+                    container webm
+                    synthesize "Stereo AAC" {
+                        codec: aac
+                        channels: stereo
+                    }
+                }
+            }"#,
+        );
+        let result = evaluate(&policy, &file);
+        let plan = &result.plans[0];
+
+        assert!(
+            !plan
+                .actions
+                .iter()
+                .any(|a| a.operation == OperationType::ConvertContainer),
+            "ConvertContainer should be retracted — synthesized AAC is not WebM-compatible"
+        );
+        let violation = plan
+            .safeguard_violations
+            .iter()
+            .find(|v| v.kind == SafeguardKind::ContainerIncompatible)
+            .expect("expected ContainerIncompatible violation");
+        assert!(
+            violation.message.contains("synthesized"),
+            "violation message should call out the synthesized track: {}",
+            violation.message
+        );
+    }
+
+    #[test]
+    fn test_container_safeguard_allows_webm_with_synthesized_opus() {
+        // MKV with vp9 + opus → policy converts to WebM AND synthesizes an
+        // Opus track. Opus is WebM-compatible, so no violation.
+        let file = container_test_file(
+            Container::Mkv,
+            vec![
+                Track::new(0, TrackType::Video, "vp9".into()),
+                Track::new(1, TrackType::AudioMain, "opus".into()),
+            ],
+        );
+        let policy = test_policy(
+            r#"policy "p" {
+                phase init {
+                    container webm
+                    synthesize "Stereo Opus" {
+                        codec: opus
+                        channels: stereo
+                    }
+                }
+            }"#,
+        );
+        let result = evaluate(&policy, &file);
+        let plan = &result.plans[0];
+
+        assert!(
+            plan.actions
+                .iter()
+                .any(|a| a.operation == OperationType::ConvertContainer),
+            "ConvertContainer should remain — synthesized Opus is WebM-compatible"
         );
         assert!(plan
             .safeguard_violations

--- a/plugins/sqlite-store/src/store/file_storage.rs
+++ b/plugins/sqlite-store/src/store/file_storage.rs
@@ -182,8 +182,11 @@ impl FileStorage for SqliteStore {
         let Some((size, content_hash, introspected_at)) = row else {
             return Ok(None);
         };
-        let Some(content_hash) = content_hash else {
-            return Ok(None);
+        // `upsert_file` writes an empty string when the caller has no hash,
+        // so treat empty as equivalent to NULL.
+        let content_hash = match content_hash {
+            Some(h) if !h.is_empty() => h,
+            _ => return Ok(None),
         };
         let last_seen = parse_datetime(&introspected_at)?;
         let size =

--- a/plugins/sqlite-store/src/store/file_storage.rs
+++ b/plugins/sqlite-store/src/store/file_storage.rs
@@ -6,13 +6,13 @@ use rusqlite::params;
 use uuid::Uuid;
 
 use voom_domain::errors::Result;
-use voom_domain::media::MediaFile;
+use voom_domain::media::{MediaFile, StoredFingerprint};
 use voom_domain::storage::{FileFilters, FileStorage};
 use voom_domain::transition::{DiscoveredFile, FileTransition, ReconcileResult, TransitionSource};
 
 use super::{
-    escape_like, format_datetime, other_storage_err, row_to_file, storage_err, FileRow,
-    OptionalExt, SqlQuery, SqliteStore,
+    escape_like, format_datetime, other_storage_err, parse_datetime, row_to_file, storage_err,
+    FileRow, OptionalExt, SqlQuery, SqliteStore,
 };
 
 impl FileStorage for SqliteStore {
@@ -166,6 +166,33 @@ impl FileStorage for SqliteStore {
             }
             None => Ok(None),
         }
+    }
+
+    fn file_fingerprint_by_path(&self, path: &Path) -> Result<Option<StoredFingerprint>> {
+        let conn = self.conn()?;
+        let path_str = path.to_string_lossy().to_string();
+        let row: Option<(i64, Option<String>, String)> = conn
+            .query_row(
+                "SELECT size, content_hash, introspected_at FROM files WHERE path = ?1",
+                params![path_str],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .optional()
+            .map_err(storage_err("failed to get file fingerprint by path"))?;
+        let Some((size, content_hash, introspected_at)) = row else {
+            return Ok(None);
+        };
+        let Some(content_hash) = content_hash else {
+            return Ok(None);
+        };
+        let last_seen = parse_datetime(&introspected_at)?;
+        let size =
+            u64::try_from(size).map_err(other_storage_err("file size does not fit in u64"))?;
+        Ok(Some(StoredFingerprint {
+            size,
+            content_hash,
+            last_seen,
+        }))
     }
 
     fn list_files(&self, filters: &FileFilters) -> Result<Vec<MediaFile>> {


### PR DESCRIPTION
## Summary

Triage of 25 open GitHub issues, closing 16 in the process. Fixes 4 with code changes (#42, #93, #131, #142) and verifies 12 already-resolved ones (#27, #28, #30, #31, #34, #38, #39, #40, #41, #43, #44, #47). Nine design-level issues remain open.

## Changes

### Planning

- `docs/plans/issue-triage-2026-04-18.md` — per-issue relevance triage + implementation plans for the still-relevant subset.

### #142 — policy-evaluator: synthesized track safeguard

- `plugins/policy-evaluator/src/evaluator.rs` — `apply_container_safeguard` now also walks `plan.actions` for `SynthesizeAudio` entries and checks each synthesized codec against the target container matrix. Violation message labels synthesized tracks as `synthesized <name> (<codec>)`.

### #42 — kernel: typed Arc registration path

- `crates/voom-kernel/src/lib.rs` — new `Kernel::init_and_register_shared<P: Plugin + 'static>(plugin, priority, ctx) -> Result<Arc<P>>`. Both init paths share a private `finish_registration` tail.
- `crates/voom-cli/src/app.rs` — `capability-collector` bootstrap migrated to the new unified path.

### #93 + #131 — discovery: fingerprint short-circuit + backup hint

- `crates/voom-domain/src/media.rs` — new `StoredFingerprint { size, content_hash, last_seen }`.
- `crates/voom-domain/src/storage.rs` — new `StorageTrait::file_fingerprint_by_path` with default impl.
- `plugins/sqlite-store/src/store/file_storage.rs` — narrow override (single-statement query, no tracks join) that also treats empty-string `content_hash` as absent.
- `plugins/discovery/src/{lib,scanner}.rs` — `ScanOptions::fingerprint_lookup` field + new `ScanProgress::HashReused` variant; `build_event` short-circuits hashing when `size` matches and `mtime <= last_seen`.
- `crates/voom-cli/src/introspect.rs` — `fingerprint_lookup()` helper backed by the store; storage errors log at `warn!` before falling back to rehashing.
- `crates/voom-cli/src/commands/{scan.rs, process/mod.rs}` — wire the lookup into every scan.
- `crates/voom-cli/src/commands/process/mod.rs` — post-process backup hint points at `voom backup list` / `voom backup cleanup` instead of a raw `find` pipe (#131). `backup-manager` already removes empty `.voom-backup` directories on success.

## Testing

- 3 new policy-evaluator unit tests covering synthesized-AAC-rejected and synthesized-Opus-accepted cases on WebM conversions.
- 3 new discovery unit tests covering fingerprint match / size mismatch / mtime mismatch (with explicit `HashReused == 0` assertions on negative paths).
- 3 new kernel tests: `init_and_register_shared` returns typed handle + calls init; rejects duplicate registration; shutdown fires during kernel drop even when a typed `Arc<P>` outlives it.
- Full workspace green: `cargo test --workspace` (500 tests across 56 binaries), `cargo test -p voom-cli --features functional`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check`.

## Notes

- Branch targets `desloppify/code-health` since that is where the work was based. Rebase onto `main` can happen when `desloppify/code-health` itself lands.
- Two rounds of review agent passes ran against this branch:
  - First round: three generic reviewers (reuse, quality, efficiency). Surfaced a redundant `file_by_path` call in the fingerprint lookup path — fixed by adding the narrow `file_fingerprint_by_path` trait method that skips the tracks join.
  - Second round: five VOOM-specific reviewers (concurrency, data-flow, error-handling, plugin-contract, security). Found and fixed: empty-string hash sentinel bypassing the NULL guard; silent storage errors in the lookup closure; `fs::metadata` permission errors being hidden at `debug!` level; misleading kernel error message; missing shutdown test for the typed-Arc lifetime.
- Nine issues remain open and are all design-level / sprint-sized work: #4, #33, #35, #36, #37, #90, #91, #92, #94. The triage doc explains why each is deferred.
- The r2d2 pool timeout is still the library default (30s). The concurrency reviewer flagged this as "medium" — it would let a pool-exhaustion burst stall worker threads before falling back to rehashing — but lowering it globally has broader impact than this branch's scope. The new `warn!` logging from `fingerprint_lookup` gives the missing visibility.
