### PR TITLE
fix(#162): persist plans by running sqlite-store before claiming executors

### DIFF
--- a/crates/voom-cli/src/app.rs
+++ b/crates/voom-cli/src/app.rs
@@ -21,14 +21,22 @@ pub struct BootstrapResult {
 // Plugin priority scheme (lower number = runs first during event dispatch).
 // mkvtoolnix at 39 runs before ffmpeg at 40 so it gets first crack at
 // MKV-specific plans (metadata, convert-to-MKV).
+//
+// Sqlite-store must dispatch BEFORE any plugin that claims an event it needs
+// to persist. Both executors claim PlanCreated, and the kernel's event bus
+// breaks dispatch on claim (see voom_kernel::EventBus::publish_recursive),
+// so storage at 38 runs just ahead of the executor cluster (39/40). Plans
+// land with status='pending' here, and PlanCompleted/PlanSkipped/PlanFailed
+// (none of which are claimed) drive the status updates afterwards via
+// update_plan_status().
 const PRIORITY_BUS_TRACER: i32 = 1;
-const PRIORITY_STORAGE: i32 = 100;
 const PRIORITY_HEALTH_CHECKER: i32 = 95;
 const PRIORITY_TOOL_DETECTOR: i32 = 90;
 const PRIORITY_DISCOVERY: i32 = 80;
 const PRIORITY_FFPROBE_INTROSPECTOR: i32 = 60;
 const PRIORITY_FFMPEG_EXECUTOR: i32 = 40;
 const PRIORITY_MKVTOOLNIX_EXECUTOR: i32 = 39;
+const PRIORITY_STORAGE: i32 = 38;
 // Capability collector dispatches before executors (35 < 39/40) so that
 // ExecutorCapabilities events emitted by executors at init are processed by
 // the collector before any subsequent event reaches the executors.
@@ -38,9 +46,8 @@ const PRIORITY_CAPABILITY_COLLECTOR: i32 = 35;
 // file is backed up before any executor mutates it.
 const PRIORITY_BACKUP_MANAGER: i32 = 30;
 const PRIORITY_JOB_MANAGER: i32 = 20;
-// Report plugin — priority 110 > storage (100), so it dispatches after
-// storage and observes lifecycle events with all upstream side effects
-// already applied.
+// Report plugin — priority 110, dispatched after every other plugin so it
+// observes lifecycle events with all upstream side effects already applied.
 const PRIORITY_REPORT: i32 = 110;
 
 /// Bootstrap a kernel with all native plugins registered.
@@ -109,7 +116,9 @@ pub fn bootstrap_kernel_with_store(config: &AppConfig) -> Result<BootstrapResult
         };
     }
 
-    // Storage plugin (highest priority — stores everything).
+    // Storage plugin (must-run-before-executor priority — captures all events
+    // including those that executors claim, by running first; persistence and
+    // event log).
     // Initialized manually (not via the macro) so we can capture the store
     // handle and return it to callers, keeping all CLI commands and the event
     // bus on the same connection pool.

