### PR TITLE
feat: automatic retention for jobs, event_log, file_transitions (#155)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ scorecard.png
 
 # More Claude agent ignores
 docs/superpowers/
+.worktrees/

--- a/crates/voom-cli/src/cli.rs
+++ b/crates/voom-cli/src/cli.rs
@@ -388,8 +388,12 @@ pub struct ServeArgs {
 
 #[derive(Subcommand)]
 pub enum DbCommands {
-    /// Remove entries for files that no longer exist
-    Prune,
+    /// Prune missing files, expired health checks, and run database retention.
+    Prune {
+        /// Show what would be pruned without making any changes.
+        #[arg(long)]
+        dry_run: bool,
+    },
     /// Compact the database
     Vacuum,
     /// Reset the database (destructive!)
@@ -1223,7 +1227,19 @@ mod tests {
     #[test]
     fn test_db_prune() {
         let cli = parse(&["voom", "db", "prune"]);
-        assert!(matches!(cli.command, Commands::Db(DbCommands::Prune)));
+        assert!(matches!(
+            cli.command,
+            Commands::Db(DbCommands::Prune { dry_run: false })
+        ));
+    }
+
+    #[test]
+    fn test_db_prune_dry_run() {
+        let cli = parse(&["voom", "db", "prune", "--dry-run"]);
+        assert!(matches!(
+            cli.command,
+            Commands::Db(DbCommands::Prune { dry_run: true })
+        ));
     }
 
     #[test]

--- a/crates/voom-cli/src/commands/db.rs
+++ b/crates/voom-cli/src/commands/db.rs
@@ -10,7 +10,7 @@ use crate::output;
 
 pub async fn run(cmd: DbCommands, global_yes: bool) -> Result<()> {
     match cmd {
-        DbCommands::Prune => prune(),
+        DbCommands::Prune { dry_run } => prune(dry_run),
         DbCommands::Vacuum => vacuum(),
         DbCommands::Reset { yes } => reset(yes || global_yes).await,
         DbCommands::ListBad { path, format } => list_bad(path, format),
@@ -19,54 +19,70 @@ pub async fn run(cmd: DbCommands, global_yes: bool) -> Result<()> {
     }
 }
 
-fn prune() -> Result<()> {
+fn prune(dry_run: bool) -> Result<()> {
     let config = config::load_config()?;
-    let store = app::open_store(&config)?;
+    let store_arc = app::open_store(&config)?;
 
-    let count = store
-        .prune_missing_files()
-        .context("failed to prune missing files")?;
+    if !dry_run {
+        let count = store_arc
+            .prune_missing_files()
+            .context("failed to prune missing files")?;
 
-    if count == 0 {
-        println!("{}", style("No stale entries found.").dim());
-    } else {
-        println!(
-            "{} Marked {} files as missing.",
-            style("OK").bold().green(),
-            style(count).bold()
-        );
-    }
+        if count == 0 {
+            println!("{}", style("No stale entries found.").dim());
+        } else {
+            println!(
+                "{} Marked {} files as missing.",
+                style("OK").bold().green(),
+                style(count).bold()
+            );
+        }
 
-    // Purge missing files older than retention period
-    let retention_days = config.pruning.retention_days;
-    if retention_days > 0 {
-        let cutoff = chrono::Utc::now() - chrono::Duration::days(i64::from(retention_days));
-        match store.purge_missing(cutoff) {
-            Ok(n) if n > 0 => {
-                println!(
-                    "{} Purged {} missing file records.",
-                    style("OK").bold().green(),
-                    style(n).bold()
-                );
+        // Purge missing files older than retention period
+        let retention_days = config.pruning.retention_days;
+        if retention_days > 0 {
+            let cutoff = chrono::Utc::now() - chrono::Duration::days(i64::from(retention_days));
+            match store_arc.purge_missing(cutoff) {
+                Ok(n) if n > 0 => {
+                    println!(
+                        "{} Purged {} missing file records.",
+                        style("OK").bold().green(),
+                        style(n).bold()
+                    );
+                }
+                Ok(_) => {}
+                Err(e) => tracing::warn!(error = %e, "purge_missing failed"),
             }
-            Ok(_) => {}
-            Err(e) => tracing::warn!(error = %e, "purge_missing failed"),
+        }
+
+        // Prune health checks using the default retention period
+        let retention =
+            i64::from(voom_health_checker::HealthCheckerConfig::default().retention_days);
+        let health_pruned = store_arc
+            .prune_health_checks(chrono::Utc::now() - chrono::Duration::days(retention))
+            .context("failed to prune old health checks")?;
+
+        if health_pruned > 0 {
+            println!(
+                "{} Pruned {} old health check records.",
+                style("OK").bold().green(),
+                style(health_pruned).bold()
+            );
         }
     }
 
-    // Prune health checks using the default retention period
-    let retention = i64::from(voom_health_checker::HealthCheckerConfig::default().retention_days);
-    let health_pruned = store
-        .prune_health_checks(chrono::Utc::now() - chrono::Duration::days(retention))
-        .context("failed to prune old health checks")?;
-
-    if health_pruned > 0 {
-        println!(
-            "{} Pruned {} old health check records.",
-            style("OK").bold().green(),
-            style(health_pruned).bold()
-        );
-    }
+    // Database retention (jobs, event_log, file_transitions).
+    let runner = crate::retention::RetentionRunner::new(
+        store_arc,
+        config.retention.clone(),
+        None, // no event bus dispatch in `db prune`
+    );
+    let summary = if dry_run {
+        runner.dry_run_summary()
+    } else {
+        runner.run_once(voom_domain::events::RetentionTrigger::OnDemand)
+    };
+    print_retention_summary(&summary, dry_run);
 
     Ok(())
 }
@@ -288,6 +304,34 @@ async fn clean_bad(yes: bool) -> Result<()> {
     Ok(())
 }
 
+fn print_retention_summary(summary: &crate::retention::RetentionSummary, dry_run: bool) {
+    let prefix = if dry_run { "Would prune" } else { "Pruned" };
+    for (table, result) in &summary.per_table {
+        match result {
+            Ok(r) if r.deleted > 0 => println!(
+                "{} {} {} rows from {} (kept {})",
+                style("OK").bold().green(),
+                prefix,
+                style(r.deleted).bold(),
+                style(table).cyan(),
+                r.kept,
+            ),
+            Ok(_) => {
+                println!(
+                    "{} no rows to prune in {}",
+                    style("·").dim(),
+                    style(table).cyan()
+                );
+            }
+            Err(e) => println!(
+                "{} {}: {e}",
+                style("WARN").bold().yellow(),
+                style(table).cyan(),
+            ),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::app;
@@ -312,5 +356,14 @@ mod tests {
         };
         let store = app::open_store(&cfg);
         assert!(store.is_ok(), "should open store in temp directory");
+    }
+
+    #[test]
+    fn print_retention_summary_handles_empty() {
+        let summary = crate::retention::RetentionSummary {
+            per_table: vec![],
+            duration: std::time::Duration::from_millis(1),
+        };
+        super::print_retention_summary(&summary, false);
     }
 }

--- a/crates/voom-cli/src/commands/db.rs
+++ b/crates/voom-cli/src/commands/db.rs
@@ -38,7 +38,6 @@ fn prune(dry_run: bool) -> Result<()> {
             );
         }
 
-        // Purge missing files older than retention period
         let retention_days = config.pruning.retention_days;
         if retention_days > 0 {
             let cutoff = chrono::Utc::now() - chrono::Duration::days(i64::from(retention_days));
@@ -55,7 +54,6 @@ fn prune(dry_run: bool) -> Result<()> {
             }
         }
 
-        // Prune health checks using the default retention period
         let retention =
             i64::from(voom_health_checker::HealthCheckerConfig::default().retention_days);
         let health_pruned = store_arc
@@ -71,12 +69,7 @@ fn prune(dry_run: bool) -> Result<()> {
         }
     }
 
-    // Database retention (jobs, event_log, file_transitions).
-    let runner = crate::retention::RetentionRunner::new(
-        store_arc,
-        config.retention.clone(),
-        None, // no event bus dispatch in `db prune`
-    );
+    let runner = crate::retention::RetentionRunner::new(store_arc, config.retention.clone(), None);
     let summary = if dry_run {
         runner.dry_run_summary()
     } else {

--- a/crates/voom-cli/src/commands/process/mod.rs
+++ b/crates/voom-cli/src/commands/process/mod.rs
@@ -71,197 +71,210 @@ pub async fn run(args: ProcessArgs, quiet: bool, token: CancellationToken) -> Re
         ..
     } = app::bootstrap_kernel_with_store(&config)?;
     let kernel = Arc::new(kernel);
+    let store_for_retention = store.clone();
+    let kernel_for_retention = kernel.clone();
     let capabilities = Arc::new(collector.snapshot());
 
     let paths = resolve_paths(&args.paths)?;
 
-    let root = if paths.len() == 1 && paths[0].is_file() {
-        paths[0]
-            .parent()
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "cannot determine parent directory of {}",
-                    paths[0].display()
-                )
-            })?
-            .to_path_buf()
-    } else {
-        paths[0].clone()
-    };
+    let primary_result: Result<()> = async {
+        let root = if paths.len() == 1 && paths[0].is_file() {
+            paths[0]
+                .parent()
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "cannot determine parent directory of {}",
+                        paths[0].display()
+                    )
+                })?
+                .to_path_buf()
+        } else {
+            paths[0].clone()
+        };
 
-    let resolver = build_policy_resolver(&args, &config, &root)?;
-    let counters = RunCounters::new();
+        let resolver = build_policy_resolver(&args, &config, &root)?;
+        let counters = RunCounters::new();
 
-    if !plan_only && !quiet {
-        let path_list: Vec<_> = paths.iter().map(|p| p.display().to_string()).collect();
-        let display_paths = path_list.join(", ");
-        print_run_header(
-            &resolver.summary(),
-            &display_paths,
-            dry_run,
-            counters.session_id,
-        );
-    }
-
-    // Auto-prune stale file entries under the target directories
-    for path in &paths {
-        match store.prune_missing_files_under(path) {
-            Ok(n) if n > 0 && !plan_only && !quiet => eprintln!("Pruned {n} stale entries."),
-            Ok(_) => {}
-            Err(e) => tracing::warn!(error = %e, "auto-prune failed"),
-        }
-    }
-
-    // Check for orphaned backups left by a previous crashed execution
-    // Extract backup-manager's global backup dir from plugin config, if set.
-    let global_backup_dir: Option<std::path::PathBuf> =
-        config.plugin.get("backup-manager").and_then(|t| {
-            let use_global = t
-                .get("use_global_dir")
-                .and_then(toml::Value::as_bool)
-                .unwrap_or(false);
-            if use_global {
-                t.get("backup_dir")
-                    .and_then(|v| v.as_str())
-                    .map(std::path::PathBuf::from)
-            } else {
-                None
-            }
-        });
-    match crate::recovery::check_and_recover_under(
-        &config.recovery,
-        &paths,
-        store.as_ref(),
-        global_backup_dir.as_deref(),
-    ) {
-        Ok(recovered) if recovered > 0 && !plan_only && !quiet => {
-            eprintln!(
-                "{} {} {} from crashed execution",
-                console::style("Recovered").bold().green(),
-                recovered,
-                if recovered == 1 { "file" } else { "files" }
+        if !plan_only && !quiet {
+            let path_list: Vec<_> = paths.iter().map(|p| p.display().to_string()).collect();
+            let display_paths = path_list.join(", ");
+            print_run_header(
+                &resolver.summary(),
+                &display_paths,
+                dry_run,
+                counters.session_id,
             );
         }
-        Ok(_) => {}
-        Err(e) => tracing::warn!(error = %e, "crash recovery check failed"),
-    }
 
-    if token.is_cancelled() {
-        if !plan_only && !quiet {
-            eprintln!("{}", style("Interrupted before discovery.").yellow());
+        // Auto-prune stale file entries under the target directories
+        for path in &paths {
+            match store.prune_missing_files_under(path) {
+                Ok(n) if n > 0 && !plan_only && !quiet => eprintln!("Pruned {n} stale entries."),
+                Ok(_) => {}
+                Err(e) => tracing::warn!(error = %e, "auto-prune failed"),
+            }
         }
-        return Ok(());
-    }
 
-    let mut events = discover_files(&paths, &args, &kernel, quiet, store.clone())?;
-    if events.is_empty() {
-        if plan_only {
-            println!("[]");
-        } else if !quiet {
-            eprintln!("{}", style("No media files found.").yellow());
-        }
-        return Ok(());
-    }
-
-    // Filter out known-bad files unless --force-rescan is set
-    if !args.force_rescan {
-        filter_bad_files(&mut events, &store, plan_only, quiet)?;
-    }
-
-    if events.is_empty() {
-        if plan_only {
-            println!("[]");
-        } else if !quiet {
-            eprintln!("{}", style("No processable files found.").yellow());
-        }
-        return Ok(());
-    }
-
-    let file_count = events.len();
-    if !plan_only && !quiet {
-        eprintln!("Found {} media files.", style(file_count).bold());
-    }
-
-    let on_error = match args.on_error {
-        ErrorHandling::Fail => JobErrorStrategy::Fail,
-        ErrorHandling::Continue => JobErrorStrategy::Continue,
-    };
-
-    if token.is_cancelled() {
-        if !quiet {
-            eprintln!("{}", style("Interrupted before processing.").yellow());
-        }
-        return Ok(());
-    }
-
-    let (pool, effective_workers) = create_worker_pool(job_queue, &args, token.clone());
-
-    let reporter = build_reporter(&events, effective_workers, plan_only, quiet, kernel.clone());
-
-    let items = build_work_items(&events, args.priority_by_date);
-    let all_phase_names = resolver.all_phase_names();
-    let resolver = Arc::new(resolver);
-    let flag_size_increase = args.flag_size_increase;
-    let flag_duration_shrink = args.flag_duration_shrink;
-    let force_rescan = args.force_rescan;
-
-    let token_for_workers = token.clone();
-    let ffprobe_path: Option<String> = config.ffprobe_path().map(String::from);
-    let ffprobe_path = Arc::new(ffprobe_path);
-    let counters_for_summary = counters.clone();
-    let kernel_for_completion = kernel.clone();
-    let _results = pool
-        .process_batch(
-            items,
-            move |job| {
-                let resolver = resolver.clone();
-                let kernel = kernel.clone();
-                let store = store.clone();
-                let token = token_for_workers.clone();
-                let ffprobe_path = ffprobe_path.clone();
-                let capabilities = capabilities.clone();
-                let counters = counters.clone();
-                async move {
-                    let ctx = ProcessContext {
-                        resolver: &resolver,
-                        kernel,
-                        store,
-                        dry_run,
-                        plan_only,
-                        flag_size_increase,
-                        flag_duration_shrink,
-                        force_rescan,
-                        token: &token,
-                        ffprobe_path: ffprobe_path.as_deref(),
-                        capabilities: &capabilities,
-                        counters: &counters,
-                    };
-                    process_single_file(job, &ctx).await
+        // Check for orphaned backups left by a previous crashed execution
+        // Extract backup-manager's global backup dir from plugin config, if set.
+        let global_backup_dir: Option<std::path::PathBuf> =
+            config.plugin.get("backup-manager").and_then(|t| {
+                let use_global = t
+                    .get("use_global_dir")
+                    .and_then(toml::Value::as_bool)
+                    .unwrap_or(false);
+                if use_global {
+                    t.get("backup_dir")
+                        .and_then(|v| v.as_str())
+                        .map(std::path::PathBuf::from)
+                } else {
+                    None
                 }
-            },
-            on_error,
-            reporter.clone(),
-        )
-        .await;
+            });
+        match crate::recovery::check_and_recover_under(
+            &config.recovery,
+            &paths,
+            store.as_ref(),
+            global_backup_dir.as_deref(),
+        ) {
+            Ok(recovered) if recovered > 0 && !plan_only && !quiet => {
+                eprintln!(
+                    "{} {} {} from crashed execution",
+                    console::style("Recovered").bold().green(),
+                    recovered,
+                    if recovered == 1 { "file" } else { "files" }
+                );
+            }
+            Ok(_) => {}
+            Err(e) => tracing::warn!(error = %e, "crash recovery check failed"),
+        }
 
-    if !token.is_cancelled() {
-        kernel_for_completion.dispatch(Event::IntrospectComplete(IntrospectCompleteEvent::new(
-            pool.completed_count(),
-        )));
+        if token.is_cancelled() {
+            if !plan_only && !quiet {
+                eprintln!("{}", style("Interrupted before discovery.").yellow());
+            }
+            return Ok(());
+        }
+
+        let mut events = discover_files(&paths, &args, &kernel, quiet, store.clone())?;
+        if events.is_empty() {
+            if plan_only {
+                println!("[]");
+            } else if !quiet {
+                eprintln!("{}", style("No media files found.").yellow());
+            }
+            return Ok(());
+        }
+
+        // Filter out known-bad files unless --force-rescan is set
+        if !args.force_rescan {
+            filter_bad_files(&mut events, &store, plan_only, quiet)?;
+        }
+
+        if events.is_empty() {
+            if plan_only {
+                println!("[]");
+            } else if !quiet {
+                eprintln!("{}", style("No processable files found.").yellow());
+            }
+            return Ok(());
+        }
+
+        let file_count = events.len();
+        if !plan_only && !quiet {
+            eprintln!("Found {} media files.", style(file_count).bold());
+        }
+
+        let on_error = match args.on_error {
+            ErrorHandling::Fail => JobErrorStrategy::Fail,
+            ErrorHandling::Continue => JobErrorStrategy::Continue,
+        };
+
+        if token.is_cancelled() {
+            if !quiet {
+                eprintln!("{}", style("Interrupted before processing.").yellow());
+            }
+            return Ok(());
+        }
+
+        let (pool, effective_workers) = create_worker_pool(job_queue, &args, token.clone());
+
+        let reporter = build_reporter(&events, effective_workers, plan_only, quiet, kernel.clone());
+
+        let items = build_work_items(&events, args.priority_by_date);
+        let all_phase_names = resolver.all_phase_names();
+        let resolver = Arc::new(resolver);
+        let flag_size_increase = args.flag_size_increase;
+        let flag_duration_shrink = args.flag_duration_shrink;
+        let force_rescan = args.force_rescan;
+
+        let token_for_workers = token.clone();
+        let ffprobe_path: Option<String> = config.ffprobe_path().map(String::from);
+        let ffprobe_path = Arc::new(ffprobe_path);
+        let counters_for_summary = counters.clone();
+        let kernel_for_completion = kernel.clone();
+        let _results = pool
+            .process_batch(
+                items,
+                move |job| {
+                    let resolver = resolver.clone();
+                    let kernel = kernel.clone();
+                    let store = store.clone();
+                    let token = token_for_workers.clone();
+                    let ffprobe_path = ffprobe_path.clone();
+                    let capabilities = capabilities.clone();
+                    let counters = counters.clone();
+                    async move {
+                        let ctx = ProcessContext {
+                            resolver: &resolver,
+                            kernel,
+                            store,
+                            dry_run,
+                            plan_only,
+                            flag_size_increase,
+                            flag_duration_shrink,
+                            force_rescan,
+                            token: &token,
+                            ffprobe_path: ffprobe_path.as_deref(),
+                            capabilities: &capabilities,
+                            counters: &counters,
+                        };
+                        process_single_file(job, &ctx).await
+                    }
+                },
+                on_error,
+                reporter.clone(),
+            )
+            .await;
+
+        if !token.is_cancelled() {
+            kernel_for_completion.dispatch(Event::IntrospectComplete(
+                IntrospectCompleteEvent::new(pool.completed_count()),
+            ));
+        }
+
+        print_run_results(&RunResultsContext {
+            counters: &counters_for_summary,
+            plan_only,
+            quiet,
+            cancelled: token.is_cancelled(),
+            pool: &pool,
+            file_count,
+            effective_workers,
+            dry_run,
+            paths: &paths,
+            all_phase_names: &all_phase_names,
+        })
     }
+    .await;
 
-    print_run_results(&RunResultsContext {
-        counters: &counters_for_summary,
-        plan_only,
-        quiet,
-        cancelled: token.is_cancelled(),
-        pool: &pool,
-        file_count,
-        effective_workers,
-        dry_run,
-        paths: &paths,
-        all_phase_names: &all_phase_names,
-    })
+    crate::retention::maybe_run_after_cli(
+        store_for_retention,
+        &config.retention,
+        Some(kernel_for_retention),
+    );
+
+    primary_result
 }
 
 /// Remove known-bad files from the event list, logging how many were skipped.

--- a/crates/voom-cli/src/commands/report.rs
+++ b/crates/voom-cli/src/commands/report.rs
@@ -41,6 +41,9 @@ pub fn run(args: &ReportArgs) -> Result<()> {
         format_summary(&result, args.format)?;
     } else {
         format_result(&result, args)?;
+        if args.database && !args.format.is_machine() {
+            print_retention_footer(&*store);
+        }
     }
     Ok(())
 }
@@ -602,6 +605,30 @@ fn print_database_section_table(db: &DatabaseStats) {
         style(format_size(free)).dim(),
     );
     println!();
+}
+
+fn print_retention_footer(store: &dyn voom_domain::storage::StorageTrait) {
+    if let Ok(Some(record)) = store.latest_event_of_type("retention.completed") {
+        if let Ok(voom_domain::events::Event::RetentionCompleted(e)) =
+            serde_json::from_str::<voom_domain::events::Event>(&record.payload)
+        {
+            println!();
+            println!(
+                "Last retention pass: {:?} ({} ms)",
+                e.trigger, e.duration_ms
+            );
+            for table in &e.per_table {
+                if let Some(ref err) = table.error {
+                    println!("  {:20} ERROR: {err}", table.table);
+                } else {
+                    println!(
+                        "  {:20} deleted={} kept={}",
+                        table.table, table.deleted, table.kept
+                    );
+                }
+            }
+        }
+    }
 }
 
 // ── Plain formatting ────────────────────────────────────────

--- a/crates/voom-cli/src/commands/scan.rs
+++ b/crates/voom-cli/src/commands/scan.rs
@@ -26,91 +26,99 @@ pub async fn run(args: ScanArgs, quiet: bool, token: CancellationToken) -> Resul
     let config = config::load_config()?;
     let app::BootstrapResult { kernel, store, .. } = app::bootstrap_kernel_with_store(&config)?;
     let kernel = Arc::new(kernel);
-    let paths = resolve_paths(&args.paths)?;
-    let hash_files = !args.no_hash;
-    let start = Instant::now();
 
-    if !quiet {
-        let path_list: Vec<_> = paths
-            .iter()
-            .map(|p| style(p.display()).cyan().to_string())
-            .collect();
-        eprintln!("{} {}", style("Scanning").bold(), path_list.join(", "));
-    }
+    let primary_result: Result<()> = async {
+        let paths = resolve_paths(&args.paths)?;
+        let hash_files = !args.no_hash;
+        let start = Instant::now();
 
-    let (mut all_events, orphans, disc_errors) =
-        run_discovery(&args, &paths, hash_files, quiet, &kernel, store.clone())?;
+        if !quiet {
+            let path_list: Vec<_> = paths
+                .iter()
+                .map(|p| style(p.display()).cyan().to_string())
+                .collect();
+            eprintln!("{} {}", style("Scanning").bold(), path_list.join(", "));
+        }
 
-    // Deduplicate events by path in case multiple scan roots overlap
-    let mut seen = HashSet::new();
-    all_events.retain(|e| seen.insert(e.path.clone()));
+        let (mut all_events, orphans, disc_errors) =
+            run_discovery(&args, &paths, hash_files, quiet, &kernel, store.clone())?;
 
-    if all_events.is_empty() {
-        handle_empty_scan(&*store, &paths, hash_files, orphans, quiet, args.format)?;
-        return Ok(());
-    }
+        // Deduplicate events by path in case multiple scan roots overlap
+        let mut seen = HashSet::new();
+        all_events.retain(|e| seen.insert(e.path.clone()));
 
-    if !quiet {
-        print_discovery_summary(
-            all_events.len(),
+        if all_events.is_empty() {
+            handle_empty_scan(&*store, &paths, hash_files, orphans, quiet, args.format)?;
+            return Ok(());
+        }
+
+        if !quiet {
+            print_discovery_summary(
+                all_events.len(),
+                start.elapsed(),
+                hash_files,
+                orphans,
+                disc_errors,
+            );
+        }
+
+        mark_missing_without_hash(&*store, &all_events, &paths, hash_files, quiet)?;
+        let reconcile_paths = reconcile_files(&*store, &all_events, &paths, hash_files, quiet)?;
+
+        // Dispatch FileDiscovered events through the kernel so subscribers react.
+        for event in &all_events {
+            kernel.dispatch(Event::FileDiscovered(event.clone()));
+        }
+
+        let needs_introspection = filter_for_introspection(&all_events, reconcile_paths.as_ref());
+        let (introspected, errors) = run_introspection(
+            &needs_introspection,
+            &kernel,
+            config.ffprobe_path(),
+            &token,
+            quiet,
+        )
+        .await;
+
+        print_scan_summary(
+            &all_events,
+            introspected,
+            errors,
             start.elapsed(),
-            hash_files,
-            orphans,
-            disc_errors,
+            token.is_cancelled(),
+            quiet,
+            args.format,
         );
+
+        if token.is_cancelled() {
+            return Ok(());
+        }
+
+        purge_stale_records(&*store, config.pruning.retention_days, quiet);
+
+        // Protected from cancelled runs by the early return above (line 91).
+        // `ScanComplete` carries both files_discovered and files_introspected and
+        // is the single lifecycle event for a full scan. We deliberately do NOT
+        // dispatch `IntrospectComplete` here — that event is reserved for
+        // standalone re-introspection runs (see commands/process/mod.rs). Emitting
+        // both would cause subscribers like the report plugin to capture two
+        // back-to-back snapshots (see issue #153).
+        kernel.dispatch(Event::ScanComplete(ScanCompleteEvent::new(
+            all_events.len() as u64,
+            introspected,
+        )));
+
+        if let Some(format) = args.format {
+            output::format_scan_results(&format_results(&all_events), format);
+        }
+
+        Ok(())
     }
-
-    mark_missing_without_hash(&*store, &all_events, &paths, hash_files, quiet)?;
-    let reconcile_paths = reconcile_files(&*store, &all_events, &paths, hash_files, quiet)?;
-
-    // Dispatch FileDiscovered events through the kernel so subscribers react.
-    for event in &all_events {
-        kernel.dispatch(Event::FileDiscovered(event.clone()));
-    }
-
-    let needs_introspection = filter_for_introspection(&all_events, reconcile_paths.as_ref());
-    let (introspected, errors) = run_introspection(
-        &needs_introspection,
-        &kernel,
-        config.ffprobe_path(),
-        &token,
-        quiet,
-    )
     .await;
 
-    print_scan_summary(
-        &all_events,
-        introspected,
-        errors,
-        start.elapsed(),
-        token.is_cancelled(),
-        quiet,
-        args.format,
-    );
+    crate::retention::maybe_run_after_cli(store, &config.retention, Some(kernel));
 
-    if token.is_cancelled() {
-        return Ok(());
-    }
-
-    purge_stale_records(&*store, config.pruning.retention_days, quiet);
-
-    // Protected from cancelled runs by the early return above (line 91).
-    // `ScanComplete` carries both files_discovered and files_introspected and
-    // is the single lifecycle event for a full scan. We deliberately do NOT
-    // dispatch `IntrospectComplete` here — that event is reserved for
-    // standalone re-introspection runs (see commands/process/mod.rs). Emitting
-    // both would cause subscribers like the report plugin to capture two
-    // back-to-back snapshots (see issue #153).
-    kernel.dispatch(Event::ScanComplete(ScanCompleteEvent::new(
-        all_events.len() as u64,
-        introspected,
-    )));
-
-    if let Some(format) = args.format {
-        output::format_scan_results(&format_results(&all_events), format);
-    }
-
-    Ok(())
+    primary_result
 }
 
 /// Run filesystem discovery across all paths, returning events and counters.

--- a/crates/voom-cli/src/commands/serve.rs
+++ b/crates/voom-cli/src/commands/serve.rs
@@ -125,14 +125,13 @@ pub async fn run(args: ServeArgs, token: CancellationToken) -> Result<()> {
 
     if retention_interval_secs > 0 && !retention_runner.is_fully_disabled() {
         let retention_token = token.clone();
-        let runner = retention_runner.clone();
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(Duration::from_secs(retention_interval_secs));
             interval.tick().await; // skip immediate first tick
             loop {
                 tokio::select! {
                     _ = interval.tick() => {
-                        let r = runner.clone();
+                        let r = retention_runner.clone();
                         let _ = tokio::task::spawn_blocking(move || {
                             r.run_once(voom_domain::events::RetentionTrigger::Scheduled);
                         }).await;

--- a/crates/voom-cli/src/commands/serve.rs
+++ b/crates/voom-cli/src/commands/serve.rs
@@ -114,6 +114,37 @@ pub async fn run(args: ServeArgs, token: CancellationToken) -> Result<()> {
         });
     }
 
+    // ── Retention task ────────────────────────────────────────────
+    let retention_runner = Arc::new(crate::retention::RetentionRunner::new(
+        store.clone(),
+        config.retention.clone(),
+        Some(kernel.clone()),
+    ));
+    let retention_interval_secs =
+        u64::from(config.retention.schedule_interval_minutes).saturating_mul(60);
+
+    if retention_interval_secs > 0 && !retention_runner.is_fully_disabled() {
+        let retention_token = token.clone();
+        let runner = retention_runner.clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(retention_interval_secs));
+            interval.tick().await; // skip immediate first tick
+            loop {
+                tokio::select! {
+                    _ = interval.tick() => {
+                        let r = runner.clone();
+                        let _ = tokio::task::spawn_blocking(move || {
+                            r.run_once(voom_domain::events::RetentionTrigger::Scheduled);
+                        }).await;
+                    }
+                    () = retention_token.cancelled() => break,
+                }
+            }
+        });
+    } else {
+        tracing::info!("retention task disabled (interval=0 or all tables disabled)");
+    }
+
     println!(
         "{} Starting VOOM web server on {}:{}",
         style("●").bold().green(),
@@ -152,6 +183,33 @@ mod tests {
         assert_eq!(server_config.port, 8080);
         assert_eq!(server_config.host, "127.0.0.1");
         assert!(server_config.auth_token.is_none());
+    }
+
+    #[test]
+    fn retention_runner_is_disabled_when_all_zero() {
+        use std::sync::Arc;
+        use voom_domain::test_support::InMemoryStore;
+
+        let cfg = crate::config::RetentionConfig {
+            schedule_interval_minutes: 60,
+            run_after_cli: true,
+            jobs: crate::config::TableRetention {
+                keep_for_days: Some(0),
+                keep_last: Some(0),
+            },
+            event_log: crate::config::TableRetention {
+                keep_for_days: Some(0),
+                keep_last: Some(0),
+            },
+            file_transitions: crate::config::TableRetention {
+                keep_for_days: Some(0),
+                keep_last: Some(0),
+            },
+        };
+
+        let store: Arc<dyn voom_domain::storage::StorageTrait> = Arc::new(InMemoryStore::new());
+        let runner = crate::retention::RetentionRunner::new(store, cfg, None);
+        assert!(runner.is_fully_disabled());
     }
 
     #[test]

--- a/crates/voom-cli/src/config.rs
+++ b/crates/voom-cli/src/config.rs
@@ -45,6 +45,69 @@ fn default_retention_days() -> u32 {
     30
 }
 
+/// Per-table retention bounds. Either field may be `Some(0)` to disable that
+/// bound; both being `Some(0)` (or both `None`) disables retention for the table.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TableRetention {
+    pub keep_for_days: Option<u32>,
+    pub keep_last: Option<u64>,
+}
+
+impl TableRetention {
+    fn for_jobs() -> Self {
+        Self {
+            keep_for_days: Some(7),
+            keep_last: Some(50_000),
+        }
+    }
+    fn for_event_log() -> Self {
+        Self {
+            keep_for_days: Some(30),
+            keep_last: Some(100_000),
+        }
+    }
+    fn for_file_transitions() -> Self {
+        Self {
+            keep_for_days: Some(90),
+            keep_last: Some(500_000),
+        }
+    }
+}
+
+/// Top-level retention configuration.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RetentionConfig {
+    #[serde(default = "default_schedule_interval_minutes")]
+    pub schedule_interval_minutes: u32,
+    #[serde(default = "default_run_after_cli")]
+    pub run_after_cli: bool,
+    #[serde(default = "TableRetention::for_jobs")]
+    pub jobs: TableRetention,
+    #[serde(default = "TableRetention::for_event_log")]
+    pub event_log: TableRetention,
+    #[serde(default = "TableRetention::for_file_transitions")]
+    pub file_transitions: TableRetention,
+}
+
+impl Default for RetentionConfig {
+    fn default() -> Self {
+        Self {
+            schedule_interval_minutes: default_schedule_interval_minutes(),
+            run_after_cli: default_run_after_cli(),
+            jobs: TableRetention::for_jobs(),
+            event_log: TableRetention::for_event_log(),
+            file_transitions: TableRetention::for_file_transitions(),
+        }
+    }
+}
+
+fn default_schedule_interval_minutes() -> u32 {
+    60
+}
+fn default_run_after_cli() -> bool {
+    true
+}
+
 /// Application configuration loaded from TOML.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct AppConfig {
@@ -70,6 +133,8 @@ pub struct AppConfig {
     pub recovery: RecoveryConfig,
     #[serde(default)]
     pub pruning: PruningConfig,
+    #[serde(default)]
+    pub retention: RetentionConfig,
 }
 
 impl std::fmt::Debug for AppConfig {
@@ -86,6 +151,7 @@ impl std::fmt::Debug for AppConfig {
             .field("policy_mapping", &self.policy_mapping)
             .field("recovery", &self.recovery)
             .field("pruning", &self.pruning)
+            .field("retention", &self.retention)
             .finish()
     }
 }
@@ -120,6 +186,7 @@ impl Default for AppConfig {
             policy_mapping: Vec::new(),
             recovery: RecoveryConfig::default(),
             pruning: PruningConfig::default(),
+            retention: RetentionConfig::default(),
         }
     }
 }
@@ -293,6 +360,27 @@ mode = "always_recover"
 # Missing file pruning: how long to keep records for files no longer on disk.
 [pruning]
 retention_days = 30
+
+# Database retention. Bounds the size of jobs, event_log, and file_transitions
+# to keep the database from growing forever. Set keep_for_days = 0 and keep_last = 0
+# for any table to disable retention for that table.
+[retention]
+# How often the periodic prune runs in `serve` mode (minutes).
+schedule_interval_minutes = 60
+# Whether `voom scan` and `voom process` run a single prune pass after they finish.
+run_after_cli = true
+
+[retention.jobs]
+keep_for_days = 7
+keep_last = 50000
+
+[retention.event_log]
+keep_for_days = 30
+keep_last = 100000
+
+[retention.file_transitions]
+keep_for_days = 90
+keep_last = 500000
 "#
     )
 }
