### PR TITLE
fix(sqlite-store): atomic post-execution writes (#158)

### DIFF
--- a/crates/voom-cli/src/commands/process/pipeline.rs
+++ b/crates/voom-cli/src/commands/process/pipeline.rs
@@ -431,21 +431,12 @@ pub(super) async fn handle_plan_success(
     let policy_name = plan.policy_name.clone();
     let phase_name = plan.phase_name.clone();
 
-    // Update the existing row's path before re-introspection so the
-    // `FileIntrospected` upsert merges into it instead of inserting a new
-    // row at the post-execution path (preserves UUID and lineage).
+    // The path rename, transition insert, and expected_hash update are
+    // bundled into one atomic write below (record_file_transition →
+    // record_post_execution). Re-introspection uses the no-dispatch
+    // variant so it doesn't auto-upsert the file row at the post-execution
+    // path before the bundle's rename can move the existing row.
     let post_exec_path = resolve_post_execution_path(file, std::slice::from_ref(&plan));
-    if post_exec_path != file.path {
-        if let Err(e) = ctx.store.rename_file_path(&file.id, &post_exec_path) {
-            tracing::warn!(
-                error = %e,
-                old_path = %file.path.display(),
-                new_path = %post_exec_path.display(),
-                "failed to update files.path after path-changing execution"
-            );
-        }
-    }
-
     let new_file = reintrospect_file(file, post_exec_path, ctx).await;
 
     record_file_transition(&FileTransitionContext {
@@ -539,10 +530,10 @@ async fn reintrospect_file(
 
     let ffp = ctx.ffprobe_path.map(String::from);
     let kernel_clone = ctx.kernel.clone();
-    match crate::introspect::introspect_file(
-        current_path,
+    match crate::introspect::introspect_file_no_dispatch(
+        current_path.clone(),
         size,
-        hash,
+        hash.clone(),
         &kernel_clone,
         ffp.as_deref(),
     )
@@ -562,8 +553,18 @@ async fn reintrospect_file(
             new_file
         }
         Err(e) => {
+            // Re-introspection failed but the file is on disk at
+            // `current_path`. Preserve the previous state but reflect
+            // the post-execution path/size/hash so the bundled write
+            // downstream still records the rename.
             tracing::warn!(error = %e, "re-introspection failed, using previous state");
-            file.clone()
+            let mut fallback = file.clone();
+            fallback.path = current_path;
+            fallback.size = size;
+            if hash.is_some() {
+                fallback.content_hash = hash;
+            }
+            fallback
         }
     }
 }

--- a/crates/voom-cli/src/commands/process/pipeline.rs
+++ b/crates/voom-cli/src/commands/process/pipeline.rs
@@ -554,13 +554,24 @@ async fn reintrospect_file(
         }
         Err(e) => {
             // Re-introspection failed but the file is on disk at
-            // `current_path`. Preserve the previous state but reflect
-            // the post-execution path/size/hash so the bundled write
-            // downstream still records the rename.
+            // `current_path`. Preserve the previous tracks/codecs/etc.
+            // (best effort — we can't introspect them) but reflect the
+            // post-execution path, size, container, and hash so the
+            // bundled write downstream still records the rename and the
+            // metadata snapshot doesn't misreport the on-disk state.
             tracing::warn!(error = %e, "re-introspection failed, using previous state");
             let mut fallback = file.clone();
+            fallback.container = voom_domain::media::Container::from_extension(
+                current_path
+                    .extension()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or(""),
+            );
             fallback.path = current_path;
             fallback.size = size;
+            // Don't clobber a known-good prior hash with None when
+            // post-execution hashing failed — the prior hash is still
+            // a better signal than nothing.
             if hash.is_some() {
                 fallback.content_hash = hash;
             }

--- a/crates/voom-cli/src/commands/process/transitions.rs
+++ b/crates/voom-cli/src/commands/process/transitions.rs
@@ -23,9 +23,13 @@ pub(super) struct FileTransitionContext<'a> {
 
 /// Record a file transition in the store if the content hash changed.
 pub(super) fn record_file_transition(tctx: &FileTransitionContext<'_>) {
-    if tctx.new_file.content_hash == tctx.old_file.content_hash {
+    if tctx.new_file.content_hash == tctx.old_file.content_hash
+        && tctx.new_file.path == tctx.old_file.path
+    {
+        // Nothing changed — no transition to record, no rename, no hash refresh.
         return;
     }
+
     let mut transition = voom_domain::FileTransition::new(
         tctx.old_file.id,
         tctx.new_file.path.clone(),
@@ -53,22 +57,24 @@ pub(super) fn record_file_transition(tctx: &FileTransitionContext<'_>) {
         transition = transition.with_from_path(tctx.old_file.path.clone());
     }
 
-    if let Err(e) = tctx.ctx.store.record_transition(&transition) {
+    let new_path = if tctx.old_file.path != tctx.new_file.path {
+        Some(tctx.new_file.path.as_path())
+    } else {
+        None
+    };
+    let new_expected_hash = tctx.new_file.content_hash.as_deref();
+
+    if let Err(e) = tctx.ctx.store.record_post_execution(
+        &tctx.old_file.id,
+        new_path,
+        new_expected_hash,
+        &transition,
+    ) {
         tracing::warn!(
             path = %tctx.old_file.path.display(),
             error = %e,
-            "failed to record transition"
+            "failed to record post-execution bundle (rename + transition + expected_hash)"
         );
-    }
-
-    if let Some(ref hash) = tctx.new_file.content_hash {
-        if let Err(e) = tctx.ctx.store.update_expected_hash(&tctx.old_file.id, hash) {
-            tracing::warn!(
-                path = %tctx.old_file.path.display(),
-                error = %e,
-                "failed to update expected_hash"
-            );
-        }
     }
 }
 

--- a/crates/voom-cli/src/commands/process/transitions.rs
+++ b/crates/voom-cli/src/commands/process/transitions.rs
@@ -21,12 +21,11 @@ pub(super) struct FileTransitionContext<'a> {
     pub ctx: &'a ProcessContext<'a>,
 }
 
-/// Record a file transition in the store if the content hash changed.
+/// Record a file transition in the store if the content hash or path changed.
 pub(super) fn record_file_transition(tctx: &FileTransitionContext<'_>) {
-    if tctx.new_file.content_hash == tctx.old_file.content_hash
-        && tctx.new_file.path == tctx.old_file.path
-    {
-        // Nothing changed — no transition to record, no rename, no hash refresh.
+    let hash_changed = tctx.new_file.content_hash != tctx.old_file.content_hash;
+    let path_changed = tctx.old_file.path != tctx.new_file.path;
+    if !hash_changed && !path_changed {
         return;
     }
 
@@ -53,23 +52,22 @@ pub(super) fn record_file_transition(tctx: &FileTransitionContext<'_>) {
     ))
     .with_session_id(tctx.ctx.counters.session_id);
 
-    if tctx.old_file.path != tctx.new_file.path {
+    if path_changed {
         transition = transition.with_from_path(tctx.old_file.path.clone());
     }
 
-    let new_path = if tctx.old_file.path != tctx.new_file.path {
-        Some(tctx.new_file.path.as_path())
-    } else {
-        None
-    };
-    let new_expected_hash = tctx.new_file.content_hash.as_deref();
+    let new_path = path_changed.then_some(tctx.new_file.path.as_path());
+    // Only refresh `expected_hash` when the content actually changed —
+    // otherwise we'd issue a no-op UPDATE on every path-only execution.
+    let new_expected_hash = hash_changed
+        .then_some(tctx.new_file.content_hash.as_deref())
+        .flatten();
 
-    if let Err(e) = tctx.ctx.store.record_post_execution(
-        &tctx.old_file.id,
-        new_path,
-        new_expected_hash,
-        &transition,
-    ) {
+    if let Err(e) = tctx
+        .ctx
+        .store
+        .record_post_execution(new_path, new_expected_hash, &transition)
+    {
         tracing::warn!(
             path = %tctx.old_file.path.display(),
             error = %e,

--- a/crates/voom-cli/src/commands/process/transitions.rs
+++ b/crates/voom-cli/src/commands/process/transitions.rs
@@ -73,7 +73,7 @@ pub(super) fn record_file_transition(tctx: &FileTransitionContext<'_>) {
         tracing::warn!(
             path = %tctx.old_file.path.display(),
             error = %e,
-            "failed to record post-execution bundle (rename + transition + expected_hash)"
+            "failed to record post-execution bundle"
         );
     }
 }

--- a/crates/voom-cli/src/introspect.rs
+++ b/crates/voom-cli/src/introspect.rs
@@ -62,6 +62,33 @@ pub async fn introspect_file(
     kernel: &std::sync::Arc<voom_kernel::Kernel>,
     ffprobe_path: Option<&str>,
 ) -> std::result::Result<voom_domain::media::MediaFile, VoomError> {
+    introspect_file_inner(path, file_size, content_hash, kernel, ffprobe_path, true).await
+}
+
+/// Like [`introspect_file`] but skips the `FileIntrospected` event dispatch.
+/// Use this from code paths that take responsibility for persistence
+/// themselves (e.g. the post-execution bundled write).
+// Called by process::handle_plan_success (Task 5). The binary-crate module
+// boundary means rustc sees this as dead until that call-site exists.
+#[allow(dead_code)]
+pub async fn introspect_file_no_dispatch(
+    path: std::path::PathBuf,
+    file_size: u64,
+    content_hash: Option<String>,
+    kernel: &std::sync::Arc<voom_kernel::Kernel>,
+    ffprobe_path: Option<&str>,
+) -> std::result::Result<voom_domain::media::MediaFile, VoomError> {
+    introspect_file_inner(path, file_size, content_hash, kernel, ffprobe_path, false).await
+}
+
+async fn introspect_file_inner(
+    path: std::path::PathBuf,
+    file_size: u64,
+    content_hash: Option<String>,
+    kernel: &std::sync::Arc<voom_kernel::Kernel>,
+    ffprobe_path: Option<&str>,
+    dispatch_event: bool,
+) -> std::result::Result<voom_domain::media::MediaFile, VoomError> {
     let mut introspector = voom_ffprobe_introspector::FfprobeIntrospectorPlugin::new();
     if let Some(fp) = ffprobe_path {
         introspector = introspector.with_ffprobe_path(fp);
@@ -69,16 +96,15 @@ pub async fn introspect_file(
     let path_for_event = path.clone();
     let hash_for_event = content_hash.clone();
     let path_display = path.display().to_string();
-    // Run introspection AND dispatch inside spawn_blocking so the entire
-    // cascade (WASM plugins, subtitle mux) runs on the blocking pool
-    // instead of the tokio runtime.
     let kernel_clone = kernel.clone();
     let intro_result = tokio::task::spawn_blocking(move || {
         let result = introspector.introspect(&path, file_size, content_hash.as_deref());
-        if let Ok(ref intro_event) = result {
-            kernel_clone.dispatch(Event::FileIntrospected(
-                voom_domain::events::FileIntrospectedEvent::new(intro_event.file.clone()),
-            ));
+        if dispatch_event {
+            if let Ok(ref intro_event) = result {
+                kernel_clone.dispatch(Event::FileIntrospected(
+                    voom_domain::events::FileIntrospectedEvent::new(intro_event.file.clone()),
+                ));
+            }
         }
         result
     })

--- a/crates/voom-cli/src/introspect.rs
+++ b/crates/voom-cli/src/introspect.rs
@@ -96,6 +96,10 @@ async fn introspect_file_inner(
     let path_for_event = path.clone();
     let hash_for_event = content_hash.clone();
     let path_display = path.display().to_string();
+    // Run introspection AND (optionally) the FileIntrospected dispatch
+    // inside spawn_blocking so the entire cascade (WASM plugins,
+    // subtitle mux subscribers) runs on the blocking pool rather than
+    // the tokio runtime.
     let kernel_clone = kernel.clone();
     let intro_result = tokio::task::spawn_blocking(move || {
         let result = introspector.introspect(&path, file_size, content_hash.as_deref());

--- a/crates/voom-cli/src/introspect.rs
+++ b/crates/voom-cli/src/introspect.rs
@@ -68,9 +68,6 @@ pub async fn introspect_file(
 /// Like [`introspect_file`] but skips the `FileIntrospected` event dispatch.
 /// Use this from code paths that take responsibility for persistence
 /// themselves (e.g. the post-execution bundled write).
-// Called by process::handle_plan_success (Task 5). The binary-crate module
-// boundary means rustc sees this as dead until that call-site exists.
-#[allow(dead_code)]
 pub async fn introspect_file_no_dispatch(
     path: std::path::PathBuf,
     file_size: u64,

--- a/crates/voom-domain/src/storage.rs
+++ b/crates/voom-domain/src/storage.rs
@@ -149,24 +149,32 @@ pub trait FileStorage: Send + Sync {
     ) -> Result<u32>;
     /// Update the expected hash for a file (set after a successful voom operation).
     fn update_expected_hash(&self, id: &Uuid, hash: &str) -> Result<()>;
-    /// Atomically perform the three post-execution writes for a successfully
+    /// Atomically perform the post-execution writes for a successfully
     /// executed plan: optionally rename the file's path, insert a transition
-    /// row, and update the file's `expected_hash`. All three writes happen
-    /// inside one `BEGIN/COMMIT`, so a mid-bundle crash cannot leave the DB
-    /// with an audit-trail gap or a path/hash mismatch.
+    /// row, and optionally update the file's `expected_hash`. All writes
+    /// happen inside one `BEGIN/COMMIT`, so a mid-bundle crash cannot leave
+    /// the DB with an audit-trail gap or a path/hash mismatch.
     ///
     /// `new_path` is `Some` only when execution changed the file's on-disk
     /// path (e.g. `ConvertContainer .mp4 → .mkv`). When `None`, the file
     /// row's `path` column is left untouched.
     ///
+    /// `new_expected_hash` is `Some` only when re-introspection produced a
+    /// usable content hash. When `None`, the file row's `expected_hash` is
+    /// left untouched. Implementations MUST NOT write an empty string —
+    /// downstream reconciliation distinguishes `NULL` (legacy / no fingerprint
+    /// recorded) from a real hash, and an empty string would be misread as a
+    /// real hash that never matches.
+    ///
     /// The `transition` argument supplies all transition fields, including
     /// `from_path` if the caller wants the audit trail to record the prior
-    /// path. Callers must build the `FileTransition` themselves.
+    /// path. The caller must ensure `transition.file_id == *id`; behavior is
+    /// otherwise undefined (debug builds will assert).
     fn record_post_execution(
         &self,
         id: &Uuid,
         new_path: Option<&Path>,
-        new_expected_hash: &str,
+        new_expected_hash: Option<&str>,
         transition: &FileTransition,
     ) -> Result<()>;
     /// Find the file that was superseded by the given file (predecessor lookup).

--- a/crates/voom-domain/src/storage.rs
+++ b/crates/voom-domain/src/storage.rs
@@ -149,6 +149,26 @@ pub trait FileStorage: Send + Sync {
     ) -> Result<u32>;
     /// Update the expected hash for a file (set after a successful voom operation).
     fn update_expected_hash(&self, id: &Uuid, hash: &str) -> Result<()>;
+    /// Atomically perform the three post-execution writes for a successfully
+    /// executed plan: optionally rename the file's path, insert a transition
+    /// row, and update the file's `expected_hash`. All three writes happen
+    /// inside one `BEGIN/COMMIT`, so a mid-bundle crash cannot leave the DB
+    /// with an audit-trail gap or a path/hash mismatch.
+    ///
+    /// `new_path` is `Some` only when execution changed the file's on-disk
+    /// path (e.g. `ConvertContainer .mp4 → .mkv`). When `None`, the file
+    /// row's `path` column is left untouched.
+    ///
+    /// The `transition` argument supplies all transition fields, including
+    /// `from_path` if the caller wants the audit trail to record the prior
+    /// path. Callers must build the `FileTransition` themselves.
+    fn record_post_execution(
+        &self,
+        id: &Uuid,
+        new_path: Option<&Path>,
+        new_expected_hash: &str,
+        transition: &FileTransition,
+    ) -> Result<()>;
     /// Find the file that was superseded by the given file (predecessor lookup).
     /// Returns the file whose `superseded_by` field equals `successor_id`.
     fn predecessor_of(&self, successor_id: &Uuid) -> Result<Option<MediaFile>>;

--- a/crates/voom-domain/src/storage.rs
+++ b/crates/voom-domain/src/storage.rs
@@ -155,24 +155,20 @@ pub trait FileStorage: Send + Sync {
     /// happen inside one `BEGIN/COMMIT`, so a mid-bundle crash cannot leave
     /// the DB with an audit-trail gap or a path/hash mismatch.
     ///
+    /// The file row to mutate is identified by `transition.file_id`.
+    ///
     /// `new_path` is `Some` only when execution changed the file's on-disk
     /// path (e.g. `ConvertContainer .mp4 → .mkv`). When `None`, the file
     /// row's `path` column is left untouched.
     ///
     /// `new_expected_hash` is `Some` only when re-introspection produced a
     /// usable content hash. When `None`, the file row's `expected_hash` is
-    /// left untouched. Implementations MUST NOT write an empty string —
-    /// downstream reconciliation distinguishes `NULL` (legacy / no fingerprint
-    /// recorded) from a real hash, and an empty string would be misread as a
-    /// real hash that never matches.
-    ///
-    /// The `transition` argument supplies all transition fields, including
-    /// `from_path` if the caller wants the audit trail to record the prior
-    /// path. The caller must ensure `transition.file_id == *id`; behavior is
-    /// otherwise undefined (debug builds will assert).
+    /// left untouched. Callers MUST NOT pass `Some("")` — downstream
+    /// reconciliation distinguishes `NULL` (legacy / no fingerprint recorded)
+    /// from a real hash, and an empty string would be misread as a real hash
+    /// that never matches. Debug builds will assert.
     fn record_post_execution(
         &self,
-        id: &Uuid,
         new_path: Option<&Path>,
         new_expected_hash: Option<&str>,
         transition: &FileTransition,

--- a/crates/voom-domain/src/test_support.rs
+++ b/crates/voom-domain/src/test_support.rs
@@ -234,6 +234,10 @@ impl FileStorage for InMemoryStore {
         Ok(())
     }
 
+    /// In-memory stub. Unlike the SQLite implementation, this does NOT roll
+    /// back partial mutations on error — the in-memory mutations have no
+    /// fallible path. Tests that exercise rollback semantics must use
+    /// `SqliteStore`.
     fn record_post_execution(
         &self,
         id: &Uuid,
@@ -242,8 +246,8 @@ impl FileStorage for InMemoryStore {
         transition: &FileTransition,
     ) -> Result<()> {
         debug_assert_eq!(
-            transition.file_id, *id,
-            "record_post_execution: transition.file_id must equal id"
+            id, &transition.file_id,
+            "record_post_execution: id must match transition.file_id"
         );
         let mut files = self.files.lock();
         if let Some(file) = files.get_mut(id) {

--- a/crates/voom-domain/src/test_support.rs
+++ b/crates/voom-domain/src/test_support.rs
@@ -240,17 +240,16 @@ impl FileStorage for InMemoryStore {
     /// `SqliteStore`.
     fn record_post_execution(
         &self,
-        id: &Uuid,
         new_path: Option<&Path>,
         new_expected_hash: Option<&str>,
         transition: &FileTransition,
     ) -> Result<()> {
-        debug_assert_eq!(
-            id, &transition.file_id,
-            "record_post_execution: id must match transition.file_id"
+        debug_assert!(
+            new_expected_hash.is_none_or(|h| !h.is_empty()),
+            "record_post_execution: empty hash passed as Some — use None instead"
         );
         let mut files = self.files.lock();
-        if let Some(file) = files.get_mut(id) {
+        if let Some(file) = files.get_mut(&transition.file_id) {
             if let Some(path) = new_path {
                 file.path = path.to_path_buf();
             }

--- a/crates/voom-domain/src/test_support.rs
+++ b/crates/voom-domain/src/test_support.rs
@@ -234,6 +234,31 @@ impl FileStorage for InMemoryStore {
         Ok(())
     }
 
+    fn record_post_execution(
+        &self,
+        id: &Uuid,
+        new_path: Option<&Path>,
+        new_expected_hash: Option<&str>,
+        transition: &FileTransition,
+    ) -> Result<()> {
+        debug_assert_eq!(
+            transition.file_id, *id,
+            "record_post_execution: transition.file_id must equal id"
+        );
+        let mut files = self.files.lock();
+        if let Some(file) = files.get_mut(id) {
+            if let Some(path) = new_path {
+                file.path = path.to_path_buf();
+            }
+            if let Some(hash) = new_expected_hash {
+                file.expected_hash = Some(hash.to_string());
+            }
+        }
+        drop(files);
+        self.transitions.lock().push(transition.clone());
+        Ok(())
+    }
+
     fn predecessor_of(&self, _successor_id: &Uuid) -> Result<Option<MediaFile>> {
         Ok(None)
     }

--- a/plugins/sqlite-store/src/store/file_storage.rs
+++ b/plugins/sqlite-store/src/store/file_storage.rs
@@ -392,12 +392,45 @@ impl FileStorage for SqliteStore {
 
     fn record_post_execution(
         &self,
-        _id: &Uuid,
-        _new_path: Option<&Path>,
-        _new_expected_hash: Option<&str>,
-        _transition: &FileTransition,
+        id: &Uuid,
+        new_path: Option<&Path>,
+        new_expected_hash: Option<&str>,
+        transition: &FileTransition,
     ) -> Result<()> {
-        todo!("record_post_execution not yet implemented — Task 3 will provide the real impl")
+        debug_assert_eq!(
+            id, &transition.file_id,
+            "record_post_execution: id must match transition.file_id"
+        );
+
+        let mut conn = self.conn()?;
+        let tx = conn
+            .transaction()
+            .map_err(storage_err("failed to begin post-execution transaction"))?;
+
+        if let Some(new_path) = new_path {
+            let now = format_datetime(&Utc::now());
+            let path_str = new_path.to_string_lossy().to_string();
+            let filename = filename_string(new_path);
+            tx.execute(
+                "UPDATE files SET path = ?1, filename = ?2, updated_at = ?3 WHERE id = ?4",
+                params![path_str, filename, now, id.to_string()],
+            )
+            .map_err(storage_err("failed to rename file path in bundle"))?;
+        }
+
+        super::file_transition_storage::insert_full_transition_in_tx(&tx, transition)?;
+
+        if let Some(hash) = new_expected_hash {
+            tx.execute(
+                "UPDATE files SET expected_hash = ?1 WHERE id = ?2",
+                params![hash, id.to_string()],
+            )
+            .map_err(storage_err("failed to update expected_hash in bundle"))?;
+        }
+
+        tx.commit()
+            .map_err(storage_err("failed to commit post-execution bundle"))?;
+        Ok(())
     }
 
     fn predecessor_of(&self, successor_id: &Uuid) -> Result<Option<MediaFile>> {
@@ -1450,6 +1483,199 @@ mod tests {
 
         let stored = store.file(&file.id).unwrap().unwrap();
         assert_eq!(stored.expected_hash.as_deref(), Some("new-hash"));
+    }
+
+    #[test]
+    fn record_post_execution_atomically_writes_all_three() {
+        use voom_domain::storage::FileTransitionStorage;
+        use voom_domain::transition::{FileTransition, TransitionSource};
+
+        let store = test_store();
+        let file = active_file("/media/movie.mp4");
+        store.upsert_file(&file).unwrap();
+        let original_id = store
+            .file_by_path(Path::new("/media/movie.mp4"))
+            .unwrap()
+            .unwrap()
+            .id;
+
+        let transition = FileTransition::new(
+            original_id,
+            PathBuf::from("/media/movie.mkv"),
+            "new_hash".to_string(),
+            2048,
+            TransitionSource::Voom,
+        )
+        .with_from(Some("abc123".to_string()), Some(1024))
+        .with_from_path(PathBuf::from("/media/movie.mp4"));
+
+        store
+            .record_post_execution(
+                &original_id,
+                Some(Path::new("/media/movie.mkv")),
+                Some("new_hash"),
+                &transition,
+            )
+            .unwrap();
+
+        // 1. Path is renamed
+        assert!(store
+            .file_by_path(Path::new("/media/movie.mp4"))
+            .unwrap()
+            .is_none());
+        let renamed = store
+            .file_by_path(Path::new("/media/movie.mkv"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(renamed.id, original_id);
+
+        // 2. expected_hash is updated
+        assert_eq!(renamed.expected_hash.as_deref(), Some("new_hash"));
+
+        // 3. Transition is recorded with from_path preserved
+        let transitions = store.transitions_for_file(&original_id).unwrap();
+        assert_eq!(transitions.len(), 1);
+        assert_eq!(transitions[0].to_hash, "new_hash");
+        assert_eq!(
+            transitions[0].from_path.as_deref(),
+            Some(Path::new("/media/movie.mp4"))
+        );
+    }
+
+    #[test]
+    fn record_post_execution_no_path_change_skips_rename() {
+        use voom_domain::storage::FileTransitionStorage;
+        use voom_domain::transition::{FileTransition, TransitionSource};
+
+        let store = test_store();
+        let file = active_file("/media/movie.mkv");
+        store.upsert_file(&file).unwrap();
+        let id = store
+            .file_by_path(Path::new("/media/movie.mkv"))
+            .unwrap()
+            .unwrap()
+            .id;
+
+        let transition = FileTransition::new(
+            id,
+            PathBuf::from("/media/movie.mkv"),
+            "new_hash".to_string(),
+            2048,
+            TransitionSource::Voom,
+        )
+        .with_from(Some("abc123".to_string()), Some(1024));
+
+        store
+            .record_post_execution(&id, None, Some("new_hash"), &transition)
+            .unwrap();
+
+        let stored = store
+            .file_by_path(Path::new("/media/movie.mkv"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(stored.id, id);
+        assert_eq!(stored.expected_hash.as_deref(), Some("new_hash"));
+        assert_eq!(store.transitions_for_file(&id).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn record_post_execution_no_hash_skips_expected_hash_update() {
+        use voom_domain::storage::FileTransitionStorage;
+        use voom_domain::transition::{FileTransition, TransitionSource};
+
+        let store = test_store();
+        let file = active_file("/media/movie.mkv"); // active_file sets expected_hash="abc123"
+        store.upsert_file(&file).unwrap();
+        let id = store
+            .file_by_path(Path::new("/media/movie.mkv"))
+            .unwrap()
+            .unwrap()
+            .id;
+        // Set a known prior expected_hash directly so we can verify it's preserved.
+        store.update_expected_hash(&id, "prior_hash").unwrap();
+
+        let transition = FileTransition::new(
+            id,
+            PathBuf::from("/media/movie.mkv"),
+            String::new(),
+            2048,
+            TransitionSource::Voom,
+        );
+
+        store
+            .record_post_execution(&id, None, None, &transition)
+            .unwrap();
+
+        let stored = store
+            .file_by_path(Path::new("/media/movie.mkv"))
+            .unwrap()
+            .unwrap();
+        // expected_hash MUST be untouched when None is passed
+        assert_eq!(stored.expected_hash.as_deref(), Some("prior_hash"));
+        // Transition still recorded
+        assert_eq!(store.transitions_for_file(&id).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn record_post_execution_rolls_back_on_duplicate_transition_id() {
+        use voom_domain::storage::FileTransitionStorage;
+        use voom_domain::transition::{FileTransition, TransitionSource};
+
+        let store = test_store();
+        let file = active_file("/media/movie.mp4");
+        store.upsert_file(&file).unwrap();
+        let original_id = store
+            .file_by_path(Path::new("/media/movie.mp4"))
+            .unwrap()
+            .unwrap()
+            .id;
+        store.update_expected_hash(&original_id, "abc123").unwrap();
+
+        // Pre-insert a transition with a known id, then try to record_post_execution
+        // with the same transition.id. The INSERT will violate the PK constraint,
+        // and the entire bundle (rename + expected_hash) must roll back.
+        let mut existing = FileTransition::new(
+            original_id,
+            PathBuf::from("/media/movie.mp4"),
+            "abc123".to_string(),
+            1024,
+            TransitionSource::Voom,
+        );
+        existing.id = uuid::Uuid::new_v4();
+        store.record_transition(&existing).unwrap();
+
+        let mut bundled = FileTransition::new(
+            original_id,
+            PathBuf::from("/media/movie.mkv"),
+            "new_hash".to_string(),
+            2048,
+            TransitionSource::Voom,
+        );
+        bundled.id = existing.id; // force a PK collision
+
+        let result = store.record_post_execution(
+            &original_id,
+            Some(Path::new("/media/movie.mkv")),
+            Some("new_hash"),
+            &bundled,
+        );
+        assert!(result.is_err(), "duplicate transition id must error");
+
+        // Rollback verification: path NOT renamed, expected_hash NOT updated,
+        // only the original transition exists.
+        let still_at_old = store.file_by_path(Path::new("/media/movie.mp4")).unwrap();
+        assert!(still_at_old.is_some(), "rename must have been rolled back");
+        let stored = still_at_old.unwrap();
+        assert_eq!(
+            stored.expected_hash.as_deref(),
+            Some("abc123"),
+            "expected_hash must have been rolled back"
+        );
+        assert_eq!(
+            store.transitions_for_file(&original_id).unwrap().len(),
+            1,
+            "only the pre-existing transition should remain"
+        );
     }
 
     #[test]

--- a/plugins/sqlite-store/src/store/file_storage.rs
+++ b/plugins/sqlite-store/src/store/file_storage.rs
@@ -390,6 +390,17 @@ impl FileStorage for SqliteStore {
         Ok(())
     }
 
+    fn record_post_execution(
+        &self,
+        _id: &Uuid,
+        _new_path: Option<&Path>,
+        _new_expected_hash: &str,
+        _transition: &FileTransition,
+    ) -> Result<()> {
+        // TODO(Task 3): implement atomic post-execution bundle
+        todo!("record_post_execution not yet implemented — Task 3 will provide the real impl")
+    }
+
     fn predecessor_of(&self, successor_id: &Uuid) -> Result<Option<MediaFile>> {
         let conn = self.conn()?;
         let file_row: Option<FileRow> = conn

--- a/plugins/sqlite-store/src/store/file_storage.rs
+++ b/plugins/sqlite-store/src/store/file_storage.rs
@@ -394,10 +394,9 @@ impl FileStorage for SqliteStore {
         &self,
         _id: &Uuid,
         _new_path: Option<&Path>,
-        _new_expected_hash: &str,
+        _new_expected_hash: Option<&str>,
         _transition: &FileTransition,
     ) -> Result<()> {
-        // TODO(Task 3): implement atomic post-execution bundle
         todo!("record_post_execution not yet implemented — Task 3 will provide the real impl")
     }
 

--- a/plugins/sqlite-store/src/store/file_storage.rs
+++ b/plugins/sqlite-store/src/store/file_storage.rs
@@ -392,16 +392,16 @@ impl FileStorage for SqliteStore {
 
     fn record_post_execution(
         &self,
-        id: &Uuid,
         new_path: Option<&Path>,
         new_expected_hash: Option<&str>,
         transition: &FileTransition,
     ) -> Result<()> {
-        debug_assert_eq!(
-            id, &transition.file_id,
-            "record_post_execution: id must match transition.file_id"
+        debug_assert!(
+            new_expected_hash.is_none_or(|h| !h.is_empty()),
+            "record_post_execution: empty hash passed as Some — use None instead"
         );
 
+        let id_str = transition.file_id.to_string();
         let mut conn = self.conn()?;
         let tx = conn
             .transaction()
@@ -413,7 +413,7 @@ impl FileStorage for SqliteStore {
             let filename = filename_string(new_path);
             tx.execute(
                 "UPDATE files SET path = ?1, filename = ?2, updated_at = ?3 WHERE id = ?4",
-                params![path_str, filename, now, id.to_string()],
+                params![path_str, filename, now, &id_str],
             )
             .map_err(storage_err("failed to rename file path in bundle"))?;
         }
@@ -423,7 +423,7 @@ impl FileStorage for SqliteStore {
         if let Some(hash) = new_expected_hash {
             tx.execute(
                 "UPDATE files SET expected_hash = ?1 WHERE id = ?2",
-                params![hash, id.to_string()],
+                params![hash, &id_str],
             )
             .map_err(storage_err("failed to update expected_hash in bundle"))?;
         }
@@ -1511,7 +1511,6 @@ mod tests {
 
         store
             .record_post_execution(
-                &original_id,
                 Some(Path::new("/media/movie.mkv")),
                 Some("new_hash"),
                 &transition,
@@ -1566,7 +1565,7 @@ mod tests {
         .with_from(Some("abc123".to_string()), Some(1024));
 
         store
-            .record_post_execution(&id, None, Some("new_hash"), &transition)
+            .record_post_execution(None, Some("new_hash"), &transition)
             .unwrap();
 
         let stored = store
@@ -1603,7 +1602,7 @@ mod tests {
         );
 
         store
-            .record_post_execution(&id, None, None, &transition)
+            .record_post_execution(None, None, &transition)
             .unwrap();
 
         let stored = store
@@ -1654,7 +1653,6 @@ mod tests {
         bundled.id = existing.id; // force a PK collision
 
         let result = store.record_post_execution(
-            &original_id,
             Some(Path::new("/media/movie.mkv")),
             Some("new_hash"),
             &bundled,

--- a/plugins/sqlite-store/src/store/file_transition_storage.rs
+++ b/plugins/sqlite-store/src/store/file_transition_storage.rs
@@ -11,15 +11,15 @@ use voom_domain::transition::{FileTransition, TransitionSource};
 
 use super::{format_datetime, storage_err, SqliteStore};
 
-/// Insert a `FileTransition` into `file_transitions` using the supplied
-/// open transaction. Used by both the standalone `record_transition`
-/// trait impl (which manages its own connection) and bundled writes that
-/// need to insert a transition alongside other operations atomically.
+/// Insert a `FileTransition` into `file_transitions`. Accepts any
+/// `&rusqlite::Connection`, including one obtained via `Deref` from an
+/// open `Transaction` — so callers can either run the insert standalone
+/// (autocommit) or as part of a larger atomic bundle.
 pub(super) fn insert_full_transition_in_tx(
-    tx: &rusqlite::Transaction<'_>,
+    conn: &rusqlite::Connection,
     t: &FileTransition,
 ) -> Result<()> {
-    tx.execute(
+    conn.execute(
         "INSERT INTO file_transitions \
          (id, file_id, path, from_path, from_hash, to_hash, from_size, to_size, \
           source, source_detail, plan_id, \
@@ -66,14 +66,8 @@ pub(super) fn insert_full_transition_in_tx(
 
 impl FileTransitionStorage for SqliteStore {
     fn record_transition(&self, t: &FileTransition) -> Result<()> {
-        let mut conn = self.conn()?;
-        let tx = conn
-            .transaction()
-            .map_err(storage_err("failed to begin transition transaction"))?;
-        insert_full_transition_in_tx(&tx, t)?;
-        tx.commit()
-            .map_err(storage_err("failed to commit transition"))?;
-        Ok(())
+        let conn = self.conn()?;
+        insert_full_transition_in_tx(&conn, t)
     }
 
     fn transitions_for_file(&self, file_id: &Uuid) -> Result<Vec<FileTransition>> {

--- a/plugins/sqlite-store/src/store/file_transition_storage.rs
+++ b/plugins/sqlite-store/src/store/file_transition_storage.rs
@@ -11,51 +11,68 @@ use voom_domain::transition::{FileTransition, TransitionSource};
 
 use super::{format_datetime, storage_err, SqliteStore};
 
+/// Insert a `FileTransition` into `file_transitions` using the supplied
+/// open transaction. Used by both the standalone `record_transition`
+/// trait impl (which manages its own connection) and bundled writes that
+/// need to insert a transition alongside other operations atomically.
+pub(super) fn insert_full_transition_in_tx(
+    tx: &rusqlite::Transaction<'_>,
+    t: &FileTransition,
+) -> Result<()> {
+    tx.execute(
+        "INSERT INTO file_transitions \
+         (id, file_id, path, from_path, from_hash, to_hash, from_size, to_size, \
+          source, source_detail, plan_id, \
+          duration_ms, actions_taken, tracks_modified, outcome, \
+          policy_name, phase_name, metadata_snapshot, \
+          error_message, session_id, created_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, \
+                 ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21)",
+        params![
+            t.id.to_string(),
+            t.file_id.to_string(),
+            t.path.to_string_lossy().to_string(),
+            t.from_path
+                .as_ref()
+                .map(|p| p.to_string_lossy().to_string()),
+            t.from_hash.as_deref().filter(|s| !s.is_empty()),
+            t.to_hash,
+            t.from_size.map(|v| v as i64),
+            t.to_size as i64,
+            t.source.as_str(),
+            t.source_detail.as_deref().filter(|s| !s.is_empty()),
+            t.plan_id.map(|id| id.to_string()),
+            t.duration_ms.map(|v| v as i64),
+            t.actions_taken.map(i64::from),
+            t.tracks_modified.map(i64::from),
+            t.outcome.map(|o| o.as_str()),
+            t.policy_name.as_deref(),
+            t.phase_name.as_deref(),
+            t.metadata_snapshot.as_ref().and_then(|s| {
+                s.to_json()
+                    .map_err(
+                        |e| tracing::warn!(error = %e, "failed to serialize metadata_snapshot"),
+                    )
+                    .ok()
+            }),
+            t.error_message.as_deref(),
+            t.session_id.map(|id| id.to_string()),
+            format_datetime(&t.created_at),
+        ],
+    )
+    .map_err(storage_err("failed to insert transition"))?;
+    Ok(())
+}
+
 impl FileTransitionStorage for SqliteStore {
     fn record_transition(&self, t: &FileTransition) -> Result<()> {
-        let conn = self.conn()?;
-        conn.execute(
-            "INSERT INTO file_transitions \
-             (id, file_id, path, from_path, from_hash, to_hash, from_size, to_size, \
-              source, source_detail, plan_id, \
-              duration_ms, actions_taken, tracks_modified, outcome, \
-              policy_name, phase_name, metadata_snapshot, \
-              error_message, session_id, created_at) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, \
-                     ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21)",
-            params![
-                t.id.to_string(),
-                t.file_id.to_string(),
-                t.path.to_string_lossy().to_string(),
-                t.from_path
-                    .as_ref()
-                    .map(|p| p.to_string_lossy().to_string()),
-                t.from_hash.as_deref().filter(|s| !s.is_empty()),
-                t.to_hash,
-                t.from_size.map(|v| v as i64),
-                t.to_size as i64,
-                t.source.as_str(),
-                t.source_detail.as_deref().filter(|s| !s.is_empty()),
-                t.plan_id.map(|id| id.to_string()),
-                t.duration_ms.map(|v| v as i64),
-                t.actions_taken.map(i64::from),
-                t.tracks_modified.map(i64::from),
-                t.outcome.map(|o| o.as_str()),
-                t.policy_name.as_deref(),
-                t.phase_name.as_deref(),
-                t.metadata_snapshot.as_ref().and_then(|s| {
-                    s.to_json()
-                        .map_err(
-                            |e| tracing::warn!(error = %e, "failed to serialize metadata_snapshot"),
-                        )
-                        .ok()
-                }),
-                t.error_message.as_deref(),
-                t.session_id.map(|id| id.to_string()),
-                format_datetime(&t.created_at),
-            ],
-        )
-        .map_err(storage_err("failed to record transition"))?;
+        let mut conn = self.conn()?;
+        let tx = conn
+            .transaction()
+            .map_err(storage_err("failed to begin transition transaction"))?;
+        insert_full_transition_in_tx(&tx, t)?;
+        tx.commit()
+            .map_err(storage_err("failed to commit transition"))?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Wraps the three post-execution storage writes (`rename_file_path` + `record_transition` + `update_expected_hash`) into one atomic SQLite transaction via a new `FileStorage::record_post_execution` trait method. A crash mid-bundle now rolls back cleanly; the previous code could leave a renamed row with no transition, or a transition with a stale `expected_hash`.

Reorders `handle_plan_success` so re-introspection runs first using a new no-dispatch variant, then the bundled write applies all three changes atomically. The no-dispatch variant prevents a duplicate row at the post-execution path racing the bundle's rename.

Closes #158.

## Highlights

- `FileStorage::record_post_execution(id, new_path: Option<&Path>, new_expected_hash: Option<&str>, transition: &FileTransition)` — single `BEGIN/COMMIT` for all three writes; conditional rename and conditional `expected_hash` update.
- Trait signature uses `Option<&str>` for `new_expected_hash`: a `&str` would have forced an empty-string write when no hash existed, which reconciliation would misread as a real hash and trigger external-change handling on the next scan.
- `introspect_file_no_dispatch` lets callers re-introspect without firing `FileIntrospected`, so the bundled write owns persistence.
- The fallback in `reintrospect_file::Err` now refreshes `path`/`size`/`container`/`hash` so the bundled rename still runs when re-introspection fails.
- Older trait methods (`rename_file_path`, `record_transition`, `update_expected_hash`) are preserved for callers like `recovery.rs` and reconciliation.

## Test plan

- [x] `cargo test -p voom-sqlite-store` (244 + 1 pass, including 4 new tests covering atomic write, no-path-change skip, no-hash skip, and PK-collision rollback)
- [x] `cargo test` workspace (175 + 12 voom-domain, 244 + 1 sqlite-store, 377 + 29 + 7 + 4 voom-cli)
- [x] `cargo test -p voom-cli --features functional -- --test-threads=4` (533 pass)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (clean)
- [x] `handle_plan_success_preserves_lineage_on_container_conversion` end-to-end test passes

## Follow-ups

- #173 — re-introspection failure leaves an orphan `bad_files` row alongside the successful transition. Pre-existing behavior made more visible by this change; tracked separately to keep this PR focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)