### PR TITLE
fix(history): resolve voom history by old path after rename (#149)

### DIFF
--- a/crates/voom-cli/src/commands/process/mod.rs
+++ b/crates/voom-cli/src/commands/process/mod.rs
@@ -1391,6 +1391,80 @@ mod tests {
     }
 
     #[test]
+    fn record_file_transition_makes_history_lookup_work_for_old_and_new_paths() {
+        // Bypass re-introspection (depends on ffprobe being on PATH) and
+        // exercise `record_file_transition` directly.
+        use std::path::PathBuf;
+        use voom_domain::media::{Container, MediaFile};
+
+        let mut old_file = MediaFile::new(PathBuf::from("/lib/movie.mp4"));
+        old_file.container = Container::Mp4;
+        old_file.size = 1024;
+        old_file.content_hash = Some("old".to_string());
+
+        let mut new_file = MediaFile::new(PathBuf::from("/lib/movie.mkv"));
+        new_file.container = Container::Mkv;
+        new_file.size = 900;
+        new_file.content_hash = Some("new".to_string());
+
+        let store: Arc<dyn voom_domain::storage::StorageTrait> =
+            Arc::new(voom_sqlite_store::store::SqliteStore::in_memory().unwrap());
+        let kernel = Arc::new(voom_kernel::Kernel::new());
+        let capabilities = voom_domain::CapabilityMap::new();
+        let counters = RunCounters::new();
+        let token = CancellationToken::new();
+        let dir = tempfile::tempdir().unwrap();
+        let resolver = PolicyResolver::from_single(
+            voom_dsl::compile_policy(r#"policy "p" { phase convert { container mkv } }"#).unwrap(),
+            dir.path(),
+        );
+        let ctx = ProcessContext {
+            resolver: &resolver,
+            kernel,
+            store: store.clone(),
+            dry_run: false,
+            plan_only: false,
+            flag_size_increase: false,
+            flag_duration_shrink: false,
+            token: &token,
+            ffprobe_path: None,
+            capabilities: &capabilities,
+            counters: &counters,
+        };
+
+        super::transitions::record_file_transition(&super::transitions::FileTransitionContext {
+            old_file: &old_file,
+            new_file: &new_file,
+            executor: "mkvtoolnix-executor",
+            elapsed_ms: 0,
+            actions_taken: 1,
+            tracks_modified: 0,
+            policy_name: "containerize",
+            phase_name: "convert",
+            plan_id: uuid::Uuid::new_v4(),
+            ctx: &ctx,
+        });
+
+        let by_new = store.transitions_for_path(&new_file.path).unwrap();
+        assert_eq!(
+            by_new.len(),
+            1,
+            "new .mkv path must locate the conversion transition"
+        );
+        let by_old = store.transitions_for_path(&old_file.path).unwrap();
+        assert_eq!(
+            by_old.len(),
+            1,
+            "old .mp4 path must locate the conversion transition via from_path"
+        );
+        assert_eq!(by_old[0].id, by_new[0].id);
+        assert_eq!(
+            by_old[0].from_path.as_deref(),
+            Some(old_file.path.as_path())
+        );
+    }
+
+    #[test]
     fn test_check_size_increase_dispatches_plan_failed_without_plan_created() {
         // Write a file with 2048 bytes so the size-increase check fires
         // when the MediaFile reports size = 1024 (smaller than actual).

--- a/crates/voom-cli/src/commands/process/transitions.rs
+++ b/crates/voom-cli/src/commands/process/transitions.rs
@@ -26,7 +26,7 @@ pub(super) fn record_file_transition(tctx: &FileTransitionContext<'_>) {
     if tctx.new_file.content_hash == tctx.old_file.content_hash {
         return;
     }
-    let transition = voom_domain::FileTransition::new(
+    let mut transition = voom_domain::FileTransition::new(
         tctx.old_file.id,
         tctx.new_file.path.clone(),
         tctx.new_file.content_hash.clone().unwrap_or_default(),
@@ -48,6 +48,10 @@ pub(super) fn record_file_transition(tctx: &FileTransitionContext<'_>) {
         tctx.new_file,
     ))
     .with_session_id(tctx.ctx.counters.session_id);
+
+    if tctx.old_file.path != tctx.new_file.path {
+        transition = transition.with_from_path(tctx.old_file.path.clone());
+    }
 
     if let Err(e) = tctx.ctx.store.record_transition(&transition) {
         tracing::warn!(

--- a/crates/voom-domain/src/test_support.rs
+++ b/crates/voom-domain/src/test_support.rs
@@ -442,8 +442,11 @@ impl FileTransitionStorage for InMemoryStore {
 
     fn transitions_for_path(&self, path: &Path) -> Result<Vec<FileTransition>> {
         let ts = self.transitions.lock();
-        let mut result: Vec<FileTransition> =
-            ts.iter().filter(|t| t.path == path).cloned().collect();
+        let mut result: Vec<FileTransition> = ts
+            .iter()
+            .filter(|t| t.path == path || t.from_path.as_deref() == Some(path))
+            .cloned()
+            .collect();
         result.sort_by_key(|t| t.created_at);
         Ok(result)
     }

--- a/crates/voom-domain/src/transition.rs
+++ b/crates/voom-domain/src/transition.rs
@@ -90,8 +90,11 @@ pub struct FileTransition {
     pub id: Uuid,
     /// The ID of the `MediaFile` this transition belongs to.
     pub file_id: Uuid,
-    /// Path of the file at the time of transition.
+    /// Path of the file after the transition.
     pub path: PathBuf,
+    /// Path of the file before the transition. Set only when the path
+    /// changed; lets path-based history queries find the row by either side.
+    pub from_path: Option<PathBuf>,
     /// Content hash before the change, if known.
     pub from_hash: Option<String>,
     /// Content hash after the change.
@@ -149,6 +152,7 @@ impl FileTransition {
             id: Uuid::new_v4(),
             file_id,
             path,
+            from_path: None,
             from_hash: None,
             to_hash,
             from_size: None,
@@ -188,6 +192,13 @@ impl FileTransition {
     pub fn with_from(mut self, hash: Option<String>, size: Option<u64>) -> Self {
         self.from_hash = hash;
         self.from_size = size;
+        self
+    }
+
+    /// Set the prior path (pre-change state).
+    #[must_use]
+    pub fn with_from_path(mut self, path: impl Into<PathBuf>) -> Self {
+        self.from_path = Some(path.into());
         self
     }
 

--- a/plugins/sqlite-store/src/schema.rs
+++ b/plugins/sqlite-store/src/schema.rs
@@ -83,6 +83,7 @@ CREATE TABLE IF NOT EXISTS file_transitions (
     id TEXT PRIMARY KEY,
     file_id TEXT NOT NULL,
     path TEXT NOT NULL,
+    from_path TEXT,
     from_hash TEXT,
     to_hash TEXT NOT NULL,
     from_size INTEGER,
@@ -104,6 +105,8 @@ CREATE TABLE IF NOT EXISTS file_transitions (
 
 CREATE INDEX IF NOT EXISTS idx_transitions_file ON file_transitions(file_id);
 CREATE INDEX IF NOT EXISTS idx_transitions_source ON file_transitions(source);
+CREATE INDEX IF NOT EXISTS idx_transitions_path ON file_transitions(path);
+CREATE INDEX IF NOT EXISTS idx_transitions_from_path ON file_transitions(from_path);
 
 CREATE TABLE IF NOT EXISTS plugin_data (
     plugin_name TEXT NOT NULL,
@@ -248,6 +251,7 @@ pub(crate) fn migrate(conn: &Connection) -> rusqlite::Result<()> {
     migrate_processing_stats_into_transitions(conn, &has_column)?;
     migrate_metadata_snapshot_column(conn, &has_column)?;
     migrate_execution_capture_columns(conn, &has_column)?;
+    migrate_from_path_column(conn, &has_column)?;
 
     Ok(())
 }
@@ -564,6 +568,24 @@ fn migrate_execution_capture_columns(
         )?;
     }
 
+    Ok(())
+}
+
+/// Add `from_path` column to `file_transitions` and create the path-lookup
+/// indexes that the OR-match in `transitions_for_path` relies on.
+fn migrate_from_path_column(
+    conn: &Connection,
+    has_column: &dyn Fn(&str, &str) -> rusqlite::Result<bool>,
+) -> rusqlite::Result<()> {
+    if !has_column("file_transitions", "from_path")? {
+        conn.execute_batch("ALTER TABLE file_transitions ADD COLUMN from_path TEXT;")?;
+    }
+    conn.execute_batch(
+        "CREATE INDEX IF NOT EXISTS idx_transitions_path \
+         ON file_transitions(path); \
+         CREATE INDEX IF NOT EXISTS idx_transitions_from_path \
+         ON file_transitions(from_path);",
+    )?;
     Ok(())
 }
 

--- a/plugins/sqlite-store/src/store/file_storage.rs
+++ b/plugins/sqlite-store/src/store/file_storage.rs
@@ -519,14 +519,22 @@ fn mark_missing_files(
     Ok(missing)
 }
 
-/// Build a hash-to-(id, size) index of missing files scoped to scanned dirs.
+/// A move-detection candidate: a missing file's identity plus its prior path,
+/// so the resulting transition can record `from_path`.
+struct MissingMatch {
+    id: String,
+    prior_path: String,
+}
+
+/// Build a content-hash → `MissingMatch` index of missing files scoped to
+/// scanned dirs.
 fn build_missing_hash_index(
     tx: &rusqlite::Transaction<'_>,
     scanned_dirs: &[PathBuf],
-) -> Result<HashMap<String, (String, i64)>> {
+) -> Result<HashMap<String, MissingMatch>> {
     let mut stmt = tx
         .prepare(
-            "SELECT id, path, expected_hash, size FROM files \
+            "SELECT id, path, expected_hash FROM files \
              WHERE status = 'missing' AND expected_hash IS NOT NULL \
              AND path IS NOT NULL",
         )
@@ -537,7 +545,6 @@ fn build_missing_hash_index(
                 row.get::<_, String>(0)?,
                 row.get::<_, String>(1)?,
                 row.get::<_, String>(2)?,
-                row.get::<_, i64>(3)?,
             ))
         })
         .map_err(storage_err("failed to query missing files"))?
@@ -545,10 +552,13 @@ fn build_missing_hash_index(
         .map_err(storage_err("failed to collect missing files"))?;
 
     let mut map = HashMap::new();
-    for (id, path, hash, size) in rows {
+    for (id, path, hash) in rows {
         let path_obj = Path::new(&path);
         if scanned_dirs.iter().any(|dir| path_obj.starts_with(dir)) {
-            map.entry(hash).or_insert((id, size));
+            map.entry(hash).or_insert(MissingMatch {
+                id,
+                prior_path: path,
+            });
         }
     }
     Ok(map)
@@ -558,7 +568,7 @@ fn build_missing_hash_index(
 fn match_discovered_files(
     tx: &rusqlite::Transaction<'_>,
     discovered: &[DiscoveredFile],
-    missing_by_hash: &HashMap<String, (String, i64)>,
+    missing_by_hash: &HashMap<String, MissingMatch>,
     now: &str,
     result: &mut ReconcileResult,
 ) -> Result<()> {
@@ -694,7 +704,7 @@ fn reconcile_existing_path(
 fn reconcile_new_path(
     tx: &rusqlite::Transaction<'_>,
     df: &DiscoveredFile,
-    missing_by_hash: &HashMap<String, (String, i64)>,
+    missing_by_hash: &HashMap<String, MissingMatch>,
     consumed_missing: &mut HashSet<String>,
     now: &str,
     result: &mut ReconcileResult,
@@ -707,10 +717,11 @@ fn reconcile_new_path(
         .unwrap_or_default();
     let move_match = missing_by_hash
         .get(&df.content_hash)
-        .filter(|(id, _)| !consumed_missing.contains(id))
-        .map(|(id, size)| (id.clone(), *size));
+        .filter(|m| !consumed_missing.contains(&m.id));
 
-    if let Some((missing_id, _missing_size)) = move_match {
+    if let Some(m) = move_match {
+        let missing_id = m.id.clone();
+        let prior_path = m.prior_path.clone();
         consumed_missing.insert(missing_id.clone());
 
         tx.execute(
@@ -737,6 +748,7 @@ fn reconcile_new_path(
             df.size,
             TransitionSource::Discovery,
         )
+        .with_from_path(PathBuf::from(prior_path))
         .with_detail("detected_move");
         insert_transition_in_tx(tx, &move_transition, now)?;
 
@@ -786,16 +798,19 @@ fn insert_transition_in_tx(
 ) -> Result<()> {
     tx.execute(
         "INSERT INTO file_transitions \
-         (id, file_id, path, from_hash, to_hash, from_size, to_size, \
+         (id, file_id, path, from_path, from_hash, to_hash, from_size, to_size, \
           source, source_detail, plan_id, \
           duration_ms, actions_taken, tracks_modified, outcome, \
           policy_name, phase_name, metadata_snapshot, created_at) \
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, \
-                 ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)",
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, \
+                 ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19)",
         params![
             t.id.to_string(),
             t.file_id.to_string(),
             t.path.to_string_lossy().to_string(),
+            t.from_path
+                .as_ref()
+                .map(|p| p.to_string_lossy().to_string()),
             t.from_hash.as_deref(),
             t.to_hash,
             t.from_size.map(|v| v as i64),
@@ -930,6 +945,62 @@ mod tests {
             new_file.id, file_a_id,
             "/movies/new.mkv must have a new UUID, not stolen from /tv/episode.mkv"
         );
+    }
+
+    #[test]
+    fn reconcile_move_records_from_path_on_move_transition() {
+        use voom_domain::storage::FileTransitionStorage;
+        use voom_domain::transition::DiscoveredFile;
+
+        let store = test_store();
+
+        // File begins life at /media/old/film.mkv.
+        let mut file = MediaFile::new(PathBuf::from("/media/old/film.mkv"));
+        file.content_hash = Some("hash".to_string());
+        store.upsert_file(&file).unwrap();
+        let original_id = store
+            .file_by_path(Path::new("/media/old/film.mkv"))
+            .unwrap()
+            .unwrap()
+            .id;
+        // upsert_file doesn't persist expected_hash; set it so the missing-by-hash
+        // index can pick the row up as a move candidate.
+        store.update_expected_hash(&original_id, "hash").unwrap();
+        store.mark_missing(&original_id).unwrap();
+
+        // Same hash discovered at a new path within the same scan root.
+        let discovered = vec![DiscoveredFile::new(
+            PathBuf::from("/media/new/film.mkv"),
+            1_000,
+            "hash".to_string(),
+        )];
+        let scanned = vec![PathBuf::from("/media")];
+        let result = store
+            .reconcile_discovered_files(&discovered, &scanned)
+            .unwrap();
+        assert_eq!(result.moved, 1);
+
+        // The move transition must reference the prior path so old-path lookups work.
+        let by_old_path = store
+            .transitions_for_path(Path::new("/media/old/film.mkv"))
+            .unwrap();
+        assert_eq!(
+            by_old_path.len(),
+            1,
+            "old path should resolve via from_path"
+        );
+        assert_eq!(
+            by_old_path[0].from_path.as_deref(),
+            Some(Path::new("/media/old/film.mkv"))
+        );
+        assert_eq!(by_old_path[0].path, Path::new("/media/new/film.mkv"));
+
+        // And the new path also resolves.
+        let by_new_path = store
+            .transitions_for_path(Path::new("/media/new/film.mkv"))
+            .unwrap();
+        assert_eq!(by_new_path.len(), 1);
+        assert_eq!(by_new_path[0].id, by_old_path[0].id);
     }
 
     #[test]

--- a/plugins/sqlite-store/src/store/file_transition_storage.rs
+++ b/plugins/sqlite-store/src/store/file_transition_storage.rs
@@ -16,17 +16,20 @@ impl FileTransitionStorage for SqliteStore {
         let conn = self.conn()?;
         conn.execute(
             "INSERT INTO file_transitions \
-             (id, file_id, path, from_hash, to_hash, from_size, to_size, \
+             (id, file_id, path, from_path, from_hash, to_hash, from_size, to_size, \
               source, source_detail, plan_id, \
               duration_ms, actions_taken, tracks_modified, outcome, \
               policy_name, phase_name, metadata_snapshot, \
               error_message, session_id, created_at) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, \
-                     ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20)",
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, \
+                     ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21)",
             params![
                 t.id.to_string(),
                 t.file_id.to_string(),
                 t.path.to_string_lossy().to_string(),
+                t.from_path
+                    .as_ref()
+                    .map(|p| p.to_string_lossy().to_string()),
                 t.from_hash.as_deref().filter(|s| !s.is_empty()),
                 t.to_hash,
                 t.from_size.map(|v| v as i64),
@@ -60,7 +63,7 @@ impl FileTransitionStorage for SqliteStore {
         let conn = self.conn()?;
         let mut stmt = conn
             .prepare(
-                "SELECT id, file_id, path, from_hash, to_hash, from_size, to_size, \
+                "SELECT id, file_id, path, from_path, from_hash, to_hash, from_size, to_size, \
                  source, source_detail, plan_id, \
                  duration_ms, actions_taken, tracks_modified, outcome, \
                  policy_name, phase_name, metadata_snapshot, created_at \
@@ -81,7 +84,7 @@ impl FileTransitionStorage for SqliteStore {
         let conn = self.conn()?;
         let mut stmt = conn
             .prepare(
-                "SELECT id, file_id, path, from_hash, to_hash, from_size, to_size, \
+                "SELECT id, file_id, path, from_path, from_hash, to_hash, from_size, to_size, \
                  source, source_detail, plan_id, \
                  duration_ms, actions_taken, tracks_modified, outcome, \
                  policy_name, phase_name, metadata_snapshot, created_at \
@@ -161,11 +164,13 @@ impl FileTransitionStorage for SqliteStore {
         let conn = self.conn()?;
         let mut stmt = conn
             .prepare(
-                "SELECT id, file_id, path, from_hash, to_hash, from_size, to_size, \
+                "SELECT id, file_id, path, from_path, from_hash, to_hash, from_size, to_size, \
                  source, source_detail, plan_id, \
                  duration_ms, actions_taken, tracks_modified, outcome, \
                  policy_name, phase_name, metadata_snapshot, created_at \
-                 FROM file_transitions WHERE path = ?1 ORDER BY created_at ASC",
+                 FROM file_transitions \
+                 WHERE path = ?1 OR from_path = ?1 \
+                 ORDER BY created_at ASC",
             )
             .map_err(storage_err("failed to prepare transitions_for_path query"))?;
 
@@ -300,6 +305,7 @@ fn row_to_transition(row: &rusqlite::Row<'_>) -> rusqlite::Result<FileTransition
     let id_str: String = row.get("id")?;
     let file_id_str: String = row.get("file_id")?;
     let path_str: String = row.get("path")?;
+    let from_path_str: Option<String> = row.get("from_path")?;
     let from_hash: Option<String> = row.get("from_hash")?;
     let to_hash: String = row.get("to_hash")?;
     let from_size: Option<i64> = row.get("from_size")?;
@@ -339,6 +345,7 @@ fn row_to_transition(row: &rusqlite::Row<'_>) -> rusqlite::Result<FileTransition
         source,
     );
     t.id = id;
+    t.from_path = from_path_str.filter(|s| !s.is_empty()).map(PathBuf::from);
     t.from_hash = from_hash.filter(|s| !s.is_empty());
     t.from_size = from_size.map(|v| v as u64);
     t.source_detail = source_detail.filter(|s| !s.is_empty());
@@ -531,5 +538,38 @@ mod tests {
 
         assert_eq!(bucket.bytes_saved, 300_000);
         assert_eq!(bucket.transition_count, 1);
+    }
+
+    #[test]
+    fn transitions_for_path_matches_either_path_column() {
+        let store = test_store();
+        let file_id = Uuid::new_v4();
+
+        let t = FileTransition::new(
+            file_id,
+            PathBuf::from("/media/movie.mkv"),
+            "new_hash".into(),
+            900_000,
+            TransitionSource::Voom,
+        )
+        .with_from(Some("old_hash".into()), Some(1_000_000))
+        .with_from_path(PathBuf::from("/media/movie.mp4"));
+        store.record_transition(&t).unwrap();
+
+        let by_new = store
+            .transitions_for_path(std::path::Path::new("/media/movie.mkv"))
+            .unwrap();
+        assert_eq!(by_new.len(), 1);
+        assert_eq!(by_new[0].id, t.id);
+
+        let by_old = store
+            .transitions_for_path(std::path::Path::new("/media/movie.mp4"))
+            .unwrap();
+        assert_eq!(by_old.len(), 1);
+        assert_eq!(by_old[0].id, t.id);
+        assert_eq!(
+            by_old[0].from_path.as_deref(),
+            Some(std::path::Path::new("/media/movie.mp4"))
+        );
     }
 }


### PR DESCRIPTION
Closes #149.

## Summary

After PR #160 fixed #148, container conversion correctly renames the existing `files` row in place — but the resulting `file_transitions` row recorded only the post-conversion path. Querying `voom history <old-mp4>` returned nothing because neither `files` nor `file_transitions` retained any link to the prior path.

This change records the pre-transition path on `file_transitions` and lets path-based history lookups match it.

- Schema: new nullable `from_path` column on `file_transitions`, with `idx_transitions_path` and `idx_transitions_from_path` so the OR-match query is index-friendly.
- Domain: `FileTransition.from_path: Option<PathBuf>` + `with_from_path` builder. Only populated when the path actually changed (no redundant column duplication for failures, recovery, or unchanged-path Voom transitions).
- Reconcile: move detection now writes `from_path` on the resulting transition. `build_missing_hash_index` returns a named `MissingMatch` instead of a positional tuple.
- Query: `transitions_for_path` becomes `WHERE path = ?1 OR from_path = ?1`.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test`
- [x] `cargo test -p voom-cli --features functional -- --test-threads=4` (502 tests, 0 failures)
- [x] New tests:
  - `transitions_for_path_matches_either_path_column` (sqlite-store)
  - `reconcile_move_records_from_path_on_move_transition` (sqlite-store)
  - `record_file_transition_makes_history_lookup_work_for_old_and_new_paths` (voom-cli)
- [ ] Manual reproduction of the original issue:
  ```
  rm ~/.config/voom/voom.db ~/.config/voom/voom.lock
  voom scan -r --no-hash <library>
  voom process -y -p 01-containerize.voom <library>
  voom history <new-mkv-path>   # should return the conversion transition
  voom history <old-mp4-path>   # should also return it (via from_path)
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)