@@ -519,6 +607,13 @@ mod tests {
             contents.contains("[pruning]"),
             "should have pruning section"
         );
+        assert!(
+            contents.contains("[retention]"),
+            "should have retention section"
+        );
+        assert!(contents.contains("[retention.jobs]"));
+        assert!(contents.contains("[retention.event_log]"));
+        assert!(contents.contains("[retention.file_transitions]"));
     }
 
     // ── load_config with temp files ──────────────────────────
@@ -699,5 +794,35 @@ api_key = "abc123"
             |t| serde_json::to_value(t).unwrap_or_default(),
         );
         assert_eq!(unconfigured, serde_json::json!({}));
+    }
+
+    #[test]
+    fn retention_config_roundtrips() {
+        let toml_str = r#"
+[retention]
+schedule_interval_minutes = 30
+run_after_cli = false
+
+[retention.jobs]
+keep_for_days = 14
+keep_last = 100000
+"#;
+        let cfg: AppConfig = toml::from_str(toml_str).expect("parse");
+        assert_eq!(cfg.retention.schedule_interval_minutes, 30);
+        assert!(!cfg.retention.run_after_cli);
+        assert_eq!(cfg.retention.jobs.keep_for_days, Some(14));
+        assert_eq!(cfg.retention.jobs.keep_last, Some(100_000));
+        // Tables not listed get the type defaults
+        assert_eq!(cfg.retention.event_log.keep_for_days, Some(30));
+        assert_eq!(cfg.retention.file_transitions.keep_for_days, Some(90));
+    }
+
+    #[test]
+    fn retention_defaults_when_absent() {
+        let cfg: AppConfig = toml::from_str("").expect("parse");
+        assert_eq!(cfg.retention.schedule_interval_minutes, 60);
+        assert!(cfg.retention.run_after_cli);
+        assert_eq!(cfg.retention.jobs.keep_for_days, Some(7));
+        assert_eq!(cfg.retention.jobs.keep_last, Some(50_000));
     }
 }

