### PR TITLE
perf(voom-cli): parallelize ffmpeg HW probes in health check

### DIFF
--- a/crates/voom-cli/src/commands/health.rs
+++ b/crates/voom-cli/src/commands/health.rs
@@ -4,8 +4,8 @@ use console::style;
 use voom_domain::storage::HealthCheckFilters;
 use voom_ffmpeg_executor::hwaccel::{resolve_hw_config, HwAccelBackend};
 use voom_ffmpeg_executor::probe::{
-    enumerate_gpus, probe_hw_decoders, probe_hw_encoders, probe_hwaccels, validate_hw_encoder,
-    validate_hw_encoder_on_device, GpuDevice,
+    probe_hw_details, probe_hwaccels, validate_hw_encoder, validate_hw_encoder_on_device,
+    GpuDevice, HwDetails,
 };
 
 use crate::app;
@@ -295,7 +295,12 @@ fn print_hw_accel_status(app_config: &config::AppConfig, ffmpeg_path: &std::path
         return;
     };
 
-    let devices = enumerate_gpus(backend);
+    let HwDetails {
+        encoders,
+        decoders,
+        devices,
+    } = probe_hw_details(&ffmpeg, backend);
+
     if !devices.is_empty() {
         println!();
         println!("  {}:", gpu_section_header(backend));
@@ -305,12 +310,8 @@ fn print_hw_accel_status(app_config: &config::AppConfig, ffmpeg_path: &std::path
     }
 
     print_configured_gpu(app_config, &devices);
-
-    let hw_encoders = probe_hw_encoders(&ffmpeg);
-    print_hw_encoders(&hw_encoders, &devices, backend);
-
-    let hw_decoders = probe_hw_decoders(&ffmpeg);
-    print_hw_decoders(&hw_decoders);
+    print_hw_encoders(&encoders, &devices, backend);
+    print_hw_decoders(&decoders);
 }
 
 fn history(

--- a/plugins/ffmpeg-executor/src/probe.rs
+++ b/plugins/ffmpeg-executor/src/probe.rs
@@ -137,6 +137,34 @@ fn probe_capabilities_with_tool(tool: &str) -> FfmpegCapabilities {
     }
 }
 
+/// Aggregate result of [`probe_hw_details`].
+///
+/// `encoders` and `decoders` come from `-encoders` / `-decoders` ffmpeg
+/// probes and degrade to empty `Vec`s on probe failure. `devices`
+/// follows the per-backend [`enumerate_gpus`] contract (e.g. always
+/// non-empty for `Videotoolbox`, dependent on `nvidia-smi` / `vainfo`
+/// availability for the others).
+pub struct HwDetails {
+    pub encoders: Vec<String>,
+    pub decoders: Vec<String>,
+    pub devices: Vec<GpuDevice>,
+}
+
+/// Run [`probe_hw_encoders`], [`probe_hw_decoders`], and
+/// [`enumerate_gpus`] concurrently using nested `rayon::join`.
+#[must_use]
+pub fn probe_hw_details(tool: &str, backend: HwAccelBackend) -> HwDetails {
+    let ((encoders, decoders), devices) = rayon::join(
+        || rayon::join(|| probe_hw_encoders(tool), || probe_hw_decoders(tool)),
+        || enumerate_gpus(backend),
+    );
+    HwDetails {
+        encoders,
+        decoders,
+        devices,
+    }
+}
+
 /// Run `tool` with `args` and `env`, returning `true` only if it exits 0
 /// before `timeout`. Spawn errors, non-zero exits, and timeouts all yield
 /// `false`. Pass `&[]` for `env` when no extra variables are needed.
@@ -918,6 +946,17 @@ vainfo: Supported profile and entrypoint
         let input: Vec<String> = vec!["a".into(), "b".into(), "c".into()];
         let result = validate_hw_encoders_parallel(&input, |_| false);
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn probe_hw_details_with_missing_tool_returns_empty_lists() {
+        // `devices` is intentionally not asserted: enumerate_gpus follows
+        // a different contract (Videotoolbox returns a hardcoded entry).
+        let details =
+            super::probe_hw_details("/nonexistent/ffmpeg-fake", HwAccelBackend::Videotoolbox);
+
+        assert!(details.encoders.is_empty());
+        assert!(details.decoders.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds `HwDetails` + `probe_hw_details(tool, backend)` in `voom-ffmpeg-executor` that runs `probe_hw_encoders`, `probe_hw_decoders`, and `enumerate_gpus` concurrently via nested `rayon::join`, mirroring the existing pattern in `probe_capabilities_with_tool`.
- Refactors `print_hw_accel_status` in `voom-cli` to use the new helper, replacing three sequential ffmpeg subprocess calls with one parallel batch. Each individual probe costs ~150–300 ms; on a HW-equipped system the wall-clock time for that section drops to ~1× sequential instead of ~3×.
- `probe_hwaccels` stays sequential — it gates the early return for no-HW systems, so parallelizing it is a separate tradeoff (tracked in #187).

Closes #182.

## Design notes

- **Conservative shape, not speculative.** Probes only run after `print_hw_backend` confirms a backend is present, so no-HW systems pay nothing extra.
- **Helper lives in `voom-ffmpeg-executor`, not `voom-cli`.** That crate already uses `rayon` heavily; keeping the parallel-probe primitive there avoids adding `rayon` as a direct dependency of `voom-cli` and makes the helper reusable (e.g. for a future `/health` web endpoint).

## Follow-ups filed during review

- #185 — per-device `validate_hw_encoder_on_device` calls in `print_encoder_block` are sequential (~24 encoders × N devices × 5 s timeout each); larger sequential cost than the three probes parallelized here.
- #186 — `enumerate_vaapi_devices` runs `vainfo` serially per render node.
- #187 — folding `probe_hwaccels` into the same parallel batch (speculative-vs-conservative tradeoff).

## Test plan

- [x] `cargo build`
- [x] `cargo test -p voom-ffmpeg-executor` (147 passed, including new `probe_hw_details_with_missing_tool_returns_empty_lists`)
- [x] `cargo test --workspace` (all suites pass, 0 failures)
- [x] `cargo test -p voom-cli --features functional -- --test-threads=4` (537 passed, 0 failed)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] `cargo fmt --all -- --check` clean
- [ ] Manual smoke: `cargo run -- health check` on a system with ffmpeg present

🤖 Generated with [Claude Code](https://claude.com/claude-code)