### PR TITLE
fix(sqlite-store): clear orphan bad_files row in record_post_execution (#173)

### DIFF
--- a/crates/voom-cli/src/commands/process/mod.rs
+++ b/crates/voom-cli/src/commands/process/mod.rs
@@ -1463,9 +1463,9 @@ mod tests {
             Arc::new(voom_sqlite_store::store::SqliteStore::in_memory().unwrap());
         store.upsert_file(&file).unwrap();
 
-        // Pre-seed a bad_files row at the post-execution path. This simulates the
-        // FileIntrospectionFailed event that would have fired during re-introspection
-        // of the post-execution file (issue #173). The bundled rename must clear it.
+        // Pre-seed a bad_files row at the post-execution path, simulating the
+        // FileIntrospectionFailed event that fires when reintrospection fails.
+        // The bundled rename must clear it.
         let orphan = BadFile::new(
             mkv_path.clone(),
             2048,
@@ -1480,11 +1480,8 @@ mod tests {
         );
 
         let kernel = Arc::new(voom_kernel::Kernel::new());
-        // Force `reintrospect_file` onto its failure-fallback branch
-        // (pipeline.rs:555) by pointing at a nonexistent ffprobe binary.
-        // This is the exact code path issue #173 describes: re-introspection
-        // fails, the synthetic MediaFile carries the post-execution path, and
-        // the bundled rename must still clear the orphan bad_files row.
+        // Nonexistent ffprobe forces reintrospection onto its failure-fallback
+        // branch deterministically, regardless of $PATH.
         let ctx = ProcessContext {
             ffprobe_path: Some("/nonexistent/ffprobe"),
             ..fixture.make_ctx(kernel, store.clone())
@@ -1493,16 +1490,10 @@ mod tests {
         let new_file =
             pipeline::handle_plan_success(plan, &file, "mkvtoolnix-executor", 0, false, &ctx).await;
 
-        // Pin the test to the actual code path under review: confirm the
-        // returned MediaFile reflects the post-execution path so that
-        // `record_file_transition`'s `path_changed` guard fired and
-        // `record_post_execution` actually ran.
         assert_eq!(
             new_file.path, mkv_path,
             "handle_plan_success must return a MediaFile reflecting the post-execution path"
         );
-
-        // The orphan must be gone after the bundled post-execution write commits.
         assert!(
             store.bad_file_by_path(&mkv_path).unwrap().is_none(),
             "handle_plan_success must clear orphan bad_files row at post-execution path"

--- a/crates/voom-cli/src/commands/process/mod.rs
+++ b/crates/voom-cli/src/commands/process/mod.rs
@@ -1480,10 +1480,27 @@ mod tests {
         );
 
         let kernel = Arc::new(voom_kernel::Kernel::new());
-        let ctx = fixture.make_ctx(kernel, store.clone());
+        // Force `reintrospect_file` onto its failure-fallback branch
+        // (pipeline.rs:555) by pointing at a nonexistent ffprobe binary.
+        // This is the exact code path issue #173 describes: re-introspection
+        // fails, the synthetic MediaFile carries the post-execution path, and
+        // the bundled rename must still clear the orphan bad_files row.
+        let ctx = ProcessContext {
+            ffprobe_path: Some("/nonexistent/ffprobe"),
+            ..fixture.make_ctx(kernel, store.clone())
+        };
 
-        let _ =
+        let new_file =
             pipeline::handle_plan_success(plan, &file, "mkvtoolnix-executor", 0, false, &ctx).await;
+
+        // Pin the test to the actual code path under review: confirm the
+        // returned MediaFile reflects the post-execution path so that
+        // `record_file_transition`'s `path_changed` guard fired and
+        // `record_post_execution` actually ran.
+        assert_eq!(
+            new_file.path, mkv_path,
+            "handle_plan_success must return a MediaFile reflecting the post-execution path"
+        );
 
         // The orphan must be gone after the bundled post-execution write commits.
         assert!(

--- a/crates/voom-cli/src/commands/process/mod.rs
+++ b/crates/voom-cli/src/commands/process/mod.rs
@@ -1432,6 +1432,66 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn handle_plan_success_clears_orphan_bad_files_row_at_post_execution_path() {
+        use voom_domain::bad_file::{BadFile, BadFileSource};
+        use voom_domain::media::{Container, MediaFile};
+        use voom_domain::plan::{ActionParams, OperationType, Plan, PlannedAction};
+
+        let fixture =
+            TestFixture::with_policy(r#"policy "test" { phase convert { container mkv } }"#);
+        let mp4_path = fixture.dir_path().join("movie.mp4");
+        let mkv_path = fixture.dir_path().join("movie.mkv");
+        // Pre-write the target so `resolve_post_execution_path` accepts the new extension.
+        std::fs::write(&mkv_path, vec![0u8; 1024]).unwrap();
+
+        let mut file = MediaFile::new(mp4_path);
+        file.container = Container::Mp4;
+        file.size = 1024;
+        file.content_hash = Some("oldhash".to_string());
+
+        let mut plan = Plan::new(file.clone(), "containerize", "convert");
+        plan.actions = vec![PlannedAction::file_op(
+            OperationType::ConvertContainer,
+            ActionParams::Container {
+                container: Container::Mkv,
+            },
+            "Convert to mkv",
+        )];
+
+        let store: Arc<dyn voom_domain::storage::StorageTrait> =
+            Arc::new(voom_sqlite_store::store::SqliteStore::in_memory().unwrap());
+        store.upsert_file(&file).unwrap();
+
+        // Pre-seed a bad_files row at the post-execution path. This simulates the
+        // FileIntrospectionFailed event that would have fired during re-introspection
+        // of the post-execution file (issue #173). The bundled rename must clear it.
+        let orphan = BadFile::new(
+            mkv_path.clone(),
+            2048,
+            Some("post_exec_hash".into()),
+            "ffprobe failed: process exited with code 1".into(),
+            BadFileSource::Introspection,
+        );
+        store.upsert_bad_file(&orphan).unwrap();
+        assert!(
+            store.bad_file_by_path(&mkv_path).unwrap().is_some(),
+            "precondition: orphan bad_files row must exist before handle_plan_success"
+        );
+
+        let kernel = Arc::new(voom_kernel::Kernel::new());
+        let ctx = fixture.make_ctx(kernel, store.clone());
+
+        let _ =
+            pipeline::handle_plan_success(plan, &file, "mkvtoolnix-executor", 0, false, &ctx).await;
+
+        // The orphan must be gone after the bundled post-execution write commits.
+        assert!(
+            store.bad_file_by_path(&mkv_path).unwrap().is_none(),
+            "handle_plan_success must clear orphan bad_files row at post-execution path"
+        );
+    }
+
     #[test]
     fn record_file_transition_makes_history_lookup_work_for_old_and_new_paths() {
         // Bypass re-introspection (depends on ffprobe being on PATH) and

--- a/crates/voom-domain/src/storage.rs
+++ b/crates/voom-domain/src/storage.rs
@@ -167,6 +167,14 @@ pub trait FileStorage: Send + Sync {
     /// reconciliation distinguishes `NULL` (legacy / no fingerprint recorded)
     /// from a real hash, and an empty string would be misread as a real hash
     /// that never matches. Debug builds will assert.
+    ///
+    /// Implementations MUST also delete any `bad_files` row whose path
+    /// equals `transition.path` inside the same transaction. A successful
+    /// post-execution bundle means the file at the post-execution path is
+    /// no longer "bad" — symmetric with the cleanup `FileIntrospected`
+    /// performs. Without this, a re-introspection failure followed by a
+    /// successful bundle would leave an orphan `bad_files` row at the
+    /// same path as the renamed files row. See issue #173.
     fn record_post_execution(
         &self,
         new_path: Option<&Path>,

--- a/crates/voom-domain/src/storage.rs
+++ b/crates/voom-domain/src/storage.rs
@@ -174,7 +174,7 @@ pub trait FileStorage: Send + Sync {
     /// no longer "bad" — symmetric with the cleanup `FileIntrospected`
     /// performs. Without this, a re-introspection failure followed by a
     /// successful bundle would leave an orphan `bad_files` row at the
-    /// same path as the renamed files row. See issue #173.
+    /// same path as the renamed files row.
     fn record_post_execution(
         &self,
         new_path: Option<&Path>,

--- a/crates/voom-domain/src/test_support.rs
+++ b/crates/voom-domain/src/test_support.rs
@@ -237,9 +237,8 @@ impl FileStorage for InMemoryStore {
     /// In-memory stub. Unlike the SQLite implementation, this does NOT roll
     /// back partial mutations on error — the in-memory mutations have no
     /// fallible path. It also does NOT clear `bad_files` rows at the
-    /// post-execution path (the SQLite impl does this for issue #173 cleanup).
-    /// Tests that exercise rollback semantics or `bad_files` cleanup must use
-    /// `SqliteStore`.
+    /// post-execution path. Tests that exercise rollback semantics or
+    /// `bad_files` cleanup must use `SqliteStore`.
     fn record_post_execution(
         &self,
         new_path: Option<&Path>,

--- a/crates/voom-domain/src/test_support.rs
+++ b/crates/voom-domain/src/test_support.rs
@@ -236,7 +236,9 @@ impl FileStorage for InMemoryStore {
 
     /// In-memory stub. Unlike the SQLite implementation, this does NOT roll
     /// back partial mutations on error — the in-memory mutations have no
-    /// fallible path. Tests that exercise rollback semantics must use
+    /// fallible path. It also does NOT clear `bad_files` rows at the
+    /// post-execution path (the SQLite impl does this for issue #173 cleanup).
+    /// Tests that exercise rollback semantics or `bad_files` cleanup must use
     /// `SqliteStore`.
     fn record_post_execution(
         &self,

--- a/plugins/sqlite-store/src/store/bad_file_storage.rs
+++ b/plugins/sqlite-store/src/store/bad_file_storage.rs
@@ -9,6 +9,22 @@ use voom_domain::storage::{BadFileFilters, BadFileStorage};
 
 use super::{escape_like, row_to_bad_file, storage_err, OptionalExt, SqlQuery, SqliteStore};
 
+/// Delete the `bad_files` row at `path` using the supplied connection.
+/// Accepts any `&rusqlite::Connection`, including one obtained via `Deref`
+/// from an open `Transaction`, so callers can run the delete standalone or
+/// as part of a larger atomic bundle.
+pub(super) fn delete_bad_file_by_path_in_tx(
+    conn: &rusqlite::Connection,
+    path: &Path,
+) -> Result<()> {
+    conn.execute(
+        "DELETE FROM bad_files WHERE path = ?1",
+        params![path.to_string_lossy().to_string()],
+    )
+    .map_err(storage_err("failed to delete bad file by path"))?;
+    Ok(())
+}
+
 impl BadFileStorage for SqliteStore {
     /// Insert or update a bad file record.
     ///
@@ -124,12 +140,7 @@ impl BadFileStorage for SqliteStore {
 
     fn delete_bad_file_by_path(&self, path: &Path) -> Result<()> {
         let conn = self.conn()?;
-        conn.execute(
-            "DELETE FROM bad_files WHERE path = ?1",
-            params![path.to_string_lossy().to_string()],
-        )
-        .map_err(storage_err("failed to delete bad file by path"))?;
-        Ok(())
+        delete_bad_file_by_path_in_tx(&conn, path)
     }
 }
 

--- a/plugins/sqlite-store/src/store/file_storage.rs
+++ b/plugins/sqlite-store/src/store/file_storage.rs
@@ -428,15 +428,9 @@ impl FileStorage for SqliteStore {
             .map_err(storage_err("failed to update expected_hash in bundle"))?;
         }
 
-        // Symmetric with `handle_file_introspected`: a successful plan
-        // means there is no longer a bad file at the post-execution path.
-        // If re-introspection failed and dispatched FileIntrospectionFailed
-        // before this bundle ran, an orphan bad_files row may exist at
-        // `transition.path` — clear it inside the same transaction so the
-        // success/failure outcome is durable as a single unit. See issue #173.
-        let path_str = transition.path.to_string_lossy().to_string();
-        tx.execute("DELETE FROM bad_files WHERE path = ?1", params![path_str])
-            .map_err(storage_err("failed to clear bad_files row in bundle"))?;
+        // Symmetric with `handle_file_introspected`'s cleanup: a successful
+        // bundle means the file at `transition.path` is no longer "bad".
+        super::bad_file_storage::delete_bad_file_by_path_in_tx(&tx, &transition.path)?;
 
         tx.commit()
             .map_err(storage_err("failed to commit post-execution bundle"))?;
@@ -1701,11 +1695,9 @@ mod tests {
             .unwrap()
             .id;
 
-        // Simulate the buggy interleaving from issue #173: re-introspection
-        // dispatched FileIntrospectionFailed for the post-execution path,
-        // which inserted a bad_files row at /media/movie.mkv. The bundled
-        // post-execution write is now about to rename the files row to that
-        // same path — and must remove the orphan in the process.
+        // Pre-seed an orphan bad_files row at the post-execution path,
+        // simulating a prior FileIntrospectionFailed dispatch. The bundled
+        // rename must clear it.
         let orphan = BadFile::new(
             PathBuf::from("/media/movie.mkv"),
             2048,
@@ -1782,10 +1774,10 @@ mod tests {
         );
         store.upsert_bad_file(&orphan).unwrap();
 
-        // Pre-insert a transition with a known id, then try to record_post_execution
-        // with the same transition.id. The INSERT will violate the PK constraint
-        // and the entire bundle (rename + expected_hash + bad_files DELETE) must
-        // roll back, leaving the orphan bad_files row in place.
+        // Force the bundle's transition INSERT to fail by colliding on the
+        // primary key with a pre-existing row. All four bundle effects
+        // (rename, transition INSERT, expected_hash UPDATE, bad_files DELETE)
+        // must roll back together.
         let mut existing = FileTransition::new(
             original_id,
             PathBuf::from("/media/movie.mp4"),
@@ -1812,15 +1804,12 @@ mod tests {
         );
         assert!(result.is_err(), "duplicate transition id must error");
 
-        // Rollback verification: rename, expected_hash, and bad_files DELETE
-        // must all have been rolled back together. `upsert_file` does not
-        // persist `expected_hash`, so the pre-bundle value is `None`;
-        // without rollback we'd observe `Some("new_hash")` from the bundle's
-        // UPDATE.
         let still_at_old = store
             .file_by_path(Path::new("/media/movie.mp4"))
             .unwrap()
             .expect("rename must have been rolled back");
+        // `upsert_file` doesn't persist `expected_hash`, so the pre-bundle
+        // value is None; without rollback we'd observe Some("new_hash").
         assert_eq!(
             still_at_old.expected_hash, None,
             "expected_hash UPDATE must have been rolled back"

--- a/plugins/sqlite-store/src/store/file_storage.rs
+++ b/plugins/sqlite-store/src/store/file_storage.rs
@@ -428,6 +428,19 @@ impl FileStorage for SqliteStore {
             .map_err(storage_err("failed to update expected_hash in bundle"))?;
         }
 
+        // Symmetric with `handle_file_introspected`: a successful plan
+        // means there is no longer a bad file at the post-execution path.
+        // If re-introspection failed and dispatched FileIntrospectionFailed
+        // before this bundle ran, an orphan bad_files row may exist at
+        // `transition.path` — clear it inside the same transaction so the
+        // success/failure outcome is durable as a single unit. See issue #173.
+        let post_exec_path = transition.path.to_string_lossy().to_string();
+        tx.execute(
+            "DELETE FROM bad_files WHERE path = ?1",
+            params![post_exec_path],
+        )
+        .map_err(storage_err("failed to clear bad_files row in bundle"))?;
+
         tx.commit()
             .map_err(storage_err("failed to commit post-execution bundle"))?;
         Ok(())
@@ -1673,6 +1686,78 @@ mod tests {
             store.transitions_for_file(&original_id).unwrap().len(),
             1,
             "only the pre-existing transition should remain"
+        );
+    }
+
+    #[test]
+    fn record_post_execution_clears_orphan_bad_files_row_at_destination() {
+        use voom_domain::bad_file::{BadFile, BadFileSource};
+        use voom_domain::storage::BadFileStorage;
+        use voom_domain::transition::{FileTransition, TransitionSource};
+
+        let store = test_store();
+        let file = active_file("/media/movie.mp4");
+        store.upsert_file(&file).unwrap();
+        let original_id = store
+            .file_by_path(Path::new("/media/movie.mp4"))
+            .unwrap()
+            .unwrap()
+            .id;
+
+        // Simulate the buggy interleaving from issue #173: re-introspection
+        // dispatched FileIntrospectionFailed for the post-execution path,
+        // which inserted a bad_files row at /media/movie.mkv. The bundled
+        // post-execution write is now about to rename the files row to that
+        // same path — and must remove the orphan in the process.
+        let orphan = BadFile::new(
+            PathBuf::from("/media/movie.mkv"),
+            2048,
+            Some("post_exec_hash".into()),
+            "ffprobe failed: process exited with code 1".into(),
+            BadFileSource::Introspection,
+        );
+        store.upsert_bad_file(&orphan).unwrap();
+        assert!(
+            store
+                .bad_file_by_path(Path::new("/media/movie.mkv"))
+                .unwrap()
+                .is_some(),
+            "precondition: orphan bad_files row must exist before record_post_execution"
+        );
+
+        let transition = FileTransition::new(
+            original_id,
+            PathBuf::from("/media/movie.mkv"),
+            "new_hash".to_string(),
+            2048,
+            TransitionSource::Voom,
+        )
+        .with_from(Some("abc123".to_string()), Some(1024))
+        .with_from_path(PathBuf::from("/media/movie.mp4"));
+
+        store
+            .record_post_execution(
+                Some(Path::new("/media/movie.mkv")),
+                Some("new_hash"),
+                &transition,
+            )
+            .unwrap();
+
+        // Files row was renamed (existing assertion shape from the
+        // ..._atomically_writes_all_three test).
+        let renamed = store
+            .file_by_path(Path::new("/media/movie.mkv"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(renamed.id, original_id);
+
+        // The orphan bad_files row at the post-execution path must be gone.
+        assert!(
+            store
+                .bad_file_by_path(Path::new("/media/movie.mkv"))
+                .unwrap()
+                .is_none(),
+            "record_post_execution must clear orphan bad_files row at the post-execution path"
         );
     }
 

--- a/plugins/sqlite-store/src/store/file_storage.rs
+++ b/plugins/sqlite-store/src/store/file_storage.rs
@@ -1813,13 +1813,17 @@ mod tests {
         assert!(result.is_err(), "duplicate transition id must error");
 
         // Rollback verification: rename, expected_hash, and bad_files DELETE
-        // must all have been rolled back together.
-        assert!(
-            store
-                .file_by_path(Path::new("/media/movie.mp4"))
-                .unwrap()
-                .is_some(),
-            "rename must have been rolled back"
+        // must all have been rolled back together. `upsert_file` does not
+        // persist `expected_hash`, so the pre-bundle value is `None`;
+        // without rollback we'd observe `Some("new_hash")` from the bundle's
+        // UPDATE.
+        let still_at_old = store
+            .file_by_path(Path::new("/media/movie.mp4"))
+            .unwrap()
+            .expect("rename must have been rolled back");
+        assert_eq!(
+            still_at_old.expected_hash, None,
+            "expected_hash UPDATE must have been rolled back"
         );
         assert!(
             store

--- a/plugins/sqlite-store/src/store/file_storage.rs
+++ b/plugins/sqlite-store/src/store/file_storage.rs
@@ -434,12 +434,9 @@ impl FileStorage for SqliteStore {
         // before this bundle ran, an orphan bad_files row may exist at
         // `transition.path` — clear it inside the same transaction so the
         // success/failure outcome is durable as a single unit. See issue #173.
-        let post_exec_path = transition.path.to_string_lossy().to_string();
-        tx.execute(
-            "DELETE FROM bad_files WHERE path = ?1",
-            params![post_exec_path],
-        )
-        .map_err(storage_err("failed to clear bad_files row in bundle"))?;
+        let path_str = transition.path.to_string_lossy().to_string();
+        tx.execute("DELETE FROM bad_files WHERE path = ?1", params![path_str])
+            .map_err(storage_err("failed to clear bad_files row in bundle"))?;
 
         tx.commit()
             .map_err(storage_err("failed to commit post-execution bundle"))?;

--- a/plugins/sqlite-store/src/store/file_storage.rs
+++ b/plugins/sqlite-store/src/store/file_storage.rs
@@ -1759,6 +1759,78 @@ mod tests {
     }
 
     #[test]
+    fn record_post_execution_rollback_preserves_bad_files_row() {
+        use voom_domain::bad_file::{BadFile, BadFileSource};
+        use voom_domain::storage::{BadFileStorage, FileTransitionStorage};
+        use voom_domain::transition::{FileTransition, TransitionSource};
+
+        let store = test_store();
+        let file = active_file("/media/movie.mp4");
+        store.upsert_file(&file).unwrap();
+        let original_id = store
+            .file_by_path(Path::new("/media/movie.mp4"))
+            .unwrap()
+            .unwrap()
+            .id;
+
+        let orphan = BadFile::new(
+            PathBuf::from("/media/movie.mkv"),
+            2048,
+            Some("post_exec_hash".into()),
+            "ffprobe failed".into(),
+            BadFileSource::Introspection,
+        );
+        store.upsert_bad_file(&orphan).unwrap();
+
+        // Pre-insert a transition with a known id, then try to record_post_execution
+        // with the same transition.id. The INSERT will violate the PK constraint
+        // and the entire bundle (rename + expected_hash + bad_files DELETE) must
+        // roll back, leaving the orphan bad_files row in place.
+        let mut existing = FileTransition::new(
+            original_id,
+            PathBuf::from("/media/movie.mp4"),
+            "abc123".to_string(),
+            1024,
+            TransitionSource::Voom,
+        );
+        existing.id = uuid::Uuid::new_v4();
+        store.record_transition(&existing).unwrap();
+
+        let mut bundled = FileTransition::new(
+            original_id,
+            PathBuf::from("/media/movie.mkv"),
+            "new_hash".to_string(),
+            2048,
+            TransitionSource::Voom,
+        );
+        bundled.id = existing.id; // force a PK collision
+
+        let result = store.record_post_execution(
+            Some(Path::new("/media/movie.mkv")),
+            Some("new_hash"),
+            &bundled,
+        );
+        assert!(result.is_err(), "duplicate transition id must error");
+
+        // Rollback verification: rename, expected_hash, and bad_files DELETE
+        // must all have been rolled back together.
+        assert!(
+            store
+                .file_by_path(Path::new("/media/movie.mp4"))
+                .unwrap()
+                .is_some(),
+            "rename must have been rolled back"
+        );
+        assert!(
+            store
+                .bad_file_by_path(Path::new("/media/movie.mkv"))
+                .unwrap()
+                .is_some(),
+            "bad_files DELETE must have been rolled back"
+        );
+    }
+
+    #[test]
     fn reconcile_discovered_files_basic_new_file() {
         let store = test_store();
         let discovered = vec![voom_domain::transition::DiscoveredFile::new(


### PR DESCRIPTION
## Summary

- Extend `FileStorage::record_post_execution` to delete any `bad_files` row at `transition.path` inside the bundle's existing transaction, symmetric with `handle_file_introspected`'s cleanup.
- Fixes the orphan `bad_files` row issue #173 surfaced: when post-execution re-introspection failed, `FileIntrospectionFailed` inserted a `bad_files` row at the post-execution path, but the bundled rename then left a stale `bad_files` row alongside the now-active `files` row at the same path.
- Document the new contract on the trait and note the in-memory stub's deliberate divergence.
- Pre-existing edge case (no-change plans bypass `record_post_execution` via `record_file_transition`'s early return) tracked separately in #180.

## Test plan

- [x] `cargo test -p voom-sqlite-store` — new unit tests cover cleanup-on-success and rollback-on-error (rename, expected_hash, and bad_files DELETE all roll back together).
- [x] `cargo test -p voom-cli --bins` — new e2e test pins `handle_plan_success` to its failure-fallback branch (via `ffprobe_path: Some("/nonexistent/ffprobe")`) and asserts the orphan is cleared.
- [x] `cargo test --workspace` — full workspace, all green.
- [x] `cargo test -p voom-cli --features functional -- --test-threads=4` — full functional suite (536 tests), all green.
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.

Closes #173.