--- a/crates/voom-cli/src/main.rs
+++ b/crates/voom-cli/src/main.rs
@@ -14,6 +14,7 @@ mod paths;
 mod policy_map;
 mod progress;
 mod recovery;
+pub mod retention;
 mod tools;
 
 use cli::{Cli, Commands};

--- a/crates/voom-cli/src/retention.rs
+++ b/crates/voom-cli/src/retention.rs
@@ -1,0 +1,191 @@
+//! Retention runner. Reads per-table policies from `RetentionConfig`,
+//! invokes each storage trait's `prune_old_*` method, and emits a
+//! `RetentionCompletedEvent` on the kernel's event bus.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use voom_domain::events::{Event, RetentionCompletedEvent, RetentionTrigger, TableRetentionResult};
+use voom_domain::storage::{
+    EventLogStorage, FileTransitionStorage, JobStorage, PruneReport, RetentionPolicy,
+};
+use voom_kernel::Kernel;
+
+use crate::config::{RetentionConfig, TableRetention};
+
+/// Convert a TOML-loaded `TableRetention` into a `RetentionPolicy`.
+///
+/// `Some(0)` collapses to `None` so the policy treats it as "no bound".
+#[must_use]
+pub fn table_retention_to_policy(t: &TableRetention) -> RetentionPolicy {
+    let max_age = t
+        .keep_for_days
+        .filter(|n| *n > 0)
+        .map(|days| chrono::Duration::days(i64::from(days)));
+    let keep_last = t.keep_last.filter(|n| *n > 0);
+    RetentionPolicy { max_age, keep_last }
+}
+
+/// Storage handle exposing the three trait surfaces the runner needs.
+pub trait RetentionStore: JobStorage + EventLogStorage + FileTransitionStorage {}
+
+impl<T> RetentionStore for T where T: JobStorage + EventLogStorage + FileTransitionStorage {}
+
+pub struct RetentionRunner {
+    store: Arc<dyn RetentionStore>,
+    config: RetentionConfig,
+    kernel: Option<Arc<Kernel>>,
+}
+
+#[derive(Debug)]
+pub struct RetentionSummary {
+    pub per_table: Vec<(String, anyhow::Result<PruneReport>)>,
+    pub duration: Duration,
+}
+
+impl RetentionRunner {
+    pub fn new(
+        store: Arc<dyn RetentionStore>,
+        config: RetentionConfig,
+        kernel: Option<Arc<Kernel>>,
+    ) -> Self {
+        Self {
+            store,
+            config,
+            kernel,
+        }
+    }
+
+    /// True when every configured table has both bounds disabled.
+    #[must_use]
+    pub fn is_fully_disabled(&self) -> bool {
+        table_retention_to_policy(&self.config.jobs).is_disabled()
+            && table_retention_to_policy(&self.config.event_log).is_disabled()
+            && table_retention_to_policy(&self.config.file_transitions).is_disabled()
+    }
+
+    /// Run all three table prunes, log results, and emit `RetentionCompletedEvent`.
+    pub fn run_once(&self, trigger: RetentionTrigger) -> RetentionSummary {
+        let start = Instant::now();
+        let per_table: Vec<(String, anyhow::Result<PruneReport>)> = vec![
+            ("jobs".to_string(), self.prune_jobs()),
+            ("event_log".to_string(), self.prune_event_log()),
+            (
+                "file_transitions".to_string(),
+                self.prune_file_transitions(),
+            ),
+        ];
+
+        let duration = start.elapsed();
+
+        for (table, result) in &per_table {
+            match result {
+                Ok(r) => tracing::info!(
+                    table = %table,
+                    deleted = r.deleted,
+                    kept = r.kept,
+                    ms = u64::try_from(duration.as_millis()).unwrap_or(u64::MAX),
+                    "retention complete"
+                ),
+                Err(e) => tracing::warn!(table = %table, error = %e, "retention failed"),
+            }
+        }
+
+        if let Some(kernel) = &self.kernel {
+            let event = Event::RetentionCompleted(RetentionCompletedEvent {
+                trigger,
+                per_table: per_table
+                    .iter()
+                    .map(|(t, r)| TableRetentionResult {
+                        table: t.clone(),
+                        deleted: r.as_ref().map(|x| x.deleted).unwrap_or(0),
+                        kept: r.as_ref().map(|x| x.kept).unwrap_or(0),
+                        error: r.as_ref().err().map(std::string::ToString::to_string),
+                    })
+                    .collect(),
+                duration_ms: u64::try_from(duration.as_millis()).unwrap_or(u64::MAX),
+            });
+            let _ = kernel.dispatch(event);
+        }
+
+        RetentionSummary {
+            per_table,
+            duration,
+        }
+    }
+
+    fn prune_jobs(&self) -> anyhow::Result<PruneReport> {
+        let policy = table_retention_to_policy(&self.config.jobs);
+        Ok(self.store.prune_old_jobs(policy)?)
+    }
+
+    fn prune_event_log(&self) -> anyhow::Result<PruneReport> {
+        let policy = table_retention_to_policy(&self.config.event_log);
+        Ok(self.store.prune_old_event_log(policy)?)
+    }
+
+    fn prune_file_transitions(&self) -> anyhow::Result<PruneReport> {
+        let policy = table_retention_to_policy(&self.config.file_transitions);
+        Ok(self.store.prune_old_file_transitions(policy)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use voom_domain::test_support::InMemoryStore;
+
+    #[test]
+    fn table_retention_zero_disables_both_bounds() {
+        let t = TableRetention {
+            keep_for_days: Some(0),
+            keep_last: Some(0),
+        };
+        let p = table_retention_to_policy(&t);
+        assert!(p.max_age.is_none());
+        assert!(p.keep_last.is_none());
+        assert!(p.is_disabled());
+    }
+
+    #[test]
+    fn table_retention_none_is_disabled() {
+        let t = TableRetention {
+            keep_for_days: None,
+            keep_last: None,
+        };
+        assert!(table_retention_to_policy(&t).is_disabled());
+    }
+
+    #[test]
+    fn run_once_returns_one_result_per_table() {
+        let store: Arc<dyn RetentionStore> = Arc::new(InMemoryStore::new());
+        let runner = RetentionRunner::new(store, RetentionConfig::default(), None);
+        let summary = runner.run_once(RetentionTrigger::OnDemand);
+        assert_eq!(summary.per_table.len(), 3);
+        assert!(summary.per_table.iter().all(|(_, r)| r.is_ok()));
+    }
+
+    #[test]
+    fn is_fully_disabled_true_when_all_zero() {
+        let zero = TableRetention {
+            keep_for_days: Some(0),
+            keep_last: Some(0),
+        };
+        let config = RetentionConfig {
+            jobs: zero.clone(),
+            event_log: zero.clone(),
+            file_transitions: zero,
+            ..RetentionConfig::default()
+        };
+        let store: Arc<dyn RetentionStore> = Arc::new(InMemoryStore::new());
+        let runner = RetentionRunner::new(store, config, None);
+        assert!(runner.is_fully_disabled());
+    }
+
+    #[test]
+    fn is_fully_disabled_false_when_any_enabled() {
+        let store: Arc<dyn RetentionStore> = Arc::new(InMemoryStore::new());
+        let runner = RetentionRunner::new(store, RetentionConfig::default(), None);
+        assert!(!runner.is_fully_disabled());
+    }
+}

--- a/crates/voom-cli/src/retention.rs
+++ b/crates/voom-cli/src/retention.rs
@@ -6,9 +6,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use voom_domain::events::{Event, RetentionCompletedEvent, RetentionTrigger, TableRetentionResult};
-use voom_domain::storage::{
-    EventLogStorage, FileTransitionStorage, JobStorage, PruneReport, RetentionPolicy,
-};
+use voom_domain::storage::{PruneReport, RetentionPolicy};
 use voom_kernel::Kernel;
 
 use crate::config::{RetentionConfig, TableRetention};
@@ -26,13 +24,8 @@ pub fn table_retention_to_policy(t: &TableRetention) -> RetentionPolicy {
     RetentionPolicy { max_age, keep_last }
 }
 
-/// Storage handle exposing the three trait surfaces the runner needs.
-pub trait RetentionStore: JobStorage + EventLogStorage + FileTransitionStorage {}
-
-impl<T> RetentionStore for T where T: JobStorage + EventLogStorage + FileTransitionStorage {}
-
 pub struct RetentionRunner {
-    store: Arc<dyn RetentionStore>,
+    store: Arc<dyn voom_domain::storage::StorageTrait>,
     config: RetentionConfig,
     kernel: Option<Arc<Kernel>>,
 }
@@ -45,7 +38,7 @@ pub struct RetentionSummary {
 
 impl RetentionRunner {
     pub fn new(
-        store: Arc<dyn RetentionStore>,
+        store: Arc<dyn voom_domain::storage::StorageTrait>,
         config: RetentionConfig,
         kernel: Option<Arc<Kernel>>,
     ) -> Self {
@@ -158,7 +151,7 @@ mod tests {
 
     #[test]
     fn run_once_returns_one_result_per_table() {
-        let store: Arc<dyn RetentionStore> = Arc::new(InMemoryStore::new());
+        let store: Arc<dyn voom_domain::storage::StorageTrait> = Arc::new(InMemoryStore::new());
         let runner = RetentionRunner::new(store, RetentionConfig::default(), None);
         let summary = runner.run_once(RetentionTrigger::OnDemand);
         assert_eq!(summary.per_table.len(), 3);
@@ -177,14 +170,14 @@ mod tests {
             file_transitions: zero,
             ..RetentionConfig::default()
         };
-        let store: Arc<dyn RetentionStore> = Arc::new(InMemoryStore::new());
+        let store: Arc<dyn voom_domain::storage::StorageTrait> = Arc::new(InMemoryStore::new());
         let runner = RetentionRunner::new(store, config, None);
         assert!(runner.is_fully_disabled());
     }
 
     #[test]
     fn is_fully_disabled_false_when_any_enabled() {
-        let store: Arc<dyn RetentionStore> = Arc::new(InMemoryStore::new());
+        let store: Arc<dyn voom_domain::storage::StorageTrait> = Arc::new(InMemoryStore::new());
         let runner = RetentionRunner::new(store, RetentionConfig::default(), None);
         assert!(!runner.is_fully_disabled());
     }

--- a/crates/voom-cli/src/retention.rs
+++ b/crates/voom-cli/src/retention.rs
@@ -107,6 +107,23 @@ impl RetentionRunner {
         }
     }
 
+    /// Compute what `run_once` would delete, without modifying the database.
+    pub fn dry_run_summary(&self) -> RetentionSummary {
+        let start = Instant::now();
+        let per_table: Vec<(String, anyhow::Result<PruneReport>)> = vec![
+            ("jobs".to_string(), self.count_jobs()),
+            ("event_log".to_string(), self.count_event_log()),
+            (
+                "file_transitions".to_string(),
+                self.count_file_transitions(),
+            ),
+        ];
+        RetentionSummary {
+            per_table,
+            duration: start.elapsed(),
+        }
+    }
+
     fn prune_jobs(&self) -> anyhow::Result<PruneReport> {
         let policy = table_retention_to_policy(&self.config.jobs);
         Ok(self.store.prune_old_jobs(policy)?)
@@ -120,6 +137,21 @@ impl RetentionRunner {
     fn prune_file_transitions(&self) -> anyhow::Result<PruneReport> {
         let policy = table_retention_to_policy(&self.config.file_transitions);
         Ok(self.store.prune_old_file_transitions(policy)?)
+    }
+
+    fn count_jobs(&self) -> anyhow::Result<PruneReport> {
+        let policy = table_retention_to_policy(&self.config.jobs);
+        Ok(self.store.count_old_jobs(policy)?)
+    }
+
+    fn count_event_log(&self) -> anyhow::Result<PruneReport> {
+        let policy = table_retention_to_policy(&self.config.event_log);
+        Ok(self.store.count_old_event_log(policy)?)
+    }
+
+    fn count_file_transitions(&self) -> anyhow::Result<PruneReport> {
+        let policy = table_retention_to_policy(&self.config.file_transitions);
+        Ok(self.store.count_old_file_transitions(policy)?)
     }
 }
 

--- a/crates/voom-cli/src/retention.rs
+++ b/crates/voom-cli/src/retention.rs
@@ -123,6 +123,24 @@ impl RetentionRunner {
     }
 }
 
+/// Best-effort end-of-run prune. Returns whether retention ran.
+/// Failures are logged but never propagate. No-op when `run_after_cli` is
+/// false or when fully disabled.
+pub fn maybe_run_after_cli(
+    store: Arc<dyn voom_domain::storage::StorageTrait>,
+    config: &RetentionConfig,
+    kernel: Option<Arc<Kernel>>,
+) {
+    if !config.run_after_cli {
+        return;
+    }
+    let runner = RetentionRunner::new(store, config.clone(), kernel);
+    if runner.is_fully_disabled() {
+        return;
+    }
+    let _ = runner.run_once(voom_domain::events::RetentionTrigger::CliEndOfRun);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/voom-cli/tests/functional_tests.rs
+++ b/crates/voom-cli/tests/functional_tests.rs
@@ -770,6 +770,144 @@ mod test_db {
             .success()
             .stdout(predicate::str::contains("1 files"));
     }
+
+    /// Seed the DB with a few rows in jobs, event_log, and file_transitions,
+    /// then verify that `voom db prune --dry-run` reports counts without
+    /// touching the rows.
+    #[test]
+    fn db_prune_dry_run_does_not_modify_database() {
+        let env = TestEnv::new();
+
+        // Initialise the schema by running any lightweight db command.
+        env.voom().args(["db", "vacuum"]).assert().success();
+
+        // Insert rows directly so we don't need ffprobe.
+        let db = env.db_path();
+        let conn = rusqlite::Connection::open(&db).unwrap();
+        let now = chrono::Utc::now().to_rfc3339();
+
+        for _ in 0..3 {
+            let id = uuid::Uuid::new_v4().to_string();
+            conn.execute(
+                "INSERT INTO jobs (id, job_type, status, created_at) VALUES (?1, 'test', 'completed', ?2)",
+                rusqlite::params![id, now],
+            )
+            .unwrap();
+        }
+        for _ in 0..3 {
+            let id = uuid::Uuid::new_v4().to_string();
+            conn.execute(
+                "INSERT INTO event_log (id, event_type, payload, summary, created_at) \
+                 VALUES (?1, 'test', '{}', 'seed', ?2)",
+                rusqlite::params![id, now],
+            )
+            .unwrap();
+        }
+        // file_transitions requires a non-empty to_hash and to_size.
+        for _ in 0..3 {
+            let id = uuid::Uuid::new_v4().to_string();
+            let file_id = uuid::Uuid::new_v4().to_string();
+            conn.execute(
+                "INSERT INTO file_transitions \
+                 (id, file_id, path, to_hash, to_size, source, created_at) \
+                 VALUES (?1, ?2, '/tmp/fake.mkv', 'abc123', 1024, 'discovery', ?3)",
+                rusqlite::params![id, file_id, now],
+            )
+            .unwrap();
+        }
+        drop(conn);
+
+        // Capture baseline counts.
+        let conn = rusqlite::Connection::open(&db).unwrap();
+        let jobs_before: i64 = conn
+            .query_row("SELECT COUNT(*) FROM jobs", [], |r| r.get(0))
+            .unwrap();
+        let events_before: i64 = conn
+            .query_row("SELECT COUNT(*) FROM event_log", [], |r| r.get(0))
+            .unwrap();
+        let transitions_before: i64 = conn
+            .query_row("SELECT COUNT(*) FROM file_transitions", [], |r| r.get(0))
+            .unwrap();
+        drop(conn);
+
+        assert_eq!(jobs_before, 3);
+        assert_eq!(events_before, 3);
+        assert_eq!(transitions_before, 3);
+
+        // Run dry-run — must succeed and mention each table.
+        env.voom()
+            .args(["db", "prune", "--dry-run"])
+            .assert()
+            .success()
+            .stdout(
+                predicate::str::contains("jobs")
+                    .and(predicate::str::contains("event_log"))
+                    .and(predicate::str::contains("file_transitions")),
+            );
+
+        // Counts must be unchanged.
+        let conn = rusqlite::Connection::open(&db).unwrap();
+        let jobs_after: i64 = conn
+            .query_row("SELECT COUNT(*) FROM jobs", [], |r| r.get(0))
+            .unwrap();
+        let events_after: i64 = conn
+            .query_row("SELECT COUNT(*) FROM event_log", [], |r| r.get(0))
+            .unwrap();
+        let transitions_after: i64 = conn
+            .query_row("SELECT COUNT(*) FROM file_transitions", [], |r| r.get(0))
+            .unwrap();
+
+        assert_eq!(jobs_after, jobs_before, "dry-run must not delete job rows");
+        assert_eq!(
+            events_after, events_before,
+            "dry-run must not delete event_log rows"
+        );
+        assert_eq!(
+            transitions_after, transitions_before,
+            "dry-run must not delete file_transitions rows"
+        );
+    }
+
+    /// `voom db prune` (no --dry-run) must exit 0 and emit a per-table
+    /// summary, even when no rows fall outside the retention window.
+    #[test]
+    fn db_prune_actually_succeeds() {
+        let env = TestEnv::new();
+
+        // Initialise schema.
+        env.voom().args(["db", "vacuum"]).assert().success();
+
+        // Seed a few recent rows so the command has something to evaluate.
+        let db = env.db_path();
+        let conn = rusqlite::Connection::open(&db).unwrap();
+        let now = chrono::Utc::now().to_rfc3339();
+        for _ in 0..2 {
+            let id = uuid::Uuid::new_v4().to_string();
+            conn.execute(
+                "INSERT INTO jobs (id, job_type, status, created_at) \
+                 VALUES (?1, 'test', 'completed', ?2)",
+                rusqlite::params![id, now],
+            )
+            .unwrap();
+        }
+        for _ in 0..2 {
+            let id = uuid::Uuid::new_v4().to_string();
+            conn.execute(
+                "INSERT INTO event_log (id, event_type, payload, summary, created_at) \
+                 VALUES (?1, 'test', '{}', 'seed', ?2)",
+                rusqlite::params![id, now],
+            )
+            .unwrap();
+        }
+        drop(conn);
+
+        // Real prune — must exit 0.
+        env.voom().args(["db", "prune"]).assert().success().stdout(
+            predicate::str::contains("jobs")
+                .and(predicate::str::contains("event_log"))
+                .and(predicate::str::contains("file_transitions")),
+        );
+    }
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/crates/voom-domain/src/events.rs
+++ b/crates/voom-domain/src/events.rs
@@ -46,6 +46,9 @@ pub enum Event {
     ScanComplete(ScanCompleteEvent),
     /// Emitted at the end of a standalone introspection pass.
     IntrospectComplete(IntrospectCompleteEvent),
+    /// Emitted by the retention runner after each scheduled, on-demand, or
+    /// end-of-CLI prune pass. Includes per-table results and an overall duration.
+    RetentionCompleted(RetentionCompletedEvent),
 }
 
 impl Event {
@@ -72,6 +75,7 @@ impl Event {
     pub const HEALTH_STATUS: &str = "health.status";
     pub const SCAN_COMPLETE: &str = "scan.complete";
     pub const INTROSPECT_COMPLETE: &str = "introspect.complete";
+    pub const RETENTION_COMPLETED: &str = "retention.completed";
 
     /// One-line human-readable summary of the event payload.
     ///
@@ -193,6 +197,13 @@ impl Event {
             Event::IntrospectComplete(e) => {
                 format!("files_introspected={}", e.files_introspected)
             }
+            Event::RetentionCompleted(e) => {
+                let total_deleted: u64 = e.per_table.iter().map(|t| t.deleted).sum();
+                format!(
+                    "trigger={:?} deleted={total_deleted} ms={}",
+                    e.trigger, e.duration_ms
+                )
+            }
         }
     }
 
@@ -220,6 +231,7 @@ impl Event {
             Event::HealthStatus(_) => Self::HEALTH_STATUS,
             Event::ScanComplete(_) => Self::SCAN_COMPLETE,
             Event::IntrospectComplete(_) => Self::INTROSPECT_COMPLETE,
+            Event::RetentionCompleted(_) => Self::RETENTION_COMPLETED,
         }
     }
 }
@@ -844,6 +856,35 @@ impl IntrospectCompleteEvent {
     }
 }
 
+/// Why retention ran.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RetentionTrigger {
+    /// Periodic task during `serve` mode.
+    Scheduled,
+    /// End-of-run hook from `voom scan` / `voom process`.
+    CliEndOfRun,
+    /// On-demand from `voom db prune`.
+    OnDemand,
+}
+
+/// Result of pruning a single table.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TableRetentionResult {
+    pub table: String,
+    pub deleted: u64,
+    pub kept: u64,
+    pub error: Option<String>,
+}
+
+/// Emitted once per retention pass.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RetentionCompletedEvent {
+    pub trigger: RetentionTrigger,
+    pub per_table: Vec<TableRetentionResult>,
+    pub duration_ms: u64,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1200,5 +1241,31 @@ mod tests {
         let bytes = rmp_serde::to_vec(&event).unwrap();
         let deserialized: Event = rmp_serde::from_slice(&bytes).unwrap();
         assert_eq!(deserialized.event_type(), "plan.skipped");
+    }
+
+    #[test]
+    fn retention_completed_event_type_and_summary() {
+        let event = Event::RetentionCompleted(RetentionCompletedEvent {
+            trigger: RetentionTrigger::Scheduled,
+            per_table: vec![
+                TableRetentionResult {
+                    table: "jobs".into(),
+                    deleted: 12,
+                    kept: 34,
+                    error: None,
+                },
+                TableRetentionResult {
+                    table: "event_log".into(),
+                    deleted: 5,
+                    kept: 10,
+                    error: None,
+                },
+            ],
+            duration_ms: 42,
+        });
+        assert_eq!(event.event_type(), Event::RETENTION_COMPLETED);
+        let s = event.summary();
+        assert!(s.contains("deleted=17"), "got: {s}");
+        assert!(s.contains("ms=42"), "got: {s}");
     }
 }

--- a/crates/voom-domain/src/storage.rs
+++ b/crates/voom-domain/src/storage.rs
@@ -33,6 +33,21 @@ impl RetentionPolicy {
     pub fn is_disabled(&self) -> bool {
         self.max_age.is_none() && self.keep_last.is_none()
     }
+
+    /// Compute the ISO-8601 cutoff timestamp for age-based deletion, suitable
+    /// for binding directly as a SQL parameter against a `TEXT` datetime column.
+    #[must_use]
+    pub fn cutoff_str(&self) -> Option<String> {
+        self.max_age
+            .map(|d| crate::utils::format::format_iso(&(chrono::Utc::now() - d)))
+    }
+
+    /// Convert `keep_last` to `Option<i64>` for use as a SQL parameter.
+    /// Returns `None` if not configured or if the value would overflow `i64`.
+    #[must_use]
+    pub fn keep_last_i64(&self) -> Option<i64> {
+        self.keep_last.and_then(|n| i64::try_from(n).ok())
+    }
 }
 
 /// Outcome of a single `prune_old_*` call.

--- a/crates/voom-domain/src/storage.rs
+++ b/crates/voom-domain/src/storage.rs
@@ -403,6 +403,8 @@ pub trait EventLogStorage: Send + Sync {
     fn prune_old_event_log(&self, policy: RetentionPolicy) -> Result<PruneReport>;
     /// Count how many event_log rows would be deleted by `policy`.
     fn count_old_event_log(&self, policy: RetentionPolicy) -> Result<PruneReport>;
+    /// Return the most recent event of the given type, or None if none exist.
+    fn latest_event_of_type(&self, event_type: &str) -> Result<Option<EventLogRecord>>;
 }
 
 /// Library snapshot storage operations.

--- a/crates/voom-domain/src/storage.rs
+++ b/crates/voom-domain/src/storage.rs
@@ -212,6 +212,12 @@ pub trait FileTransitionStorage: Send + Sync {
     fn latest_failure_session(&self) -> Result<Option<Uuid>>;
     /// List sessions that have failures, most recent first.
     fn failure_sessions(&self) -> Result<Vec<SessionSummary>>;
+    /// Delete file_transitions rows per `policy`.
+    ///
+    /// Always preserves the most-recent transition per `file_id` regardless of
+    /// `policy` — this protects "current state" forensics. Age is measured by
+    /// `created_at`.
+    fn prune_old_file_transitions(&self, policy: RetentionPolicy) -> Result<PruneReport>;
 }
 
 /// A failed transition with plan result details for error reporting.

--- a/crates/voom-domain/src/storage.rs
+++ b/crates/voom-domain/src/storage.rs
@@ -12,6 +12,39 @@ use crate::plan::Plan;
 use crate::stats::{LibrarySnapshot, SavingsReport, SnapshotTrigger, TimePeriod};
 use crate::transition::{DiscoveredFile, FileTransition, ReconcileResult, TransitionSource};
 
+/// Row retention policy for time- or count-based pruning.
+///
+/// A row is deleted if **either** `max_age` is exceeded **or** the row's
+/// rank (newest first) exceeds `keep_last`. If both fields are `None`,
+/// the policy is disabled and the implementing trait method must be a no-op.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RetentionPolicy {
+    /// Delete rows older than this. `None` means no age bound.
+    pub max_age: Option<chrono::Duration>,
+    /// Keep at most this many rows (newest-first). `None` means no count bound.
+    pub keep_last: Option<u64>,
+}
+
+impl RetentionPolicy {
+    /// Returns true when no bounds are configured. Trait implementations must
+    /// short-circuit and return `PruneReport { deleted: 0, kept: <count> }`
+    /// without executing a `DELETE` when this is true.
+    #[must_use]
+    pub fn is_disabled(&self) -> bool {
+        self.max_age.is_none() && self.keep_last.is_none()
+    }
+}
+
+/// Outcome of a single `prune_old_*` call.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct PruneReport {
+    /// Rows deleted by this call.
+    pub deleted: u64,
+    /// Rows that survived (only counts the rows the policy was *eligible* to delete,
+    /// i.e., for jobs this excludes pending/running rows).
+    pub kept: u64,
+}
+
 /// Filters for querying jobs from storage.
 #[non_exhaustive]
 #[derive(Debug, Clone, Default)]
