### PR TITLE
fix(report): emit empty-state messages for --plans/--issues (#150)

### DIFF
--- a/crates/voom-cli/src/commands/report.rs
+++ b/crates/voom-cli/src/commands/report.rs
@@ -231,6 +231,24 @@ fn format_result(result: &ReportResult, args: &ReportArgs) -> Result<()> {
 
 // ── Table formatting ────────────────────────────────────────
 
+const PLANS_TITLE: &str = "Plan Processing Summary";
+const PLANS_EMPTY_HINT: &str = "No plans recorded yet. Run 'voom process' to generate plans.";
+
+const SAVINGS_TITLE: &str = "Space Savings by Provenance";
+const SAVINGS_EMPTY_HINT: &str = "No completed plans with size deltas yet.";
+
+const HISTORY_TITLE: &str = "Snapshot History";
+const HISTORY_EMPTY_HINT: &str = "No snapshots captured yet.";
+
+const ISSUES_TITLE: &str = "Safeguard Violations";
+const ISSUES_EMPTY_HINT: &str = "No safeguard violations found.";
+
+fn print_empty_section(title: &str, hint: &str) {
+    eprintln!("{}", style(title).bold().underlined());
+    eprintln!("  {}", style(hint).dim());
+    eprintln!();
+}
+
 fn format_result_table(result: &ReportResult) {
     if let Some(ref snapshot) = result.library {
         print_stats_table(snapshot);
@@ -393,11 +411,12 @@ fn aggregate_plan_stats(stats: &[PlanPhaseStat]) -> (Vec<String>, HashMap<String
 
 fn print_plans_section_table(stats: &[PlanPhaseStat]) {
     if stats.is_empty() {
+        print_empty_section(PLANS_TITLE, PLANS_EMPTY_HINT);
         return;
     }
     let (phases, by_phase) = aggregate_plan_stats(stats);
 
-    println!("{}", style("Plan Processing Summary").bold().underlined());
+    println!("{}", style(PLANS_TITLE).bold().underlined());
     println!();
 
     let mut table = output::new_table();
@@ -427,15 +446,13 @@ fn print_savings_section_table(report: &SavingsReport) {
     use voom_domain::utils::format::{format_duration, format_size};
 
     if report.buckets.is_empty() {
+        print_empty_section(SAVINGS_TITLE, SAVINGS_EMPTY_HINT);
         return;
     }
 
     let show_period = report.buckets.iter().any(|b| b.period.is_some());
 
-    println!(
-        "{}",
-        style("Space Savings by Provenance").bold().underlined()
-    );
+    println!("{}", style(SAVINGS_TITLE).bold().underlined());
     println!();
 
     let mut table = output::new_table();
@@ -495,10 +512,11 @@ fn print_history_section_table(snapshots: &[LibrarySnapshot]) {
     use voom_domain::utils::format::{format_duration, format_size};
 
     if snapshots.is_empty() {
+        print_empty_section(HISTORY_TITLE, HISTORY_EMPTY_HINT);
         return;
     }
 
-    println!("{}", style("Snapshot History").bold().underlined());
+    println!("{}", style(HISTORY_TITLE).bold().underlined());
     println!();
     let mut table = output::new_table();
     table.set_header(vec![
@@ -527,12 +545,13 @@ fn print_history_section_table(snapshots: &[LibrarySnapshot]) {
 
 fn print_issues_section_table(issues: &[IssueReport]) {
     if issues.is_empty() {
+        print_empty_section(ISSUES_TITLE, ISSUES_EMPTY_HINT);
         return;
     }
 
     println!(
         "{} ({} files)",
-        style("Safeguard Violations").bold().underlined(),
+        style(ISSUES_TITLE).bold().underlined(),
         issues.len()
     );
     println!();
@@ -795,9 +814,6 @@ fn write_library_csv(snapshot: &LibrarySnapshot) -> Result<()> {
 }
 
 fn write_plans_csv(stats: &[PlanPhaseStat]) -> Result<()> {
-    if stats.is_empty() {
-        return Ok(());
-    }
     let (phases, by_phase) = aggregate_plan_stats(stats);
 
     let stdout = std::io::stdout();
@@ -828,10 +844,6 @@ fn write_plans_csv(stats: &[PlanPhaseStat]) -> Result<()> {
 }
 
 fn write_savings_csv(report: &SavingsReport) -> Result<()> {
-    if report.buckets.is_empty() {
-        return Ok(());
-    }
-
     let stdout = std::io::stdout();
     let mut out = stdout.lock();
     writeln!(out, "# savings")?;
@@ -870,10 +882,6 @@ fn write_savings_csv(report: &SavingsReport) -> Result<()> {
 }
 
 fn write_history_csv(snapshots: &[LibrarySnapshot]) -> Result<()> {
-    if snapshots.is_empty() {
-        return Ok(());
-    }
-
     let stdout = std::io::stdout();
     let mut out = stdout.lock();
     writeln!(out, "# history")?;
@@ -912,10 +920,6 @@ fn write_history_csv(snapshots: &[LibrarySnapshot]) -> Result<()> {
 }
 
 fn write_issues_csv(issues: &[IssueReport]) -> Result<()> {
-    if issues.is_empty() {
-        return Ok(());
-    }
-
     let stdout = std::io::stdout();
     let mut out = stdout.lock();
     writeln!(out, "# issues")?;

--- a/crates/voom-cli/tests/functional_tests.rs
+++ b/crates/voom-cli/tests/functional_tests.rs
@@ -962,17 +962,21 @@ mod test_plugin {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// test_report (--issues)
+// test_report (empty-state messaging — issue #150)
 // ═══════════════════════════════════════════════════════════════════════════
 
-mod test_report_issues {
+mod test_report_empty_states {
     use super::*;
 
     #[test]
     fn report_issues_on_empty_db() {
         let env = TestEnv::new();
-        // With no files, the issues section produces no output
-        env.voom().args(["report", "--issues"]).assert().success();
+        env.voom()
+            .args(["report", "--issues"])
+            .assert()
+            .success()
+            .stderr(predicate::str::contains("Safeguard Violations"))
+            .stderr(predicate::str::contains("No safeguard violations found"));
     }
 
     #[test]
@@ -987,12 +991,99 @@ mod test_report_issues {
             .assert()
             .success();
 
-        // With no violations, the issues section produces no table output
         env.voom()
             .args(["report", "--issues"])
             .assert()
             .success()
-            .stdout(predicate::str::contains("Safeguard Violations").not());
+            .stderr(predicate::str::contains("No safeguard violations found"));
+    }
+
+    #[test]
+    fn report_plans_on_empty_db() {
+        let env = TestEnv::new();
+        env.voom()
+            .args(["report", "--plans"])
+            .assert()
+            .success()
+            .stderr(predicate::str::contains("Plan Processing Summary"))
+            .stderr(predicate::str::contains("No plans recorded yet"));
+    }
+
+    #[test]
+    fn report_savings_on_empty_db() {
+        let env = TestEnv::new();
+        env.voom()
+            .args(["report", "--savings"])
+            .assert()
+            .success()
+            .stderr(predicate::str::contains("Space Savings by Provenance"))
+            .stderr(predicate::str::contains("No completed plans"));
+    }
+
+    #[test]
+    fn report_history_on_empty_db() {
+        let env = TestEnv::new();
+        env.voom()
+            .args(["report", "--history", "10"])
+            .assert()
+            .success()
+            .stderr(predicate::str::contains("Snapshot History"))
+            .stderr(predicate::str::contains("No snapshots captured yet"));
+    }
+
+    #[test]
+    fn report_plans_json_empty() {
+        let env = TestEnv::new();
+        env.voom()
+            .args(["report", "--plans", "-f", "json"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("\"plans\""))
+            .stdout(predicate::str::contains("[]"));
+    }
+
+    #[test]
+    fn report_issues_json_empty() {
+        let env = TestEnv::new();
+        env.voom()
+            .args(["report", "--issues", "-f", "json"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("\"issues\""))
+            .stdout(predicate::str::contains("[]"));
+    }
+
+    #[test]
+    fn report_plans_plain_empty_is_silent() {
+        let env = TestEnv::new();
+        env.voom()
+            .args(["report", "--plans", "-f", "plain"])
+            .assert()
+            .success()
+            .stdout(predicate::str::is_empty())
+            .stderr(predicate::str::is_empty());
+    }
+
+    #[test]
+    fn report_plans_csv_empty_emits_header() {
+        let env = TestEnv::new();
+        env.voom()
+            .args(["report", "--plans", "-f", "csv"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("# plans"))
+            .stdout(predicate::str::contains("phase,completed,skipped,failed"));
+    }
+
+    #[test]
+    fn report_issues_csv_empty_emits_header() {
+        let env = TestEnv::new();
+        env.voom()
+            .args(["report", "--issues", "-f", "csv"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("# issues"))
+            .stdout(predicate::str::contains("path,violation,phase,message"));
     }
 }
 


### PR DESCRIPTION
## Summary

- `voom report --plans` and `voom report --issues` produced no output at all when their queries were empty — indistinguishable from a hang. They now emit a header + hint to stderr in table mode, matching the contract set by `voom report --errors`.
- Same treatment applied to `--savings` and `--history`, which had the same defect.
- Machine formats: JSON already produced `{"plans": []}`; CSV now emits the `# section` marker + header row even when empty (was silent); Plain stays silent (matches `run_file_list` precedent for machine formats).

## Implementation notes

- Added a single `print_empty_section(title, hint)` helper that writes `style(title).bold().underlined()` + a dim hint to stderr.
- Extracted four `<SECTION>_TITLE` / `<SECTION>_EMPTY_HINT` constants so the empty-state and populated-state renderers share one source of truth for the strings.
- Dropped the `if .is_empty() { return Ok(()); }` early-return guards in `write_plans_csv`, `write_savings_csv`, `write_history_csv`, and `write_issues_csv`.

## Out of scope (tracked separately)

The original report flagged that `report --database` shows `plans: 0` after a successful `process` run, suggesting plans are not persisted. That is a data-persistence question independent of this rendering fix — filed as #162.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test` (full unit + integration suite)
- [x] `cargo test -p voom-cli --features functional -- --test-threads=4` (111 passed, including 10 new tests in `test_report_empty_states`)
- [x] New tests cover: table empty-state for plans / issues / savings / history; JSON empty (`{"plans":[]}`, `{"issues":[]}`); CSV empty (header-only); Plain empty (silent stdout + stderr)

Closes #150