### PR TITLE
fix(voom-cli): clear bad_files at post-execution path on no-change plans (#180)

### DIFF
--- a/crates/voom-cli/src/commands/process/mod.rs
+++ b/crates/voom-cli/src/commands/process/mod.rs
@@ -1500,6 +1500,95 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn handle_plan_success_clears_bad_files_row_when_plan_is_no_op_and_reintrospection_fails()
+    {
+        // Issue #180: when a plan executes "successfully" but produces no
+        // observable change (same path AND same hash), `record_file_transition`
+        // short-circuits (hash_changed=false, path_changed=false) before the
+        // bundled `record_post_execution` call can clear any `bad_files` row.
+        //
+        // This test simulates the orphan row that exists at the start of
+        // `handle_plan_success` (e.g. left by a previous failed scan or a
+        // re-introspection failure in a concurrent job) and verifies it is
+        // cleared even when the plan produces no observable change.
+        use voom_domain::bad_file::{BadFile, BadFileSource};
+        use voom_domain::media::{Container, MediaFile};
+        use voom_domain::plan::{ActionParams, OperationType, Plan, PlannedAction};
+
+        let fixture = TestFixture::with_policy(
+            r#"policy "test" { phase tag { defaults { audio: first } } }"#,
+        );
+        let path = fixture.dir_path().join("movie.mkv");
+        // Real bytes on disk so post-execution hashing succeeds and matches the
+        // pre-execution hash — that is what triggers the no-change short-circuit.
+        let payload = vec![7u8; 1024];
+        std::fs::write(&path, &payload).unwrap();
+        let known_hash = voom_discovery::hash_file(&path).unwrap();
+
+        let mut file = MediaFile::new(path.clone());
+        file.container = Container::Mkv;
+        file.size = u64::try_from(payload.len()).unwrap();
+        file.content_hash = Some(known_hash.clone());
+
+        // A track-op-only plan: same container, same path, no container
+        // conversion — `record_file_transition` will see hash_changed=false
+        // and path_changed=false and return early without calling
+        // `record_post_execution`.
+        let mut plan = Plan::new(file.clone(), "tag-defaults", "tag");
+        plan.actions = vec![PlannedAction::track_op(
+            OperationType::SetDefault,
+            0,
+            ActionParams::Empty,
+            "Mark first track default",
+        )];
+
+        let store: Arc<dyn voom_domain::storage::StorageTrait> =
+            Arc::new(voom_sqlite_store::store::SqliteStore::in_memory().unwrap());
+        store.upsert_file(&file).unwrap();
+
+        // Pre-seed a bad_files row at `path`, simulating the state that the
+        // bug leaves behind: a FileIntrospectionFailed event from a previous
+        // pass (or re-introspection failure) wrote a bad_files row, and the
+        // bundled cleanup in `record_post_execution` was never reached because
+        // `record_file_transition` short-circuited on the no-change check.
+        let orphan = BadFile::new(
+            path.clone(),
+            file.size,
+            file.content_hash.clone(),
+            "ffprobe failed: no such file".into(),
+            BadFileSource::Introspection,
+        );
+        store.upsert_bad_file(&orphan).unwrap();
+        assert!(
+            store.bad_file_by_path(&path).unwrap().is_some(),
+            "precondition: orphan bad_files row must exist before handle_plan_success"
+        );
+
+        let kernel = Arc::new(voom_kernel::Kernel::new());
+        let ctx = ProcessContext {
+            ffprobe_path: Some("/nonexistent/ffprobe"),
+            ..fixture.make_ctx(kernel, store.clone())
+        };
+
+        let new_file =
+            pipeline::handle_plan_success(plan, &file, "mkvtoolnix-executor", 0, false, &ctx).await;
+
+        assert_eq!(
+            new_file.path, path,
+            "no-op plan must leave the file path unchanged"
+        );
+        assert_eq!(
+            new_file.content_hash.as_deref(),
+            Some(known_hash.as_str()),
+            "no-op plan must leave the content hash unchanged (this is what triggers the short-circuit)"
+        );
+        assert!(
+            store.bad_file_by_path(&path).unwrap().is_none(),
+            "handle_plan_success must not leave an orphan bad_files row when the plan produces no observable change"
+        );
+    }
+
     #[test]
     fn record_file_transition_makes_history_lookup_work_for_old_and_new_paths() {
         // Bypass re-introspection (depends on ffprobe being on PATH) and

--- a/crates/voom-cli/src/commands/process/pipeline.rs
+++ b/crates/voom-cli/src/commands/process/pipeline.rs
@@ -452,6 +452,22 @@ pub(super) async fn handle_plan_success(
         ctx,
     });
 
+    // Defense-in-depth: clear any `bad_files` row at the post-execution
+    // path. The bundle in `record_post_execution` already does this for
+    // the path-change / hash-change paths atomically, but
+    // `record_file_transition` short-circuits when nothing changed
+    // (same path AND same hash), so the bundle never runs and an orphan
+    // row from a re-introspection failure (or stale scan-time failure)
+    // would persist. Idempotent — DELETE WHERE path = … is safe even
+    // when no row exists. See issue #180.
+    if let Err(e) = ctx.store.delete_bad_file_by_path(&new_file.path) {
+        tracing::warn!(
+            path = %new_file.path.display(),
+            error = %e,
+            "failed to clear bad_files row at post-execution path"
+        );
+    }
+
     new_file
 }
 