@@ -558,5 +591,44 @@ impl PlanSummary {
             executed_at: None,
             result: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod retention_policy_tests {
+    use super::{PruneReport, RetentionPolicy};
+
+    #[test]
+    fn retention_policy_disabled_when_both_none() {
+        let p = RetentionPolicy {
+            max_age: None,
+            keep_last: None,
+        };
+        assert!(p.is_disabled());
+    }
+
+    #[test]
+    fn retention_policy_not_disabled_when_age_set() {
+        let p = RetentionPolicy {
+            max_age: Some(chrono::Duration::days(1)),
+            keep_last: None,
+        };
+        assert!(!p.is_disabled());
+    }
+
+    #[test]
+    fn retention_policy_not_disabled_when_count_set() {
+        let p = RetentionPolicy {
+            max_age: None,
+            keep_last: Some(10),
+        };
+        assert!(!p.is_disabled());
+    }
+
+    #[test]
+    fn prune_report_default_is_zero() {
+        let r = PruneReport::default();
+        assert_eq!(r.deleted, 0);
+        assert_eq!(r.kept, 0);
     }
 }

--- a/crates/voom-domain/src/storage.rs
+++ b/crates/voom-domain/src/storage.rs
@@ -166,6 +166,9 @@ pub trait JobStorage: Send + Sync {
     /// Pending and running jobs are never touched, regardless of age. Returns
     /// the number deleted and the number that survived (eligible only).
     fn prune_old_jobs(&self, policy: RetentionPolicy) -> Result<PruneReport>;
+    /// Count how many terminal-state jobs would be deleted by `policy`.
+    /// Mirrors `prune_old_jobs` but does not modify the database.
+    fn count_old_jobs(&self, policy: RetentionPolicy) -> Result<PruneReport>;
 }
 
 /// Plan persistence operations.
@@ -218,6 +221,9 @@ pub trait FileTransitionStorage: Send + Sync {
     /// `policy` — this protects "current state" forensics. Age is measured by
     /// `created_at`.
     fn prune_old_file_transitions(&self, policy: RetentionPolicy) -> Result<PruneReport>;
+    /// Count how many file_transitions rows would be deleted by `policy`.
+    /// Always preserves most-recent-per-file (mirrors prune behavior).
+    fn count_old_file_transitions(&self, policy: RetentionPolicy) -> Result<PruneReport>;
 }
 
 /// A failed transition with plan result details for error reporting.
@@ -395,6 +401,8 @@ pub trait EventLogStorage: Send + Sync {
     ///
     /// Age is measured by `created_at`. Rank is by `rowid` DESC (newest first).
     fn prune_old_event_log(&self, policy: RetentionPolicy) -> Result<PruneReport>;
+    /// Count how many event_log rows would be deleted by `policy`.
+    fn count_old_event_log(&self, policy: RetentionPolicy) -> Result<PruneReport>;
 }
 
 /// Library snapshot storage operations.

--- a/crates/voom-domain/src/storage.rs
+++ b/crates/voom-domain/src/storage.rs
@@ -161,6 +161,11 @@ pub trait JobStorage: Send + Sync {
     /// (completed, failed, cancelled). Never deletes pending/running.
     /// Returns the number of deleted rows.
     fn delete_jobs(&self, status: Option<JobStatus>) -> Result<u64>;
+    /// Delete terminal-state jobs (`completed` / `failed` / `cancelled`) per `policy`.
+    ///
+    /// Pending and running jobs are never touched, regardless of age. Returns
+    /// the number deleted and the number that survived (eligible only).
+    fn prune_old_jobs(&self, policy: RetentionPolicy) -> Result<PruneReport>;
 }
 
 /// Plan persistence operations.

--- a/crates/voom-domain/src/storage.rs
+++ b/crates/voom-domain/src/storage.rs
@@ -385,6 +385,10 @@ pub trait EventLogStorage: Send + Sync {
     fn insert_event_log(&self, record: &EventLogRecord) -> Result<i64>;
     fn list_event_log(&self, filters: &EventLogFilters) -> Result<Vec<EventLogRecord>>;
     fn prune_event_log(&self, keep_last: u64) -> Result<u64>;
+    /// Delete event_log rows per `policy`.
+    ///
+    /// Age is measured by `created_at`. Rank is by `rowid` DESC (newest first).
+    fn prune_old_event_log(&self, policy: RetentionPolicy) -> Result<PruneReport>;
 }
 
 /// Library snapshot storage operations.

--- a/crates/voom-domain/src/test_support.rs
+++ b/crates/voom-domain/src/test_support.rs
@@ -637,6 +637,13 @@ impl crate::storage::EventLogStorage for InMemoryStore {
     ) -> crate::errors::Result<crate::storage::PruneReport> {
         Ok(crate::storage::PruneReport::default())
     }
+
+    fn latest_event_of_type(
+        &self,
+        _event_type: &str,
+    ) -> crate::errors::Result<Option<crate::storage::EventLogRecord>> {
+        Ok(None)
+    }
 }
 
 impl SnapshotStorage for InMemoryStore {

--- a/crates/voom-domain/src/test_support.rs
+++ b/crates/voom-domain/src/test_support.rs
@@ -393,6 +393,13 @@ impl JobStorage for InMemoryStore {
     ) -> crate::errors::Result<crate::storage::PruneReport> {
         Ok(crate::storage::PruneReport::default())
     }
+
+    fn count_old_jobs(
+        &self,
+        _policy: crate::storage::RetentionPolicy,
+    ) -> crate::errors::Result<crate::storage::PruneReport> {
+        Ok(crate::storage::PruneReport::default())
+    }
 }
 
 impl PlanStorage for InMemoryStore {
@@ -481,6 +488,13 @@ impl FileTransitionStorage for InMemoryStore {
     }
 
     fn prune_old_file_transitions(
+        &self,
+        _policy: crate::storage::RetentionPolicy,
+    ) -> crate::errors::Result<crate::storage::PruneReport> {
+        Ok(crate::storage::PruneReport::default())
+    }
+
+    fn count_old_file_transitions(
         &self,
         _policy: crate::storage::RetentionPolicy,
     ) -> crate::errors::Result<crate::storage::PruneReport> {
@@ -611,6 +625,13 @@ impl crate::storage::EventLogStorage for InMemoryStore {
     }
 
     fn prune_old_event_log(
+        &self,
+        _policy: crate::storage::RetentionPolicy,
+    ) -> crate::errors::Result<crate::storage::PruneReport> {
+        Ok(crate::storage::PruneReport::default())
+    }
+
+    fn count_old_event_log(
         &self,
         _policy: crate::storage::RetentionPolicy,
     ) -> crate::errors::Result<crate::storage::PruneReport> {

--- a/crates/voom-domain/src/test_support.rs
+++ b/crates/voom-domain/src/test_support.rs
@@ -480,9 +480,10 @@ impl FileTransitionStorage for InMemoryStore {
         Ok(Vec::new())
     }
 
-    fn prune_old_file_transitions(&self, _policy: crate::storage::RetentionPolicy)
-        -> crate::errors::Result<crate::storage::PruneReport>
-    {
+    fn prune_old_file_transitions(
+        &self,
+        _policy: crate::storage::RetentionPolicy,
+    ) -> crate::errors::Result<crate::storage::PruneReport> {
         Ok(crate::storage::PruneReport::default())
     }
 }

--- a/crates/voom-domain/src/test_support.rs
+++ b/crates/voom-domain/src/test_support.rs
@@ -479,6 +479,12 @@ impl FileTransitionStorage for InMemoryStore {
     fn failure_sessions(&self) -> Result<Vec<crate::storage::SessionSummary>> {
         Ok(Vec::new())
     }
+
+    fn prune_old_file_transitions(&self, _policy: crate::storage::RetentionPolicy)
+        -> crate::errors::Result<crate::storage::PruneReport>
+    {
+        Ok(crate::storage::PruneReport::default())
+    }
 }
 
 impl PluginDataStorage for InMemoryStore {

--- a/crates/voom-domain/src/test_support.rs
+++ b/crates/voom-domain/src/test_support.rs
@@ -602,6 +602,13 @@ impl crate::storage::EventLogStorage for InMemoryStore {
             Ok(0)
         }
     }
+
+    fn prune_old_event_log(
+        &self,
+        _policy: crate::storage::RetentionPolicy,
+    ) -> crate::errors::Result<crate::storage::PruneReport> {
+        Ok(crate::storage::PruneReport::default())
+    }
 }
 
 impl SnapshotStorage for InMemoryStore {

--- a/crates/voom-domain/src/test_support.rs
+++ b/crates/voom-domain/src/test_support.rs
@@ -386,6 +386,13 @@ impl JobStorage for InMemoryStore {
         }
         Ok((before - jobs.len()) as u64)
     }
+
+    fn prune_old_jobs(
+        &self,
+        _policy: crate::storage::RetentionPolicy,
+    ) -> crate::errors::Result<crate::storage::PruneReport> {
+        Ok(crate::storage::PruneReport::default())
+    }
 }
 
 impl PlanStorage for InMemoryStore {

--- a/plugins/job-manager/src/worker.rs
+++ b/plugins/job-manager/src/worker.rs
@@ -894,6 +894,13 @@ mod tests {
         ) -> voom_domain::errors::Result<voom_domain::storage::PruneReport> {
             self.inner.prune_old_jobs(policy)
         }
+
+        fn count_old_jobs(
+            &self,
+            policy: voom_domain::storage::RetentionPolicy,
+        ) -> voom_domain::errors::Result<voom_domain::storage::PruneReport> {
+            self.inner.count_old_jobs(policy)
+        }
     }
 
     #[tokio::test]

--- a/plugins/job-manager/src/worker.rs
+++ b/plugins/job-manager/src/worker.rs
@@ -887,6 +887,13 @@ mod tests {
         ) -> voom_domain::errors::Result<u64> {
             self.inner.delete_jobs(status)
         }
+
+        fn prune_old_jobs(
+            &self,
+            policy: voom_domain::storage::RetentionPolicy,
+        ) -> voom_domain::errors::Result<voom_domain::storage::PruneReport> {
+            self.inner.prune_old_jobs(policy)
+        }
     }
 
     #[tokio::test]