--- a/crates/voom-cli/tests/functional_tests.rs
+++ b/crates/voom-cli/tests/functional_tests.rs
@@ -4148,14 +4148,11 @@ mod test_policy_diff {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// test_plan_persistence — regression coverage for issue #162
+// test_plan_persistence — regression coverage for issue #162: voom process
+// must persist completed Plan rows into the SQLite store so downstream
+// commands (`plans show`, `report --plans`, `report --database`) can audit
+// what was executed.
 // ═══════════════════════════════════════════════════════════════════════════
-//
-// `voom process` should persist completed `Plan` rows into the SQLite store
-// so that downstream commands (`plans show`, `report`, etc.) can audit what
-// was actually executed. As of this commit the rows never land in the
-// `plans` table — the live test below FAILS to lock in the reproduction
-// before the fix lands.
 
 mod test_plan_persistence {
     use super::*;

--- a/crates/voom-cli/tests/functional_tests.rs
+++ b/crates/voom-cli/tests/functional_tests.rs
@@ -4146,3 +4146,110 @@ mod test_policy_diff {
             );
     }
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// test_plan_persistence — regression coverage for issue #162
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// `voom process` should persist completed `Plan` rows into the SQLite store
+// so that downstream commands (`plans show`, `report`, etc.) can audit what
+// was actually executed. As of this commit the rows never land in the
+// `plans` table — the live test below FAILS to lock in the reproduction
+// before the fix lands.
+
+mod test_plan_persistence {
+    use super::*;
+    use rusqlite::Connection;
+
+    /// Count rows in `plans` (and the subset matching `status = 'completed'`).
+    fn plan_counts(db_path: &Path) -> (i64, i64) {
+        let conn = Connection::open(db_path).expect("open voom.db");
+        let total: i64 = conn
+            .query_row("SELECT COUNT(*) FROM plans", [], |row| row.get(0))
+            .expect("count plans rows");
+        let completed: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM plans WHERE status = 'completed'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count completed plans rows");
+        (total, completed)
+    }
+
+    /// After a successful `voom process` run the `plans` table must contain
+    /// at least one row for the executed file, with `status = 'completed'`.
+    /// This is the regression test for issue #162.
+    #[test]
+    fn process_live_persists_completed_plans() {
+        require_tool!("ffprobe");
+        require_tool!("mkvmerge");
+        require_tool!("mkvpropedit");
+        let env = TestEnv::new();
+        env.populate_media(&["hevc-surround"]);
+        let policy = env.write_policy("test", TEST_POLICY);
+
+        env.voom()
+            .args([
+                "process",
+                env.media_dir().to_str().unwrap(),
+                "--policy",
+                policy.to_str().unwrap(),
+                "--no-backup",
+            ])
+            .timeout(std::time::Duration::from_secs(120))
+            .assert()
+            .success()
+            .stderr(predicate::str::contains("Applying"));
+
+        let db_path = env.db_path();
+        assert!(
+            db_path.exists(),
+            "voom.db should exist after process run at {}",
+            db_path.display()
+        );
+        let (total, completed) = plan_counts(&db_path);
+        assert!(
+            total > 0,
+            "expected plans table to contain rows after a successful process run, got {total}"
+        );
+        assert!(
+            completed > 0,
+            "expected plans table to contain at least one row with status='completed', got {completed} (total rows: {total})"
+        );
+    }
+
+    /// Dry-run mode must NOT persist any plans — they're computed and
+    /// displayed but never executed, so nothing should land in the table.
+    #[test]
+    fn process_dry_run_does_not_persist_plans() {
+        require_tool!("ffprobe");
+        let env = TestEnv::new();
+        env.populate_media(&["hevc-surround"]);
+        let policy = env.write_policy("test", TEST_POLICY);
+
+        env.voom()
+            .args([
+                "process",
+                env.media_dir().to_str().unwrap(),
+                "--policy",
+                policy.to_str().unwrap(),
+                "--dry-run",
+            ])
+            .timeout(std::time::Duration::from_secs(60))
+            .assert()
+            .success();
+
+        let db_path = env.db_path();
+        assert!(
+            db_path.exists(),
+            "voom.db should exist after dry-run at {}",
+            db_path.display()
+        );
+        let (total, _completed) = plan_counts(&db_path);
+        assert_eq!(
+            total, 0,
+            "dry-run must not persist plans, but found {total} row(s) in plans table"
+        );
+    }
+}

--- a/plugins/sqlite-store/src/lib.rs
+++ b/plugins/sqlite-store/src/lib.rs
@@ -177,9 +177,12 @@ fn handle_plan_executing(store: &SqliteStore, e: &voom_domain::events::PlanExecu
     }
 }
 
