### PR TITLE
fix(introspector): classify cover-art video streams as attachments (#156)

### DIFF
--- a/plugins/ffprobe-introspector/src/parser.rs
+++ b/plugins/ffprobe-introspector/src/parser.rs
@@ -81,6 +81,42 @@ fn parse_streams(streams: &[serde_json::Value]) -> Vec<Track> {
         .collect()
 }
 
+/// Codecs that are image-only in a film library context. A track using one of
+/// these codecs is treated as cover art / thumbnail when it lacks evidence of
+/// real motion (frame count > 1 AND non-zero duration).
+const IMAGE_ONLY_CODECS: &[&str] = &["mjpeg", "png", "bmp", "gif", "webp"];
+
+/// Returns true when a `codec_type=video` stream looks like an embedded cover
+/// image rather than primary motion video.
+///
+/// Heuristic (codec must be in `IMAGE_ONLY_CODECS`, then any of):
+/// - `nb_frames` parses to a value `<= 1`
+/// - `nb_frames` is absent AND `duration` is missing/`N/A`/parses to `0.0`
+///
+/// `codec` is the *normalized* codec name (matches the value stored on `Track.codec`).
+fn is_likely_cover_art_stream(codec: &str, stream: &serde_json::Value) -> bool {
+    if !IMAGE_ONLY_CODECS.contains(&codec) {
+        return false;
+    }
+
+    let nb_frames = stream
+        .get("nb_frames")
+        .and_then(|v| v.as_str())
+        .and_then(|s| s.parse::<u64>().ok());
+
+    if let Some(frames) = nb_frames {
+        return frames <= 1;
+    }
+
+    let duration = stream
+        .get("duration")
+        .and_then(|v| v.as_str())
+        .filter(|s| *s != "N/A")
+        .and_then(|s| s.parse::<f64>().ok())
+        .unwrap_or(0.0);
+    duration <= 0.0
+}
+
 #[allow(clippy::too_many_lines)] // Single match over codec_type; splitting would scatter field logic.
 fn parse_stream(index: u32, stream: &serde_json::Value) -> Option<Track> {
     let codec_type = stream.get("codec_type")?.as_str()?;
@@ -134,6 +170,14 @@ fn parse_stream(index: u32, stream: &serde_json::Value) -> Option<Track> {
         "video" => {
             // Skip attached pictures (album art)
             if disp_flag("attached_pic") {
+                common.track_type = TrackType::Attachment;
+                return Some(common);
+            }
+
+            // Heuristic: image codecs with no real motion are cover art even
+            // when the muxer didn't set the attached_pic disposition flag.
+            // See issue #156.
+            if is_likely_cover_art_stream(&common.codec, stream) {
                 common.track_type = TrackType::Attachment;
                 return Some(common);
             }
@@ -657,5 +701,80 @@ mod tests {
         let stream = serde_json::json!({"r_frame_rate": "25/1"});
         let rate = parse_frame_rate(&stream).unwrap();
         assert!((rate - 25.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn mjpeg_with_single_frame_classified_as_attachment() {
+        let stream = serde_json::json!({
+            "index": 0,
+            "codec_type": "video",
+            "codec_name": "mjpeg",
+            "width": 600,
+            "height": 600,
+            "r_frame_rate": "0/0",
+            "avg_frame_rate": "0/0",
+            "nb_frames": "1",
+            "disposition": {"default": 0, "forced": 0, "attached_pic": 0, "comment": 0},
+            "tags": {}
+        });
+        let json = make_ffprobe_json(&[stream]);
+        let file = parse_ffprobe_output(&json, Path::new("/test.mkv"), 0, None).unwrap();
+        assert_eq!(file.tracks[0].track_type, TrackType::Attachment);
+    }
+
+    #[test]
+    fn png_cover_without_frame_count_classified_as_attachment() {
+        let stream = serde_json::json!({
+            "index": 0,
+            "codec_type": "video",
+            "codec_name": "png",
+            "width": 1000,
+            "height": 1500,
+            "r_frame_rate": "0/0",
+            "avg_frame_rate": "0/0",
+            "disposition": {"default": 0, "forced": 0, "attached_pic": 0, "comment": 0},
+            "tags": {}
+        });
+        let json = make_ffprobe_json(&[stream]);
+        let file = parse_ffprobe_output(&json, Path::new("/test.mkv"), 0, None).unwrap();
+        assert_eq!(file.tracks[0].track_type, TrackType::Attachment);
+    }
+
+    #[test]
+    fn motion_mjpeg_with_real_frames_stays_video() {
+        let stream = serde_json::json!({
+            "index": 0,
+            "codec_type": "video",
+            "codec_name": "mjpeg",
+            "width": 1920,
+            "height": 1080,
+            "r_frame_rate": "24000/1001",
+            "avg_frame_rate": "24000/1001",
+            "nb_frames": "138165",
+            "duration": "5760.000000",
+            "disposition": {"default": 1, "forced": 0, "attached_pic": 0, "comment": 0},
+            "tags": {}
+        });
+        let json = make_ffprobe_json(&[stream]);
+        let file = parse_ffprobe_output(&json, Path::new("/test.mkv"), 0, None).unwrap();
+        assert_eq!(file.tracks[0].track_type, TrackType::Video);
+    }
+
+    #[test]
+    fn hevc_with_missing_nb_frames_stays_video() {
+        let stream = serde_json::json!({
+            "index": 0,
+            "codec_type": "video",
+            "codec_name": "hevc",
+            "width": 3840,
+            "height": 2160,
+            "r_frame_rate": "24000/1001",
+            "avg_frame_rate": "24000/1001",
+            "disposition": {"default": 1, "forced": 0, "attached_pic": 0, "comment": 0},
+            "tags": {}
+        });
+        let json = make_ffprobe_json(&[stream]);
+        let file = parse_ffprobe_output(&json, Path::new("/test.mkv"), 0, None).unwrap();
+        assert_eq!(file.tracks[0].track_type, TrackType::Video);
     }
 }

--- a/plugins/ffprobe-introspector/src/parser.rs
+++ b/plugins/ffprobe-introspector/src/parser.rs
@@ -704,7 +704,7 @@ mod tests {
     }
 
     #[test]
-    fn mjpeg_with_single_frame_classified_as_attachment() {
+    fn test_mjpeg_with_single_frame_classified_as_attachment() {
         let stream = serde_json::json!({
             "index": 0,
             "codec_type": "video",
@@ -723,7 +723,7 @@ mod tests {
     }
 
     #[test]
-    fn png_cover_without_frame_count_classified_as_attachment() {
+    fn test_png_cover_without_frame_count_classified_as_attachment() {
         let stream = serde_json::json!({
             "index": 0,
             "codec_type": "video",
@@ -741,7 +741,7 @@ mod tests {
     }
 
     #[test]
-    fn motion_mjpeg_with_real_frames_stays_video() {
+    fn test_motion_mjpeg_with_real_frames_stays_video() {
         let stream = serde_json::json!({
             "index": 0,
             "codec_type": "video",
@@ -761,7 +761,7 @@ mod tests {
     }
 
     #[test]
-    fn hevc_with_missing_nb_frames_stays_video() {
+    fn test_hevc_with_missing_nb_frames_stays_video() {
         let stream = serde_json::json!({
             "index": 0,
             "codec_type": "video",

--- a/plugins/sqlite-store/src/schema.rs
+++ b/plugins/sqlite-store/src/schema.rs
@@ -252,6 +252,7 @@ pub(crate) fn migrate(conn: &Connection) -> rusqlite::Result<()> {
     migrate_metadata_snapshot_column(conn, &has_column)?;
     migrate_execution_capture_columns(conn, &has_column)?;
     migrate_from_path_column(conn, &has_column)?;
+    migrate_cover_art_track_types(conn)?;
 
     Ok(())
 }
@@ -605,6 +606,46 @@ fn migrate_execution_capture_columns(
     Ok(())
 }
 
+/// Reclassify cover-art / thumbnail tracks misclassified as primary video by
+/// older introspector versions. See issue #156.
+///
+/// - `png`/`bmp`/`gif`/`webp` rows are always image-only in a film library.
+/// - `mjpeg` rows are reclassified only when a sibling video track exists for
+///   the same file (protects rare genuine motion-mjpeg encodes).
+///
+/// Idempotent: a clean database has no `track_type='video'` rows with image
+/// codecs, so the UPDATE statements affect zero rows.
+fn migrate_cover_art_track_types(conn: &Connection) -> rusqlite::Result<()> {
+    let tracks_exists: bool = conn.query_row(
+        "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='tracks'",
+        [],
+        |row| row.get(0),
+    )?;
+    if !tracks_exists {
+        return Ok(());
+    }
+
+    conn.execute_batch(
+        "UPDATE tracks SET track_type = 'attachment' \
+         WHERE track_type = 'video' \
+         AND codec IN ('png', 'bmp', 'gif', 'webp');",
+    )?;
+
+    conn.execute_batch(
+        "UPDATE tracks SET track_type = 'attachment' \
+         WHERE track_type = 'video' \
+         AND codec = 'mjpeg' \
+         AND file_id IN ( \
+             SELECT file_id FROM tracks \
+             WHERE track_type = 'video' \
+             GROUP BY file_id \
+             HAVING COUNT(*) > 1 \
+         );",
+    )?;
+
+    Ok(())
+}
+
 /// Add `from_path` column to `file_transitions` and create the path-lookup
 /// indexes that the OR-match in `transitions_for_path` relies on.
 fn migrate_from_path_column(
@@ -833,5 +874,59 @@ mod tests {
                 "missing index {required}; got {names:?}"
             );
         }
+    }
+
+    #[test]
+    fn migration_reclassifies_cover_art_tracks() {
+        let conn = Connection::open_in_memory().unwrap();
+        create_schema(&conn).unwrap();
+
+        // file_a: real h264 + mjpeg cover (mjpeg should be reclassified)
+        conn.execute_batch(
+            "INSERT INTO files (id, path, filename, size, content_hash, container, introspected_at, created_at, updated_at) \
+             VALUES ('file_a', '/a.mkv', 'a.mkv', 0, 'h', 'mkv', '2026-01-01', '2026-01-01', '2026-01-01'); \
+             INSERT INTO tracks (id, file_id, stream_index, track_type, codec) \
+             VALUES ('t_a0', 'file_a', 0, 'video', 'h264'), \
+                    ('t_a1', 'file_a', 1, 'video', 'mjpeg');",
+        ).unwrap();
+
+        // file_b: lone mjpeg track (real motion encode — must NOT be reclassified)
+        conn.execute_batch(
+            "INSERT INTO files (id, path, filename, size, content_hash, container, introspected_at, created_at, updated_at) \
+             VALUES ('file_b', '/b.mkv', 'b.mkv', 0, 'h', 'mkv', '2026-01-01', '2026-01-01', '2026-01-01'); \
+             INSERT INTO tracks (id, file_id, stream_index, track_type, codec) \
+             VALUES ('t_b0', 'file_b', 0, 'video', 'mjpeg');",
+        ).unwrap();
+
+        // file_c: hevc + png cover (png ALWAYS reclassified)
+        conn.execute_batch(
+            "INSERT INTO files (id, path, filename, size, content_hash, container, introspected_at, created_at, updated_at) \
+             VALUES ('file_c', '/c.mkv', 'c.mkv', 0, 'h', 'mkv', '2026-01-01', '2026-01-01', '2026-01-01'); \
+             INSERT INTO tracks (id, file_id, stream_index, track_type, codec) \
+             VALUES ('t_c0', 'file_c', 0, 'video', 'hevc'), \
+                    ('t_c1', 'file_c', 1, 'video', 'png');",
+        ).unwrap();
+
+        migrate_cover_art_track_types(&conn).unwrap();
+
+        let track_type = |id: &str| -> String {
+            conn.query_row("SELECT track_type FROM tracks WHERE id = ?", [id], |row| {
+                row.get(0)
+            })
+            .unwrap()
+        };
+        assert_eq!(track_type("t_a0"), "video");
+        assert_eq!(
+            track_type("t_a1"),
+            "attachment",
+            "mjpeg paired with real video reclassified"
+        );
+        assert_eq!(track_type("t_b0"), "video", "lone mjpeg preserved");
+        assert_eq!(track_type("t_c0"), "video");
+        assert_eq!(track_type("t_c1"), "attachment", "png always reclassified");
+
+        // Re-running is a no-op.
+        migrate_cover_art_track_types(&conn).unwrap();
+        assert_eq!(track_type("t_a1"), "attachment");
     }
 }

--- a/plugins/sqlite-store/src/schema.rs
+++ b/plugins/sqlite-store/src/schema.rs
@@ -214,6 +214,14 @@ pub fn create_schema(conn: &Connection) -> rusqlite::Result<()> {
     Ok(())
 }
 
+fn table_exists(conn: &Connection, name: &str) -> rusqlite::Result<bool> {
+    conn.query_row(
+        "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name=?1",
+        [name],
+        |row| row.get(0),
+    )
+}
+
 /// Run migrations for existing databases that may lack newer columns/tables.
 pub(crate) fn migrate(conn: &Connection) -> rusqlite::Result<()> {
     // Check plans table for new columns
@@ -450,12 +458,7 @@ fn migrate_indexes_and_constraints(conn: &Connection) -> rusqlite::Result<()> {
         )
     };
 
-    let tracks_exists: bool = conn.query_row(
-        "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='tracks'",
-        [],
-        |row| row.get(0),
-    )?;
-    if tracks_exists && !has_index("idx_tracks_type")? {
+    if table_exists(conn, "tracks")? && !has_index("idx_tracks_type")? {
         conn.execute_batch("CREATE INDEX IF NOT EXISTS idx_tracks_type ON tracks(track_type);")?;
     }
 
@@ -616,12 +619,21 @@ fn migrate_execution_capture_columns(
 /// Idempotent: a clean database has no `track_type='video'` rows with image
 /// codecs, so the UPDATE statements affect zero rows.
 fn migrate_cover_art_track_types(conn: &Connection) -> rusqlite::Result<()> {
-    let tracks_exists: bool = conn.query_row(
-        "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='tracks'",
+    if !table_exists(conn, "tracks")? {
+        return Ok(());
+    }
+
+    // Cheap pre-check using idx_tracks_type: skip the UPDATE work entirely once
+    // a database has been migrated. Avoids re-evaluating the correlated mjpeg
+    // subquery on every startup.
+    let has_candidates: bool = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM tracks \
+         WHERE track_type = 'video' \
+         AND codec IN ('png', 'bmp', 'gif', 'webp', 'mjpeg'))",
         [],
         |row| row.get(0),
     )?;
-    if !tracks_exists {
+    if !has_candidates {
         return Ok(());
     }
 


### PR DESCRIPTION
## Summary
- Adds a heuristic in the ffprobe parser that reclassifies image-codec video streams (`mjpeg`/`png`/`bmp`/`gif`/`webp`) with no real motion as `TrackType::Attachment`, even when the muxer omits the `attached_pic` disposition flag.
- Adds an idempotent SQLite migration that backfills the same classification for existing rows: `png`/`bmp`/`gif`/`webp` rows are always reclassified; `mjpeg` rows are reclassified only when a sibling video track exists for the same file, preserving rare genuine motion-mjpeg encodes.

Closes #156.

## Test plan
- [x] `cargo test -p voom-ffprobe-introspector` — 4 new unit tests covering the heuristic cases (mjpeg+nb_frames=1 → Attachment, png with no frame count → Attachment, motion mjpeg stays Video, hevc with missing nb_frames stays Video).
- [x] `cargo test -p voom-sqlite-store` — new migration test covering reclassification, lone-mjpeg preservation, and idempotency.
- [x] `cargo test` (workspace) — all green, no regressions.
- [x] `cargo test -p voom-cli --features functional -- --test-threads=4` — all green.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [ ] (manual) `voom report --library` on the affected 6774-file library — expect `mjpeg` and `png` to disappear from the Video Codecs section. *Pending user verification.*