### PR TITLE
Rename introspect.complete to introspect.session.completed (#193)

### DIFF
--- a/crates/voom-cli/src/commands/process/mod.rs
+++ b/crates/voom-cli/src/commands/process/mod.rs
@@ -25,7 +25,7 @@ use crate::policy_map::PolicyResolver;
 use crate::progress::{BatchProgress, DiscoveryProgress};
 use voom_domain::bad_file::BadFileSource;
 use voom_domain::events::{
-    Event, IntrospectCompleteEvent, JobCompletedEvent, JobProgressEvent, JobStartedEvent,
+    Event, IntrospectSessionCompletedEvent, JobCompletedEvent, JobProgressEvent, JobStartedEvent,
 };
 use voom_domain::utils::format::format_size;
 use voom_job_manager::progress::{CompositeReporter, ProgressReporter};
@@ -248,8 +248,8 @@ pub async fn run(args: ProcessArgs, quiet: bool, token: CancellationToken) -> Re
             .await;
 
         if !token.is_cancelled() {
-            kernel_for_completion.dispatch(Event::IntrospectComplete(
-                IntrospectCompleteEvent::new(pool.completed_count()),
+            kernel_for_completion.dispatch(Event::IntrospectSessionCompleted(
+                IntrospectSessionCompletedEvent::new(pool.completed_count()),
             ));
         }
 

--- a/crates/voom-cli/src/commands/scan.rs
+++ b/crates/voom-cli/src/commands/scan.rs
@@ -519,7 +519,7 @@ mod tests {
     use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
     use voom_domain::capabilities::Capability;
     use voom_domain::events::{
-        EventResult, FileDiscoveredEvent, FileIntrospectedEvent, IntrospectCompleteEvent,
+        EventResult, FileDiscoveredEvent, FileIntrospectedEvent, IntrospectSessionCompletedEvent,
     };
     use voom_domain::media::MediaFile;
 
@@ -527,8 +527,8 @@ mod tests {
     struct RecordingPlugin {
         discovered_count: AtomicUsize,
         introspected_count: AtomicUsize,
-        introspect_complete_count: AtomicUsize,
-        introspect_complete_files: AtomicU64,
+        introspect_session_completed_count: AtomicUsize,
+        introspect_session_completed_files: AtomicU64,
     }
 
     impl RecordingPlugin {
@@ -536,8 +536,8 @@ mod tests {
             Self {
                 discovered_count: AtomicUsize::new(0),
                 introspected_count: AtomicUsize::new(0),
-                introspect_complete_count: AtomicUsize::new(0),
-                introspect_complete_files: AtomicU64::new(0),
+                introspect_session_completed_count: AtomicUsize::new(0),
+                introspect_session_completed_files: AtomicU64::new(0),
             }
         }
     }
@@ -555,7 +555,9 @@ mod tests {
         fn handles(&self, event_type: &str) -> bool {
             matches!(
                 event_type,
-                Event::FILE_DISCOVERED | Event::FILE_INTROSPECTED | Event::INTROSPECT_COMPLETE
+                Event::FILE_DISCOVERED
+                    | Event::FILE_INTROSPECTED
+                    | Event::INTROSPECT_SESSION_COMPLETED
             )
         }
         fn on_event(&self, event: &Event) -> voom_domain::errors::Result<Option<EventResult>> {
@@ -566,10 +568,10 @@ mod tests {
                 Event::FileIntrospected(_) => {
                     self.introspected_count.fetch_add(1, Ordering::SeqCst);
                 }
-                Event::IntrospectComplete(e) => {
-                    self.introspect_complete_count
+                Event::IntrospectSessionCompleted(e) => {
+                    self.introspect_session_completed_count
                         .fetch_add(1, Ordering::SeqCst);
-                    self.introspect_complete_files
+                    self.introspect_session_completed_files
                         .store(e.files_introspected, Ordering::SeqCst);
                 }
                 _ => {}
@@ -625,16 +627,25 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_introspect_complete_kernel_roundtrip() {
+    async fn test_introspect_session_completed_kernel_roundtrip() {
         let mut kernel = voom_kernel::Kernel::new();
         let recorder = Arc::new(RecordingPlugin::new());
         kernel.register_plugin(recorder.clone(), 50).unwrap();
 
-        kernel.dispatch(Event::IntrospectComplete(IntrospectCompleteEvent::new(42)));
+        kernel.dispatch(Event::IntrospectSessionCompleted(
+            IntrospectSessionCompletedEvent::new(42),
+        ));
 
-        assert_eq!(recorder.introspect_complete_count.load(Ordering::SeqCst), 1);
         assert_eq!(
-            recorder.introspect_complete_files.load(Ordering::SeqCst),
+            recorder
+                .introspect_session_completed_count
+                .load(Ordering::SeqCst),
+            1
+        );
+        assert_eq!(
+            recorder
+                .introspect_session_completed_files
+                .load(Ordering::SeqCst),
             42
         );
     }

--- a/crates/voom-domain/src/events.rs
+++ b/crates/voom-domain/src/events.rs
@@ -44,8 +44,11 @@ pub enum Event {
     /// Emitted at the end of a scan. Consumed by the report plugin to
     /// auto-capture a library snapshot.
     ScanComplete(ScanCompleteEvent),
-    /// Emitted at the end of a standalone introspection pass.
-    IntrospectComplete(IntrospectCompleteEvent),
+    /// Emitted at the end of a standalone introspection batch (one per
+    /// `voom process` run). This is a **session-level** event, not a
+    /// per-file signal — subscribers wanting per-file completion should
+    /// use `Event::FileIntrospected` (`file.introspected`) instead.
+    IntrospectSessionCompleted(IntrospectSessionCompletedEvent),
     /// Emitted by the retention runner after each scheduled, on-demand, or
     /// end-of-CLI prune pass. Includes per-table results and an overall duration.
     RetentionCompleted(RetentionCompletedEvent),
@@ -74,7 +77,7 @@ impl Event {
     pub const PLUGIN_ERROR: &str = "plugin.error";
     pub const HEALTH_STATUS: &str = "health.status";
     pub const SCAN_COMPLETE: &str = "scan.complete";
-    pub const INTROSPECT_COMPLETE: &str = "introspect.complete";
+    pub const INTROSPECT_SESSION_COMPLETED: &str = "introspect.session.completed";
     pub const RETENTION_COMPLETED: &str = "retention.completed";
 
     /// One-line human-readable summary of the event payload.
@@ -194,7 +197,7 @@ impl Event {
                     e.files_discovered, e.files_introspected
                 )
             }
-            Event::IntrospectComplete(e) => {
+            Event::IntrospectSessionCompleted(e) => {
                 format!("files_introspected={}", e.files_introspected)
             }
             Event::RetentionCompleted(e) => {
@@ -230,7 +233,7 @@ impl Event {
             Event::PluginError(_) => Self::PLUGIN_ERROR,
             Event::HealthStatus(_) => Self::HEALTH_STATUS,
             Event::ScanComplete(_) => Self::SCAN_COMPLETE,
-            Event::IntrospectComplete(_) => Self::INTROSPECT_COMPLETE,
+            Event::IntrospectSessionCompleted(_) => Self::INTROSPECT_SESSION_COMPLETED,
             Event::RetentionCompleted(_) => Self::RETENTION_COMPLETED,
         }
     }
@@ -816,9 +819,9 @@ impl HealthStatusEvent {
 /// Emitted exactly once at the end of a successful `scan` run, after
 /// discovery + introspection finish. Carries both totals so subscribers
 /// (currently just the report plugin's snapshot writer) do not need a
-/// preceding `IntrospectComplete` to learn the introspected count.
+/// preceding `IntrospectSessionCompleted` to learn the introspected count.
 ///
-/// **Do NOT also emit `IntrospectComplete` from the same run.** See
+/// **Do NOT also emit `IntrospectSessionCompleted` from the same run.** See
 /// `crates/voom-cli/src/commands/scan.rs` and issue #153.
 #[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -842,14 +845,18 @@ impl ScanCompleteEvent {
 /// discovered files before evaluating policies). Reserved for paths that
 /// did NOT run discovery — full scans must emit `ScanComplete` instead.
 ///
+/// This is a **session-level** event. Subscribers wanting a per-file
+/// completion signal should use `FileIntrospectedEvent`
+/// (`file.introspected`), which fires once per file. See issue #193.
+///
 /// The report plugin subscribes to this to auto-capture a library snapshot.
 #[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct IntrospectCompleteEvent {
+pub struct IntrospectSessionCompletedEvent {
     pub files_introspected: u64,
 }
 
-impl IntrospectCompleteEvent {
+impl IntrospectSessionCompletedEvent {
     #[must_use]
     pub fn new(files_introspected: u64) -> Self {
         Self { files_introspected }
@@ -1216,14 +1223,14 @@ mod tests {
     }
 
     #[test]
-    fn test_introspect_complete_event_type() {
-        let event = Event::IntrospectComplete(IntrospectCompleteEvent {
+    fn test_introspect_session_completed_event_type() {
+        let event = Event::IntrospectSessionCompleted(IntrospectSessionCompletedEvent {
             files_introspected: 15,
         });
-        assert_eq!(event.event_type(), "introspect.complete");
+        assert_eq!(event.event_type(), "introspect.session.completed");
         let json = serde_json::to_string(&event).expect("serialize");
         let deserialized: Event = serde_json::from_str(&json).expect("deserialize");
-        assert_eq!(deserialized.event_type(), "introspect.complete");
+        assert_eq!(deserialized.event_type(), "introspect.session.completed");
     }
 
     #[test]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -172,6 +172,8 @@ The event bus is the sole communication mechanism between plugins. It uses synch
 | `file.discovered` | Discovery | New file found during scan |
 | `file.introspected` | CLI (introspect helper) | File metadata extracted via ffprobe |
 | `file.introspection_failed` | CLI (introspect helper) | File introspection failed |
+| `introspect.session.completed` | CLI (`process` command) | End of a standalone re-introspection batch (one per run); session-level, not per-file — for per-file see `file.introspected` |
+| `scan.complete` | CLI (`scan` command) | End of a discovery + introspection scan; carries both totals |
 | `metadata.enriched` | WASM plugins | External metadata added |
 | `plan.created` | CLI (process command) | Execution plan dispatched for executor claiming |
 | `plan.executing` | CLI (process command) | Plan execution about to start (triggers backup) |

--- a/plugins/report/src/lib.rs
+++ b/plugins/report/src/lib.rs
@@ -163,7 +163,7 @@ impl Plugin for ReportPlugin {
     }
 
     fn handles(&self, event_type: &str) -> bool {
-        event_type == Event::SCAN_COMPLETE || event_type == Event::INTROSPECT_COMPLETE
+        event_type == Event::SCAN_COMPLETE || event_type == Event::INTROSPECT_SESSION_COMPLETED
     }
 
     fn on_event(&self, event: &Event) -> Result<Option<EventResult>> {
@@ -171,7 +171,7 @@ impl Plugin for ReportPlugin {
             Event::ScanComplete(_) => {
                 Ok(self.handle_lifecycle_event(SnapshotTrigger::ScanComplete))
             }
-            Event::IntrospectComplete(_) => {
+            Event::IntrospectSessionCompleted(_) => {
                 Ok(self.handle_lifecycle_event(SnapshotTrigger::IntrospectComplete))
             }
             _ => Ok(None),


### PR DESCRIPTION
## Summary

- Renames bus topic `introspect.complete` → `introspect.session.completed` (and corresponding Rust symbols `Event::IntrospectComplete` → `Event::IntrospectSessionCompleted`, `IntrospectCompleteEvent` → `IntrospectSessionCompletedEvent`, constant `INTROSPECT_COMPLETE` → `INTROSPECT_SESSION_COMPLETED`).
- The old name read as a per-file completion signal, but the event fires once per `voom process` run — observers (web SSE consumers, bus tracers, the E2E containerize harness) could and did mistake it for per-file. Subscribers that genuinely want per-file completion should use the existing `Event::FileIntrospected` (`file.introspected`), which already fires per file.
- `SnapshotTrigger::IntrospectComplete` and the `"introspect_complete"` value persisted in `library_snapshots.trigger` are deliberately unchanged — that's a DB column value, not a bus topic, and renaming would force a migration for no consumer benefit.
- Adds `introspect.session.completed` (and previously-undocumented `scan.complete`) to the events table in `docs/architecture.md`.

Closes #193.

## Test Plan

- [x] `cargo build --workspace` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test --workspace` all green
- [x] `cargo test -p voom-cli --features functional -- --test-threads=4` all green (119 functional tests, including `scan_produces_single_snapshot` regression for #153)
- [x] Cross-tree sweep: `rg "introspect\.complete|INTROSPECT_COMPLETE\b|IntrospectCompleteEvent\b|Event::IntrospectComplete\b"` returns zero hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)