### PR TITLE
perf(voom-cli): parallelize per-device HW encoder validation (#185)

### DIFF
--- a/crates/voom-cli/src/commands/health.rs
+++ b/crates/voom-cli/src/commands/health.rs
@@ -5,7 +5,7 @@ use voom_domain::storage::HealthCheckFilters;
 use voom_ffmpeg_executor::hwaccel::{resolve_hw_config, HwAccelBackend};
 use voom_ffmpeg_executor::probe::{
     probe_hw_details, probe_hwaccels, validate_hw_encoder, validate_hw_encoder_on_device,
-    GpuDevice, HwDetails,
+    validate_hw_encoders_parallel_with_status, GpuDevice, HwDetails,
 };
 
 use crate::app;
@@ -176,8 +176,11 @@ fn print_encoder_block(hw_encoders: &[String], backend: HwAccelBackend, device: 
     let label = encoder_block_label(device, backend);
     println!();
     println!("  HW Encoders ({label}):");
-    for enc in hw_encoders {
-        if validate_hw_encoder_on_device(enc, backend, device) {
+    let results = validate_hw_encoders_parallel_with_status(hw_encoders, |enc| {
+        validate_hw_encoder_on_device(enc, backend, device)
+    });
+    for (enc, ok) in results {
+        if ok {
             println!("    {:<20}{}", enc, style("OK (device validated)").green());
         } else {
             println!("    {:<20}{}", enc, style("UNSUPPORTED").yellow());

--- a/plugins/ffmpeg-executor/src/probe.rs
+++ b/plugins/ffmpeg-executor/src/probe.rs
@@ -1016,6 +1016,20 @@ vainfo: Supported profile and entrypoint
     }
 
     #[test]
+    fn test_validate_hw_encoders_parallel_with_status_all_accepted() {
+        let input: Vec<String> = vec!["a".into(), "b".into(), "c".into()];
+        let result = validate_hw_encoders_parallel_with_status(&input, |_| true);
+        assert_eq!(
+            result,
+            vec![
+                ("a".to_string(), true),
+                ("b".to_string(), true),
+                ("c".to_string(), true),
+            ],
+        );
+    }
+
+    #[test]
     fn probe_hw_details_with_missing_tool_returns_empty_lists() {
         // `devices` is intentionally not asserted: enumerate_gpus follows
         // a different contract (Videotoolbox returns a hardcoded entry).

--- a/plugins/ffmpeg-executor/src/probe.rs
+++ b/plugins/ffmpeg-executor/src/probe.rs
@@ -355,6 +355,28 @@ where
         .collect()
 }
 
+/// Run an encoder validator across all candidates in parallel, returning
+/// `(name, ok)` pairs in source order.
+///
+/// Same parallelization rationale as [`validate_hw_encoders_parallel`], but
+/// keeps both passing and failing entries so callers can render per-encoder
+/// status (e.g. `OK` vs `UNSUPPORTED`) instead of a filtered list.
+///
+/// `par_iter().map().collect()` preserves the source order of `encoders`,
+/// which keeps grouped output deterministic.
+pub fn validate_hw_encoders_parallel_with_status<F>(
+    encoders: &[String],
+    validator: F,
+) -> Vec<(String, bool)>
+where
+    F: Fn(&str) -> bool + Sync,
+{
+    encoders
+        .par_iter()
+        .map(|enc| (enc.clone(), validator(enc.as_str())))
+        .collect()
+}
+
 /// Test whether an ffmpeg HW encoder actually works on the current device.
 ///
 /// Tries to encode a single frame from a synthetic source. Returns `false`
@@ -946,6 +968,51 @@ vainfo: Supported profile and entrypoint
         let input: Vec<String> = vec!["a".into(), "b".into(), "c".into()];
         let result = validate_hw_encoders_parallel(&input, |_| false);
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_validate_hw_encoders_parallel_with_status_preserves_order() {
+        let input: Vec<String> = vec![
+            "av1_nvenc".into(),
+            "h264_nvenc".into(),
+            "av1_qsv".into(),
+            "hevc_nvenc".into(),
+            "vp9_qsv".into(),
+        ];
+        let result =
+            validate_hw_encoders_parallel_with_status(&input, |name| name.ends_with("_nvenc"));
+        assert_eq!(
+            result,
+            vec![
+                ("av1_nvenc".to_string(), true),
+                ("h264_nvenc".to_string(), true),
+                ("av1_qsv".to_string(), false),
+                ("hevc_nvenc".to_string(), true),
+                ("vp9_qsv".to_string(), false),
+            ],
+            "with_status must preserve source order even when run in parallel"
+        );
+    }
+
+    #[test]
+    fn test_validate_hw_encoders_parallel_with_status_empty_input() {
+        let input: Vec<String> = Vec::new();
+        let result = validate_hw_encoders_parallel_with_status(&input, |_| true);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_validate_hw_encoders_parallel_with_status_all_rejected() {
+        let input: Vec<String> = vec!["a".into(), "b".into(), "c".into()];
+        let result = validate_hw_encoders_parallel_with_status(&input, |_| false);
+        assert_eq!(
+            result,
+            vec![
+                ("a".to_string(), false),
+                ("b".to_string(), false),
+                ("c".to_string(), false),
+            ],
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `validate_hw_encoders_parallel_with_status` to `voom-ffmpeg-executor` — parallel sibling of `validate_hw_encoders_parallel` that returns `(name, ok)` pairs in source order.
- Use it from `print_encoder_block` so per-device candidate validation runs on rayon's pool instead of sequentially spawning one ffmpeg per encoder.
- Outer device loop stays sequential — grouped output remains deterministic.

Closes #185.

## Test plan
- [x] `cargo test -p voom-ffmpeg-executor probe::tests::test_validate_hw_encoders_parallel` (7 tests, all pass)
- [x] `cargo test` (full workspace)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` (clean)
- [x] `cargo fmt --all -- --check` (clean)
- [x] `cargo test -p voom-cli --features functional -- --test-threads=4` (118 + 4 functional tests pass)
- [ ] Manual: `cargo run -- health check` on a host with an HW backend; encoder lines within a device block appear in source order.