### PR TITLE
fix(ffmpeg-executor): parallelize init() capability probes (#169)

### DIFF
--- a/plugins/ffmpeg-executor/src/lib.rs
+++ b/plugins/ffmpeg-executor/src/lib.rs
@@ -510,14 +510,12 @@ impl Plugin for FfmpegExecutorPlugin {
     fn init(&mut self, ctx: &PluginContext) -> Result<Vec<Event>> {
         let caps = probe_capabilities();
 
-        let Some(mut codecs) = caps.codecs else {
+        let Some(codecs) = caps.codecs else {
             tracing::warn!("ffmpeg not found; ffmpeg executor disabled");
             return Ok(vec![]);
         };
         self.available = true;
 
-        codecs.hw_encoders = caps.hw_encoders;
-        codecs.hw_decoders = caps.hw_decoders;
         let formats = caps.formats;
         let hw_accels = caps.hw_accels;
 

--- a/plugins/ffmpeg-executor/src/lib.rs
+++ b/plugins/ffmpeg-executor/src/lib.rs
@@ -9,7 +9,6 @@ pub mod hwaccel;
 pub mod probe;
 pub mod progress;
 
-use std::process::Command;
 use std::time::Duration;
 
 use voom_domain::capabilities::Capability;
@@ -27,8 +26,8 @@ use voom_kernel::{Plugin, PluginContext};
 
 use crate::hwaccel::{resolve_hw_config, HwAccelConfig};
 use crate::probe::{
-    enumerate_gpus, parse_codecs, parse_formats, parse_hw_implementations, parse_hwaccels,
-    validate_hw_encoder, validate_hw_encoder_on_device, validate_hw_encoders_parallel, GpuDevice,
+    enumerate_gpus, probe_capabilities, validate_hw_encoder, validate_hw_encoder_on_device,
+    validate_hw_encoders_parallel, GpuDevice,
 };
 
 /// Per-plugin configuration from `[plugin.ffmpeg-executor]` in config.toml.
@@ -509,55 +508,18 @@ impl Plugin for FfmpegExecutorPlugin {
     }
 
     fn init(&mut self, ctx: &PluginContext) -> Result<Vec<Event>> {
-        let codecs_output = if let Ok(o) = Command::new("ffmpeg")
-            .args(["-codecs", "-hide_banner"])
-            .output()
-        {
-            o
-        } else {
+        let caps = probe_capabilities();
+
+        let Some(mut codecs) = caps.codecs else {
             tracing::warn!("ffmpeg not found; ffmpeg executor disabled");
             return Ok(vec![]);
         };
         self.available = true;
 
-        let mut codecs = parse_codecs(&String::from_utf8_lossy(&codecs_output.stdout));
-
-        let formats = Command::new("ffmpeg")
-            .args(["-formats", "-hide_banner"])
-            .output()
-            .map(|o| parse_formats(&String::from_utf8_lossy(&o.stdout)))
-            .unwrap_or_else(|e| {
-                tracing::warn!(error = %e, "failed to probe ffmpeg formats");
-                Vec::new()
-            });
-
-        let hw_accels = Command::new("ffmpeg")
-            .args(["-hwaccels", "-hide_banner"])
-            .output()
-            .map(|o| parse_hwaccels(&String::from_utf8_lossy(&o.stdout)))
-            .unwrap_or_else(|e| {
-                tracing::warn!(error = %e, "failed to probe ffmpeg hwaccels");
-                Vec::new()
-            });
-
-        // Probe HW encoder/decoder implementations
-        codecs.hw_encoders = Command::new("ffmpeg")
-            .args(["-encoders", "-hide_banner"])
-            .output()
-            .map(|o| parse_hw_implementations(&String::from_utf8_lossy(&o.stdout)))
-            .unwrap_or_else(|e| {
-                tracing::warn!(error = %e, "failed to probe ffmpeg hw encoders");
-                Vec::new()
-            });
-
-        codecs.hw_decoders = Command::new("ffmpeg")
-            .args(["-decoders", "-hide_banner"])
-            .output()
-            .map(|o| parse_hw_implementations(&String::from_utf8_lossy(&o.stdout)))
-            .unwrap_or_else(|e| {
-                tracing::warn!(error = %e, "failed to probe ffmpeg hw decoders");
-                Vec::new()
-            });
+        codecs.hw_encoders = caps.hw_encoders;
+        codecs.hw_decoders = caps.hw_decoders;
+        let formats = caps.formats;
+        let hw_accels = caps.hw_accels;
 
         self.probed_codecs = Some(codecs.clone());
         self.probed_formats = Some(formats.clone());

--- a/plugins/ffmpeg-executor/src/probe.rs
+++ b/plugins/ffmpeg-executor/src/probe.rs
@@ -15,6 +15,49 @@ const HW_ENCODER_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 /// remote-display paths while still bounding pathological hangs.
 const TOOL_ENUMERATION_TIMEOUT: Duration = Duration::from_secs(10);
 
+/// Upper bound for a single fast capability probe (`-codecs`, `-formats`,
+/// `-hwaccels`, `-encoders`, `-decoders`). These calls don't touch the GPU
+/// and normally finish in under 200 ms; 5 s caps a pathological hang.
+// Allowed: consumed by `probe_capabilities_with_tool` in Task 4 of issue #169.
+#[allow(dead_code)]
+const CAPABILITY_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Aggregate result of running the five fast `ffmpeg` capability probes
+/// concurrently.
+///
+/// `codecs == None` means the `-codecs` probe failed (treated by the
+/// plugin as "ffmpeg not found / unusable"). The four secondary fields
+/// degrade independently to empty `Vec`s on probe failure, matching the
+/// pre-parallel sequential code path.
+pub struct FfmpegCapabilities {
+    pub codecs: Option<CodecCapabilities>,
+    pub formats: Vec<String>,
+    pub hw_accels: Vec<String>,
+    pub hw_encoders: Vec<String>,
+    pub hw_decoders: Vec<String>,
+}
+
+/// Run the five fast `ffmpeg` capability probes concurrently using
+/// `rayon::join`. Each probe is independently bounded by
+/// `CAPABILITY_PROBE_TIMEOUT`. A failure on any non-codecs probe yields
+/// an empty `Vec` for that field, with a `tracing::warn!` recording why.
+///
+/// `codecs == None` is the canonical "ffmpeg is unavailable" signal —
+/// callers should disable the plugin in that case.
+#[must_use]
+pub fn probe_capabilities() -> FfmpegCapabilities {
+    probe_capabilities_with_tool("ffmpeg")
+}
+
+/// Internal: parameterized variant of `probe_capabilities` taking the
+/// tool path. Lets tests drive the failure path with a non-existent
+/// binary without manipulating `PATH`.
+// Allowed: parameter is consumed once Task 5 of issue #169 fills in the body.
+#[allow(unused_variables)]
+fn probe_capabilities_with_tool(tool: &str) -> FfmpegCapabilities {
+    todo!("filled in by Task 5")
+}
+
 /// Run `tool` with `args` and `env`, returning `true` only if it exits 0
 /// before `timeout`. Spawn errors, non-zero exits, and timeouts all yield
 /// `false`. Pass `&[]` for `env` when no extra variables are needed.

--- a/plugins/ffmpeg-executor/src/probe.rs
+++ b/plugins/ffmpeg-executor/src/probe.rs
@@ -18,8 +18,6 @@ const TOOL_ENUMERATION_TIMEOUT: Duration = Duration::from_secs(10);
 /// Upper bound for a single fast capability probe (`-codecs`, `-formats`,
 /// `-hwaccels`, `-encoders`, `-decoders`). These calls don't touch the GPU
 /// and normally finish in under 200 ms; 5 s caps a pathological hang.
-// Allowed: consumed by `probe_capabilities_with_tool` in Task 4 of issue #169.
-#[allow(dead_code)]
 const CAPABILITY_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Aggregate result of running the five fast `ffmpeg` capability probes
@@ -40,8 +38,6 @@ pub struct FfmpegCapabilities {
 /// Run a single `ffmpeg <flag> -hide_banner` probe and return its stdout
 /// as a UTF-8 string on success. On spawn error, non-zero exit, or
 /// timeout, logs a warning naming `flag` and returns `None`.
-// Allowed: consumed by `probe_capabilities_with_tool` in Task 5 of issue #169.
-#[allow(dead_code)]
 fn run_capability_probe(tool: &str, flag: &str) -> Option<String> {
     match voom_process::run_with_timeout(tool, &[flag, "-hide_banner"], CAPABILITY_PROBE_TIMEOUT) {
         Ok(out) if out.status.success() => Some(String::from_utf8_lossy(&out.stdout).into_owned()),
@@ -61,38 +57,28 @@ fn run_capability_probe(tool: &str, flag: &str) -> Option<String> {
     }
 }
 
-// Allowed: consumed by `probe_capabilities_with_tool` in Task 5 of issue #169.
-#[allow(dead_code)]
 fn probe_codecs(tool: &str) -> Option<CodecCapabilities> {
     run_capability_probe(tool, "-codecs").map(|s| parse_codecs(&s))
 }
 
-// Allowed: consumed by `probe_capabilities_with_tool` in Task 5 of issue #169.
-#[allow(dead_code)]
 fn probe_formats(tool: &str) -> Vec<String> {
     run_capability_probe(tool, "-formats")
         .map(|s| parse_formats(&s))
         .unwrap_or_default()
 }
 
-// Allowed: consumed by `probe_capabilities_with_tool` in Task 5 of issue #169.
-#[allow(dead_code)]
 fn probe_hwaccels(tool: &str) -> Vec<String> {
     run_capability_probe(tool, "-hwaccels")
         .map(|s| parse_hwaccels(&s))
         .unwrap_or_default()
 }
 
-// Allowed: consumed by `probe_capabilities_with_tool` in Task 5 of issue #169.
-#[allow(dead_code)]
 fn probe_hw_encoders(tool: &str) -> Vec<String> {
     run_capability_probe(tool, "-encoders")
         .map(|s| parse_hw_implementations(&s))
         .unwrap_or_default()
 }
 
-// Allowed: consumed by `probe_capabilities_with_tool` in Task 5 of issue #169.
-#[allow(dead_code)]
 fn probe_hw_decoders(tool: &str) -> Vec<String> {
     run_capability_probe(tool, "-decoders")
         .map(|s| parse_hw_implementations(&s))
@@ -114,10 +100,24 @@ pub fn probe_capabilities() -> FfmpegCapabilities {
 /// Internal: parameterized variant of `probe_capabilities` taking the
 /// tool path. Lets tests drive the failure path with a non-existent
 /// binary without manipulating `PATH`.
-// Allowed: parameter is consumed once Task 5 of issue #169 fills in the body.
-#[allow(unused_variables)]
 fn probe_capabilities_with_tool(tool: &str) -> FfmpegCapabilities {
-    todo!("filled in by Task 5")
+    let ((codecs, formats), (hw_accels, (hw_encoders, hw_decoders))) = rayon::join(
+        || rayon::join(|| probe_codecs(tool), || probe_formats(tool)),
+        || {
+            rayon::join(
+                || probe_hwaccels(tool),
+                || rayon::join(|| probe_hw_encoders(tool), || probe_hw_decoders(tool)),
+            )
+        },
+    );
+
+    FfmpegCapabilities {
+        codecs,
+        formats,
+        hw_accels,
+        hw_encoders,
+        hw_decoders,
+    }
 }
 
 /// Run `tool` with `args` and `env`, returning `true` only if it exits 0

--- a/plugins/ffmpeg-executor/src/probe.rs
+++ b/plugins/ffmpeg-executor/src/probe.rs
@@ -37,6 +37,68 @@ pub struct FfmpegCapabilities {
     pub hw_decoders: Vec<String>,
 }
 
+/// Run a single `ffmpeg <flag> -hide_banner` probe and return its stdout
+/// as a UTF-8 string on success. On spawn error, non-zero exit, or
+/// timeout, logs a warning naming `flag` and returns `None`.
+// Allowed: consumed by `probe_capabilities_with_tool` in Task 5 of issue #169.
+#[allow(dead_code)]
+fn run_capability_probe(tool: &str, flag: &str) -> Option<String> {
+    match voom_process::run_with_timeout(tool, &[flag, "-hide_banner"], CAPABILITY_PROBE_TIMEOUT) {
+        Ok(out) if out.status.success() => Some(String::from_utf8_lossy(&out.stdout).into_owned()),
+        Ok(out) => {
+            tracing::warn!(
+                tool,
+                flag,
+                exit = ?out.status.code(),
+                "ffmpeg probe exited non-zero"
+            );
+            None
+        }
+        Err(e) => {
+            tracing::warn!(tool, flag, error = %e, "ffmpeg probe failed");
+            None
+        }
+    }
+}
+
+// Allowed: consumed by `probe_capabilities_with_tool` in Task 5 of issue #169.
+#[allow(dead_code)]
+fn probe_codecs(tool: &str) -> Option<CodecCapabilities> {
+    run_capability_probe(tool, "-codecs").map(|s| parse_codecs(&s))
+}
+
+// Allowed: consumed by `probe_capabilities_with_tool` in Task 5 of issue #169.
+#[allow(dead_code)]
+fn probe_formats(tool: &str) -> Vec<String> {
+    run_capability_probe(tool, "-formats")
+        .map(|s| parse_formats(&s))
+        .unwrap_or_default()
+}
+
+// Allowed: consumed by `probe_capabilities_with_tool` in Task 5 of issue #169.
+#[allow(dead_code)]
+fn probe_hwaccels(tool: &str) -> Vec<String> {
+    run_capability_probe(tool, "-hwaccels")
+        .map(|s| parse_hwaccels(&s))
+        .unwrap_or_default()
+}
+
+// Allowed: consumed by `probe_capabilities_with_tool` in Task 5 of issue #169.
+#[allow(dead_code)]
+fn probe_hw_encoders(tool: &str) -> Vec<String> {
+    run_capability_probe(tool, "-encoders")
+        .map(|s| parse_hw_implementations(&s))
+        .unwrap_or_default()
+}
+
+// Allowed: consumed by `probe_capabilities_with_tool` in Task 5 of issue #169.
+#[allow(dead_code)]
+fn probe_hw_decoders(tool: &str) -> Vec<String> {
+    run_capability_probe(tool, "-decoders")
+        .map(|s| parse_hw_implementations(&s))
+        .unwrap_or_default()
+}
+
 /// Run the five fast `ffmpeg` capability probes concurrently using
 /// `rayon::join`. Each probe is independently bounded by
 /// `CAPABILITY_PROBE_TIMEOUT`. A failure on any non-codecs probe yields

--- a/plugins/ffmpeg-executor/src/probe.rs
+++ b/plugins/ffmpeg-executor/src/probe.rs
@@ -841,6 +841,24 @@ vainfo: Supported profile and entrypoint
         assert!(result.is_empty());
     }
 
+    #[test]
+    fn probe_capabilities_with_missing_tool_returns_empty_result() {
+        // Drive the full failure path: every probe will fail to spawn
+        // because the binary doesn't exist. We assert the contract the
+        // plugin's init() relies on: codecs is None (the disable signal),
+        // and the four secondary fields are empty.
+        let caps = super::probe_capabilities_with_tool("/nonexistent/ffmpeg-fake");
+
+        assert!(
+            caps.codecs.is_none(),
+            "missing tool must surface as codecs == None"
+        );
+        assert!(caps.formats.is_empty());
+        assert!(caps.hw_accels.is_empty());
+        assert!(caps.hw_encoders.is_empty());
+        assert!(caps.hw_decoders.is_empty());
+    }
+
     #[cfg(unix)]
     mod probe_helpers {
         use super::*;

--- a/plugins/ffmpeg-executor/src/probe.rs
+++ b/plugins/ffmpeg-executor/src/probe.rs
@@ -20,19 +20,19 @@ const TOOL_ENUMERATION_TIMEOUT: Duration = Duration::from_secs(10);
 /// and normally finish in under 200 ms; 5 s caps a pathological hang.
 const CAPABILITY_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// Aggregate result of running the five fast `ffmpeg` capability probes
+/// Aggregate result of running the fast `ffmpeg` capability probes
 /// concurrently.
 ///
-/// `codecs == None` means the `-codecs` probe failed (treated by the
-/// plugin as "ffmpeg not found / unusable"). The four secondary fields
-/// degrade independently to empty `Vec`s on probe failure, matching the
-/// pre-parallel sequential code path.
+/// `codecs == None` is the canonical "ffmpeg is unavailable" signal —
+/// callers should disable the plugin in that case. When `codecs` is
+/// `Some`, its `hw_encoders` and `hw_decoders` fields are populated from
+/// separate `-encoders` / `-decoders` probes. `formats` and `hw_accels`
+/// degrade independently to empty `Vec`s on probe failure, with a
+/// `tracing::warn!` recording the cause.
 pub struct FfmpegCapabilities {
     pub codecs: Option<CodecCapabilities>,
     pub formats: Vec<String>,
     pub hw_accels: Vec<String>,
-    pub hw_encoders: Vec<String>,
-    pub hw_decoders: Vec<String>,
 }
 
 /// Run a single `ffmpeg <flag> -hide_banner` probe and return its stdout
@@ -87,11 +87,8 @@ fn probe_hw_decoders(tool: &str) -> Vec<String> {
 
 /// Run the five fast `ffmpeg` capability probes concurrently using
 /// `rayon::join`. Each probe is independently bounded by
-/// `CAPABILITY_PROBE_TIMEOUT`. A failure on any non-codecs probe yields
-/// an empty `Vec` for that field, with a `tracing::warn!` recording why.
-///
-/// `codecs == None` is the canonical "ffmpeg is unavailable" signal —
-/// callers should disable the plugin in that case.
+/// `CAPABILITY_PROBE_TIMEOUT`; failures degrade to empty values with a
+/// `tracing::warn!` recording the cause.
 #[must_use]
 pub fn probe_capabilities() -> FfmpegCapabilities {
     probe_capabilities_with_tool("ffmpeg")
@@ -111,12 +108,16 @@ fn probe_capabilities_with_tool(tool: &str) -> FfmpegCapabilities {
         },
     );
 
+    let codecs = codecs.map(|mut c| {
+        c.hw_encoders = hw_encoders;
+        c.hw_decoders = hw_decoders;
+        c
+    });
+
     FfmpegCapabilities {
         codecs,
         formats,
         hw_accels,
-        hw_encoders,
-        hw_decoders,
     }
 }
 
@@ -907,8 +908,8 @@ vainfo: Supported profile and entrypoint
     fn probe_capabilities_with_missing_tool_returns_empty_result() {
         // Drive the full failure path: every probe will fail to spawn
         // because the binary doesn't exist. We assert the contract the
-        // plugin's init() relies on: codecs is None (the disable signal),
-        // and the four secondary fields are empty.
+        // plugin's init() relies on: codecs is None (the disable signal)
+        // and the secondary fields are empty.
         let caps = super::probe_capabilities_with_tool("/nonexistent/ffmpeg-fake");
 
         assert!(
@@ -917,8 +918,6 @@ vainfo: Supported profile and entrypoint
         );
         assert!(caps.formats.is_empty());
         assert!(caps.hw_accels.is_empty());
-        assert!(caps.hw_encoders.is_empty());
-        assert!(caps.hw_decoders.is_empty());
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary
- Replace the five sequential `ffmpeg -hide_banner` capability probes in `init()` with a single `probe_capabilities()` helper that fans them out via nested `rayon::join`.
- Each probe is individually bounded by a 5 s timeout via `voom_process::run_with_timeout`, closing the same hang-class that #168 closed for HW-encoder probes.
- Wall-clock cold start collapses from ~500-750 ms to roughly the slowest single probe (~150 ms).

Closes #169.

## Test plan
- [x] `cargo test -p voom-ffmpeg-executor` passes (includes new `probe_capabilities_with_missing_tool_returns_empty_result`).
- [x] `cargo test --workspace` passes.
- [x] `cargo test -p voom-cli --features functional` passes (122 tests).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.