### PR TITLE
fix(scan): emit only ScanComplete to avoid duplicate snapshots (#153)

### DIFF
--- a/crates/voom-cli/src/commands/scan.rs
+++ b/crates/voom-cli/src/commands/scan.rs
@@ -15,7 +15,7 @@ use console::style;
 use indicatif::HumanDuration;
 use tokio_util::sync::CancellationToken;
 use voom_domain::bad_file::BadFileSource;
-use voom_domain::events::{Event, FileDiscoveredEvent, IntrospectCompleteEvent, ScanCompleteEvent};
+use voom_domain::events::{Event, FileDiscoveredEvent, ScanCompleteEvent};
 
 /// Run the scan command.
 ///
@@ -95,9 +95,12 @@ pub async fn run(args: ScanArgs, quiet: bool, token: CancellationToken) -> Resul
     purge_stale_records(&*store, config.pruning.retention_days, quiet);
 
     // Protected from cancelled runs by the early return above (line 91).
-    kernel.dispatch(Event::IntrospectComplete(IntrospectCompleteEvent::new(
-        introspected,
-    )));
+    // `ScanComplete` carries both files_discovered and files_introspected and
+    // is the single lifecycle event for a full scan. We deliberately do NOT
+    // dispatch `IntrospectComplete` here — that event is reserved for
+    // standalone re-introspection runs (see commands/process/mod.rs). Emitting
+    // both would cause subscribers like the report plugin to capture two
+    // back-to-back snapshots (see issue #153).
     kernel.dispatch(Event::ScanComplete(ScanCompleteEvent::new(
         all_events.len() as u64,
         introspected,

--- a/crates/voom-cli/tests/functional_tests.rs
+++ b/crates/voom-cli/tests/functional_tests.rs
@@ -577,6 +577,21 @@ mod test_process {
 mod test_report {
     use super::*;
 
+    /// Read the number of rows currently in `library_snapshots` by querying
+    /// `voom report --history --format json`.
+    fn snapshot_count(env: &TestEnv) -> usize {
+        let output = env
+            .voom()
+            .args(["report", "--history", "100", "--format", "json"])
+            .output()
+            .expect("run report --history");
+        assert!(output.status.success());
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let json: serde_json::Value = serde_json::from_str(&stdout)
+            .expect("report --history --format json should produce valid JSON");
+        json["history"].as_array().map(Vec::len).unwrap_or(0)
+    }
+
     #[test]
     fn report_on_empty_db() {
         let env = TestEnv::new();
@@ -615,34 +630,11 @@ mod test_report {
     #[test]
     fn report_snapshot_persists_to_history() {
         let env = TestEnv::new();
+        let before_count = snapshot_count(&env);
 
-        // Check initial snapshot count (may be zero or non-zero).
-        let before_output = env
-            .voom()
-            .args(["report", "--history", "10", "--format", "json"])
-            .output()
-            .expect("run report --history before snapshot");
-        assert!(before_output.status.success());
-        let before_stdout = String::from_utf8_lossy(&before_output.stdout);
-        let before_json: serde_json::Value = serde_json::from_str(&before_stdout)
-            .expect("report --history --format json should produce valid JSON");
-        let before_count = before_json["history"].as_array().map(Vec::len).unwrap_or(0);
-
-        // Capture a snapshot.
         env.voom().args(["report", "--snapshot"]).assert().success();
 
-        // Verify the history count increased by 1.
-        let after_output = env
-            .voom()
-            .args(["report", "--history", "10", "--format", "json"])
-            .output()
-            .expect("run report --history after snapshot");
-        assert!(after_output.status.success());
-        let after_stdout = String::from_utf8_lossy(&after_output.stdout);
-        let after_json: serde_json::Value = serde_json::from_str(&after_stdout)
-            .expect("report --history --format json should produce valid JSON");
-        let after_count = after_json["history"].as_array().map(Vec::len).unwrap_or(0);
-
+        let after_count = snapshot_count(&env);
         assert_eq!(
             after_count,
             before_count + 1,
@@ -662,36 +654,14 @@ mod test_report {
         let env = TestEnv::new();
         env.populate_media(&["basic-h264-aac"]);
 
-        // Baseline snapshot count before the scan.
-        let before_output = env
-            .voom()
-            .args(["report", "--history", "100", "--format", "json"])
-            .output()
-            .expect("run report --history before scan");
-        assert!(before_output.status.success());
-        let before_stdout = String::from_utf8_lossy(&before_output.stdout);
-        let before_json: serde_json::Value = serde_json::from_str(&before_stdout)
-            .expect("report --history --format json should produce valid JSON");
-        let before_count = before_json["history"].as_array().map(Vec::len).unwrap_or(0);
+        let before_count = snapshot_count(&env);
 
-        // Run a single scan.
         env.voom()
             .args(["scan", env.media_dir().to_str().unwrap()])
             .assert()
             .success();
 
-        // After the scan, exactly one new snapshot row should exist.
-        let after_output = env
-            .voom()
-            .args(["report", "--history", "100", "--format", "json"])
-            .output()
-            .expect("run report --history after scan");
-        assert!(after_output.status.success());
-        let after_stdout = String::from_utf8_lossy(&after_output.stdout);
-        let after_json: serde_json::Value = serde_json::from_str(&after_stdout)
-            .expect("report --history --format json should produce valid JSON");
-        let after_count = after_json["history"].as_array().map(Vec::len).unwrap_or(0);
-
+        let after_count = snapshot_count(&env);
         assert_eq!(
             after_count,
             before_count + 1,

--- a/crates/voom-cli/tests/functional_tests.rs
+++ b/crates/voom-cli/tests/functional_tests.rs
@@ -649,6 +649,56 @@ mod test_report {
             "snapshot count should increase by 1 after --snapshot (was {before_count}, got {after_count})"
         );
     }
+
+    /// Regression test for #153: a single `scan` invocation must produce
+    /// exactly one library snapshot, not two.
+    ///
+    /// Before the fix, `scan` dispatched both `IntrospectComplete` and
+    /// `ScanComplete`, and the report plugin subscribed to both, producing
+    /// duplicate snapshot rows captured milliseconds apart.
+    #[test]
+    fn scan_produces_single_snapshot() {
+        require_tool!("ffprobe");
+        let env = TestEnv::new();
+        env.populate_media(&["basic-h264-aac"]);
+
+        // Baseline snapshot count before the scan.
+        let before_output = env
+            .voom()
+            .args(["report", "--history", "100", "--format", "json"])
+            .output()
+            .expect("run report --history before scan");
+        assert!(before_output.status.success());
+        let before_stdout = String::from_utf8_lossy(&before_output.stdout);
+        let before_json: serde_json::Value = serde_json::from_str(&before_stdout)
+            .expect("report --history --format json should produce valid JSON");
+        let before_count = before_json["history"].as_array().map(Vec::len).unwrap_or(0);
+
+        // Run a single scan.
+        env.voom()
+            .args(["scan", env.media_dir().to_str().unwrap()])
+            .assert()
+            .success();
+
+        // After the scan, exactly one new snapshot row should exist.
+        let after_output = env
+            .voom()
+            .args(["report", "--history", "100", "--format", "json"])
+            .output()
+            .expect("run report --history after scan");
+        assert!(after_output.status.success());
+        let after_stdout = String::from_utf8_lossy(&after_output.stdout);
+        let after_json: serde_json::Value = serde_json::from_str(&after_stdout)
+            .expect("report --history --format json should produce valid JSON");
+        let after_count = after_json["history"].as_array().map(Vec::len).unwrap_or(0);
+
+        assert_eq!(
+            after_count,
+            before_count + 1,
+            "a single `scan` must produce exactly one new snapshot \
+             (was {before_count}, got {after_count})"
+        );
+    }
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/crates/voom-domain/src/events.rs
+++ b/crates/voom-domain/src/events.rs
@@ -801,8 +801,13 @@ impl HealthStatusEvent {
     }
 }
 
-/// Emitted when a scan completes (discovery + introspection).
-/// The report plugin subscribes to this to auto-capture a library snapshot.
+/// Emitted exactly once at the end of a successful `scan` run, after
+/// discovery + introspection finish. Carries both totals so subscribers
+/// (currently just the report plugin's snapshot writer) do not need a
+/// preceding `IntrospectComplete` to learn the introspected count.
+///
+/// **Do NOT also emit `IntrospectComplete` from the same run.** See
+/// `crates/voom-cli/src/commands/scan.rs` and issue #153.
 #[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ScanCompleteEvent {
@@ -820,7 +825,11 @@ impl ScanCompleteEvent {
     }
 }
 
-/// Emitted when introspection completes for a batch of files.
+/// Emitted exactly once at the end of a standalone re-introspection batch
+/// (currently only the `process` command, which re-introspects already-
+/// discovered files before evaluating policies). Reserved for paths that
+/// did NOT run discovery — full scans must emit `ScanComplete` instead.
+///
 /// The report plugin subscribes to this to auto-capture a library snapshot.
 #[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
- `scan` was dispatching both `IntrospectComplete` and `ScanComplete`; the report plugin subscribed to both, capturing two `library_snapshots` rows back-to-back per run.
- `scan` now dispatches only `ScanComplete` (which already carries `files_discovered` + `files_introspected`).
- `process` is intentionally unchanged — it remains the sole owner of `IntrospectComplete` for its standalone re-introspection path.
- Docstrings on `ScanCompleteEvent` and `IntrospectCompleteEvent` now spell out which command owns each event so the duplication can't be silently re-introduced.

## Notes for reviewers
- Empty-scan and cancelled-scan runs continue to emit no lifecycle event (pre-existing behavior, unchanged).
- The new `scan_produces_single_snapshot` functional test fails on `main` with `(was 0, got 2)` and passes on this branch.

## Test plan
- [x] `cargo test`
- [x] `cargo test -p voom-cli --features functional -- --test-threads=4`
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] Manual: a single `voom scan` produces exactly one row in `library_snapshots`

Closes #153.