--- a/plugins/sqlite-store/src/lib.rs
+++ b/plugins/sqlite-store/src/lib.rs
@@ -335,17 +335,8 @@ fn log_event(store: &SqliteStore, event: &Event) {
         serde_json::to_string(event).unwrap_or_default(),
         event.summary(),
     );
-    match store.insert_event_log(&log_record) {
-        Ok(rowid) => {
-            if rowid % 1000 == 0 {
-                if let Err(e) = store.prune_event_log(10_000) {
-                    tracing::warn!(error = %e, "event log prune failed");
-                }
-            }
-        }
-        Err(e) => {
-            tracing::warn!(error = %e, "event log insert failed");
-        }
+    if let Err(e) = store.insert_event_log(&log_record) {
+        tracing::warn!(error = %e, "event log insert failed");
     }
 }
 

--- a/plugins/sqlite-store/src/schema.rs
+++ b/plugins/sqlite-store/src/schema.rs
@@ -489,6 +489,12 @@ fn migrate_indexes_and_constraints(conn: &Connection) -> rusqlite::Result<()> {
         )?;
     }
 
+    conn.execute_batch(
+        "CREATE INDEX IF NOT EXISTS idx_jobs_completed_at ON jobs(completed_at);
+         CREATE INDEX IF NOT EXISTS idx_event_log_created_at ON event_log(created_at);
+         CREATE INDEX IF NOT EXISTS idx_transitions_created_at ON file_transitions(created_at);",
+    )?;
+
     Ok(())
 }
 