--- a/crates/voom-domain/src/storage.rs
+++ b/crates/voom-domain/src/storage.rs
@@ -172,9 +172,17 @@ pub trait FileStorage: Send + Sync {
     /// equals `transition.path` inside the same transaction. A successful
     /// post-execution bundle means the file at the post-execution path is
     /// no longer "bad" — symmetric with the cleanup `FileIntrospected`
-    /// performs. Without this, a re-introspection failure followed by a
-    /// successful bundle would leave an orphan `bad_files` row at the
-    /// same path as the renamed files row.
+    /// performs.
+    ///
+    /// This is one of two cleanup layers. The bundle's in-transaction
+    /// DELETE handles plans that change the file's path or content hash
+    /// (so the rename + transition INSERT + bad_files DELETE all commit
+    /// atomically). For no-change plans where `record_file_transition`
+    /// short-circuits before calling `record_post_execution`, the
+    /// orchestration in `handle_plan_success` performs an additional
+    /// idempotent DELETE on the post-execution path so an orphan row
+    /// (e.g. from a re-introspection failure) cannot survive a
+    /// successful plan. See issue #180.
     fn record_post_execution(
         &self,
         new_path: Option<&Path>,


### PR DESCRIPTION
## Summary

Closes #180.

When `handle_plan_success` runs for a plan that produced no observable change (same path AND same hash), `record_file_transition` early-returns at `crates/voom-cli/src/commands/process/transitions.rs:28-30` and the bundled `record_post_execution` cleanup never fires — leaving any orphan `bad_files` row at the file's path untouched (e.g. one inserted by a `FileIntrospectionFailed` event from the post-execution re-introspection step, or a stale row from a prior scan-time failure).

## Approach

Option A from the issue, with the bundle cleanup retained as defense-in-depth:

- Added an unconditional `ctx.store.delete_bad_file_by_path(&new_file.path)` call in `handle_plan_success` after `record_file_transition`. Idempotent — a no-op when the bundle already cleared the row, the actual cleanup when the bundle short-circuited.
- Bundle's in-transaction DELETE in `record_post_execution` is unchanged. The two layers now cover both the path/hash-change paths (atomic with rename + transition INSERT) and the no-change short-circuit path (post-bundle backstop).
- Updated the `FileStorage::record_post_execution` doc to describe both layers.

The implementation is the 16-line block in `pipeline.rs`. The rest of the diff is the regression test and the contract doc update.

## Test plan

- [x] New regression test `handle_plan_success_clears_bad_files_row_when_plan_is_no_op_and_reintrospection_fails` fails on parent commit, passes on this branch.
- [x] `cargo test -p voom-cli --lib handle_plan_success` — all 3 tests pass (no regression on the existing post-execution-path cleanup test).
- [x] `cargo test --workspace` passes.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` is clean.
- [x] `cargo fmt --all -- --check` is clean.
- [x] `cargo test -p voom-cli --features functional -- --test-threads=4` — 118 functional + 4 pipeline integration tests pass, including `process_skips_reintrospection_when_unchanged`.