### PR TITLE
fix(ffmpeg-executor): bound subprocess probes with timeouts (#168)

### DIFF
--- a/plugins/ffmpeg-executor/src/probe.rs
+++ b/plugins/ffmpeg-executor/src/probe.rs
@@ -236,8 +236,9 @@ where
 ///
 /// Uses 256x256 to satisfy NVENC minimum resolution requirements.
 pub fn validate_hw_encoder(encoder: &str) -> bool {
-    let ok = std::process::Command::new("ffmpeg")
-        .args([
+    let ok = probe_tool_status(
+        "ffmpeg",
+        &[
             "-hide_banner",
             "-nostdin",
             "-f",
@@ -251,13 +252,9 @@ pub fn validate_hw_encoder(encoder: &str) -> bool {
             "-f",
             "null",
             "-",
-        ])
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false);
+        ],
+        HW_ENCODER_PROBE_TIMEOUT,
+    );
 
     if ok {
         tracing::debug!(encoder, "HW encoder validated");
@@ -494,9 +491,9 @@ pub fn validate_hw_encoder_on_device(
 ) -> bool {
     match backend {
         HwAccelBackend::Nvenc => {
-            let ok = std::process::Command::new("ffmpeg")
-                .env("CUDA_VISIBLE_DEVICES", &device.id)
-                .args([
+            let ok = probe_tool_status_env(
+                "ffmpeg",
+                &[
                     "-hide_banner",
                     "-nostdin",
                     "-f",
@@ -510,13 +507,10 @@ pub fn validate_hw_encoder_on_device(
                     "-f",
                     "null",
                     "-",
-                ])
-                .stdin(std::process::Stdio::null())
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::null())
-                .status()
-                .map(|s| s.success())
-                .unwrap_or(false);
+                ],
+                HW_ENCODER_PROBE_TIMEOUT,
+                &[("CUDA_VISIBLE_DEVICES", device.id.as_str())],
+            );
             if ok {
                 tracing::debug!(
                     encoder, gpu = %device.id,
@@ -527,8 +521,9 @@ pub fn validate_hw_encoder_on_device(
         }
         HwAccelBackend::Vaapi => {
             let filter = "format=nv12,hwupload";
-            let ok = std::process::Command::new("ffmpeg")
-                .args([
+            let ok = probe_tool_status(
+                "ffmpeg",
+                &[
                     "-hide_banner",
                     "-nostdin",
                     "-f",
@@ -536,7 +531,7 @@ pub fn validate_hw_encoder_on_device(
                     "-i",
                     "nullsrc=s=256x256:d=0.04",
                     "-vaapi_device",
-                    &device.id,
+                    device.id.as_str(),
                     "-vf",
                     filter,
                     "-frames:v",
@@ -546,13 +541,9 @@ pub fn validate_hw_encoder_on_device(
                     "-f",
                     "null",
                     "-",
-                ])
-                .stdin(std::process::Stdio::null())
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::null())
-                .status()
-                .map(|s| s.success())
-                .unwrap_or(false);
+                ],
+                HW_ENCODER_PROBE_TIMEOUT,
+            );
             if ok {
                 tracing::debug!(
                     encoder, device = %device.id,
@@ -562,8 +553,9 @@ pub fn validate_hw_encoder_on_device(
             ok
         }
         HwAccelBackend::Qsv => {
-            let ok = std::process::Command::new("ffmpeg")
-                .args([
+            let ok = probe_tool_status(
+                "ffmpeg",
+                &[
                     "-hide_banner",
                     "-nostdin",
                     "-f",
@@ -571,7 +563,7 @@ pub fn validate_hw_encoder_on_device(
                     "-i",
                     "nullsrc=s=256x256:d=0.04",
                     "-qsv_device",
-                    &device.id,
+                    device.id.as_str(),
                     "-frames:v",
                     "1",
                     "-c:v",
@@ -579,13 +571,9 @@ pub fn validate_hw_encoder_on_device(
                     "-f",
                     "null",
                     "-",
-                ])
-                .stdin(std::process::Stdio::null())
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::null())
-                .status()
-                .map(|s| s.success())
-                .unwrap_or(false);
+                ],
+                HW_ENCODER_PROBE_TIMEOUT,
+            );
             if ok {
                 tracing::debug!(
                     encoder, device = %device.id,

--- a/plugins/ffmpeg-executor/src/probe.rs
+++ b/plugins/ffmpeg-executor/src/probe.rs
@@ -2,7 +2,60 @@
 
 use crate::hwaccel::HwAccelBackend;
 use rayon::prelude::*;
+use std::time::Duration;
 use voom_domain::events::CodecCapabilities;
+
+/// Upper bound for a single hardware-encoder validation invocation
+/// (`ffmpeg -c:v <enc> -frames:v 1 ...`). On healthy hardware these
+/// finish in well under 1 s; we cap at 5 s so a wedged GPU driver or
+/// stuck device node can no longer hang a rayon worker forever.
+#[allow(dead_code)]
+const HW_ENCODER_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Upper bound for tool-enumeration calls (`nvidia-smi --query-gpu`,
+/// `vainfo`, `nvidia-smi --list-gpus`). These are normally millisecond
+/// operations; 10 s catches pathological hangs while leaving slow
+/// remote-display or first-init paths headroom.
+#[allow(dead_code)]
+const TOOL_ENUMERATION_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Run `tool` with `args` under `timeout`; return `true` iff it
+/// exited 0 within the deadline. Spawn errors, non-zero exit, and
+/// timeout all collapse to `false` — matching the prior
+/// `Command::status().map(...).unwrap_or(false)` semantics that the
+/// callers already depend on.
+#[allow(dead_code)]
+fn probe_tool_status(tool: &str, args: &[&str], timeout: Duration) -> bool {
+    voom_process::run_with_timeout(tool, args, timeout)
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Same as [`probe_tool_status`] but with extra environment variables
+/// (used by the Nvenc branch which sets `CUDA_VISIBLE_DEVICES`).
+#[allow(dead_code)]
+fn probe_tool_status_env(
+    tool: &str,
+    args: &[&str],
+    timeout: Duration,
+    env: &[(&str, &str)],
+) -> bool {
+    voom_process::run_with_timeout_env(tool, args, timeout, env)
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Run `tool` with `args` under `timeout`; return its stdout iff
+/// it exited 0 within the deadline. Spawn errors, non-zero exit,
+/// and timeout collapse to `None` — matching the prior
+/// `Command::output().ok().filter(|o| o.status.success())` pattern.
+#[allow(dead_code)]
+fn probe_tool_stdout(tool: &str, args: &[&str], timeout: Duration) -> Option<Vec<u8>> {
+    voom_process::run_with_timeout(tool, args, timeout)
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| o.stdout)
+}
 
 /// Parse `ffmpeg -codecs` output into decoder and encoder lists.
 ///

--- a/plugins/ffmpeg-executor/src/probe.rs
+++ b/plugins/ffmpeg-executor/src/probe.rs
@@ -806,4 +806,114 @@ vainfo: Supported profile and entrypoint
         let result = validate_hw_encoders_parallel(&input, |_| false);
         assert!(result.is_empty());
     }
+
+    #[test]
+    fn probe_tool_status_returns_true_on_success() {
+        // `true` is a POSIX builtin/binary that exits 0 immediately.
+        let ok = probe_tool_status("true", &[], Duration::from_secs(5));
+        assert!(ok, "`true` should report success");
+    }
+
+    #[test]
+    fn probe_tool_status_returns_false_on_nonzero_exit() {
+        // `false` is a POSIX builtin/binary that exits 1 immediately.
+        let ok = probe_tool_status("false", &[], Duration::from_secs(5));
+        assert!(!ok, "`false` should report non-success");
+    }
+
+    #[test]
+    fn probe_tool_status_returns_false_on_missing_tool() {
+        let ok = probe_tool_status(
+            "voom_nonexistent_probe_tool_xyz",
+            &[],
+            Duration::from_secs(5),
+        );
+        assert!(!ok, "missing tool should be treated as unsupported");
+    }
+
+    #[test]
+    fn probe_tool_status_returns_false_on_timeout() {
+        // `sleep 60` will be killed after 1 s; we expect false.
+        let started = std::time::Instant::now();
+        let ok = probe_tool_status("sleep", &["60"], Duration::from_secs(1));
+        let elapsed = started.elapsed();
+        assert!(!ok, "hung tool should be treated as unsupported");
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "probe must return within a few seconds of the timeout, took {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn probe_tool_status_env_passes_environment() {
+        // `sh -c '[ "$VOOM_PROBE_TEST" = "yes" ]'` exits 0 only if the
+        // env var got through.
+        let ok = probe_tool_status_env(
+            "sh",
+            &["-c", "[ \"$VOOM_PROBE_TEST\" = \"yes\" ]"],
+            Duration::from_secs(5),
+            &[("VOOM_PROBE_TEST", "yes")],
+        );
+        assert!(ok, "env var should reach the child");
+
+        let not_ok = probe_tool_status_env(
+            "sh",
+            &["-c", "[ \"$VOOM_PROBE_TEST\" = \"yes\" ]"],
+            Duration::from_secs(5),
+            &[("VOOM_PROBE_TEST", "no")],
+        );
+        assert!(!not_ok, "wrong env value should fail the comparison");
+    }
+
+    #[test]
+    fn probe_tool_status_env_returns_false_on_timeout() {
+        let started = std::time::Instant::now();
+        let ok = probe_tool_status_env(
+            "sleep",
+            &["60"],
+            Duration::from_secs(1),
+            &[("IGNORED", "value")],
+        );
+        let elapsed = started.elapsed();
+        assert!(!ok);
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "env-variant must also honor the timeout, took {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn probe_tool_stdout_captures_stdout_on_success() {
+        let out = probe_tool_stdout("echo", &["hello"], Duration::from_secs(5))
+            .expect("echo should succeed");
+        assert_eq!(String::from_utf8_lossy(&out).trim(), "hello");
+    }
+
+    #[test]
+    fn probe_tool_stdout_returns_none_on_nonzero_exit() {
+        let out = probe_tool_stdout("false", &[], Duration::from_secs(5));
+        assert!(out.is_none(), "non-zero exit should yield None");
+    }
+
+    #[test]
+    fn probe_tool_stdout_returns_none_on_missing_tool() {
+        let out = probe_tool_stdout(
+            "voom_nonexistent_probe_tool_xyz",
+            &[],
+            Duration::from_secs(5),
+        );
+        assert!(out.is_none());
+    }
+
+    #[test]
+    fn probe_tool_stdout_returns_none_on_timeout() {
+        let started = std::time::Instant::now();
+        let out = probe_tool_stdout("sleep", &["60"], Duration::from_secs(1));
+        let elapsed = started.elapsed();
+        assert!(out.is_none(), "hung tool should yield None");
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "stdout-variant must also honor the timeout, took {elapsed:?}"
+        );
+    }
 }

--- a/plugins/ffmpeg-executor/src/probe.rs
+++ b/plugins/ffmpeg-executor/src/probe.rs
@@ -9,14 +9,12 @@ use voom_domain::events::CodecCapabilities;
 /// (`ffmpeg -c:v <enc> -frames:v 1 ...`). On healthy hardware these
 /// finish in well under 1 s; we cap at 5 s so a wedged GPU driver or
 /// stuck device node can no longer hang a rayon worker forever.
-#[allow(dead_code)]
 const HW_ENCODER_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Upper bound for tool-enumeration calls (`nvidia-smi --query-gpu`,
 /// `vainfo`, `nvidia-smi --list-gpus`). These are normally millisecond
 /// operations; 10 s catches pathological hangs while leaving slow
 /// remote-display or first-init paths headroom.
-#[allow(dead_code)]
 const TOOL_ENUMERATION_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Run `tool` with `args` under `timeout`; return `true` iff it
@@ -24,7 +22,6 @@ const TOOL_ENUMERATION_TIMEOUT: Duration = Duration::from_secs(10);
 /// timeout all collapse to `false` — matching the prior
 /// `Command::status().map(...).unwrap_or(false)` semantics that the
 /// callers already depend on.
-#[allow(dead_code)]
 fn probe_tool_status(tool: &str, args: &[&str], timeout: Duration) -> bool {
     voom_process::run_with_timeout(tool, args, timeout)
         .map(|o| o.status.success())
@@ -33,7 +30,6 @@ fn probe_tool_status(tool: &str, args: &[&str], timeout: Duration) -> bool {
 
 /// Same as [`probe_tool_status`] but with extra environment variables
 /// (used by the Nvenc branch which sets `CUDA_VISIBLE_DEVICES`).
-#[allow(dead_code)]
 fn probe_tool_status_env(
     tool: &str,
     args: &[&str],
@@ -49,7 +45,6 @@ fn probe_tool_status_env(
 /// it exited 0 within the deadline. Spawn errors, non-zero exit,
 /// and timeout collapse to `None` — matching the prior
 /// `Command::output().ok().filter(|o| o.status.success())` pattern.
-#[allow(dead_code)]
 fn probe_tool_stdout(tool: &str, args: &[&str], timeout: Duration) -> Option<Vec<u8>> {
     voom_process::run_with_timeout(tool, args, timeout)
         .ok()
@@ -298,19 +293,19 @@ pub fn enumerate_gpus(backend: HwAccelBackend) -> Vec<GpuDevice> {
 }
 
 fn enumerate_nvidia_gpus() -> Vec<GpuDevice> {
-    let output = std::process::Command::new("nvidia-smi")
-        .args([
+    match probe_tool_stdout(
+        "nvidia-smi",
+        &[
             "--query-gpu=index,name,memory.total",
             "--format=csv,noheader,nounits",
-        ])
-        .output();
-
-    match output {
-        Ok(o) if o.status.success() => {
-            let stdout = String::from_utf8_lossy(&o.stdout);
-            parse_nvidia_smi(&stdout)
+        ],
+        TOOL_ENUMERATION_TIMEOUT,
+    ) {
+        Some(stdout) => {
+            let text = String::from_utf8_lossy(&stdout);
+            parse_nvidia_smi(&text)
         }
-        _ => Vec::new(),
+        None => Vec::new(),
     }
 }
 
@@ -330,16 +325,16 @@ fn enumerate_vaapi_devices() -> Vec<GpuDevice> {
         let path = entry.path();
         let path_str = path.to_string_lossy().to_string();
 
-        let device_name = std::process::Command::new("vainfo")
-            .args(["--display", "drm", "--device", &path_str])
-            .output()
-            .ok()
-            .filter(|o| o.status.success())
-            .and_then(|o| {
-                let stdout = String::from_utf8_lossy(&o.stdout);
-                parse_vainfo_device_name(&stdout)
-            })
-            .unwrap_or_else(|| name_str.to_string());
+        let device_name = probe_tool_stdout(
+            "vainfo",
+            &["--display", "drm", "--device", path_str.as_str()],
+            TOOL_ENUMERATION_TIMEOUT,
+        )
+        .and_then(|stdout| {
+            let text = String::from_utf8_lossy(&stdout);
+            parse_vainfo_device_name(&text)
+        })
+        .unwrap_or_else(|| name_str.to_string());
 
         devices.push(GpuDevice {
             id: path_str,
@@ -353,14 +348,7 @@ fn enumerate_vaapi_devices() -> Vec<GpuDevice> {
 
 /// Check whether NVIDIA GPU hardware is present.
 pub(crate) fn has_nvidia_hardware() -> bool {
-    std::process::Command::new("nvidia-smi")
-        .arg("--list-gpus")
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
+    probe_tool_status("nvidia-smi", &["--list-gpus"], TOOL_ENUMERATION_TIMEOUT)
 }
 
 /// Check whether a working VA-API device exists.
@@ -385,14 +373,11 @@ pub(crate) fn has_vaapi_devices() -> bool {
     let path = entry.path();
     let path_str = path.to_string_lossy();
 
-    let ok = std::process::Command::new("vainfo")
-        .args(["--display", "drm", "--device", &path_str])
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false);
+    let ok = probe_tool_status(
+        "vainfo",
+        &["--display", "drm", "--device", path_str.as_ref()],
+        TOOL_ENUMERATION_TIMEOUT,
+    );
 
     if ok {
         tracing::debug!(device = %path_str, "VA-API device verified via vainfo");

--- a/plugins/ffmpeg-executor/src/probe.rs
+++ b/plugins/ffmpeg-executor/src/probe.rs
@@ -5,46 +5,28 @@ use rayon::prelude::*;
 use std::time::Duration;
 use voom_domain::events::CodecCapabilities;
 
-/// Upper bound for a single hardware-encoder validation invocation
-/// (`ffmpeg -c:v <enc> -frames:v 1 ...`). On healthy hardware these
-/// finish in well under 1 s; we cap at 5 s so a wedged GPU driver or
-/// stuck device node can no longer hang a rayon worker forever.
+/// Upper bound for a single hardware-encoder validation invocation.
+/// On healthy hardware these finish well under 1 s; the 5 s cap keeps a
+/// wedged GPU driver or stuck device node from hanging a rayon worker.
 const HW_ENCODER_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// Upper bound for tool-enumeration calls (`nvidia-smi --query-gpu`,
-/// `vainfo`, `nvidia-smi --list-gpus`). These are normally millisecond
-/// operations; 10 s catches pathological hangs while leaving slow
-/// remote-display or first-init paths headroom.
+/// Upper bound for `nvidia-smi` / `vainfo` enumeration calls. Normally
+/// millisecond operations; 10 s leaves headroom for first-init or
+/// remote-display paths while still bounding pathological hangs.
 const TOOL_ENUMERATION_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// Run `tool` with `args` under `timeout`; return `true` iff it
-/// exited 0 within the deadline. Spawn errors, non-zero exit, and
-/// timeout all collapse to `false` — matching the prior
-/// `Command::status().map(...).unwrap_or(false)` semantics that the
-/// callers already depend on.
-fn probe_tool_status(tool: &str, args: &[&str], timeout: Duration) -> bool {
-    voom_process::run_with_timeout(tool, args, timeout)
-        .map(|o| o.status.success())
-        .unwrap_or(false)
-}
-
-/// Same as [`probe_tool_status`] but with extra environment variables
-/// (used by the Nvenc branch which sets `CUDA_VISIBLE_DEVICES`).
-fn probe_tool_status_env(
-    tool: &str,
-    args: &[&str],
-    timeout: Duration,
-    env: &[(&str, &str)],
-) -> bool {
+/// Run `tool` with `args` and `env`, returning `true` only if it exits 0
+/// before `timeout`. Spawn errors, non-zero exits, and timeouts all yield
+/// `false`. Pass `&[]` for `env` when no extra variables are needed.
+fn probe_tool_status(tool: &str, args: &[&str], timeout: Duration, env: &[(&str, &str)]) -> bool {
     voom_process::run_with_timeout_env(tool, args, timeout, env)
         .map(|o| o.status.success())
         .unwrap_or(false)
 }
 
-/// Run `tool` with `args` under `timeout`; return its stdout iff
-/// it exited 0 within the deadline. Spawn errors, non-zero exit,
-/// and timeout collapse to `None` — matching the prior
-/// `Command::output().ok().filter(|o| o.status.success())` pattern.
+/// Run `tool` with `args`, returning captured stdout only if it exits 0
+/// before `timeout`. Spawn errors, non-zero exits, and timeouts all yield
+/// `None`.
 fn probe_tool_stdout(tool: &str, args: &[&str], timeout: Duration) -> Option<Vec<u8>> {
     voom_process::run_with_timeout(tool, args, timeout)
         .ok()
@@ -249,6 +231,7 @@ pub fn validate_hw_encoder(encoder: &str) -> bool {
             "-",
         ],
         HW_ENCODER_PROBE_TIMEOUT,
+        &[],
     );
 
     if ok {
@@ -348,7 +331,12 @@ fn enumerate_vaapi_devices() -> Vec<GpuDevice> {
 
 /// Check whether NVIDIA GPU hardware is present.
 pub(crate) fn has_nvidia_hardware() -> bool {
-    probe_tool_status("nvidia-smi", &["--list-gpus"], TOOL_ENUMERATION_TIMEOUT)
+    probe_tool_status(
+        "nvidia-smi",
+        &["--list-gpus"],
+        TOOL_ENUMERATION_TIMEOUT,
+        &[],
+    )
 }
 
 /// Check whether a working VA-API device exists.
@@ -377,6 +365,7 @@ pub(crate) fn has_vaapi_devices() -> bool {
         "vainfo",
         &["--display", "drm", "--device", path_str.as_ref()],
         TOOL_ENUMERATION_TIMEOUT,
+        &[],
     );
 
     if ok {
@@ -476,7 +465,7 @@ pub fn validate_hw_encoder_on_device(
 ) -> bool {
     match backend {
         HwAccelBackend::Nvenc => {
-            let ok = probe_tool_status_env(
+            let ok = probe_tool_status(
                 "ffmpeg",
                 &[
                     "-hide_banner",
@@ -528,6 +517,7 @@ pub fn validate_hw_encoder_on_device(
                     "-",
                 ],
                 HW_ENCODER_PROBE_TIMEOUT,
+                &[],
             );
             if ok {
                 tracing::debug!(
@@ -558,6 +548,7 @@ pub fn validate_hw_encoder_on_device(
                     "-",
                 ],
                 HW_ENCODER_PROBE_TIMEOUT,
+                &[],
             );
             if ok {
                 tracing::debug!(
@@ -807,113 +798,90 @@ vainfo: Supported profile and entrypoint
         assert!(result.is_empty());
     }
 
-    #[test]
-    fn probe_tool_status_returns_true_on_success() {
-        // `true` is a POSIX builtin/binary that exits 0 immediately.
-        let ok = probe_tool_status("true", &[], Duration::from_secs(5));
-        assert!(ok, "`true` should report success");
-    }
+    #[cfg(unix)]
+    mod probe_helpers {
+        use super::*;
+        use std::time::Instant;
 
-    #[test]
-    fn probe_tool_status_returns_false_on_nonzero_exit() {
-        // `false` is a POSIX builtin/binary that exits 1 immediately.
-        let ok = probe_tool_status("false", &[], Duration::from_secs(5));
-        assert!(!ok, "`false` should report non-success");
-    }
+        #[test]
+        fn returns_true_on_success() {
+            let ok = probe_tool_status("true", &[], Duration::from_secs(5), &[]);
+            assert!(ok);
+        }
 
-    #[test]
-    fn probe_tool_status_returns_false_on_missing_tool() {
-        let ok = probe_tool_status(
-            "voom_nonexistent_probe_tool_xyz",
-            &[],
-            Duration::from_secs(5),
-        );
-        assert!(!ok, "missing tool should be treated as unsupported");
-    }
+        #[test]
+        fn returns_false_on_nonzero_exit() {
+            let ok = probe_tool_status("false", &[], Duration::from_secs(5), &[]);
+            assert!(!ok);
+        }
 
-    #[test]
-    fn probe_tool_status_returns_false_on_timeout() {
-        // `sleep 60` will be killed after 1 s; we expect false.
-        let started = std::time::Instant::now();
-        let ok = probe_tool_status("sleep", &["60"], Duration::from_secs(1));
-        let elapsed = started.elapsed();
-        assert!(!ok, "hung tool should be treated as unsupported");
-        assert!(
-            elapsed < Duration::from_secs(5),
-            "probe must return within a few seconds of the timeout, took {elapsed:?}"
-        );
-    }
+        #[test]
+        fn returns_false_on_missing_tool() {
+            let ok = probe_tool_status(
+                "voom_nonexistent_probe_tool_xyz",
+                &[],
+                Duration::from_secs(5),
+                &[],
+            );
+            assert!(!ok);
+        }
 
-    #[test]
-    fn probe_tool_status_env_passes_environment() {
-        // `sh -c '[ "$VOOM_PROBE_TEST" = "yes" ]'` exits 0 only if the
-        // env var got through.
-        let ok = probe_tool_status_env(
-            "sh",
-            &["-c", "[ \"$VOOM_PROBE_TEST\" = \"yes\" ]"],
-            Duration::from_secs(5),
-            &[("VOOM_PROBE_TEST", "yes")],
-        );
-        assert!(ok, "env var should reach the child");
+        #[test]
+        fn returns_false_on_timeout() {
+            let started = Instant::now();
+            let ok = probe_tool_status("sleep", &["60"], Duration::from_secs(1), &[]);
+            let elapsed = started.elapsed();
+            assert!(!ok);
+            assert!(
+                elapsed < Duration::from_secs(5),
+                "probe must return within a few seconds of the timeout, took {elapsed:?}"
+            );
+        }
 
-        let not_ok = probe_tool_status_env(
-            "sh",
-            &["-c", "[ \"$VOOM_PROBE_TEST\" = \"yes\" ]"],
-            Duration::from_secs(5),
-            &[("VOOM_PROBE_TEST", "no")],
-        );
-        assert!(!not_ok, "wrong env value should fail the comparison");
-    }
+        #[test]
+        fn passes_environment() {
+            let ok = probe_tool_status(
+                "sh",
+                &["-c", "[ \"$VOOM_PROBE_TEST\" = \"yes\" ]"],
+                Duration::from_secs(5),
+                &[("VOOM_PROBE_TEST", "yes")],
+            );
+            assert!(ok);
+        }
 
-    #[test]
-    fn probe_tool_status_env_returns_false_on_timeout() {
-        let started = std::time::Instant::now();
-        let ok = probe_tool_status_env(
-            "sleep",
-            &["60"],
-            Duration::from_secs(1),
-            &[("IGNORED", "value")],
-        );
-        let elapsed = started.elapsed();
-        assert!(!ok);
-        assert!(
-            elapsed < Duration::from_secs(5),
-            "env-variant must also honor the timeout, took {elapsed:?}"
-        );
-    }
+        #[test]
+        fn stdout_captures_on_success() {
+            let out = probe_tool_stdout("echo", &["hello"], Duration::from_secs(5))
+                .expect("echo should succeed");
+            assert_eq!(String::from_utf8_lossy(&out).trim(), "hello");
+        }
 
-    #[test]
-    fn probe_tool_stdout_captures_stdout_on_success() {
-        let out = probe_tool_stdout("echo", &["hello"], Duration::from_secs(5))
-            .expect("echo should succeed");
-        assert_eq!(String::from_utf8_lossy(&out).trim(), "hello");
-    }
+        #[test]
+        fn stdout_none_on_nonzero_exit() {
+            let out = probe_tool_stdout("false", &[], Duration::from_secs(5));
+            assert!(out.is_none());
+        }
 
-    #[test]
-    fn probe_tool_stdout_returns_none_on_nonzero_exit() {
-        let out = probe_tool_stdout("false", &[], Duration::from_secs(5));
-        assert!(out.is_none(), "non-zero exit should yield None");
-    }
+        #[test]
+        fn stdout_none_on_missing_tool() {
+            let out = probe_tool_stdout(
+                "voom_nonexistent_probe_tool_xyz",
+                &[],
+                Duration::from_secs(5),
+            );
+            assert!(out.is_none());
+        }
 
-    #[test]
-    fn probe_tool_stdout_returns_none_on_missing_tool() {
-        let out = probe_tool_stdout(
-            "voom_nonexistent_probe_tool_xyz",
-            &[],
-            Duration::from_secs(5),
-        );
-        assert!(out.is_none());
-    }
-
-    #[test]
-    fn probe_tool_stdout_returns_none_on_timeout() {
-        let started = std::time::Instant::now();
-        let out = probe_tool_stdout("sleep", &["60"], Duration::from_secs(1));
-        let elapsed = started.elapsed();
-        assert!(out.is_none(), "hung tool should yield None");
-        assert!(
-            elapsed < Duration::from_secs(5),
-            "stdout-variant must also honor the timeout, took {elapsed:?}"
-        );
+        #[test]
+        fn stdout_none_on_timeout() {
+            let started = Instant::now();
+            let out = probe_tool_stdout("sleep", &["60"], Duration::from_secs(1));
+            let elapsed = started.elapsed();
+            assert!(out.is_none());
+            assert!(
+                elapsed < Duration::from_secs(5),
+                "stdout-variant must also honor the timeout, took {elapsed:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Wrap every `Command::new` site in `plugins/ffmpeg-executor/src/probe.rs` with `voom_process::run_with_timeout` / `run_with_timeout_env`.
- Encoder validators (`validate_hw_encoder`, `validate_hw_encoder_on_device`) cap each probe at 5 s; enumeration helpers (`enumerate_nvidia_gpus`, the `vainfo` lookup in `enumerate_vaapi_devices`, `has_nvidia_hardware`, `has_vaapi_devices`) cap at 10 s.
- Behavior on success and ordinary failure is unchanged. On timeout the candidate is treated as unsupported, matching the existing fallback.

Closes #168.

## Test plan
- [x] `cargo test -p voom-ffmpeg-executor` (existing parser tests + 9 new helper tests gated `#[cfg(unix)]`)
- [x] `cargo test` (full unit + integration suite)
- [x] `cargo test -p voom-cli --features functional -- --test-threads=4` (535 functional tests)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`

## Follow-ups (not in this PR)
- The same fold-to-bool pattern exists in `ffmpeg-executor::lib::init` (5 sites), `ffprobe-introspector::detect_available`, `mkvtoolnix-executor::init`, and `tool-detector` — same hang risk, different code paths. Worth promoting the helpers to `voom-process` and wiring them in.
- The four `validate_hw_encoder*` ffmpeg arg blocks share a 9-arg prefix and 5-arg suffix that could be deduplicated.