@@ -773,5 +779,31 @@ mod tests {
             )
             .unwrap();
         assert!(has_index, "idx_files_superseded_by index should exist");
+    }
+
+    #[test]
+    fn migration_creates_retention_indexes() {
+        let conn = Connection::open_in_memory().unwrap();
+        configure_connection(&conn).unwrap();
+        create_schema(&conn).unwrap();
+
+        let names: Vec<String> = conn
+            .prepare("SELECT name FROM sqlite_master WHERE type='index' AND name LIKE 'idx_%'")
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap();
+
+        for required in &[
+            "idx_jobs_completed_at",
+            "idx_event_log_created_at",
+            "idx_transitions_created_at",
+        ] {
+            assert!(
+                names.iter().any(|n| n == required),
+                "missing index {required}; got {names:?}"
+            );
+        }
     }
 }

--- a/plugins/sqlite-store/src/schema.rs
+++ b/plugins/sqlite-store/src/schema.rs
@@ -489,11 +489,39 @@ fn migrate_indexes_and_constraints(conn: &Connection) -> rusqlite::Result<()> {
         )?;
     }
 
-    conn.execute_batch(
-        "CREATE INDEX IF NOT EXISTS idx_jobs_completed_at ON jobs(completed_at);
-         CREATE INDEX IF NOT EXISTS idx_event_log_created_at ON event_log(created_at);
-         CREATE INDEX IF NOT EXISTS idx_transitions_created_at ON file_transitions(created_at);",
+    let jobs_exists: bool = conn.query_row(
+        "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='jobs'",
+        [],
+        |row| row.get(0),
     )?;
+    if jobs_exists && !has_index("idx_jobs_completed_at")? {
+        conn.execute_batch(
+            "CREATE INDEX IF NOT EXISTS idx_jobs_completed_at ON jobs(completed_at);",
+        )?;
+    }
+
+    let event_log_exists: bool = conn.query_row(
+        "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='event_log'",
+        [],
+        |row| row.get(0),
+    )?;
+    if event_log_exists && !has_index("idx_event_log_created_at")? {
+        conn.execute_batch(
+            "CREATE INDEX IF NOT EXISTS idx_event_log_created_at ON event_log(created_at);",
+        )?;
+    }
+
+    let transitions_exists: bool = conn.query_row(
+        "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='file_transitions'",
+        [],
+        |row| row.get(0),
+    )?;
+    if transitions_exists && !has_index("idx_transitions_created_at")? {
+        conn.execute_batch(
+            "CREATE INDEX IF NOT EXISTS idx_transitions_created_at \
+             ON file_transitions(created_at);",
+        )?;
+    }
 
     Ok(())
 }

--- a/plugins/sqlite-store/src/store/event_log_storage.rs
+++ b/plugins/sqlite-store/src/store/event_log_storage.rs
@@ -1,7 +1,9 @@
 use rusqlite::params;
 
 use voom_domain::errors::Result;
-use voom_domain::storage::{EventLogFilters, EventLogRecord, EventLogStorage};
+use voom_domain::storage::{
+    EventLogFilters, EventLogRecord, EventLogStorage, PruneReport, RetentionPolicy,
+};
 
 use super::{format_datetime, storage_err, SqliteStore};
 
@@ -89,6 +91,46 @@ impl EventLogStorage for SqliteStore {
             )
             .map_err(storage_err("failed to prune event log"))?;
         Ok(deleted as u64)
+    }
+
+    fn prune_old_event_log(&self, policy: RetentionPolicy) -> Result<PruneReport> {
+        if policy.is_disabled() {
+            let conn = self.conn()?;
+            let kept: u64 = conn
+                .query_row("SELECT COUNT(*) FROM event_log", [], |row| row.get(0))
+                .map_err(storage_err("failed to count event_log"))?;
+            return Ok(PruneReport { deleted: 0, kept });
+        }
+
+        let conn = self.conn()?;
+        let cutoff = policy
+            .max_age
+            .map(|d| super::format_datetime(&(chrono::Utc::now() - d)));
+        let keep_last = policy.keep_last.and_then(|n| i64::try_from(n).ok());
+
+        let deleted = conn
+            .execute(
+                "WITH ranked AS (
+                    SELECT rowid,
+                           ROW_NUMBER() OVER (ORDER BY rowid DESC) AS rn,
+                           created_at
+                    FROM event_log
+                )
+                DELETE FROM event_log
+                WHERE rowid IN (
+                    SELECT rowid FROM ranked
+                    WHERE (?1 IS NOT NULL AND created_at < ?1)
+                       OR (?2 IS NOT NULL AND rn > ?2)
+                )",
+                params![cutoff, keep_last],
+            )
+            .map_err(storage_err("failed to prune event_log"))? as u64;
+
+        let kept: u64 = conn
+            .query_row("SELECT COUNT(*) FROM event_log", [], |row| row.get(0))
+            .map_err(storage_err("failed to count remaining event_log"))?;
+
+        Ok(PruneReport { deleted, kept })
     }
 }
 
@@ -241,5 +283,72 @@ mod tests {
         let store = test_store();
         let pruned = store.prune_event_log(100).expect("prune");
         assert_eq!(pruned, 0);
+    }
+
+    use voom_domain::storage::RetentionPolicy;
+
+    fn insert_at(store: &SqliteStore, when: chrono::DateTime<chrono::Utc>) -> i64 {
+        let mut record = EventLogRecord::new(
+            uuid::Uuid::new_v4(),
+            "file.discovered".into(),
+            "{}".into(),
+            "test".into(),
+        );
+        record.created_at = when;
+        store.insert_event_log(&record).unwrap()
+    }
+
+    #[test]
+    fn prune_old_event_log_disabled_is_noop() {
+        let store = test_store();
+        insert_at(&store, chrono::Utc::now() - chrono::Duration::days(365));
+        let report = store
+            .prune_old_event_log(RetentionPolicy::default())
+            .unwrap();
+        assert_eq!(report.deleted, 0);
+        assert_eq!(report.kept, 1);
+    }
+
+    #[test]
+    fn prune_old_event_log_age_only() {
+        let store = test_store();
+        let now = chrono::Utc::now();
+        insert_at(&store, now - chrono::Duration::days(60));
+        insert_at(&store, now - chrono::Duration::hours(1));
+        let policy = RetentionPolicy {
+            max_age: Some(chrono::Duration::days(30)),
+            keep_last: None,
+        };
+        let report = store.prune_old_event_log(policy).unwrap();
+        assert_eq!(report.deleted, 1);
+        assert_eq!(report.kept, 1);
+    }
+
+    #[test]
+    fn prune_old_event_log_count_only() {
+        let store = test_store();
+        let now = chrono::Utc::now();
+        for i in 0..5i64 {
+            insert_at(&store, now - chrono::Duration::seconds(i));
+        }
+        let policy = RetentionPolicy {
+            max_age: None,
+            keep_last: Some(2),
+        };
+        let report = store.prune_old_event_log(policy).unwrap();
+        assert_eq!(report.deleted, 3);
+        assert_eq!(report.kept, 2);
+    }
+
+    #[test]
+    fn prune_old_event_log_empty_is_noop() {
+        let store = test_store();
+        let policy = RetentionPolicy {
+            max_age: Some(chrono::Duration::days(1)),
+            keep_last: Some(10),
+        };
+        let report = store.prune_old_event_log(policy).unwrap();
+        assert_eq!(report.deleted, 0);
+        assert_eq!(report.kept, 0);
     }
 }

--- a/plugins/sqlite-store/src/store/event_log_storage.rs
+++ b/plugins/sqlite-store/src/store/event_log_storage.rs
@@ -132,6 +132,46 @@ impl EventLogStorage for SqliteStore {
 
         Ok(PruneReport { deleted, kept })
     }
