### PR TITLE
perf(voom-cli/health): parallelize probe_hwaccels with the post-detection probes

### DIFF
--- a/crates/voom-cli/src/commands/health.rs
+++ b/crates/voom-cli/src/commands/health.rs
@@ -4,8 +4,8 @@ use console::style;
 use voom_domain::storage::HealthCheckFilters;
 use voom_ffmpeg_executor::hwaccel::{resolve_hw_config, HwAccelBackend};
 use voom_ffmpeg_executor::probe::{
-    probe_hw_details, probe_hwaccels, validate_hw_encoder, validate_hw_encoder_on_device,
-    validate_hw_encoders_parallel_with_status, GpuDevice, HwDetails,
+    enumerate_gpus, probe_hw_capabilities, validate_hw_encoder, validate_hw_encoder_on_device,
+    validate_hw_encoders_parallel_with_status, GpuDevice, HwCapabilities,
 };
 
 use crate::app;
@@ -286,7 +286,11 @@ fn print_hw_accel_status(app_config: &config::AppConfig, ffmpeg_path: &std::path
     println!("{}", style("Hardware acceleration:").bold());
 
     let ffmpeg = ffmpeg_path.to_string_lossy();
-    let hw_accels = probe_hwaccels(&ffmpeg);
+    let HwCapabilities {
+        hw_accels,
+        encoders,
+        decoders,
+    } = probe_hw_capabilities(&ffmpeg);
 
     let hw_accel_override = app_config
         .plugin
@@ -298,11 +302,7 @@ fn print_hw_accel_status(app_config: &config::AppConfig, ffmpeg_path: &std::path
         return;
     };
 
-    let HwDetails {
-        encoders,
-        decoders,
-        devices,
-    } = probe_hw_details(&ffmpeg, backend);
+    let devices = enumerate_gpus(backend);
 
     if !devices.is_empty() {
         println!();

--- a/plugins/ffmpeg-executor/src/probe.rs
+++ b/plugins/ffmpeg-executor/src/probe.rs
@@ -114,26 +114,21 @@ pub fn probe_capabilities() -> FfmpegCapabilities {
 /// tool path. Lets tests drive the failure path with a non-existent
 /// binary without manipulating `PATH`.
 fn probe_capabilities_with_tool(tool: &str) -> FfmpegCapabilities {
-    let ((codecs, formats), (hw_accels, (hw_encoders, hw_decoders))) = rayon::join(
+    let ((codecs, formats), hw) = rayon::join(
         || rayon::join(|| probe_codecs(tool), || probe_formats(tool)),
-        || {
-            rayon::join(
-                || probe_hwaccels(tool),
-                || rayon::join(|| probe_hw_encoders(tool), || probe_hw_decoders(tool)),
-            )
-        },
+        || probe_hw_capabilities(tool),
     );
 
     let codecs = codecs.map(|mut c| {
-        c.hw_encoders = hw_encoders;
-        c.hw_decoders = hw_decoders;
+        c.hw_encoders = hw.encoders;
+        c.hw_decoders = hw.decoders;
         c
     });
 
     FfmpegCapabilities {
         codecs,
         formats,
-        hw_accels,
+        hw_accels: hw.hw_accels,
     }
 }
 
@@ -141,9 +136,7 @@ fn probe_capabilities_with_tool(tool: &str) -> FfmpegCapabilities {
 ///
 /// All three fields degrade independently to empty `Vec`s on probe
 /// failure (spawn error, non-zero exit, or timeout), with a
-/// `tracing::warn!` recording the cause. The caller derives the active
-/// HW backend from `hw_accels` and applies any early-return gate after
-/// the parallel block has completed.
+/// `tracing::warn!` recording the cause.
 pub struct HwCapabilities {
     pub hw_accels: Vec<String>,
     pub encoders: Vec<String>,
@@ -1071,19 +1064,16 @@ vainfo: Supported profile and entrypoint
 
     #[test]
     fn probe_hw_capabilities_returns_promptly_under_failure_path() {
-        // Three failed spawns of a non-existent binary should each
-        // return in <100 ms. Run sequentially that's <300 ms; in
-        // parallel it's <100 ms. The 500 ms ceiling is the smallest
-        // budget that still catches a regression to serial dispatch
-        // on a slow CI host while remaining stable across runs.
-        use std::time::Instant;
-        let started = Instant::now();
+        // Smallest budget that still catches a regression to serial
+        // dispatch while remaining stable on slow CI runners.
+        const BUDGET: Duration = Duration::from_millis(500);
+        let started = std::time::Instant::now();
         let _ = super::probe_hw_capabilities("/nonexistent/ffmpeg-fake");
         let elapsed = started.elapsed();
         assert!(
-            elapsed < std::time::Duration::from_millis(500),
+            elapsed < BUDGET,
             "probe_hw_capabilities took {elapsed:?} on the failure path; \
-             expected <500 ms — regression to serial dispatch?"
+             expected <{BUDGET:?} — regression to serial dispatch?"
         );
     }
 

--- a/plugins/ffmpeg-executor/src/probe.rs
+++ b/plugins/ffmpeg-executor/src/probe.rs
@@ -171,34 +171,6 @@ pub fn probe_hw_capabilities(tool: &str) -> HwCapabilities {
     }
 }
 
-/// Aggregate result of [`probe_hw_details`].
-///
-/// `encoders` and `decoders` come from `-encoders` / `-decoders` ffmpeg
-/// probes and degrade to empty `Vec`s on probe failure. `devices`
-/// follows the per-backend [`enumerate_gpus`] contract (e.g. always
-/// non-empty for `Videotoolbox`, dependent on `nvidia-smi` / `vainfo`
-/// availability for the others).
-pub struct HwDetails {
-    pub encoders: Vec<String>,
-    pub decoders: Vec<String>,
-    pub devices: Vec<GpuDevice>,
-}
-
-/// Run [`probe_hw_encoders`], [`probe_hw_decoders`], and
-/// [`enumerate_gpus`] concurrently using nested `rayon::join`.
-#[must_use]
-pub fn probe_hw_details(tool: &str, backend: HwAccelBackend) -> HwDetails {
-    let ((encoders, decoders), devices) = rayon::join(
-        || rayon::join(|| probe_hw_encoders(tool), || probe_hw_decoders(tool)),
-        || enumerate_gpus(backend),
-    );
-    HwDetails {
-        encoders,
-        decoders,
-        devices,
-    }
-}
-
 /// Run `tool` with `args` and `env`, returning `true` only if it exits 0
 /// before `timeout`. Spawn errors, non-zero exits, and timeouts all yield
 /// `false`. Pass `&[]` for `env` when no extra variables are needed.
@@ -1087,17 +1059,6 @@ vainfo: Supported profile and entrypoint
                 ("c".to_string(), true),
             ],
         );
-    }
-
-    #[test]
-    fn probe_hw_details_with_missing_tool_returns_empty_lists() {
-        // `devices` is intentionally not asserted: enumerate_gpus follows
-        // a different contract (Videotoolbox returns a hardcoded entry).
-        let details =
-            super::probe_hw_details("/nonexistent/ffmpeg-fake", HwAccelBackend::Videotoolbox);
-
-        assert!(details.encoders.is_empty());
-        assert!(details.decoders.is_empty());
     }
 
     #[test]

--- a/plugins/ffmpeg-executor/src/probe.rs
+++ b/plugins/ffmpeg-executor/src/probe.rs
@@ -1070,6 +1070,24 @@ vainfo: Supported profile and entrypoint
     }
 
     #[test]
+    fn probe_hw_capabilities_returns_promptly_under_failure_path() {
+        // Three failed spawns of a non-existent binary should each
+        // return in <100 ms. Run sequentially that's <300 ms; in
+        // parallel it's <100 ms. The 500 ms ceiling is the smallest
+        // budget that still catches a regression to serial dispatch
+        // on a slow CI host while remaining stable across runs.
+        use std::time::Instant;
+        let started = Instant::now();
+        let _ = super::probe_hw_capabilities("/nonexistent/ffmpeg-fake");
+        let elapsed = started.elapsed();
+        assert!(
+            elapsed < std::time::Duration::from_millis(500),
+            "probe_hw_capabilities took {elapsed:?} on the failure path; \
+             expected <500 ms — regression to serial dispatch?"
+        );
+    }
+
+    #[test]
     fn probe_capabilities_with_missing_tool_returns_empty_result() {
         // Drive the full failure path: every probe will fail to spawn
         // because the binary doesn't exist. We assert the contract the

--- a/plugins/ffmpeg-executor/src/probe.rs
+++ b/plugins/ffmpeg-executor/src/probe.rs
@@ -137,6 +137,40 @@ fn probe_capabilities_with_tool(tool: &str) -> FfmpegCapabilities {
     }
 }
 
+/// Aggregate result of [`probe_hw_capabilities`].
+///
+/// All three fields degrade independently to empty `Vec`s on probe
+/// failure (spawn error, non-zero exit, or timeout), with a
+/// `tracing::warn!` recording the cause. The caller derives the active
+/// HW backend from `hw_accels` and applies any early-return gate after
+/// the parallel block has completed.
+pub struct HwCapabilities {
+    pub hw_accels: Vec<String>,
+    pub encoders: Vec<String>,
+    pub decoders: Vec<String>,
+}
+
+/// Run [`probe_hwaccels`], [`probe_hw_encoders`], and
+/// [`probe_hw_decoders`] concurrently using nested `rayon::join`.
+///
+/// Each probe is independently bounded by `CAPABILITY_PROBE_TIMEOUT`;
+/// the three calls run on rayon's pool so the wall-clock cost is
+/// roughly one probe instead of three. GPU device enumeration is *not*
+/// part of this bundle: it depends on the resolved backend and is the
+/// caller's responsibility (see [`enumerate_gpus`]).
+#[must_use]
+pub fn probe_hw_capabilities(tool: &str) -> HwCapabilities {
+    let (hw_accels, (encoders, decoders)) = rayon::join(
+        || probe_hwaccels(tool),
+        || rayon::join(|| probe_hw_encoders(tool), || probe_hw_decoders(tool)),
+    );
+    HwCapabilities {
+        hw_accels,
+        encoders,
+        decoders,
+    }
+}
+
 /// Aggregate result of [`probe_hw_details`].
 ///
 /// `encoders` and `decoders` come from `-encoders` / `-decoders` ffmpeg
@@ -1064,6 +1098,14 @@ vainfo: Supported profile and entrypoint
 
         assert!(details.encoders.is_empty());
         assert!(details.decoders.is_empty());
+    }
+
+    #[test]
+    fn probe_hw_capabilities_with_missing_tool_returns_empty_lists() {
+        let caps = super::probe_hw_capabilities("/nonexistent/ffmpeg-fake");
+        assert!(caps.hw_accels.is_empty());
+        assert!(caps.encoders.is_empty());
+        assert!(caps.decoders.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Closes #187.

## Summary

- Folds `probe_hwaccels` into the existing parallel HW-probe join via a new `probe_hw_capabilities(tool) -> HwCapabilities` helper that runs hwaccels, encoders, and decoders concurrently on rayon's pool.
- Moves the no-HW early-return gate in `print_hw_accel_status` from before the probes to after, accepting 2 wasted ffmpeg spawns on no-HW systems in exchange for ~150–300 ms saved on every HW-equipped run.
- Removes the now-orphaned `probe_hw_details` and `HwDetails` per the project's "Replace, don't deprecate" rule.

## Approach

This is the conservative half of the speculative-vs-conservative tradeoff the issue asks us to revisit. `enumerate_gpus(backend)` stays serial after backend resolution because it depends on which backend the resolver picked; running every backend's enumerator speculatively is left for a follow-up if measurement shows it warrants the complexity.

## Test plan

- [x] `cargo fmt --all -- --check` (no diff)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test` (full workspace unit/integration suite — 0 failures)
- [x] `cargo test -p voom-cli --features functional` (537 tests, 0 failures)
- [x] Manual `voom health check` smoke test on macOS (VideoToolbox backend) — output rendering identical to pre-change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>