### PR TITLE
fix(voom-kernel): rename publish span to dispatch (closes #152)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3085,6 +3085,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-test"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a4c448db514d4f24c5ddb9f73f2ee71bfb24c526cf0c570ba142d1119e0051"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "trait-variant"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3436,6 +3457,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "tracing-test",
  "ureq",
  "uuid",
  "voom-domain",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,7 @@ semver = "1.0.27"
 # Logging
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-test = "0.2"
 
 # WASM
 wasmtime = { version = "29", features = ["component-model"] }

--- a/crates/voom-kernel/Cargo.toml
+++ b/crates/voom-kernel/Cargo.toml
@@ -37,6 +37,7 @@ workspace = true
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
 tracing-subscriber = { workspace = true }
+tracing-test = "0.2"
 tempfile = { workspace = true }
 chrono = { workspace = true }
 voom-domain = { workspace = true, features = ["testing"] }

--- a/crates/voom-kernel/Cargo.toml
+++ b/crates/voom-kernel/Cargo.toml
@@ -37,7 +37,7 @@ workspace = true
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
 tracing-subscriber = { workspace = true }
-tracing-test = "0.2"
+tracing-test = { workspace = true }
 tempfile = { workspace = true }
 chrono = { workspace = true }
 voom-domain = { workspace = true, features = ["testing"] }

--- a/crates/voom-kernel/src/bus.rs
+++ b/crates/voom-kernel/src/bus.rs
@@ -616,8 +616,6 @@ mod tests {
     #[test]
     #[tracing_test::traced_test]
     fn test_publish_span_uses_dispatch_naming_for_handler_logs() {
-        /// Plugin that emits an info-level log inside its handler so we can
-        /// verify what span the log line is attributed to.
         struct LoggingPlugin;
 
         impl Plugin for LoggingPlugin {
@@ -649,22 +647,14 @@ mod tests {
         ));
         let _ = bus.publish(event);
 
-        // The handler-side log must be wrapped in the renamed span and field.
         assert!(
             logs_contain("dispatch{"),
             "expected span name 'dispatch' in captured logs"
         );
         assert!(
-            logs_contain("dispatching_event"),
-            "expected field 'dispatching_event' in captured logs"
-        );
-        assert!(
-            logs_contain("dispatching_event=\"file.discovered\"")
-                || logs_contain("dispatching_event=file.discovered"),
+            logs_contain("dispatching_event=file.discovered"),
             "expected dispatching_event field to carry the event type"
         );
-
-        // The old span name and field must not appear.
         assert!(
             !logs_contain("publish{event_type"),
             "old span signature 'publish{{event_type=...}}' must not appear"

--- a/crates/voom-kernel/src/bus.rs
+++ b/crates/voom-kernel/src/bus.rs
@@ -79,7 +79,11 @@ impl EventBus {
     /// Publish an event to all subscribers that handle its type.
     /// Returns results from all handlers, in priority order.
     /// Produced events are automatically cascaded up to a depth limit.
-    #[tracing::instrument(skip(self, event), fields(event_type = %event.event_type()))]
+    #[tracing::instrument(
+        name = "dispatch",
+        skip(self, event),
+        fields(dispatching_event = %event.event_type())
+    )]
     pub fn publish(&self, event: Event) -> Vec<EventResult> {
         self.publish_recursive(event, 0)
     }
@@ -607,6 +611,64 @@ mod tests {
         assert_eq!(results.len(), 2);
         assert_eq!(results[0].plugin_name, "first");
         assert_eq!(results[1].plugin_name, "second");
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn test_publish_span_uses_dispatch_naming_for_handler_logs() {
+        /// Plugin that emits an info-level log inside its handler so we can
+        /// verify what span the log line is attributed to.
+        struct LoggingPlugin;
+
+        impl Plugin for LoggingPlugin {
+            fn name(&self) -> &str {
+                "logging-plugin"
+            }
+            fn version(&self) -> &str {
+                "0.1.0"
+            }
+            fn capabilities(&self) -> &[Capability] {
+                &[]
+            }
+            fn handles(&self, event_type: &str) -> bool {
+                event_type == Event::FILE_DISCOVERED
+            }
+            fn on_event(&self, _event: &Event) -> voom_domain::errors::Result<Option<EventResult>> {
+                tracing::info!("handler-side log message");
+                Ok(Some(EventResult::new("logging-plugin")))
+            }
+        }
+
+        let bus = EventBus::new();
+        bus.subscribe_plugin(Arc::new(LoggingPlugin), 0);
+
+        let event = Event::FileDiscovered(FileDiscoveredEvent::new(
+            "/test.mkv".into(),
+            1024,
+            Some("abc".into()),
+        ));
+        let _ = bus.publish(event);
+
+        // The handler-side log must be wrapped in the renamed span and field.
+        assert!(
+            logs_contain("dispatch"),
+            "expected span name 'dispatch' in captured logs"
+        );
+        assert!(
+            logs_contain("dispatching_event"),
+            "expected field 'dispatching_event' in captured logs"
+        );
+        assert!(
+            logs_contain("dispatching_event=\"file.discovered\"")
+                || logs_contain("dispatching_event=file.discovered"),
+            "expected dispatching_event field to carry the event type"
+        );
+
+        // The old span name and field must not appear.
+        assert!(
+            !logs_contain("publish{event_type"),
+            "old span signature 'publish{{event_type=...}}' must not appear"
+        );
     }
 
     #[test]

--- a/crates/voom-kernel/src/bus.rs
+++ b/crates/voom-kernel/src/bus.rs
@@ -651,7 +651,7 @@ mod tests {
 
         // The handler-side log must be wrapped in the renamed span and field.
         assert!(
-            logs_contain("dispatch"),
+            logs_contain("dispatch{"),
             "expected span name 'dispatch' in captured logs"
         );
         assert!(


### PR DESCRIPTION
## Summary
- Rename the `EventBus::publish` `tracing::instrument` span from `publish` to `dispatch`, and the `event_type` field to `dispatching_event`.
- Synchronous handler dispatch shares the publisher's span, so the rename clarifies that handler-side log lines are emitted *while dispatching* a given event, not as emissions of that event.
- Add a regression test using `tracing-test` that captures span output and asserts both the new naming and the absence of the old `publish{event_type=...}` form.

Before: `publish{event_type=plan.created}: running merge actions ...`
After: `dispatch{dispatching_event=plan.created}: running merge actions ...`

## Test plan
- [x] `cargo test -p voom-kernel` passes (including new regression test)
- [x] `cargo test` (full workspace) passes
- [x] `cargo test -p voom-cli --features functional -- --test-threads=4` passes
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

Closes #152.