### PR TITLE
test(voom-cli): TestFixture helper for ProcessContext setup (closes #159)

### DIFF
--- a/crates/voom-cli/src/commands/process/mod.rs
+++ b/crates/voom-cli/src/commands/process/mod.rs
@@ -951,7 +951,6 @@ mod tests {
     /// Bundle of long-lived test fixtures shared across `ProcessContext`
     /// construction sites. Owns the `TempDir` so the resolver's working path
     /// stays valid for the test's lifetime.
-    #[allow(dead_code)] // populated by Tasks 2-6 of issue #159
     pub(super) struct TestFixture {
         pub(super) capabilities: voom_domain::CapabilityMap,
         pub(super) counters: RunCounters,
@@ -961,7 +960,6 @@ mod tests {
         dir: tempfile::TempDir,
     }
 
-    #[allow(dead_code)] // populated by Tasks 2-6 of issue #159
     impl TestFixture {
         /// Default fixture with the canonical `phase normalize { container mkv }` policy.
         pub(super) fn new() -> Self {

--- a/crates/voom-cli/src/commands/process/mod.rs
+++ b/crates/voom-cli/src/commands/process/mod.rs
@@ -1486,8 +1486,8 @@ mod tests {
     fn test_check_size_increase_dispatches_plan_failed_without_plan_created() {
         // Write a file with 2048 bytes so the size-increase check fires
         // when the MediaFile reports size = 1024 (smaller than actual).
-        let dir = tempfile::tempdir().unwrap();
-        let file_path = dir.path().join("test.mkv");
+        let fixture = TestFixture::new();
+        let file_path = fixture.dir_path().join("test.mkv");
         std::fs::write(&file_path, vec![0u8; 2048]).unwrap();
 
         let mut file = MediaFile::new(file_path);
@@ -1502,27 +1502,9 @@ mod tests {
 
         let store: Arc<dyn voom_domain::storage::StorageTrait> =
             Arc::new(voom_domain::test_support::InMemoryStore::new());
-        let capabilities = voom_domain::CapabilityMap::new();
-        let counters = RunCounters::new();
-        let token = CancellationToken::new();
-        let resolver = PolicyResolver::from_single(
-            voom_dsl::compile_policy(r#"policy "test" { phase normalize { container mkv } }"#)
-                .unwrap(),
-            dir.path(),
-        );
         let ctx = ProcessContext {
-            resolver: &resolver,
-            kernel: Arc::new(kernel),
-            store,
-            dry_run: false,
-            plan_only: false,
             flag_size_increase: true,
-            flag_duration_shrink: false,
-            force_rescan: false,
-            token: &token,
-            ffprobe_path: None,
-            capabilities: &capabilities,
-            counters: &counters,
+            ..fixture.make_ctx(Arc::new(kernel), store)
         };
 
         // Should return true (size increased).

--- a/crates/voom-cli/src/commands/process/mod.rs
+++ b/crates/voom-cli/src/commands/process/mod.rs
@@ -952,10 +952,10 @@ mod tests {
     /// construction sites. Owns the `TempDir` so the resolver's working path
     /// stays valid for the test's lifetime.
     pub(super) struct TestFixture {
-        pub(super) capabilities: voom_domain::CapabilityMap,
-        pub(super) counters: RunCounters,
-        pub(super) token: CancellationToken,
-        pub(super) resolver: PolicyResolver,
+        capabilities: voom_domain::CapabilityMap,
+        counters: RunCounters,
+        token: CancellationToken,
+        resolver: PolicyResolver,
         // Held for lifetime; the resolver borrows `dir.path()`.
         dir: tempfile::TempDir,
     }
@@ -1005,11 +1005,11 @@ mod tests {
         ///     ..fixture.make_ctx(Arc::new(kernel), store)
         /// };
         /// ```
-        pub(super) fn make_ctx<'a>(
-            &'a self,
+        pub(super) fn make_ctx(
+            &self,
             kernel: Arc<voom_kernel::Kernel>,
             store: Arc<dyn voom_domain::storage::StorageTrait>,
-        ) -> ProcessContext<'a> {
+        ) -> ProcessContext<'_> {
             ProcessContext {
                 resolver: &self.resolver,
                 kernel,
@@ -1024,6 +1024,16 @@ mod tests {
                 capabilities: &self.capabilities,
                 counters: &self.counters,
             }
+        }
+
+        /// Convenience: builds a `ProcessContext` with a fresh empty `Kernel`
+        /// and an `InMemoryStore`. Use for tests that don't need to register
+        /// plugins or use a SQLite store.
+        pub(super) fn make_default_ctx(&self) -> ProcessContext<'_> {
+            self.make_ctx(
+                Arc::new(voom_kernel::Kernel::new()),
+                Arc::new(voom_domain::test_support::InMemoryStore::new()),
+            )
         }
     }
 
@@ -1321,10 +1331,7 @@ mod tests {
 
         let plan = test_plan("normalize", false);
 
-        let kernel = Arc::new(voom_kernel::Kernel::new());
-        let store: Arc<dyn voom_domain::storage::StorageTrait> =
-            Arc::new(voom_domain::test_support::InMemoryStore::new());
-        let ctx = fixture.make_ctx(kernel, store);
+        let ctx = fixture.make_default_ctx();
 
         // Should return false (enough space)
         assert!(!check_disk_space(&plan, &file, &ctx));
@@ -1445,7 +1452,8 @@ mod tests {
         let store: Arc<dyn voom_domain::storage::StorageTrait> =
             Arc::new(voom_sqlite_store::store::SqliteStore::in_memory().unwrap());
         let kernel = Arc::new(voom_kernel::Kernel::new());
-        let fixture = TestFixture::with_policy(r#"policy "p" { phase convert { container mkv } }"#);
+        let fixture =
+            TestFixture::with_policy(r#"policy "test" { phase convert { container mkv } }"#);
         let ctx = fixture.make_ctx(kernel, store.clone());
 
         super::transitions::record_file_transition(&super::transitions::FileTransitionContext {
@@ -1534,10 +1542,7 @@ mod tests {
 
         let plan = test_plan("normalize", false);
 
-        let kernel = Arc::new(voom_kernel::Kernel::new());
-        let store: Arc<dyn voom_domain::storage::StorageTrait> =
-            Arc::new(voom_domain::test_support::InMemoryStore::new());
-        let ctx = fixture.make_ctx(kernel, store);
+        let ctx = fixture.make_default_ctx();
 
         // Flag disabled — must early-return false without invoking ffprobe.
         assert!(!check_duration_shrink(&plan, &file, &ctx).await);
@@ -1555,12 +1560,9 @@ mod tests {
 
         let plan = test_plan("normalize", false);
 
-        let kernel = Arc::new(voom_kernel::Kernel::new());
-        let store: Arc<dyn voom_domain::storage::StorageTrait> =
-            Arc::new(voom_domain::test_support::InMemoryStore::new());
         let ctx = ProcessContext {
             flag_duration_shrink: true,
-            ..fixture.make_ctx(kernel, store)
+            ..fixture.make_default_ctx()
         };
 
         // Input duration is 0.0 — can't compute a percentage; must early-return false.
@@ -1579,13 +1581,10 @@ mod tests {
 
         let plan = test_plan("normalize", false);
 
-        let kernel = Arc::new(voom_kernel::Kernel::new());
-        let store: Arc<dyn voom_domain::storage::StorageTrait> =
-            Arc::new(voom_domain::test_support::InMemoryStore::new());
         fixture.cancel();
         let ctx = ProcessContext {
             flag_duration_shrink: true,
-            ..fixture.make_ctx(kernel, store)
+            ..fixture.make_default_ctx()
         };
 
         // Token cancelled — must early-return false without launching ffprobe.

--- a/crates/voom-cli/src/commands/process/mod.rs
+++ b/crates/voom-cli/src/commands/process/mod.rs
@@ -1447,28 +1447,8 @@ mod tests {
         let store: Arc<dyn voom_domain::storage::StorageTrait> =
             Arc::new(voom_sqlite_store::store::SqliteStore::in_memory().unwrap());
         let kernel = Arc::new(voom_kernel::Kernel::new());
-        let capabilities = voom_domain::CapabilityMap::new();
-        let counters = RunCounters::new();
-        let token = CancellationToken::new();
-        let dir = tempfile::tempdir().unwrap();
-        let resolver = PolicyResolver::from_single(
-            voom_dsl::compile_policy(r#"policy "p" { phase convert { container mkv } }"#).unwrap(),
-            dir.path(),
-        );
-        let ctx = ProcessContext {
-            resolver: &resolver,
-            kernel,
-            store: store.clone(),
-            dry_run: false,
-            plan_only: false,
-            flag_size_increase: false,
-            flag_duration_shrink: false,
-            force_rescan: false,
-            token: &token,
-            ffprobe_path: None,
-            capabilities: &capabilities,
-            counters: &counters,
-        };
+        let fixture = TestFixture::with_policy(r#"policy "p" { phase convert { container mkv } }"#);
+        let ctx = fixture.make_ctx(kernel, store.clone());
 
         super::transitions::record_file_transition(&super::transitions::FileTransitionContext {
             old_file: &old_file,

--- a/crates/voom-cli/src/commands/process/mod.rs
+++ b/crates/voom-cli/src/commands/process/mod.rs
@@ -957,8 +957,8 @@ mod tests {
         pub(super) counters: RunCounters,
         pub(super) token: CancellationToken,
         pub(super) resolver: PolicyResolver,
-        // Held for lifetime; the resolver borrows `_dir.path()`.
-        _dir: tempfile::TempDir,
+        // Held for lifetime; the resolver borrows `dir.path()`.
+        dir: tempfile::TempDir,
     }
 
     #[allow(dead_code)] // populated by Tasks 2-6 of issue #159
@@ -970,9 +970,11 @@ mod tests {
 
         /// Fixture parameterised by an arbitrary policy DSL source.
         pub(super) fn with_policy(dsl: &str) -> Self {
-            let dir = tempfile::tempdir().expect("tempdir");
+            let dir =
+                tempfile::tempdir().expect("TestFixture: failed to create tempdir for resolver");
             let resolver = PolicyResolver::from_single(
-                voom_dsl::compile_policy(dsl).expect("compile fixture policy"),
+                voom_dsl::compile_policy(dsl)
+                    .expect("TestFixture: fixture policy DSL must compile"),
                 dir.path(),
             );
             Self {
@@ -980,14 +982,14 @@ mod tests {
                 counters: RunCounters::new(),
                 token: CancellationToken::new(),
                 resolver,
-                _dir: dir,
+                dir,
             }
         }
 
         /// Path to the held `TempDir`. Use for placing fixture media files
         /// alongside the resolver's working directory.
         pub(super) fn dir_path(&self) -> &std::path::Path {
-            self._dir.path()
+            self.dir.path()
         }
 
         /// Pre-cancel the fixture token. Used by tests that exercise

--- a/crates/voom-cli/src/commands/process/mod.rs
+++ b/crates/voom-cli/src/commands/process/mod.rs
@@ -1314,9 +1314,8 @@ mod tests {
 
     #[test]
     fn test_check_disk_space_passes_with_enough_space() {
-        // Use a tempdir — the local filesystem should have plenty of space.
-        let dir = tempfile::tempdir().unwrap();
-        let file_path = dir.path().join("test.mkv");
+        let fixture = TestFixture::new();
+        let file_path = fixture.dir_path().join("test.mkv");
         std::fs::write(&file_path, vec![0u8; 1024]).unwrap();
 
         let mut file = MediaFile::new(file_path);
@@ -1324,31 +1323,10 @@ mod tests {
 
         let plan = test_plan("normalize", false);
 
-        let kernel = voom_kernel::Kernel::new();
+        let kernel = Arc::new(voom_kernel::Kernel::new());
         let store: Arc<dyn voom_domain::storage::StorageTrait> =
             Arc::new(voom_domain::test_support::InMemoryStore::new());
-        let capabilities = voom_domain::CapabilityMap::new();
-        let counters = RunCounters::new();
-        let token = CancellationToken::new();
-        let resolver = PolicyResolver::from_single(
-            voom_dsl::compile_policy(r#"policy "test" { phase normalize { container mkv } }"#)
-                .unwrap(),
-            dir.path(),
-        );
-        let ctx = ProcessContext {
-            resolver: &resolver,
-            kernel: Arc::new(kernel),
-            store,
-            dry_run: false,
-            plan_only: false,
-            flag_size_increase: false,
-            flag_duration_shrink: false,
-            force_rescan: false,
-            token: &token,
-            ffprobe_path: None,
-            capabilities: &capabilities,
-            counters: &counters,
-        };
+        let ctx = fixture.make_ctx(kernel, store);
 
         // Should return false (enough space)
         assert!(!check_disk_space(&plan, &file, &ctx));
@@ -1356,9 +1334,8 @@ mod tests {
 
     #[test]
     fn test_check_disk_space_dispatches_plan_failed_without_plan_created() {
-        // Use a tempdir so we get a valid path for disk-space checks.
-        let dir = tempfile::tempdir().unwrap();
-        let file_path = dir.path().join("test.mkv");
+        let fixture = TestFixture::new();
+        let file_path = fixture.dir_path().join("test.mkv");
         std::fs::write(&file_path, vec![0u8; 1024]).unwrap();
 
         let mut file = MediaFile::new(file_path);
@@ -1373,28 +1350,7 @@ mod tests {
 
         let store: Arc<dyn voom_domain::storage::StorageTrait> =
             Arc::new(voom_domain::test_support::InMemoryStore::new());
-        let capabilities = voom_domain::CapabilityMap::new();
-        let counters = RunCounters::new();
-        let token = CancellationToken::new();
-        let resolver = PolicyResolver::from_single(
-            voom_dsl::compile_policy(r#"policy "test" { phase normalize { container mkv } }"#)
-                .unwrap(),
-            dir.path(),
-        );
-        let ctx = ProcessContext {
-            resolver: &resolver,
-            kernel: Arc::new(kernel),
-            store,
-            dry_run: false,
-            plan_only: false,
-            flag_size_increase: false,
-            flag_duration_shrink: false,
-            force_rescan: false,
-            token: &token,
-            ffprobe_path: None,
-            capabilities: &capabilities,
-            counters: &counters,
-        };
+        let ctx = fixture.make_ctx(Arc::new(kernel), store);
 
         // Should return true (insufficient space).
         assert!(check_disk_space(&plan, &file, &ctx));

--- a/crates/voom-cli/src/commands/process/mod.rs
+++ b/crates/voom-cli/src/commands/process/mod.rs
@@ -1371,9 +1371,10 @@ mod tests {
         use voom_domain::media::{Container, MediaFile};
         use voom_domain::plan::{ActionParams, OperationType, Plan, PlannedAction};
 
-        let dir = tempfile::tempdir().unwrap();
-        let mp4_path = dir.path().join("movie.mp4");
-        let mkv_path = dir.path().join("movie.mkv");
+        let fixture =
+            TestFixture::with_policy(r#"policy "test" { phase convert { container mkv } }"#);
+        let mp4_path = fixture.dir_path().join("movie.mp4");
+        let mkv_path = fixture.dir_path().join("movie.mkv");
         // The executor renames source-to-target; pre-write the target so
         // `resolve_post_execution_path` accepts the new extension.
         std::fs::write(&mkv_path, vec![0u8; 1024]).unwrap();
@@ -1399,28 +1400,7 @@ mod tests {
         assert_eq!(store.count_files(&Default::default()).unwrap(), 1);
 
         let kernel = Arc::new(voom_kernel::Kernel::new());
-        let capabilities = voom_domain::CapabilityMap::new();
-        let counters = RunCounters::new();
-        let token = CancellationToken::new();
-        let resolver = PolicyResolver::from_single(
-            voom_dsl::compile_policy(r#"policy "test" { phase convert { container mkv } }"#)
-                .unwrap(),
-            dir.path(),
-        );
-        let ctx = ProcessContext {
-            resolver: &resolver,
-            kernel,
-            store: store.clone(),
-            dry_run: false,
-            plan_only: false,
-            flag_size_increase: false,
-            flag_duration_shrink: false,
-            force_rescan: false,
-            token: &token,
-            ffprobe_path: None,
-            capabilities: &capabilities,
-            counters: &counters,
-        };
+        let ctx = fixture.make_ctx(kernel, store.clone());
 
         let _ =
             pipeline::handle_plan_success(plan, &file, "mkvtoolnix-executor", 0, false, &ctx).await;
@@ -1440,7 +1420,7 @@ mod tests {
         );
         assert!(
             store
-                .file_by_path(&dir.path().join("movie.mp4"))
+                .file_by_path(&fixture.dir_path().join("movie.mp4"))
                 .unwrap()
                 .is_none(),
             "the original .mp4 path must no longer resolve to a row",

--- a/crates/voom-cli/src/commands/process/mod.rs
+++ b/crates/voom-cli/src/commands/process/mod.rs
@@ -1526,8 +1526,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_check_duration_shrink_flag_disabled_returns_false() {
-        let dir = tempfile::tempdir().unwrap();
-        let file_path = dir.path().join("test.mkv");
+        let fixture = TestFixture::new();
+        let file_path = fixture.dir_path().join("test.mkv");
         std::fs::write(&file_path, vec![0u8; 1024]).unwrap();
 
         let mut file = MediaFile::new(file_path);
@@ -1536,31 +1536,10 @@ mod tests {
 
         let plan = test_plan("normalize", false);
 
-        let kernel = voom_kernel::Kernel::new();
+        let kernel = Arc::new(voom_kernel::Kernel::new());
         let store: Arc<dyn voom_domain::storage::StorageTrait> =
             Arc::new(voom_domain::test_support::InMemoryStore::new());
-        let capabilities = voom_domain::CapabilityMap::new();
-        let counters = RunCounters::new();
-        let token = CancellationToken::new();
-        let resolver = PolicyResolver::from_single(
-            voom_dsl::compile_policy(r#"policy "test" { phase normalize { container mkv } }"#)
-                .unwrap(),
-            dir.path(),
-        );
-        let ctx = ProcessContext {
-            resolver: &resolver,
-            kernel: Arc::new(kernel),
-            store,
-            dry_run: false,
-            plan_only: false,
-            flag_size_increase: false,
-            flag_duration_shrink: false,
-            force_rescan: false,
-            token: &token,
-            ffprobe_path: None,
-            capabilities: &capabilities,
-            counters: &counters,
-        };
+        let ctx = fixture.make_ctx(kernel, store);
 
         // Flag disabled — must early-return false without invoking ffprobe.
         assert!(!check_duration_shrink(&plan, &file, &ctx).await);
@@ -1568,8 +1547,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_check_duration_shrink_zero_input_duration_returns_false() {
-        let dir = tempfile::tempdir().unwrap();
-        let file_path = dir.path().join("test.mkv");
+        let fixture = TestFixture::new();
+        let file_path = fixture.dir_path().join("test.mkv");
         std::fs::write(&file_path, vec![0u8; 1024]).unwrap();
 
         let mut file = MediaFile::new(file_path);
@@ -1578,30 +1557,12 @@ mod tests {
 
         let plan = test_plan("normalize", false);
 
-        let kernel = voom_kernel::Kernel::new();
+        let kernel = Arc::new(voom_kernel::Kernel::new());
         let store: Arc<dyn voom_domain::storage::StorageTrait> =
             Arc::new(voom_domain::test_support::InMemoryStore::new());
-        let capabilities = voom_domain::CapabilityMap::new();
-        let counters = RunCounters::new();
-        let token = CancellationToken::new();
-        let resolver = PolicyResolver::from_single(
-            voom_dsl::compile_policy(r#"policy "test" { phase normalize { container mkv } }"#)
-                .unwrap(),
-            dir.path(),
-        );
         let ctx = ProcessContext {
-            resolver: &resolver,
-            kernel: Arc::new(kernel),
-            store,
-            dry_run: false,
-            plan_only: false,
-            flag_size_increase: false,
             flag_duration_shrink: true,
-            force_rescan: false,
-            token: &token,
-            ffprobe_path: None,
-            capabilities: &capabilities,
-            counters: &counters,
+            ..fixture.make_ctx(kernel, store)
         };
 
         // Input duration is 0.0 — can't compute a percentage; must early-return false.
@@ -1610,8 +1571,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_check_duration_shrink_cancelled_returns_false() {
-        let dir = tempfile::tempdir().unwrap();
-        let file_path = dir.path().join("test.mkv");
+        let fixture = TestFixture::new();
+        let file_path = fixture.dir_path().join("test.mkv");
         std::fs::write(&file_path, vec![0u8; 1024]).unwrap();
 
         let mut file = MediaFile::new(file_path);
@@ -1620,31 +1581,13 @@ mod tests {
 
         let plan = test_plan("normalize", false);
 
-        let kernel = voom_kernel::Kernel::new();
+        let kernel = Arc::new(voom_kernel::Kernel::new());
         let store: Arc<dyn voom_domain::storage::StorageTrait> =
             Arc::new(voom_domain::test_support::InMemoryStore::new());
-        let capabilities = voom_domain::CapabilityMap::new();
-        let counters = RunCounters::new();
-        let token = CancellationToken::new();
-        token.cancel();
-        let resolver = PolicyResolver::from_single(
-            voom_dsl::compile_policy(r#"policy "test" { phase normalize { container mkv } }"#)
-                .unwrap(),
-            dir.path(),
-        );
+        fixture.cancel();
         let ctx = ProcessContext {
-            resolver: &resolver,
-            kernel: Arc::new(kernel),
-            store,
-            dry_run: false,
-            plan_only: false,
-            flag_size_increase: false,
             flag_duration_shrink: true,
-            force_rescan: false,
-            token: &token,
-            ffprobe_path: None,
-            capabilities: &capabilities,
-            counters: &counters,
+            ..fixture.make_ctx(kernel, store)
         };
 
         // Token cancelled — must early-return false without launching ffprobe.

--- a/crates/voom-cli/src/commands/process/mod.rs
+++ b/crates/voom-cli/src/commands/process/mod.rs
@@ -948,6 +948,85 @@ mod tests {
         plan
     }
 
+    /// Bundle of long-lived test fixtures shared across `ProcessContext`
+    /// construction sites. Owns the `TempDir` so the resolver's working path
+    /// stays valid for the test's lifetime.
+    #[allow(dead_code)] // populated by Tasks 2-6 of issue #159
+    pub(super) struct TestFixture {
+        pub(super) capabilities: voom_domain::CapabilityMap,
+        pub(super) counters: RunCounters,
+        pub(super) token: CancellationToken,
+        pub(super) resolver: PolicyResolver,
+        // Held for lifetime; the resolver borrows `_dir.path()`.
+        _dir: tempfile::TempDir,
+    }
+
+    #[allow(dead_code)] // populated by Tasks 2-6 of issue #159
+    impl TestFixture {
+        /// Default fixture with the canonical `phase normalize { container mkv }` policy.
+        pub(super) fn new() -> Self {
+            Self::with_policy(r#"policy "test" { phase normalize { container mkv } }"#)
+        }
+
+        /// Fixture parameterised by an arbitrary policy DSL source.
+        pub(super) fn with_policy(dsl: &str) -> Self {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let resolver = PolicyResolver::from_single(
+                voom_dsl::compile_policy(dsl).expect("compile fixture policy"),
+                dir.path(),
+            );
+            Self {
+                capabilities: voom_domain::CapabilityMap::new(),
+                counters: RunCounters::new(),
+                token: CancellationToken::new(),
+                resolver,
+                _dir: dir,
+            }
+        }
+
+        /// Path to the held `TempDir`. Use for placing fixture media files
+        /// alongside the resolver's working directory.
+        pub(super) fn dir_path(&self) -> &std::path::Path {
+            self._dir.path()
+        }
+
+        /// Pre-cancel the fixture token. Used by tests that exercise
+        /// cancellation-aware code paths.
+        pub(super) fn cancel(&self) {
+            self.token.cancel();
+        }
+
+        /// Build a `ProcessContext` with all flags defaulted to `false` and
+        /// `ffprobe_path = None`. Override per-test using struct-update syntax:
+        ///
+        /// ```ignore
+        /// let ctx = ProcessContext {
+        ///     flag_size_increase: true,
+        ///     ..fixture.make_ctx(Arc::new(kernel), store)
+        /// };
+        /// ```
+        pub(super) fn make_ctx<'a>(
+            &'a self,
+            kernel: Arc<voom_kernel::Kernel>,
+            store: Arc<dyn voom_domain::storage::StorageTrait>,
+        ) -> ProcessContext<'a> {
+            ProcessContext {
+                resolver: &self.resolver,
+                kernel,
+                store,
+                dry_run: false,
+                plan_only: false,
+                flag_size_increase: false,
+                flag_duration_shrink: false,
+                force_rescan: false,
+                token: &self.token,
+                ffprobe_path: None,
+                capabilities: &self.capabilities,
+                counters: &self.counters,
+            }
+        }
+    }
+
     #[tokio::test]
     async fn test_execute_single_plan_dispatches_lifecycle_events() {
         let mut kernel = voom_kernel::Kernel::new();


### PR DESCRIPTION
## Summary
- Add a private `TestFixture` helper in `crates/voom-cli/src/commands/process/mod.rs` that owns the borrowed test fixtures (`PolicyResolver`, `CancellationToken`, `CapabilityMap`, `RunCounters`, `TempDir`) and exposes `make_ctx(kernel, store)` returning a fully-default `ProcessContext`.
- Migrate all eight `ProcessContext { ... }` construction sites in `mod tests` to use the helper. Tests with non-default flags use struct-update syntax (`ProcessContext { flag_x: true, ..fixture.make_ctx(...) }`).
- The PR includes ~140 net deletions across the eight migrated test sites with no production-code changes; behaviour is unchanged.

Closes #159.

## Test plan
- [x] `cargo test -p voom-cli --bin voom commands::process` — 26 passed
- [x] `cargo test --workspace --all-targets` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] `cargo test -p voom-cli --features functional` — deferred to CI (the refactor is test-internal; no production code changes)