+    fn count_old_event_log(&self, policy: RetentionPolicy) -> Result<PruneReport> {
+        if policy.is_disabled() {
+            let conn = self.conn()?;
+            let kept: u64 = conn
+                .query_row("SELECT COUNT(*) FROM event_log", [], |row| row.get(0))
+                .map_err(storage_err("failed to count event_log"))?;
+            return Ok(PruneReport { deleted: 0, kept });
+        }
+
+        let conn = self.conn()?;
+        let cutoff = policy
+            .max_age
+            .map(|d| super::format_datetime(&(chrono::Utc::now() - d)));
+        let keep_last = policy.keep_last.and_then(|n| i64::try_from(n).ok());
+
+        let deleted: u64 = conn
+            .query_row(
+                "WITH ranked AS (
+                    SELECT rowid,
+                           ROW_NUMBER() OVER (ORDER BY rowid DESC) AS rn,
+                           created_at
+                    FROM event_log
+                )
+                SELECT COUNT(*) FROM ranked
+                WHERE (?1 IS NOT NULL AND created_at < ?1)
+                   OR (?2 IS NOT NULL AND rn > ?2)",
+                params![cutoff, keep_last],
+                |row| row.get(0),
+            )
+            .map_err(storage_err("failed to count old event_log"))?;
+
+        let total: u64 = conn
+            .query_row("SELECT COUNT(*) FROM event_log", [], |row| row.get(0))
+            .map_err(storage_err("failed to count event_log"))?;
+
+        Ok(PruneReport {
+            deleted,
+            kept: total.saturating_sub(deleted),
+        })
+    }
 }
 
 fn row_to_event_log(row: &rusqlite::Row<'_>) -> rusqlite::Result<EventLogRecord> {
@@ -350,5 +390,32 @@ mod tests {
         let report = store.prune_old_event_log(policy).unwrap();
         assert_eq!(report.deleted, 0);
         assert_eq!(report.kept, 0);
+    }
+
+    #[test]
+    fn count_old_event_log_matches_prune_count() {
+        let store = test_store();
+        let now = chrono::Utc::now();
+        for days in [10i64, 5, 3, 1, 0] {
+            insert_at(&store, now - chrono::Duration::days(days));
+        }
+        let policy = RetentionPolicy {
+            max_age: Some(chrono::Duration::days(4)),
+            keep_last: Some(3),
+        };
+        let count_report = store.count_old_event_log(policy).unwrap();
+        // Verify non-destructive: all 5 rows still present
+        let total_before: u64 = store
+            .conn()
+            .unwrap()
+            .query_row("SELECT COUNT(*) FROM event_log", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(
+            total_before, 5,
+            "count_old_event_log must not modify the database"
+        );
+        let prune_report = store.prune_old_event_log(policy).unwrap();
+        assert_eq!(count_report.deleted, prune_report.deleted);
+        assert_eq!(count_report.kept, prune_report.kept);
     }
 }

--- a/plugins/sqlite-store/src/store/event_log_storage.rs
+++ b/plugins/sqlite-store/src/store/event_log_storage.rs
@@ -103,10 +103,8 @@ impl EventLogStorage for SqliteStore {
         }
 
         let conn = self.conn()?;
-        let cutoff = policy
-            .max_age
-            .map(|d| super::format_datetime(&(chrono::Utc::now() - d)));
-        let keep_last = policy.keep_last.and_then(|n| i64::try_from(n).ok());
+        let cutoff = policy.cutoff_str();
+        let keep_last = policy.keep_last_i64();
 
         let deleted = conn
             .execute(
@@ -142,10 +140,8 @@ impl EventLogStorage for SqliteStore {
         }
 
         let conn = self.conn()?;
-        let cutoff = policy
-            .max_age
-            .map(|d| super::format_datetime(&(chrono::Utc::now() - d)));
-        let keep_last = policy.keep_last.and_then(|n| i64::try_from(n).ok());
+        let cutoff = policy.cutoff_str();
+        let keep_last = policy.keep_last_i64();
 
         let deleted: u64 = conn
             .query_row(

--- a/plugins/sqlite-store/src/store/event_log_storage.rs
+++ b/plugins/sqlite-store/src/store/event_log_storage.rs
@@ -1,4 +1,4 @@
-use rusqlite::params;
+use rusqlite::{params, OptionalExtension};
 
 use voom_domain::errors::Result;
 use voom_domain::storage::{
@@ -171,6 +171,19 @@ impl EventLogStorage for SqliteStore {
             deleted,
             kept: total.saturating_sub(deleted),
         })
+    }
+
+    fn latest_event_of_type(&self, event_type: &str) -> Result<Option<EventLogRecord>> {
+        let conn = self.conn()?;
+        conn.query_row(
+            "SELECT rowid, id, event_type, payload, summary, created_at
+             FROM event_log WHERE event_type = ?1
+             ORDER BY rowid DESC LIMIT 1",
+            params![event_type],
+            row_to_event_log,
+        )
+        .optional()
+        .map_err(storage_err("failed to query latest event"))
     }
 }
 
@@ -390,6 +403,32 @@ mod tests {
         let report = store.prune_old_event_log(policy).unwrap();
         assert_eq!(report.deleted, 0);
         assert_eq!(report.kept, 0);
+    }
+
+    #[test]
+    fn latest_event_of_type_returns_newest() {
+        let store = test_store();
+        for i in 0..5 {
+            let r = EventLogRecord::new(
+                uuid::Uuid::new_v4(),
+                "retention.completed".into(),
+                format!(r#"{{"n":{i}}}"#),
+                format!("event {i}"),
+            );
+            store.insert_event_log(&r).unwrap();
+        }
+        let got = store
+            .latest_event_of_type("retention.completed")
+            .unwrap()
+            .unwrap();
+        assert!(got.payload.contains(r#""n":4"#));
+    }
+
+    #[test]
+    fn latest_event_of_type_none_when_absent() {
+        let store = test_store();
+        let got = store.latest_event_of_type("retention.completed").unwrap();
+        assert!(got.is_none());
     }
 
     #[test]

--- a/plugins/sqlite-store/src/store/file_transition_storage.rs
+++ b/plugins/sqlite-store/src/store/file_transition_storage.rs
@@ -355,6 +355,63 @@ impl FileTransitionStorage for SqliteStore {
 
         Ok(PruneReport { deleted, kept })
     }
+
+    fn count_old_file_transitions(&self, policy: RetentionPolicy) -> Result<PruneReport> {
+        if policy.is_disabled() {
+            let conn = self.conn()?;
+            let kept: u64 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM file_transitions
+                     WHERE rowid NOT IN (SELECT MAX(rowid) FROM file_transitions GROUP BY file_id)",
+                    [],
+                    |row| row.get(0),
+                )
+                .map_err(storage_err("failed to count file_transitions"))?;
+            return Ok(PruneReport { deleted: 0, kept });
+        }
+
+        let conn = self.conn()?;
+        let cutoff = policy
+            .max_age
+            .map(|d| format_datetime(&(chrono::Utc::now() - d)));
+        let keep_last = policy.keep_last.and_then(|n| i64::try_from(n).ok());
+
+        let deleted: u64 = conn
+            .query_row(
+                "WITH last_per_file AS (
+                    SELECT MAX(rowid) AS keep_rowid
+                    FROM file_transitions
+                    GROUP BY file_id
+                ),
+                ranked AS (
+                    SELECT rowid,
+                           ROW_NUMBER() OVER (ORDER BY created_at DESC) AS rn,
+                           created_at
+                    FROM file_transitions
+                    WHERE rowid NOT IN (SELECT keep_rowid FROM last_per_file)
+                )
+                SELECT COUNT(*) FROM ranked
+                WHERE (?1 IS NOT NULL AND created_at < ?1)
+                   OR (?2 IS NOT NULL AND rn > ?2)",
+                params![cutoff, keep_last],
+                |row| row.get(0),
+            )
+            .map_err(storage_err("failed to count old file_transitions"))?;
+
+        let eligible: u64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM file_transitions
+                 WHERE rowid NOT IN (SELECT MAX(rowid) FROM file_transitions GROUP BY file_id)",
+                [],
+                |row| row.get(0),
+            )
+            .map_err(storage_err("failed to count eligible file_transitions"))?;
+
+        Ok(PruneReport {
+            deleted,
+            kept: eligible.saturating_sub(deleted),
+        })
+    }
 }
 
 fn row_to_transition(row: &rusqlite::Row<'_>) -> rusqlite::Result<FileTransition> {
@@ -735,5 +792,37 @@ mod retention_tests {
         let report = store.prune_old_file_transitions(policy).unwrap();
         assert_eq!(report.deleted, 0);
         assert_eq!(report.kept, 0);
+    }
+
+    #[test]
+    fn count_old_file_transitions_matches_prune_count() {
+        let store = test_store();
+        let now = chrono::Utc::now();
+        // Single file with 5 transitions at different ages
+        let file_id = uuid::Uuid::new_v4();
+        for days in [10i64, 5, 3, 1, 0] {
+            let t = make_transition(file_id, now - chrono::Duration::days(days));
+            store.record_transition(&t).unwrap();
+        }
+        let policy = RetentionPolicy {
+            max_age: Some(chrono::Duration::days(4)),
+            keep_last: Some(3),
+        };
+        let count_report = store.count_old_file_transitions(policy).unwrap();
+        // Verify non-destructive: all 5 rows still present
+        let total_before: u64 = store
+            .conn()
+            .unwrap()
+            .query_row("SELECT COUNT(*) FROM file_transitions", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(
+            total_before, 5,
+            "count_old_file_transitions must not modify the database"
+        );
+        let prune_report = store.prune_old_file_transitions(policy).unwrap();
+        assert_eq!(count_report.deleted, prune_report.deleted);
+        assert_eq!(count_report.kept, prune_report.kept);
     }
 }

--- a/plugins/sqlite-store/src/store/file_transition_storage.rs
+++ b/plugins/sqlite-store/src/store/file_transition_storage.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 
 use voom_domain::errors::Result;
 use voom_domain::stats::{ProcessingOutcome, SavingsBucket, SavingsReport, TimePeriod};
-use voom_domain::storage::FileTransitionStorage;
+use voom_domain::storage::{FileTransitionStorage, PruneReport, RetentionPolicy};
 use voom_domain::transition::{FileTransition, TransitionSource};
 
 use super::{format_datetime, storage_err, SqliteStore};
@@ -299,6 +299,62 @@ impl FileTransitionStorage for SqliteStore {
 
         Ok(rows)
     }
+
+    fn prune_old_file_transitions(&self, policy: RetentionPolicy) -> Result<PruneReport> {
+        if policy.is_disabled() {
+            let conn = self.conn()?;
+            let kept: u64 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM file_transitions
+                     WHERE rowid NOT IN (SELECT MAX(rowid) FROM file_transitions GROUP BY file_id)",
+                    [],
+                    |row| row.get(0),
+                )
+                .map_err(storage_err("failed to count file_transitions"))?;
+            return Ok(PruneReport { deleted: 0, kept });
+        }
+
+        let conn = self.conn()?;
+        let cutoff = policy
+            .max_age
+            .map(|d| format_datetime(&(chrono::Utc::now() - d)));
+        let keep_last = policy.keep_last.and_then(|n| i64::try_from(n).ok());
+
+        let deleted = conn
+            .execute(
+                "WITH last_per_file AS (
+                    SELECT MAX(rowid) AS keep_rowid
+                    FROM file_transitions
+                    GROUP BY file_id
+                ),
+                ranked AS (
+                    SELECT rowid,
+                           ROW_NUMBER() OVER (ORDER BY created_at DESC) AS rn,
+                           created_at
+                    FROM file_transitions
+                    WHERE rowid NOT IN (SELECT keep_rowid FROM last_per_file)
+                )
+                DELETE FROM file_transitions
+                WHERE rowid IN (
+                    SELECT rowid FROM ranked
+                    WHERE (?1 IS NOT NULL AND created_at < ?1)
+                       OR (?2 IS NOT NULL AND rn > ?2)
+                )",
+                params![cutoff, keep_last],
+            )
+            .map_err(storage_err("failed to prune file_transitions"))? as u64;
+
+        let kept: u64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM file_transitions
+                 WHERE rowid NOT IN (SELECT MAX(rowid) FROM file_transitions GROUP BY file_id)",
+                [],
+                |row| row.get(0),
+            )
+            .map_err(storage_err("failed to count remaining file_transitions"))?;
+
+        Ok(PruneReport { deleted, kept })
+    }
 }
 
 fn row_to_transition(row: &rusqlite::Row<'_>) -> rusqlite::Result<FileTransition> {
@@ -571,5 +627,113 @@ mod tests {
             by_old[0].from_path.as_deref(),
             Some(std::path::Path::new("/media/movie.mp4"))
         );
+    }
+}
+
+#[cfg(test)]
+mod retention_tests {
+    use super::*;
+    use voom_domain::storage::RetentionPolicy;
+    use voom_domain::transition::{FileTransition, TransitionSource};
+
+    fn test_store() -> SqliteStore {
+        SqliteStore::in_memory().unwrap()
+    }
+
+    fn make_transition(file_id: uuid::Uuid, when: chrono::DateTime<chrono::Utc>) -> FileTransition {
+        let mut t = FileTransition::new(
+            file_id,
+            std::path::PathBuf::from("/test.mkv"),
+            "h2".into(),
+            1024,
+            TransitionSource::Discovery,
+        );
+        t.created_at = when;
+        t
+    }
+
+    #[test]
+    fn prune_old_file_transitions_preserves_latest_per_file() {
+        let store = test_store();
+        let file_id = uuid::Uuid::new_v4();
+        let now = chrono::Utc::now();
+        // Three transitions for same file: oldest 100d, then 50d, then 1d
+        for days in [100i64, 50, 1] {
+            let t = make_transition(file_id, now - chrono::Duration::days(days));
+            store.record_transition(&t).unwrap();
+        }
+        let policy = RetentionPolicy {
+            max_age: Some(chrono::Duration::days(30)),
+            keep_last: None,
+        };
+        let report = store.prune_old_file_transitions(policy).unwrap();
+        // Most recent (1d) is preserved; the other two (100d, 50d) are eligible
+        // and both exceed the 30d cutoff, so both deleted.
+        assert_eq!(report.deleted, 2);
+        let remaining = store.transitions_for_file(&file_id).unwrap();
+        assert_eq!(remaining.len(), 1);
+    }
+
+    #[test]
+    fn prune_old_file_transitions_protects_singleton_old_row() {
+        let store = test_store();
+        let file_id = uuid::Uuid::new_v4();
+        let t = make_transition(file_id, chrono::Utc::now() - chrono::Duration::days(365));
+        store.record_transition(&t).unwrap();
+        let policy = RetentionPolicy {
+            max_age: Some(chrono::Duration::days(1)),
+            keep_last: None,
+        };
+        let report = store.prune_old_file_transitions(policy).unwrap();
+        assert_eq!(report.deleted, 0, "the only row for a file is always kept");
+        assert_eq!(store.transitions_for_file(&file_id).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn prune_old_file_transitions_disabled_is_noop() {
+        let store = test_store();
+        let file_id = uuid::Uuid::new_v4();
+        for _ in 0..3 {
+            store
+                .record_transition(&make_transition(file_id, chrono::Utc::now()))
+                .unwrap();
+        }
+        let report = store
+            .prune_old_file_transitions(RetentionPolicy::default())
+            .unwrap();
+        assert_eq!(report.deleted, 0);
+        // kept counts the rows the policy was eligible to consider — i.e., everything
+        // except the most-recent-per-file. Two are eligible, both kept.
+        assert_eq!(report.kept, 2);
+    }
+
+    #[test]
+    fn prune_old_file_transitions_count_caps_eligible_set() {
+        let store = test_store();
+        // 5 separate files, one transition each — all are "most recent per file"
+        // and therefore exempt.
+        for _ in 0..5 {
+            store
+                .record_transition(&make_transition(uuid::Uuid::new_v4(), chrono::Utc::now()))
+                .unwrap();
+        }
+        let policy = RetentionPolicy {
+            max_age: None,
+            keep_last: Some(0),
+        };
+        let report = store.prune_old_file_transitions(policy).unwrap();
+        assert_eq!(report.deleted, 0, "all rows are most-recent-per-file");
+    }
+
+    #[test]
+    fn prune_old_file_transitions_empty_is_noop() {
+        let store = test_store();
+        let policy = RetentionPolicy {
+            max_age: Some(chrono::Duration::days(1)),
+            keep_last: Some(10),
+        };
+        let report = store.prune_old_file_transitions(policy).unwrap();
+        assert_eq!(report.deleted, 0);
+        assert_eq!(report.kept, 0);
     }
 }

--- a/plugins/sqlite-store/src/store/file_transition_storage.rs
+++ b/plugins/sqlite-store/src/store/file_transition_storage.rs
@@ -315,10 +315,8 @@ impl FileTransitionStorage for SqliteStore {
         }
 
         let conn = self.conn()?;
-        let cutoff = policy
-            .max_age
-            .map(|d| format_datetime(&(chrono::Utc::now() - d)));
-        let keep_last = policy.keep_last.and_then(|n| i64::try_from(n).ok());
+        let cutoff = policy.cutoff_str();
+        let keep_last = policy.keep_last_i64();
 
         let deleted = conn
             .execute(
@@ -344,6 +342,10 @@ impl FileTransitionStorage for SqliteStore {
             )
             .map_err(storage_err("failed to prune file_transitions"))? as u64;
 
+        // `kept` counts only the rows that were *eligible* for pruning (i.e.,
+        // not the most-recent-per-file). The pinned most-recent rows are
+        // intentionally excluded — `deleted + kept` therefore equals the
+        // eligible-set size, not the total table size.
         let kept: u64 = conn
             .query_row(
                 "SELECT COUNT(*) FROM file_transitions
@@ -371,10 +373,8 @@ impl FileTransitionStorage for SqliteStore {
         }
 
         let conn = self.conn()?;
-        let cutoff = policy
-            .max_age
-            .map(|d| format_datetime(&(chrono::Utc::now() - d)));
-        let keep_last = policy.keep_last.and_then(|n| i64::try_from(n).ok());
+        let cutoff = policy.cutoff_str();
+        let keep_last = policy.keep_last_i64();
 
         let deleted: u64 = conn
             .query_row(

--- a/plugins/sqlite-store/src/store/job_storage.rs
+++ b/plugins/sqlite-store/src/store/job_storage.rs
@@ -285,6 +285,56 @@ impl JobStorage for SqliteStore {
         Ok(PruneReport { deleted, kept })
     }
 
+    fn count_old_jobs(&self, policy: RetentionPolicy) -> Result<PruneReport> {
+        if policy.is_disabled() {
+            let conn = self.conn()?;
+            let kept: u64 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM jobs WHERE status IN ('completed','failed','cancelled')",
+                    [],
+                    |row| row.get(0),
+                )
+                .map_err(storage_err("failed to count jobs"))?;
+            return Ok(PruneReport { deleted: 0, kept });
+        }
+
+        let conn = self.conn()?;
+        let cutoff = policy
+            .max_age
+            .map(|d| format_datetime(&(chrono::Utc::now() - d)));
+        let keep_last: Option<i64> = policy.keep_last.and_then(|n| i64::try_from(n).ok());
+
+        let deleted: u64 = conn
+            .query_row(
+                "WITH ranked AS (
+                    SELECT id,
+                           ROW_NUMBER() OVER (ORDER BY COALESCE(completed_at, created_at) DESC) AS rn,
+                           COALESCE(completed_at, created_at) AS effective_at
+                    FROM jobs
+                    WHERE status IN ('completed','failed','cancelled')
+                )
+                SELECT COUNT(*) FROM ranked
+                WHERE (?1 IS NOT NULL AND effective_at < ?1)
+                   OR (?2 IS NOT NULL AND rn > ?2)",
+                rusqlite::params![cutoff, keep_last],
+                |row| row.get(0),
+            )
+            .map_err(storage_err("failed to count old jobs"))?;
+
+        let total: u64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM jobs WHERE status IN ('completed','failed','cancelled')",
+                [],
+                |row| row.get(0),
+            )
+            .map_err(storage_err("failed to count terminal jobs"))?;
+
+        Ok(PruneReport {
+            deleted,
+            kept: total.saturating_sub(deleted),
+        })
+    }
+
     fn count_jobs_by_status(&self) -> Result<Vec<(JobStatus, u64)>> {
         let conn = self.conn()?;
         let mut stmt = conn
@@ -648,6 +698,41 @@ mod tests {
         let report = store.prune_old_jobs(policy).unwrap();
         assert_eq!(report.deleted, 0);
         assert_eq!(report.kept, 0);
+    }
+
+    #[test]
+    fn count_old_jobs_matches_prune_count() {
+        let store = SqliteStore::in_memory().unwrap();
+        let now = chrono::Utc::now();
+        for days in [10i64, 5, 3, 1, 0] {
+            insert_test_job(
+                &store,
+                voom_domain::job::JobStatus::Completed,
+                Some(now - chrono::Duration::days(days)),
+            );
+        }
+        let policy = RetentionPolicy {
+            max_age: Some(chrono::Duration::days(4)),
+            keep_last: Some(3),
+        };
+        let count_report = store.count_old_jobs(policy).unwrap();
+        // Same data still in store (count is non-destructive): verify by counting
+        let total_before: u64 = store
+            .conn()
+            .unwrap()
+            .query_row(
+                "SELECT COUNT(*) FROM jobs WHERE status IN ('completed','failed','cancelled')",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            total_before, 5,
+            "count_old_jobs must not modify the database"
+        );
+        let prune_report = store.prune_old_jobs(policy).unwrap();
+        assert_eq!(count_report.deleted, prune_report.deleted);
+        assert_eq!(count_report.kept, prune_report.kept);
     }
 
     #[test]

--- a/plugins/sqlite-store/src/store/job_storage.rs
+++ b/plugins/sqlite-store/src/store/job_storage.rs
@@ -250,10 +250,8 @@ impl JobStorage for SqliteStore {
         }
 
         let conn = self.conn()?;
-        let cutoff = policy
-            .max_age
-            .map(|d| format_datetime(&(chrono::Utc::now() - d)));
-        let keep_last: Option<i64> = policy.keep_last.and_then(|n| i64::try_from(n).ok());
+        let cutoff = policy.cutoff_str();
+        let keep_last = policy.keep_last_i64();
 
         let deleted = conn
             .execute(
@@ -299,10 +297,8 @@ impl JobStorage for SqliteStore {
         }
 
         let conn = self.conn()?;
-        let cutoff = policy
-            .max_age
-            .map(|d| format_datetime(&(chrono::Utc::now() - d)));
-        let keep_last: Option<i64> = policy.keep_last.and_then(|n| i64::try_from(n).ok());
+        let cutoff = policy.cutoff_str();
+        let keep_last = policy.keep_last_i64();
 
         let deleted: u64 = conn
             .query_row(

--- a/plugins/sqlite-store/src/store/job_storage.rs
+++ b/plugins/sqlite-store/src/store/job_storage.rs
@@ -4,7 +4,7 @@ use uuid::Uuid;
 
 use voom_domain::errors::{Result, StorageErrorKind, VoomError};
 use voom_domain::job::{Job, JobStatus, JobUpdate};
-use voom_domain::storage::{JobFilters, JobStorage};
+use voom_domain::storage::{JobFilters, JobStorage, PruneReport, RetentionPolicy};
 
 use super::{format_datetime, other_storage_err, row_to_job, storage_err, SqlQuery, SqliteStore};
 
@@ -236,6 +236,55 @@ impl JobStorage for SqliteStore {
         Ok(count as u64)
     }
 
+    fn prune_old_jobs(&self, policy: RetentionPolicy) -> Result<PruneReport> {
+        if policy.is_disabled() {
+            let conn = self.conn()?;
+            let kept: u64 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM jobs WHERE status IN ('completed','failed','cancelled')",
+                    [],
+                    |row| row.get(0),
+                )
+                .map_err(storage_err("failed to count jobs"))?;
+            return Ok(PruneReport { deleted: 0, kept });
+        }
+
+        let conn = self.conn()?;
+        let cutoff = policy
+            .max_age
+            .map(|d| format_datetime(&(chrono::Utc::now() - d)));
+        let keep_last: Option<i64> = policy.keep_last.and_then(|n| i64::try_from(n).ok());
+
+        let deleted = conn
+            .execute(
+                "WITH ranked AS (
+                    SELECT id,
+                           ROW_NUMBER() OVER (ORDER BY COALESCE(completed_at, created_at) DESC) AS rn,
+                           COALESCE(completed_at, created_at) AS effective_at
+                    FROM jobs
+                    WHERE status IN ('completed','failed','cancelled')
+                )
+                DELETE FROM jobs
+                WHERE id IN (
+                    SELECT id FROM ranked
+                    WHERE (?1 IS NOT NULL AND effective_at < ?1)
+                       OR (?2 IS NOT NULL AND rn > ?2)
+                )",
+                rusqlite::params![cutoff, keep_last],
+            )
+            .map_err(storage_err("failed to prune old jobs"))? as u64;
+
+        let kept: u64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM jobs WHERE status IN ('completed','failed','cancelled')",
+                [],
+                |row| row.get(0),
+            )
+            .map_err(storage_err("failed to count remaining jobs"))?;
+
+        Ok(PruneReport { deleted, kept })
+    }
+
     fn count_jobs_by_status(&self) -> Result<Vec<(JobStatus, u64)>> {
         let conn = self.conn()?;
         let mut stmt = conn
@@ -461,6 +510,144 @@ mod tests {
         let deleted = store.delete_jobs(Some(JobStatus::Completed)).unwrap();
         assert_eq!(deleted, 1);
         assert!(store.job(&job.id).unwrap().is_none());
+    }
+
+    use voom_domain::storage::RetentionPolicy;
+
+    fn insert_test_job(
+        store: &SqliteStore,
+        status: voom_domain::job::JobStatus,
+        completed_at: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> uuid::Uuid {
+        let mut job = voom_domain::job::Job::new(voom_domain::job::JobType::Introspect);
+        job.status = status;
+        job.completed_at = completed_at;
+        store.create_job(&job).unwrap();
+        job.id
+    }
+
+    #[test]
+    fn prune_old_jobs_disabled_policy_is_noop() {
+        let store = SqliteStore::in_memory().unwrap();
+        insert_test_job(
+            &store,
+            voom_domain::job::JobStatus::Completed,
+            Some(chrono::Utc::now() - chrono::Duration::days(365)),
+        );
+        let report = store.prune_old_jobs(RetentionPolicy::default()).unwrap();
+        assert_eq!(report.deleted, 0);
+        assert_eq!(report.kept, 1);
+    }
+
+    #[test]
+    fn prune_old_jobs_respects_terminal_status_only() {
+        let store = SqliteStore::in_memory().unwrap();
+        insert_test_job(&store, voom_domain::job::JobStatus::Pending, None);
+        insert_test_job(&store, voom_domain::job::JobStatus::Running, None);
+        let policy = RetentionPolicy {
+            max_age: Some(chrono::Duration::seconds(0)),
+            keep_last: None,
+        };
+        let report = store.prune_old_jobs(policy).unwrap();
+        assert_eq!(
+            report.deleted, 0,
+            "pending/running rows must never be deleted"
+        );
+        assert_eq!(report.kept, 0, "kept counts only eligible rows");
+    }
+
+    #[test]
+    fn prune_old_jobs_age_only_deletes_old() {
+        let store = SqliteStore::in_memory().unwrap();
+        let now = chrono::Utc::now();
+        insert_test_job(
+            &store,
+            voom_domain::job::JobStatus::Completed,
+            Some(now - chrono::Duration::days(30)),
+        );
+        insert_test_job(
+            &store,
+            voom_domain::job::JobStatus::Completed,
+            Some(now - chrono::Duration::hours(1)),
+        );
+        let policy = RetentionPolicy {
+            max_age: Some(chrono::Duration::days(7)),
+            keep_last: None,
+        };
+        let report = store.prune_old_jobs(policy).unwrap();
+        assert_eq!(report.deleted, 1);
+        assert_eq!(report.kept, 1);
+    }
+
+    #[test]
+    fn prune_old_jobs_count_only_keeps_newest() {
+        let store = SqliteStore::in_memory().unwrap();
+        let now = chrono::Utc::now();
+        for i in 0..5i64 {
+            insert_test_job(
+                &store,
+                voom_domain::job::JobStatus::Completed,
+                Some(now - chrono::Duration::minutes(i)),
+            );
+        }
+        let policy = RetentionPolicy {
+            max_age: None,
+            keep_last: Some(2),
+        };
+        let report = store.prune_old_jobs(policy).unwrap();
+        assert_eq!(report.deleted, 3);
+        assert_eq!(report.kept, 2);
+    }
+
+    #[test]
+    fn prune_old_jobs_or_semantics_combines_bounds() {
+        let store = SqliteStore::in_memory().unwrap();
+        let now = chrono::Utc::now();
+        // 5 rows, age in days: [10, 5, 3, 1, 0]
+        for days in [10i64, 5, 3, 1, 0] {
+            insert_test_job(
+                &store,
+                voom_domain::job::JobStatus::Completed,
+                Some(now - chrono::Duration::days(days)),
+            );
+        }
+        let policy = RetentionPolicy {
+            max_age: Some(chrono::Duration::days(4)), // deletes 10d, 5d
+            keep_last: Some(3),                       // would also delete the 4th-newest (5d)
+        };
+        let report = store.prune_old_jobs(policy).unwrap();
+        // OR semantics: 10d (too old), 5d (too old AND beyond rank 3), nothing else qualifies
+        assert_eq!(report.deleted, 2);
+        assert_eq!(report.kept, 3);
+    }
+
+    #[test]
+    fn prune_old_jobs_completed_at_fallback_to_created_at() {
+        let store = SqliteStore::in_memory().unwrap();
+        // A failed job with no completed_at — falls back to created_at (defaults to now in Job::new)
+        insert_test_job(&store, voom_domain::job::JobStatus::Failed, None);
+        // Make policy aggressively short so created_at (≈now) is NOT older
+        let policy = RetentionPolicy {
+            max_age: Some(chrono::Duration::days(1)),
+            keep_last: None,
+        };
+        let report = store.prune_old_jobs(policy).unwrap();
+        assert_eq!(
+            report.deleted, 0,
+            "row younger than max_age via created_at fallback"
+        );
+    }
+
+    #[test]
+    fn prune_old_jobs_empty_table_is_noop() {
+        let store = SqliteStore::in_memory().unwrap();
+        let policy = RetentionPolicy {
+            max_age: Some(chrono::Duration::days(1)),
+            keep_last: Some(10),
+        };
+        let report = store.prune_old_jobs(policy).unwrap();
+        assert_eq!(report.deleted, 0);
+        assert_eq!(report.kept, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds automatic, configurable retention to the `jobs`, `event_log`, and `file_transitions` tables so VOOM databases stop growing unboundedly.

- **New `RetentionPolicy` / `PruneReport` types** in `voom-domain`.
- **Three new prune trait methods** (one per table) on the existing `JobStorage`, `EventLogStorage`, `FileTransitionStorage` traits, plus paired `count_old_*` variants for `--dry-run`.
- **`RetentionRunner`** in `voom-cli` reads `[retention.*]` config, calls each storage method, and emits a `RetentionCompletedEvent` on the bus.
- **Trigger sites:** periodic tokio task in `serve` mode, end-of-run hook in `scan` and `process`, on-demand via `voom db prune` (with new `--dry-run` flag).
- **Removes the legacy event_log auto-prune** at the every-1000-inserts call site (replaced by the new system; default cap raised from 10k to 100k).
- **`voom report --database`** shows the last retention pass.

OR semantics between bounds (delete if too old OR beyond count cap). File-transitions retention always preserves the most-recent transition per `file_id`. Terminal-state-only filter for jobs (pending/running never touched).

Closes #155.

## Defaults

| Table              | keep_for_days | keep_last  |
|--------------------|---------------|------------|
| jobs               | 7             | 50,000     |
| event_log          | 30            | 100,000    |
| file_transitions   | 90            | 500,000    |

Schedule: 60 min in `serve`. End-of-run hook on by default. Set both fields to 0 to disable a table.

## Test plan

- [x] Unit tests for each storage `prune_old_*` and `count_old_*` (age, count, OR semantics, terminal-status, completed_at fallback, empty, fully-disabled): 16 in voom-sqlite-store
- [x] `RetentionRunner` unit tests (per-table mapping, fully-disabled detection, run_once shape): 9 in voom-cli
- [x] `RetentionPolicy` helper tests: 4 in voom-domain
- [x] Schema migration test asserts new indexes exist
- [x] Event round-trip test for `RetentionCompletedEvent`
- [x] Functional tests: `voom db prune --dry-run` does not modify DB; real `voom db prune` succeeds against a populated DB
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] Full `cargo test` passes

## Notes

- Spec at `docs/superpowers/specs/2026-05-02-jobs-table-retention-design.md`, plan at `docs/superpowers/plans/2026-05-02-jobs-table-retention.md` (both gitignored).
- The 5×-jobs-per-file ratio noted as a secondary concern in #155 was not investigated here; #151's fix likely already mitigates it.
- Stale-row sweeps for `discovered_files` / `pending_operations` were intentionally out of scope.