-// sqlite-store runs at priority 100, so executors (priority 39/40)
-// have already processed the plan by the time we record it here.
-// This is audit-after-execution by design, not a race condition.
+// sqlite-store runs at priority 38, BEFORE the executors (priority 39/40),
+// so the plan is recorded with status='pending' before any executor claims
+// the event and short-circuits dispatch (see
+// voom_kernel::EventBus::publish_recursive's break-on-claim behavior).
+// PlanCompleted / PlanSkipped / PlanFailed (none claimed) drive the status
+// update via update_plan_status() in their respective handlers.
 fn handle_plan_created(
     store: &SqliteStore,
     e: &voom_domain::events::PlanCreatedEvent,

--- a/plugins/sqlite-store/src/lib.rs
+++ b/plugins/sqlite-store/src/lib.rs
@@ -187,26 +187,7 @@ fn handle_plan_created(
     store: &SqliteStore,
     e: &voom_domain::events::PlanCreatedEvent,
 ) -> Result<()> {
-    tracing::info!(
-        plan_id = %e.plan.id,
-        path = %e.plan.file.path.display(),
-        phase = %e.plan.phase_name,
-        "ISSUE-162 PROBE: handle_plan_created entered"
-    );
-    let plan_id = match store.save_plan(&e.plan) {
-        Ok(id) => {
-            tracing::info!(%id, "ISSUE-162 PROBE: save_plan OK");
-            id
-        }
-        Err(err) => {
-            tracing::error!(
-                error = %err,
-                plan_id = %e.plan.id,
-                "ISSUE-162 PROBE: save_plan FAILED"
-            );
-            return Err(err);
-        }
-    };
+    let plan_id = store.save_plan(&e.plan)?;
     tracing::info!(%plan_id, "stored plan");
     Ok(())
 }
@@ -215,7 +196,6 @@ fn handle_plan_completed(
     store: &SqliteStore,
     e: &voom_domain::events::PlanCompletedEvent,
 ) -> Result<()> {
-    tracing::info!(plan_id = %e.plan_id, "ISSUE-162 PROBE: handle_plan_completed entered");
     tracing::info!(path = %e.path.display(), phase = %e.phase_name, "plan completed");
     store.update_plan_status(&e.plan_id, voom_domain::storage::PlanStatus::Completed)?;
     if let Err(err) = store.delete_pending_op(&e.plan_id) {
@@ -232,7 +212,6 @@ fn handle_plan_skipped(
     store: &SqliteStore,
     e: &voom_domain::events::PlanSkippedEvent,
 ) -> Result<()> {
-    tracing::info!(plan_id = %e.plan_id, "ISSUE-162 PROBE: handle_plan_skipped entered");
     tracing::info!(
         path = %e.path.display(),
         phase = %e.phase_name,
@@ -244,7 +223,6 @@ fn handle_plan_skipped(
 }
 
 fn handle_plan_failed(store: &SqliteStore, e: &voom_domain::events::PlanFailedEvent) -> Result<()> {
-    tracing::info!(plan_id = %e.plan_id, "ISSUE-162 PROBE: handle_plan_failed entered");
     tracing::info!(path = %e.path.display(), phase = %e.phase_name, error = %e.error, "plan failed");
     store.update_plan_status(&e.plan_id, voom_domain::storage::PlanStatus::Failed)?;
     store.update_plan_error(&e.plan_id, &e.error, e.execution_detail.as_ref())?;

--- a/plugins/sqlite-store/src/lib.rs
+++ b/plugins/sqlite-store/src/lib.rs
@@ -177,12 +177,9 @@ fn handle_plan_executing(store: &SqliteStore, e: &voom_domain::events::PlanExecu
     }
 }
 
-// sqlite-store runs at priority 38, BEFORE the executors (priority 39/40),
-// so the plan is recorded with status='pending' before any executor claims
-// the event and short-circuits dispatch (see
-// voom_kernel::EventBus::publish_recursive's break-on-claim behavior).
-// PlanCompleted / PlanSkipped / PlanFailed (none claimed) drive the status
-// update via update_plan_status() in their respective handlers.
+// Plan is recorded with status='pending' here; PlanCompleted/Skipped/Failed
+// drive the subsequent status update via update_plan_status(). See
+// PRIORITY_STORAGE in crates/voom-cli/src/app.rs for the ordering rationale.
 fn handle_plan_created(
     store: &SqliteStore,
     e: &voom_domain::events::PlanCreatedEvent,

--- a/plugins/sqlite-store/src/lib.rs
+++ b/plugins/sqlite-store/src/lib.rs
@@ -184,7 +184,26 @@ fn handle_plan_created(
     store: &SqliteStore,
     e: &voom_domain::events::PlanCreatedEvent,
 ) -> Result<()> {
-    let plan_id = store.save_plan(&e.plan)?;
+    tracing::info!(
+        plan_id = %e.plan.id,
+        path = %e.plan.file.path.display(),
+        phase = %e.plan.phase_name,
+        "ISSUE-162 PROBE: handle_plan_created entered"
+    );
+    let plan_id = match store.save_plan(&e.plan) {
+        Ok(id) => {
+            tracing::info!(%id, "ISSUE-162 PROBE: save_plan OK");
+            id
+        }
+        Err(err) => {
+            tracing::error!(
+                error = %err,
+                plan_id = %e.plan.id,
+                "ISSUE-162 PROBE: save_plan FAILED"
+            );
+            return Err(err);
+        }
+    };
     tracing::info!(%plan_id, "stored plan");
     Ok(())
 }
@@ -193,6 +212,7 @@ fn handle_plan_completed(
     store: &SqliteStore,
     e: &voom_domain::events::PlanCompletedEvent,
 ) -> Result<()> {
+    tracing::info!(plan_id = %e.plan_id, "ISSUE-162 PROBE: handle_plan_completed entered");
     tracing::info!(path = %e.path.display(), phase = %e.phase_name, "plan completed");
     store.update_plan_status(&e.plan_id, voom_domain::storage::PlanStatus::Completed)?;
     if let Err(err) = store.delete_pending_op(&e.plan_id) {
@@ -209,6 +229,7 @@ fn handle_plan_skipped(
     store: &SqliteStore,
     e: &voom_domain::events::PlanSkippedEvent,
 ) -> Result<()> {
+    tracing::info!(plan_id = %e.plan_id, "ISSUE-162 PROBE: handle_plan_skipped entered");
     tracing::info!(
         path = %e.path.display(),
         phase = %e.phase_name,
@@ -220,6 +241,7 @@ fn handle_plan_skipped(
 }
 
 fn handle_plan_failed(store: &SqliteStore, e: &voom_domain::events::PlanFailedEvent) -> Result<()> {
+    tracing::info!(plan_id = %e.plan_id, "ISSUE-162 PROBE: handle_plan_failed entered");
     tracing::info!(path = %e.path.display(), phase = %e.phase_name, error = %e.error, "plan failed");
     store.update_plan_status(&e.plan_id, voom_domain::storage::PlanStatus::Failed)?;
     store.update_plan_error(&e.plan_id, &e.error, e.execution_detail.as_ref())?;

--- a/plugins/sqlite-store/src/store/plan_storage.rs
+++ b/plugins/sqlite-store/src/store/plan_storage.rs
@@ -74,32 +74,22 @@ impl PlanStorage for SqliteStore {
         // When a file is re-scanned, upsert_file keeps the original DB ID, but
         // the Plan's file.id may be a fresh UUID from the new introspection.
         let path_str = plan.file.path.to_string_lossy().to_string();
-        let resolved: Option<String> = conn
+        let effective_file_id: String = conn
             .query_row(
                 "SELECT id FROM files WHERE path = ?1",
                 params![&path_str],
                 |row| row.get(0),
             )
             .optional()
-            .map_err(storage_err("failed to resolve file id"))?;
-        let effective_file_id: String = match resolved {
-            Some(id) => {
-                tracing::info!(
-                    path = %path_str,
-                    %id,
-                    "ISSUE-162 PROBE: save_plan resolved file_id by path"
-                );
-                id
-            }
-            None => {
+            .map_err(storage_err("failed to resolve file id"))?
+            .unwrap_or_else(|| {
                 tracing::warn!(
                     path = %path_str,
                     fallback_id = %plan.file.id,
-                    "ISSUE-162 PROBE: file path not found in DB, falling back to plan.file.id"
+                    "file path not found in DB, falling back to plan.file.id"
                 );
                 plan.file.id.to_string()
-            }
-        };
+            });
 
         conn.execute(
             "INSERT INTO plans (id, file_id, policy_name, phase_name, status, actions, warnings, skip_reason, policy_hash, evaluated_at, created_at, session_id)

--- a/plugins/sqlite-store/src/store/plan_storage.rs
+++ b/plugins/sqlite-store/src/store/plan_storage.rs
@@ -74,22 +74,32 @@ impl PlanStorage for SqliteStore {
         // When a file is re-scanned, upsert_file keeps the original DB ID, but
         // the Plan's file.id may be a fresh UUID from the new introspection.
         let path_str = plan.file.path.to_string_lossy().to_string();
-        let effective_file_id: String = conn
+        let resolved: Option<String> = conn
             .query_row(
                 "SELECT id FROM files WHERE path = ?1",
                 params![&path_str],
                 |row| row.get(0),
             )
             .optional()
-            .map_err(storage_err("failed to resolve file id"))?
-            .unwrap_or_else(|| {
+            .map_err(storage_err("failed to resolve file id"))?;
+        let effective_file_id: String = match resolved {
+            Some(id) => {
+                tracing::info!(
+                    path = %path_str,
+                    %id,
+                    "ISSUE-162 PROBE: save_plan resolved file_id by path"
+                );
+                id
+            }
+            None => {
                 tracing::warn!(
                     path = %path_str,
                     fallback_id = %plan.file.id,
-                    "file path not found in DB, falling back to plan.file.id"
+                    "ISSUE-162 PROBE: file path not found in DB, falling back to plan.file.id"
                 );
                 plan.file.id.to_string()
-            });
+            }
+        };
 
         conn.execute(
             "INSERT INTO plans (id, file_id, policy_name, phase_name, status, actions, warnings, skip_reason, policy_hash, evaluated_at, created_at, session_id)


### PR DESCRIPTION
## Summary

- The kernel's event bus breaks dispatch as soon as a handler returns `EventResult::claimed = true` (`crates/voom-kernel/src/bus.rs:114-117`). Both executors claim `PlanCreated`, so sqlite-store at the prior `PRIORITY_STORAGE = 100` never received the event and `save_plan` was never called — leaving the `plans` table empty after every `voom process` run.
- Lower `PRIORITY_STORAGE` to `38` (just below the executors at 39/40) so sqlite-store records the plan with `status='pending'` before the executors claim it. `PlanCompleted` / `PlanSkipped` / `PlanFailed` (none claimed) drive the status update afterwards via the existing handlers.
- Added a functional regression test (`test_plan_persistence`) that opens the SQLite DB after a `voom process` run and asserts both `total > 0` and `completed > 0`. A companion dry-run test asserts nothing is persisted on `--dry-run`.
- Positive side effect: `event_log` now also captures previously-claimed `PlanCreated` rows, so `voom events --filter plan.created` works for the first time.

## Test plan

- [x] `cargo test -p voom-cli --features functional --test functional_tests test_plan_persistence -- --test-threads=1` (regression test passes: 2 passed, 0 failed)
- [x] `cargo test --workspace` (~2000+ tests, 0 failures)
- [x] `cargo test -p voom-cli --features functional -- --test-threads=4` (118/118 functional tests pass)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Manual: `voom process … --no-backup && voom report --database` shows `plans: 1`; `voom report --plans` shows `normalize: 1 completed` in the breakdown

Closes #162.