### PR TITLE
fix(cli): preserve file lineage across container conversion (#148)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2432,9 +2432,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2725,7 +2725,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/crates/voom-cli/src/commands/process/mod.rs
+++ b/crates/voom-cli/src/commands/process/mod.rs
@@ -1310,6 +1310,86 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn handle_plan_success_preserves_lineage_on_container_conversion() {
+        use voom_domain::media::{Container, MediaFile};
+        use voom_domain::plan::{ActionParams, OperationType, Plan, PlannedAction};
+
+        let dir = tempfile::tempdir().unwrap();
+        let mp4_path = dir.path().join("movie.mp4");
+        let mkv_path = dir.path().join("movie.mkv");
+        // The executor renames source-to-target; pre-write the target so
+        // `resolve_post_execution_path` accepts the new extension.
+        std::fs::write(&mkv_path, vec![0u8; 1024]).unwrap();
+
+        let mut file = MediaFile::new(mp4_path);
+        file.container = Container::Mp4;
+        file.size = 1024;
+        file.content_hash = Some("oldhash".to_string());
+        let original_id = file.id;
+
+        let mut plan = Plan::new(file.clone(), "containerize", "convert");
+        plan.actions = vec![PlannedAction::file_op(
+            OperationType::ConvertContainer,
+            ActionParams::Container {
+                container: Container::Mkv,
+            },
+            "Convert to mkv",
+        )];
+
+        let store: Arc<dyn voom_domain::storage::StorageTrait> =
+            Arc::new(voom_sqlite_store::store::SqliteStore::in_memory().unwrap());
+        store.upsert_file(&file).unwrap();
+        assert_eq!(store.count_files(&Default::default()).unwrap(), 1);
+
+        let kernel = Arc::new(voom_kernel::Kernel::new());
+        let capabilities = voom_domain::CapabilityMap::new();
+        let counters = RunCounters::new();
+        let token = CancellationToken::new();
+        let resolver = PolicyResolver::from_single(
+            voom_dsl::compile_policy(r#"policy "test" { phase convert { container mkv } }"#)
+                .unwrap(),
+            dir.path(),
+        );
+        let ctx = ProcessContext {
+            resolver: &resolver,
+            kernel,
+            store: store.clone(),
+            dry_run: false,
+            plan_only: false,
+            flag_size_increase: false,
+            flag_duration_shrink: false,
+            token: &token,
+            ffprobe_path: None,
+            capabilities: &capabilities,
+            counters: &counters,
+        };
+
+        let _ =
+            pipeline::handle_plan_success(plan, &file, "mkvtoolnix-executor", 0, false, &ctx).await;
+
+        assert_eq!(
+            store.count_files(&Default::default()).unwrap(),
+            1,
+            "ConvertContainer must not introduce a duplicate files row"
+        );
+        let surviving = store
+            .file_by_path(&mkv_path)
+            .unwrap()
+            .expect("row must follow the file to its post-conversion path");
+        assert_eq!(
+            surviving.id, original_id,
+            "lineage UUID must be preserved across container conversion"
+        );
+        assert!(
+            store
+                .file_by_path(&dir.path().join("movie.mp4"))
+                .unwrap()
+                .is_none(),
+            "the original .mp4 path must no longer resolve to a row",
+        );
+    }
+
     #[test]
     fn test_check_size_increase_dispatches_plan_failed_without_plan_created() {
         // Write a file with 2048 bytes so the size-increase check fires

--- a/crates/voom-cli/src/commands/process/pipeline.rs
+++ b/crates/voom-cli/src/commands/process/pipeline.rs
@@ -397,7 +397,7 @@ fn dispatch_plan_failure(failed: PlanFailedEvent, phase_name: &str, ctx: &Proces
 
 /// Handle a successfully executed plan: dispatch completion, re-introspect,
 /// and record the file transition.
-async fn handle_plan_success(
+pub(super) async fn handle_plan_success(
     plan: voom_domain::plan::Plan,
     file: &voom_domain::media::MediaFile,
     executor: &str,
@@ -434,7 +434,22 @@ async fn handle_plan_success(
     let policy_name = plan.policy_name.clone();
     let phase_name = plan.phase_name.clone();
 
-    let new_file = reintrospect_file(file, &[plan], ctx).await;
+    // Update the existing row's path before re-introspection so the
+    // `FileIntrospected` upsert merges into it instead of inserting a new
+    // row at the post-execution path (preserves UUID and lineage).
+    let post_exec_path = resolve_post_execution_path(file, std::slice::from_ref(&plan));
+    if post_exec_path != file.path {
+        if let Err(e) = ctx.store.rename_file_path(&file.id, &post_exec_path) {
+            tracing::warn!(
+                error = %e,
+                old_path = %file.path.display(),
+                new_path = %post_exec_path.display(),
+                "failed to update files.path after path-changing execution"
+            );
+        }
+    }
+
+    let new_file = reintrospect_file(file, post_exec_path, ctx).await;
 
     record_file_transition(&FileTransitionContext {
         old_file: file,
@@ -497,10 +512,9 @@ async fn check_file_hash(file: &voom_domain::media::MediaFile) -> Option<serde_j
 /// `MediaFile` with the current on-disk path, tracks, and metadata.
 async fn reintrospect_file(
     file: &voom_domain::media::MediaFile,
-    plans: &[voom_domain::plan::Plan],
+    current_path: std::path::PathBuf,
     ctx: &ProcessContext<'_>,
 ) -> voom_domain::media::MediaFile {
-    let current_path = resolve_post_execution_path(file, plans);
     if !current_path.exists() {
         tracing::warn!(
             path = %current_path.display(),

--- a/crates/voom-domain/src/storage.rs
+++ b/crates/voom-domain/src/storage.rs
@@ -75,6 +75,14 @@ pub trait FileStorage: Send + Sync {
     fn mark_missing(&self, id: &Uuid) -> Result<()>;
     /// Restore a missing file to active status, updating its path.
     fn reactivate_file(&self, id: &Uuid, new_path: &Path) -> Result<()>;
+    /// Update the path (and derived filename) of an existing file row,
+    /// identified by `id`. After this call, [`Self::file_by_path`] using
+    /// `new_path` must return the same row.
+    ///
+    /// Leaves `status`, `content_hash`, and `expected_hash` untouched;
+    /// callers that also need to refresh content metadata should follow
+    /// up with [`Self::upsert_file`].
+    fn rename_file_path(&self, id: &Uuid, new_path: &Path) -> Result<()>;
     /// Permanently delete all files with Missing status older than `older_than`.
     /// Returns the number of rows purged.
     fn purge_missing(&self, older_than: DateTime<Utc>) -> Result<u64>;

--- a/crates/voom-domain/src/test_support.rs
+++ b/crates/voom-domain/src/test_support.rs
@@ -203,6 +203,14 @@ impl FileStorage for InMemoryStore {
         Ok(())
     }
 
+    fn rename_file_path(&self, id: &Uuid, new_path: &Path) -> Result<()> {
+        let mut files = self.files.lock();
+        if let Some(file) = files.get_mut(id) {
+            file.path = new_path.to_path_buf();
+        }
+        Ok(())
+    }
+
     fn purge_missing(&self, _older_than: chrono::DateTime<chrono::Utc>) -> Result<u64> {
         let mut files = self.files.lock();
         let before = files.len();

--- a/plugins/sqlite-store/src/store/file_storage.rs
+++ b/plugins/sqlite-store/src/store/file_storage.rs
@@ -324,6 +324,22 @@ impl FileStorage for SqliteStore {
         Ok(())
     }
 
+    fn rename_file_path(&self, id: &Uuid, new_path: &Path) -> Result<()> {
+        let conn = self.conn()?;
+        let now = format_datetime(&Utc::now());
+        let path_str = new_path.to_string_lossy().to_string();
+        let filename = new_path
+            .file_name()
+            .map(|f| f.to_string_lossy().to_string())
+            .unwrap_or_default();
+        conn.execute(
+            "UPDATE files SET path = ?1, filename = ?2, updated_at = ?3 WHERE id = ?4",
+            params![path_str, filename, now, id.to_string()],
+        )
+        .map_err(storage_err("failed to rename file path"))?;
+        Ok(())
+    }
+
     fn purge_missing(&self, older_than: DateTime<Utc>) -> Result<u64> {
         let conn = self.conn()?;
         let cutoff = format_datetime(&older_than);
@@ -1081,6 +1097,94 @@ mod tests {
 
         let no_pred = store.predecessor_id_of(&old_file.id).unwrap();
         assert!(no_pred.is_none());
+    }
+
+    #[test]
+    fn rename_file_path_preserves_id_and_data() {
+        let store = test_store();
+        let file = active_file("/media/movie.mp4");
+        store.upsert_file(&file).unwrap();
+
+        let stored_before = store
+            .file_by_path(Path::new("/media/movie.mp4"))
+            .unwrap()
+            .unwrap();
+        let original_id = stored_before.id;
+
+        store
+            .rename_file_path(&original_id, Path::new("/media/movie.mkv"))
+            .unwrap();
+
+        // Old path no longer maps to a row
+        assert!(store
+            .file_by_path(Path::new("/media/movie.mp4"))
+            .unwrap()
+            .is_none());
+
+        // New path maps to the same row (same id, same hash, status untouched)
+        let stored_after = store
+            .file_by_path(Path::new("/media/movie.mkv"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(stored_after.id, original_id);
+        assert_eq!(stored_after.content_hash.as_deref(), Some("abc123"));
+        assert_eq!(stored_after.status, FileStatus::Active);
+
+        // Filename was derived from the new path
+        let conn = store.conn().unwrap();
+        let filename: String = conn
+            .query_row(
+                "SELECT filename FROM files WHERE id = ?1",
+                rusqlite::params![original_id.to_string()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(filename, "movie.mkv");
+    }
+
+    #[test]
+    fn rename_then_upsert_updates_existing_row_in_place() {
+        // Simulates the ConvertContainer flow: existing mp4 row is renamed
+        // to the .mkv path, then re-introspection upserts a freshly-introspected
+        // MediaFile with a NEW UUID at that path. The path-based ON CONFLICT
+        // must merge into the existing row rather than insert a duplicate.
+        let store = test_store();
+        let original = active_file("/media/movie.mp4");
+        store.upsert_file(&original).unwrap();
+        let original_id = store
+            .file_by_path(Path::new("/media/movie.mp4"))
+            .unwrap()
+            .unwrap()
+            .id;
+
+        store
+            .rename_file_path(&original_id, Path::new("/media/movie.mkv"))
+            .unwrap();
+
+        // Simulated re-introspection: brand-new MediaFile (new UUID) at the new path.
+        let mut reintrospected = MediaFile::new(PathBuf::from("/media/movie.mkv"));
+        reintrospected.content_hash = Some("def456".to_string());
+        reintrospected.container = voom_domain::media::Container::Mkv;
+        assert_ne!(reintrospected.id, original_id, "test setup: new uuid");
+
+        store.upsert_file(&reintrospected).unwrap();
+
+        // Exactly one row, surviving id is the original, content reflects the upsert.
+        let count = store
+            .count_files(&voom_domain::storage::FileFilters::default())
+            .unwrap();
+        assert_eq!(count, 1, "rename + upsert must not duplicate the row");
+
+        let surviving = store
+            .file_by_path(Path::new("/media/movie.mkv"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            surviving.id, original_id,
+            "lineage must be preserved via path-based upsert merge"
+        );
+        assert_eq!(surviving.content_hash.as_deref(), Some("def456"));
+        assert_eq!(surviving.container, voom_domain::media::Container::Mkv);
     }
 
     #[test]


### PR DESCRIPTION
Closes #148.

## Summary

- `ConvertContainer` (mp4 → mkv) left the original `files` row at the now-stale `.mp4` path while inserting a new row at the `.mkv` path with a fresh UUID, breaking lineage and inflating container counts until `voom db prune` ran.
- Added `FileStorage::rename_file_path(id, new_path)`. `handle_plan_success` calls it before re-introspection so the post-execution `FileIntrospected` upsert merges into the existing row instead of inserting a duplicate.
- Refactored `reintrospect_file` to take the resolved post-execution path directly (avoids recomputing it twice on the success path).

Files: `crates/voom-domain/src/storage.rs`, `crates/voom-domain/src/test_support.rs`, `plugins/sqlite-store/src/store/file_storage.rs`, `crates/voom-cli/src/commands/process.rs`.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test` (1570 tests, 0 failures)
- [x] `cargo test -p voom-cli --features functional -- --test-threads=4` (491 tests, 0 failures)
- [x] New unit tests:
  - `rename_file_path_preserves_id_and_data` (sqlite-store)
  - `rename_then_upsert_updates_existing_row_in_place` (sqlite-store) — exercises the path-based upsert merge that the fix relies on
  - `handle_plan_success_preserves_lineage_on_container_conversion` (voom-cli) — end-to-end regression test against `SqliteStore::in_memory()`
- [ ] Manual reproduction of the original issue:
  ```
  rm ~/.config/voom/voom.db ~/.config/voom/voom.lock
  voom scan -r --no-hash <library>
  voom process -y -p 01-containerize.voom <library>
  voom report --library    # 'mp4: 1' should be gone without `voom db prune`
  voom files list --container mp4    # should be empty
  ```

## Follow-ups

Filed during the cleanup pass (out of scope here):
- #157 — extract filename-from-path idiom in sqlite-store (5x duplication)
- #158 — wrap post-execution writes (rename + transition + expected_hash) in one transaction
- #159 — extract `make_test_ctx()` helper for `ProcessContext` setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)