### PR TITLE
fix(events): paginate via since_rowid so --limit is fully honored (#192)

### DIFF
--- a/crates/voom-cli/src/cli.rs
+++ b/crates/voom-cli/src/cli.rs
@@ -607,7 +607,8 @@ pub struct EventsArgs {
     #[arg(short, long, default_value = "table")]
     pub format: OutputFormat,
 
-    /// Maximum events to display
+    /// Maximum events to display. Values above 10,000 are fetched from
+    /// storage in pages of 10,000 and streamed to stdout.
     #[arg(short = 'n', long, default_value = "50")]
     pub limit: u32,
 }

--- a/crates/voom-cli/src/commands/events.rs
+++ b/crates/voom-cli/src/commands/events.rs
@@ -6,6 +6,55 @@ use crate::app;
 use crate::cli::{EventsArgs, OutputFormat};
 use crate::config;
 
+/// Storage clamps `list_event_log` to 10_000 rows per call; we use the same
+/// chunk size so a single call returns either everything matching or a full
+/// page that we can advance past via `since_rowid`.
+// `dead_code` allow lifts once `run` is wired up to use the helper (issue #192, task 3).
+#[allow(dead_code)]
+const EVENT_LOG_PAGE_SIZE: u32 = 10_000;
+
+/// Page through the event log via `since_rowid`, invoking `f` on each record
+/// in order, until either `max_total` records have been emitted or storage
+/// returns fewer than `EVENT_LOG_PAGE_SIZE` rows (i.e., the table is drained).
+// `dead_code` allow lifts once `run` is wired up to use the helper (issue #192, task 3).
+#[allow(dead_code)]
+fn fetch_paginated(
+    store: &std::sync::Arc<dyn voom_domain::storage::StorageTrait>,
+    base_filters: &EventLogFilters,
+    max_total: u32,
+    mut f: impl FnMut(&voom_domain::storage::EventLogRecord) -> Result<()>,
+) -> Result<()> {
+    let mut emitted: u32 = 0;
+    let mut since_rowid: i64 = base_filters.since_rowid.unwrap_or(0);
+
+    while emitted < max_total {
+        let mut page_filters = base_filters.clone();
+        page_filters.since_rowid = Some(since_rowid);
+        let remaining = max_total - emitted;
+        let page_size = remaining.min(EVENT_LOG_PAGE_SIZE);
+        page_filters.limit = Some(page_size);
+
+        let page = store.list_event_log(&page_filters)?;
+        let page_len = page.len() as u32;
+
+        for record in &page {
+            f(record)?;
+            since_rowid = since_rowid.max(record.rowid);
+            emitted += 1;
+            if emitted >= max_total {
+                break;
+            }
+        }
+
+        // Storage returned fewer rows than the page size — we've drained the table.
+        if page_len < page_size {
+            break;
+        }
+    }
+
+    Ok(())
+}
+
 pub async fn run(args: EventsArgs, token: CancellationToken) -> Result<()> {
     let config = config::load_config().unwrap_or_default();
     let store = app::open_store(&config)?;
@@ -135,5 +184,67 @@ fn print_follow_row(format: OutputFormat, r: &voom_domain::storage::EventLogReco
                 r.summary,
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use voom_domain::storage::{EventLogRecord, EventLogStorage};
+    use voom_domain::test_support::InMemoryStore;
+
+    fn store_with_n_events(n: usize) -> Arc<dyn voom_domain::storage::StorageTrait> {
+        let store = InMemoryStore::new();
+        for i in 0..n {
+            let record = EventLogRecord::new(
+                uuid::Uuid::new_v4(),
+                "file.discovered".into(),
+                format!(r#"{{"n":{i}}}"#),
+                format!("event {i}"),
+            );
+            store.insert_event_log(&record).expect("insert");
+        }
+        Arc::new(store)
+    }
+
+    #[test]
+    fn fetch_paginated_returns_all_when_under_page_size() {
+        let store = store_with_n_events(50);
+        let filters = EventLogFilters::default();
+        let mut total = 0;
+        fetch_paginated(&store, &filters, 1000, |r| {
+            assert_eq!(r.event_type, "file.discovered");
+            total += 1;
+            Ok(())
+        })
+        .expect("paginate");
+        assert_eq!(total, 50);
+    }
+
+    #[test]
+    fn fetch_paginated_returns_more_than_page_size() {
+        let store = store_with_n_events(25_000);
+        let filters = EventLogFilters::default();
+        let mut total = 0;
+        fetch_paginated(&store, &filters, 25_000, |_| {
+            total += 1;
+            Ok(())
+        })
+        .expect("paginate");
+        assert_eq!(total, 25_000);
+    }
+
+    #[test]
+    fn fetch_paginated_respects_max_total() {
+        let store = store_with_n_events(25_000);
+        let filters = EventLogFilters::default();
+        let mut total = 0;
+        fetch_paginated(&store, &filters, 12_345, |_| {
+            total += 1;
+            Ok(())
+        })
+        .expect("paginate");
+        assert_eq!(total, 12_345);
     }
 }

--- a/crates/voom-cli/src/commands/events.rs
+++ b/crates/voom-cli/src/commands/events.rs
@@ -53,6 +53,24 @@ fn fetch_paginated(
     Ok(())
 }
 
+/// Treat a broken pipe (e.g., `voom events | head`) as a clean exit instead of
+/// propagating an error. Other I/O failures still bubble up.
+fn ignore_broken_pipe(result: Result<()>) -> Result<()> {
+    match result {
+        Ok(()) => Ok(()),
+        Err(err) => {
+            for cause in err.chain() {
+                if let Some(io_err) = cause.downcast_ref::<std::io::Error>() {
+                    if io_err.kind() == std::io::ErrorKind::BrokenPipe {
+                        return Ok(());
+                    }
+                }
+            }
+            Err(err)
+        }
+    }
+}
+
 pub async fn run(args: EventsArgs, token: CancellationToken) -> Result<()> {
     let config = config::load_config().unwrap_or_default();
     let store = app::open_store(&config)?;
@@ -80,7 +98,7 @@ fn run_streaming(
         OutputFormat::Table => {
             let mut header_written = false;
             let mut any = false;
-            fetch_paginated(store, base_filters, limit, |r| {
+            ignore_broken_pipe(fetch_paginated(store, base_filters, limit, |r| {
                 if !header_written {
                     writeln!(out, "{:<20} {:<28} SUMMARY", "TIMESTAMP", "TYPE")?;
                     writeln!(out, "{}", "-".repeat(78))?;
@@ -95,7 +113,7 @@ fn run_streaming(
                     r.summary,
                 )?;
                 Ok(())
-            })?;
+            }))?;
             if !any {
                 eprintln!("No events found.");
             }
@@ -104,32 +122,33 @@ fn run_streaming(
             // Stream a JSON array element-by-element so memory stays bounded
             // by EVENT_LOG_PAGE_SIZE rather than scaling with `limit`.
             let mut first = true;
-            writeln!(out, "[")?;
-            fetch_paginated(store, base_filters, limit, |r| {
-                if !first {
-                    writeln!(out, ",")?;
-                }
-                first = false;
-                let value = record_to_json(r);
-                let s = serde_json::to_string_pretty(&value)?;
-                // Indent each line by two spaces so output matches the prior
-                // pretty-printed array shape.
-                for (i, line) in s.lines().enumerate() {
-                    if i == 0 {
-                        write!(out, "  {line}")?;
-                    } else {
-                        write!(out, "\n  {line}")?;
+            ignore_broken_pipe((|| -> Result<()> {
+                writeln!(out, "[")?;
+                fetch_paginated(store, base_filters, limit, |r| {
+                    if !first {
+                        writeln!(out, ",")?;
                     }
-                }
+                    first = false;
+                    let value = record_to_json(r);
+                    let s = serde_json::to_string_pretty(&value)?;
+                    // Indent each line by two spaces so output matches the prior
+                    // pretty-printed array shape.
+                    for (i, line) in s.lines().enumerate() {
+                        if i == 0 {
+                            write!(out, "  {line}")?;
+                        } else {
+                            write!(out, "\n  {line}")?;
+                        }
+                    }
+                    Ok(())
+                })?;
+                writeln!(out)?;
+                writeln!(out, "]")?;
                 Ok(())
-            })?;
-            writeln!(out)?;
-            writeln!(out, "]")?;
+            })())?;
         }
         OutputFormat::Plain | OutputFormat::Csv => {
-            let mut any = false;
-            fetch_paginated(store, base_filters, limit, |r| {
-                any = true;
+            ignore_broken_pipe(fetch_paginated(store, base_filters, limit, |r| {
                 writeln!(
                     out,
                     "{}\t{}\t{}",
@@ -138,10 +157,7 @@ fn run_streaming(
                     r.summary,
                 )?;
                 Ok(())
-            })?;
-            if !any {
-                eprintln!("No events found.");
-            }
+            }))?;
         }
     }
     Ok(())
@@ -156,14 +172,11 @@ async fn run_follow(
     let mut last_rowid = 0i64;
 
     // Initial backfill — same behavior as non-follow mode, including pagination.
-    {
-        let store_ref = &store;
-        fetch_paginated(store_ref, &base_filters, args.limit, |r| {
-            print_follow_row(args.format, r);
-            last_rowid = last_rowid.max(r.rowid);
-            Ok(())
-        })?;
-    }
+    fetch_paginated(&store, &base_filters, args.limit, |r| {
+        print_follow_row(args.format, r);
+        last_rowid = last_rowid.max(r.rowid);
+        Ok(())
+    })?;
 
     let mut poll_filters = base_filters.clone();
     poll_filters.limit = Some(200);

--- a/crates/voom-cli/src/commands/events.rs
+++ b/crates/voom-cli/src/commands/events.rs
@@ -119,33 +119,7 @@ fn run_streaming(
             }
         }
         OutputFormat::Json => {
-            // Stream a JSON array element-by-element so memory stays bounded
-            // by EVENT_LOG_PAGE_SIZE rather than scaling with `limit`.
-            let mut first = true;
-            ignore_broken_pipe((|| -> Result<()> {
-                writeln!(out, "[")?;
-                fetch_paginated(store, base_filters, limit, |r| {
-                    if !first {
-                        writeln!(out, ",")?;
-                    }
-                    first = false;
-                    let value = record_to_json(r);
-                    let s = serde_json::to_string_pretty(&value)?;
-                    // Indent each line by two spaces so output matches the prior
-                    // pretty-printed array shape.
-                    for (i, line) in s.lines().enumerate() {
-                        if i == 0 {
-                            write!(out, "  {line}")?;
-                        } else {
-                            write!(out, "\n  {line}")?;
-                        }
-                    }
-                    Ok(())
-                })?;
-                writeln!(out)?;
-                writeln!(out, "]")?;
-                Ok(())
-            })())?;
+            ignore_broken_pipe(write_json_stream(&mut out, store, base_filters, limit))?;
         }
         OutputFormat::Plain | OutputFormat::Csv => {
             ignore_broken_pipe(fetch_paginated(store, base_filters, limit, |r| {
@@ -160,6 +134,39 @@ fn run_streaming(
             }))?;
         }
     }
+    Ok(())
+}
+
+/// Stream the event log as a single JSON array, hand-formatted so output is
+/// byte-compatible with the previous `serde_json::to_string_pretty(&Vec<_>)`
+/// call site — downstream consumers (e.g., `voom events -f json | jq`) keep
+/// working unchanged.
+fn write_json_stream<W: Write>(
+    out: &mut W,
+    store: &std::sync::Arc<dyn voom_domain::storage::StorageTrait>,
+    base_filters: &EventLogFilters,
+    limit: u32,
+) -> Result<()> {
+    let mut first = true;
+    writeln!(out, "[")?;
+    fetch_paginated(store, base_filters, limit, |r| {
+        if !first {
+            writeln!(out, ",")?;
+        }
+        first = false;
+        let value = record_to_json(r);
+        let s = serde_json::to_string_pretty(&value)?;
+        for (i, line) in s.lines().enumerate() {
+            if i == 0 {
+                write!(out, "  {line}")?;
+            } else {
+                write!(out, "\n  {line}")?;
+            }
+        }
+        Ok(())
+    })?;
+    writeln!(out)?;
+    writeln!(out, "]")?;
     Ok(())
 }
 

--- a/crates/voom-cli/src/commands/events.rs
+++ b/crates/voom-cli/src/commands/events.rs
@@ -1,3 +1,5 @@
+use std::io::Write;
+
 use anyhow::Result;
 use tokio_util::sync::CancellationToken;
 use voom_domain::storage::EventLogFilters;
@@ -9,15 +11,11 @@ use crate::config;
 /// Storage clamps `list_event_log` to 10_000 rows per call; we use the same
 /// chunk size so a single call returns either everything matching or a full
 /// page that we can advance past via `since_rowid`.
-// `dead_code` allow lifts once `run` is wired up to use the helper (issue #192, task 3).
-#[allow(dead_code)]
 const EVENT_LOG_PAGE_SIZE: u32 = 10_000;
 
 /// Page through the event log via `since_rowid`, invoking `f` on each record
 /// in order, until either `max_total` records have been emitted or storage
 /// returns fewer than `EVENT_LOG_PAGE_SIZE` rows (i.e., the table is drained).
-// `dead_code` allow lifts once `run` is wired up to use the helper (issue #192, task 3).
-#[allow(dead_code)]
 fn fetch_paginated(
     store: &std::sync::Arc<dyn voom_domain::storage::StorageTrait>,
     base_filters: &EventLogFilters,
@@ -59,52 +57,90 @@ pub async fn run(args: EventsArgs, token: CancellationToken) -> Result<()> {
     let config = config::load_config().unwrap_or_default();
     let store = app::open_store(&config)?;
 
-    let mut filters = EventLogFilters::default();
-    filters.event_type = args.filter.clone();
-    filters.limit = Some(args.limit);
-
-    let records = store.list_event_log(&filters)?;
+    let mut base_filters = EventLogFilters::default();
+    base_filters.event_type = args.filter.clone();
 
     if args.follow {
-        run_follow(store, &args, records, token).await
+        run_follow(store, &args, base_filters, token).await
     } else {
-        run_default(args.format, &records)
+        run_streaming(&store, &base_filters, args.limit, args.format)
     }
 }
 
-fn run_default(
+fn run_streaming(
+    store: &std::sync::Arc<dyn voom_domain::storage::StorageTrait>,
+    base_filters: &EventLogFilters,
+    limit: u32,
     format: OutputFormat,
-    records: &[voom_domain::storage::EventLogRecord],
 ) -> Result<()> {
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+
     match format {
         OutputFormat::Table => {
-            if records.is_empty() {
-                eprintln!("No events found.");
-                return Ok(());
-            }
-            println!("{:<20} {:<28} SUMMARY", "TIMESTAMP", "TYPE");
-            println!("{}", "-".repeat(78));
-            for r in records {
-                println!(
+            let mut header_written = false;
+            let mut any = false;
+            fetch_paginated(store, base_filters, limit, |r| {
+                if !header_written {
+                    writeln!(out, "{:<20} {:<28} SUMMARY", "TIMESTAMP", "TYPE")?;
+                    writeln!(out, "{}", "-".repeat(78))?;
+                    header_written = true;
+                }
+                any = true;
+                writeln!(
+                    out,
                     "{:<20} {:<28} {}",
                     r.created_at.format("%Y-%m-%d %H:%M:%S"),
                     r.event_type,
                     r.summary,
-                );
+                )?;
+                Ok(())
+            })?;
+            if !any {
+                eprintln!("No events found.");
             }
         }
         OutputFormat::Json => {
-            let json: Vec<serde_json::Value> = records.iter().map(record_to_json).collect();
-            println!("{}", serde_json::to_string_pretty(&json)?);
+            // Stream a JSON array element-by-element so memory stays bounded
+            // by EVENT_LOG_PAGE_SIZE rather than scaling with `limit`.
+            let mut first = true;
+            writeln!(out, "[")?;
+            fetch_paginated(store, base_filters, limit, |r| {
+                if !first {
+                    writeln!(out, ",")?;
+                }
+                first = false;
+                let value = record_to_json(r);
+                let s = serde_json::to_string_pretty(&value)?;
+                // Indent each line by two spaces so output matches the prior
+                // pretty-printed array shape.
+                for (i, line) in s.lines().enumerate() {
+                    if i == 0 {
+                        write!(out, "  {line}")?;
+                    } else {
+                        write!(out, "\n  {line}")?;
+                    }
+                }
+                Ok(())
+            })?;
+            writeln!(out)?;
+            writeln!(out, "]")?;
         }
         OutputFormat::Plain | OutputFormat::Csv => {
-            for r in records {
-                println!(
+            let mut any = false;
+            fetch_paginated(store, base_filters, limit, |r| {
+                any = true;
+                writeln!(
+                    out,
                     "{}\t{}\t{}",
                     r.event_type,
                     r.created_at.format("%Y-%m-%d %H:%M:%S"),
                     r.summary,
-                );
+                )?;
+                Ok(())
+            })?;
+            if !any {
+                eprintln!("No events found.");
             }
         }
     }
@@ -114,19 +150,22 @@ fn run_default(
 async fn run_follow(
     store: std::sync::Arc<dyn voom_domain::storage::StorageTrait>,
     args: &EventsArgs,
-    initial: Vec<voom_domain::storage::EventLogRecord>,
+    base_filters: EventLogFilters,
     token: CancellationToken,
 ) -> Result<()> {
     let mut last_rowid = 0i64;
 
-    // Print initial batch
-    for r in &initial {
-        print_follow_row(args.format, r);
-        last_rowid = last_rowid.max(r.rowid);
+    // Initial backfill — same behavior as non-follow mode, including pagination.
+    {
+        let store_ref = &store;
+        fetch_paginated(store_ref, &base_filters, args.limit, |r| {
+            print_follow_row(args.format, r);
+            last_rowid = last_rowid.max(r.rowid);
+            Ok(())
+        })?;
     }
 
-    let mut poll_filters = EventLogFilters::default();
-    poll_filters.event_type = args.filter.clone();
+    let mut poll_filters = base_filters.clone();
     poll_filters.limit = Some(200);
 
     let mut interval = tokio::time::interval(std::time::Duration::from_millis(500));

--- a/crates/voom-cli/tests/functional_tests.rs
+++ b/crates/voom-cli/tests/functional_tests.rs
@@ -1660,6 +1660,54 @@ mod test_events {
                 .or(predicate::str::contains("file.introspected")),
         );
     }
+
+    #[test]
+    fn events_returns_more_than_10000_when_limit_is_higher() {
+        use rusqlite::Connection;
+
+        let env = TestEnv::new();
+
+        // Run the CLI once with no events so the schema is created.
+        env.voom().args(["events"]).assert().success();
+
+        // Insert 12_000 event_log rows directly via SQLite.
+        let conn = Connection::open(env.db_path()).expect("open db");
+        let tx = conn.unchecked_transaction().expect("begin tx");
+        for i in 0..12_000u32 {
+            tx.execute(
+                "INSERT INTO event_log (id, event_type, payload, summary, created_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                rusqlite::params![
+                    uuid::Uuid::new_v4().to_string(),
+                    "file.discovered",
+                    format!(r#"{{"FileDiscovered":{{"path":"/x/{i}.mkv","size":{i}}}}}"#),
+                    format!("path=/x/{i}.mkv"),
+                    "2026-05-04T00:00:00Z",
+                ],
+            )
+            .expect("insert event_log row");
+        }
+        tx.commit().expect("commit");
+        drop(conn);
+
+        let output = env
+            .voom()
+            .args(["events", "-n", "20000", "-f", "json"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let json: serde_json::Value =
+            serde_json::from_slice(&output).expect("stdout is valid JSON");
+        let arr = json.as_array().expect("JSON array at top level");
+        assert_eq!(
+            arr.len(),
+            12_000,
+            "expected all 12k events, got {}",
+            arr.len()
+        );
+    }
 }
 
 // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Closes #192. `voom events --limit/-n N` now returns up to N rows from the event log, paged from storage in chunks of 10,000 and streamed to stdout. Previously the CLI silently truncated at 10,000 regardless of `--limit`, hiding events from any consumer that asked for more.

The storage-layer cap at `plugins/sqlite-store/src/store/event_log_storage.rs:59` (`limit.min(10_000)`) is intentionally unchanged — it remains a defensive guard for non-CLI callers (web UI, programmatic queries). The fix lives entirely in the CLI by paging via `since_rowid`, a mechanism already used by `--follow` mode.

## Changes

`crates/voom-cli/src/commands/events.rs`
- New private `fetch_paginated` helper loops `store.list_event_log` with `since_rowid` advancement, terminating on either `max_total` or a short page (table drained).
- New private `ignore_broken_pipe` helper walks the anyhow error chain for `io::ErrorKind::BrokenPipe` and treats it as a clean exit, so `voom events | head` no longer prints `Error: Broken pipe (os error 32)` and exits 1.
- `run` now dispatches to a new `run_streaming` (Table/Plain/Csv stream row-by-row) or to `run_follow` (initial backfill via `fetch_paginated`, then existing 200-row poll loop).
- JSON output is hand-streamed by `write_json_stream` as a single `[ ... ]` array, byte-compatible with the previous `serde_json::to_string_pretty(&Vec<_>)` so `voom events -f json | jq 'length'` keeps working.
- Old `run_default` removed.

`crates/voom-cli/src/cli.rs`
- `EventsArgs::limit` doc comment now describes the pagination behavior so it shows up in `voom events --help`.

`crates/voom-cli/tests/functional_tests.rs`
- New `events_returns_more_than_10000_when_limit_is_higher` in `mod test_events`. Bulk-inserts 12,000 event_log rows directly via rusqlite and asserts `voom events -n 20000 -f json` returns all 12,000.

## Testing

- `cargo fmt --all -- --check`: clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean
- `cargo test --workspace`: 1832 passed / 0 failed
- `cargo test -p voom-cli --features functional`: 541 passed / 0 failed
- 3 new unit tests for `fetch_paginated` (under page size, crossing page boundary, `max_total` clamps before drain) using `voom_domain::test_support::InMemoryStore`.
- 1 new functional test verifies the bug repro (12k rows requested, 12k returned) end-to-end.

Manual smoke check confirmed `voom events -n 50000 -f json | head -1` exits 0 with no stderr noise.

## Notes

- For default `-n 50` the new code makes exactly one storage call (page_size = 50, drained on first iter) — no regression for the common case.
- Memory is bounded by `EVENT_LOG_PAGE_SIZE` (10,000) plus, for JSON output, one pretty-printed record at a time. Independent of `--limit`.
- `run_follow`'s initial backfill now also honors large `--limit` values (previously truncated). The 500ms / 200-row poll loop is unchanged.
- Pre-existing latent issue not addressed here: `fetch_paginated` runs synchronously inside `pub async fn run` (mirroring the original `store.list_event_log` call site). Wrapping the backfill in `tokio::task::spawn_blocking` would improve Ctrl-C responsiveness during very large `--follow` backfills — worth a separate ticket if anyone cares.
