### PR TITLE
refactor(ffmpeg-executor): tighten probe.rs parser visibility (#179)

### DIFF
--- a/crates/voom-cli/src/commands/health.rs
+++ b/crates/voom-cli/src/commands/health.rs
@@ -4,7 +4,7 @@ use console::style;
 use voom_domain::storage::HealthCheckFilters;
 use voom_ffmpeg_executor::hwaccel::{resolve_hw_config, HwAccelBackend};
 use voom_ffmpeg_executor::probe::{
-    enumerate_gpus, parse_hw_implementations, parse_hwaccels, validate_hw_encoder,
+    enumerate_gpus, probe_hw_decoders, probe_hw_encoders, probe_hwaccels, validate_hw_encoder,
     validate_hw_encoder_on_device, GpuDevice,
 };
 
@@ -282,17 +282,8 @@ fn print_hw_accel_status(app_config: &config::AppConfig, ffmpeg_path: &std::path
     println!();
     println!("{}", style("Hardware acceleration:").bold());
 
-    let hwaccels_output = std::process::Command::new(ffmpeg_path)
-        .args(["-hwaccels", "-hide_banner"])
-        .output();
-
-    let hw_accels = match hwaccels_output {
-        Ok(output) => {
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            parse_hwaccels(&stdout)
-        }
-        Err(_) => return,
-    };
+    let ffmpeg = ffmpeg_path.to_string_lossy();
+    let hw_accels = probe_hwaccels(&ffmpeg);
 
     let hw_accel_override = app_config
         .plugin
@@ -315,24 +306,11 @@ fn print_hw_accel_status(app_config: &config::AppConfig, ffmpeg_path: &std::path
 
     print_configured_gpu(app_config, &devices);
 
-    let encoders_output = std::process::Command::new(ffmpeg_path)
-        .args(["-encoders", "-hide_banner"])
-        .output();
-    let decoders_output = std::process::Command::new(ffmpeg_path)
-        .args(["-decoders", "-hide_banner"])
-        .output();
+    let hw_encoders = probe_hw_encoders(&ffmpeg);
+    print_hw_encoders(&hw_encoders, &devices, backend);
 
-    if let Ok(output) = encoders_output {
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let hw_encoders = parse_hw_implementations(&stdout);
-        print_hw_encoders(&hw_encoders, &devices, backend);
-    }
-
-    if let Ok(output) = decoders_output {
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let hw_decoders = parse_hw_implementations(&stdout);
-        print_hw_decoders(&hw_decoders);
-    }
+    let hw_decoders = probe_hw_decoders(&ffmpeg);
+    print_hw_decoders(&hw_decoders);
 }
 
 fn history(

--- a/plugins/ffmpeg-executor/src/probe.rs
+++ b/plugins/ffmpeg-executor/src/probe.rs
@@ -67,19 +67,35 @@ fn probe_formats(tool: &str) -> Vec<String> {
         .unwrap_or_default()
 }
 
-fn probe_hwaccels(tool: &str) -> Vec<String> {
+/// Probe `tool` (an `ffmpeg` command name or path) for available hardware
+/// acceleration backend names via `-hwaccels`. Bounded by
+/// `CAPABILITY_PROBE_TIMEOUT`. Returns an empty `Vec` on spawn failure,
+/// non-zero exit, or timeout (logged via `tracing::warn!`); empty is also
+/// the legitimate "no HW backends" result, so the two are not
+/// distinguishable from the return value alone.
+#[must_use]
+pub fn probe_hwaccels(tool: &str) -> Vec<String> {
     run_capability_probe(tool, "-hwaccels")
         .map(|s| parse_hwaccels(&s))
         .unwrap_or_default()
 }
 
-fn probe_hw_encoders(tool: &str) -> Vec<String> {
+/// Probe `tool` for hardware-accelerated encoder names via `-encoders`,
+/// keeping only entries whose suffix matches a known HW backend
+/// (`_nvenc`, `_qsv`, `_vaapi`, etc.). See [`probe_hwaccels`] for the
+/// failure-mode contract.
+#[must_use]
+pub fn probe_hw_encoders(tool: &str) -> Vec<String> {
     run_capability_probe(tool, "-encoders")
         .map(|s| parse_hw_implementations(&s))
         .unwrap_or_default()
 }
 
-fn probe_hw_decoders(tool: &str) -> Vec<String> {
+/// Probe `tool` for hardware-accelerated decoder names via `-decoders`,
+/// keeping only entries whose suffix matches a known HW backend. See
+/// [`probe_hwaccels`] for the failure-mode contract.
+#[must_use]
+pub fn probe_hw_decoders(tool: &str) -> Vec<String> {
     run_capability_probe(tool, "-decoders")
         .map(|s| parse_hw_implementations(&s))
         .unwrap_or_default()
@@ -145,7 +161,7 @@ fn probe_tool_stdout(tool: &str, args: &[&str], timeout: Duration) -> Option<Vec
 /// Each codec line (after the `-------` separator) has flags in columns 0-5:
 /// `D` = decoding, `E` = encoding. The codec name follows after whitespace.
 #[must_use]
-pub fn parse_codecs(output: &str) -> CodecCapabilities {
+fn parse_codecs(output: &str) -> CodecCapabilities {
     let mut decoders = Vec::new();
     let mut encoders = Vec::new();
     let mut past_separator = false;
@@ -186,7 +202,7 @@ pub fn parse_codecs(output: &str) -> CodecCapabilities {
 /// Each format line (after the `-------` separator) has flags in columns 0-2:
 /// `D` = demux, `E` = mux. We collect any format that can be muxed or demuxed.
 #[must_use]
-pub fn parse_formats(output: &str) -> Vec<String> {
+fn parse_formats(output: &str) -> Vec<String> {
     let mut formats = Vec::new();
     let mut past_separator = false;
 
@@ -238,7 +254,7 @@ const HW_SUFFIXES: &[&str] = &[
 /// The format mirrors `-codecs`: a flag block, then a name, after a
 /// `------` separator.
 #[must_use]
-pub fn parse_hw_implementations(output: &str) -> Vec<String> {
+fn parse_hw_implementations(output: &str) -> Vec<String> {
     let mut result = Vec::new();
     let mut past_separator = false;
 
@@ -271,7 +287,7 @@ pub fn parse_hw_implementations(output: &str) -> Vec<String> {
 ///
 /// Lines after "Hardware acceleration methods:" are individual backend names.
 #[must_use]
-pub fn parse_hwaccels(output: &str) -> Vec<String> {
+fn parse_hwaccels(output: &str) -> Vec<String> {
     let mut accels = Vec::new();
     let mut past_header = false;
 
@@ -520,7 +536,7 @@ pub(crate) fn has_intel_gpu() -> bool {
 /// 1, Quadro RTX 4000, 8192
 /// ```
 #[must_use]
-pub fn parse_nvidia_smi(output: &str) -> Vec<GpuDevice> {
+fn parse_nvidia_smi(output: &str) -> Vec<GpuDevice> {
     let mut devices = Vec::new();
     for line in output.lines() {
         let line = line.trim();
@@ -545,7 +561,7 @@ pub fn parse_nvidia_smi(output: &str) -> Vec<GpuDevice> {
 /// Looks for a line like `Driver version: Intel iHD driver - 24.1.0`
 /// or `vainfo: Driver version: Mesa Gallium driver 23.3.1 ...`
 #[must_use]
-pub fn parse_vainfo_device_name(output: &str) -> Option<String> {
+fn parse_vainfo_device_name(output: &str) -> Option<String> {
     for line in output.lines() {
         if line.contains("Driver version") {
             let after_colon = line.rsplit(':').next()?.trim();


### PR DESCRIPTION
Closes #179.

## Summary
- Privatized the six `parse_*` helpers in `plugins/ffmpeg-executor/src/probe.rs` (`parse_codecs`, `parse_formats`, `parse_hw_implementations`, `parse_hwaccels`, `parse_nvidia_smi`, `parse_vainfo_device_name`). The over-broad `pub` was vestigial from before #169 wired `probe_capabilities()`.
- Promoted `probe_hwaccels`, `probe_hw_encoders`, `probe_hw_decoders` from private to `pub` (with docstrings + `#[must_use]` matching the file's other public-API conventions).
- Updated `crates/voom-cli/src/commands/health.rs::print_hw_accel_status` to call the new `pub probe_*` helpers instead of hand-rolling `Command::new(ffmpeg_path).args([...]).output()` + the now-private parsers. Side benefit: the new path picks up `CAPABILITY_PROBE_TIMEOUT` bounds that the original `Command::new` calls lacked.

The issue description originally claimed no external callers existed; verification turned up `voom-cli`'s health command using `parse_hw_implementations` and `parse_hwaccels` directly. The refactor above resolves that, letting all six parsers go private.

## Follow-up
Filed #182 to track parallelizing the three sequential `ffmpeg` subprocess calls in `print_hw_accel_status` — out of scope for this visibility-tightening change.

## Test plan
- [x] `cargo build`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace` (all green)
- [x] `cargo test -p voom-cli --features functional -- --test-threads=4` (118 functional tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)