### PR TITLE
fix(retention): tune event_log defaults and warn on asymmetry (#194)

### DIFF
--- a/crates/voom-cli/src/commands/health.rs
+++ b/crates/voom-cli/src/commands/health.rs
@@ -15,7 +15,7 @@ use crate::output::sanitize_for_display;
 use crate::tools::print_tool_status;
 
 mod retention_coverage {
-    use chrono::{DateTime, Utc};
+    use chrono::{DateTime, Duration, Utc};
 
     /// Hard floor below which we treat a positive lag as noise: the two
     /// `MIN(created_at)` queries that feed `evaluate` are not atomic, and a
@@ -24,7 +24,7 @@ mod retention_coverage {
     /// reported as an asymmetry. Operators who want a stricter check can lower
     /// the threshold; doing so trades fewer false negatives for more false
     /// positives during normal retention runs.
-    const NOISE_FLOOR: chrono::TimeDelta = chrono::Duration::hours(1);
+    const NOISE_FLOOR: Duration = Duration::hours(1);
 
     #[derive(Debug, PartialEq, Eq)]
     pub enum CoverageStatus {
@@ -131,7 +131,7 @@ pub fn check() -> Result<()> {
         }
     }
 
-    // 2b. Retention coverage (issue #194)
+    // 2b. Retention coverage
     print!("  Retention coverage ... ");
     if let Ok(app::BootstrapResult { store, .. }) = &kernel_result {
         let oldest_job = store.oldest_job_created_at().ok().flatten();

--- a/crates/voom-cli/src/commands/health.rs
+++ b/crates/voom-cli/src/commands/health.rs
@@ -17,14 +17,19 @@ use crate::tools::print_tool_status;
 mod retention_coverage {
     use chrono::{DateTime, Utc};
 
-    /// Hard floor below which we treat a positive lag as noise (clock skew,
-    /// the gap between an event being inserted and a job row being written).
-    /// Anything below this is reported as `Ok`.
+    /// Hard floor below which we treat a positive lag as noise: the two
+    /// `MIN(created_at)` queries that feed `evaluate` are not atomic, and a
+    /// short pruning burst can briefly leave the event log starting after the
+    /// oldest job by minutes. Anything strictly greater than this floor is
+    /// reported as an asymmetry. Operators who want a stricter check can lower
+    /// the threshold; doing so trades fewer false negatives for more false
+    /// positives during normal retention runs.
     const NOISE_FLOOR: chrono::TimeDelta = chrono::Duration::hours(1);
 
     #[derive(Debug, PartialEq, Eq)]
     pub enum CoverageStatus {
-        /// No jobs and no events, or events comfortably cover the jobs.
+        /// No jobs to under-cover (table empty, regardless of event_log),
+        /// or events comfortably cover the jobs.
         Ok,
         /// Jobs exist but the event_log is empty.
         EventLogEmptyButJobsExist,
@@ -146,13 +151,15 @@ pub fn check() -> Result<()> {
             }
             retention_coverage::CoverageStatus::AsymmetryDetected { gap_seconds } => {
                 let hours = gap_seconds / 3600;
+                let unit = if hours == 1 { "hour" } else { "hours" };
                 println!(
-                    "{} oldest event is {} hours newer than the oldest job. \
+                    "{} oldest event is {} {} newer than the oldest job. \
                      event_log retention is pruning events faster than jobs \
                      are pruned, so `voom events` and SSE history will \
                      undercount completed work. See issue #194.",
                     style("WARN").yellow(),
-                    hours
+                    hours,
+                    unit
                 );
                 issues += 1;
             }
@@ -551,6 +558,28 @@ mod retention_coverage_tests {
         match evaluate(oldest_job, None) {
             CoverageStatus::EventLogEmptyButJobsExist => {}
             other => panic!("expected EventLogEmptyButJobsExist, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ok_when_lag_equals_noise_floor() {
+        let oldest_job = chrono::Utc::now() - chrono::Duration::days(1);
+        let oldest_event = oldest_job + chrono::Duration::hours(1);
+        assert_eq!(
+            evaluate(Some(oldest_job), Some(oldest_event)),
+            CoverageStatus::Ok
+        );
+    }
+
+    #[test]
+    fn warn_when_lag_exceeds_noise_floor_by_one_second() {
+        let oldest_job = chrono::Utc::now() - chrono::Duration::days(1);
+        let oldest_event = oldest_job + chrono::Duration::hours(1) + chrono::Duration::seconds(1);
+        match evaluate(Some(oldest_job), Some(oldest_event)) {
+            CoverageStatus::AsymmetryDetected { gap_seconds } => {
+                assert_eq!(gap_seconds, 3601);
+            }
+            other => panic!("expected AsymmetryDetected, got {other:?}"),
         }
     }
 }

--- a/crates/voom-cli/src/commands/health.rs
+++ b/crates/voom-cli/src/commands/health.rs
@@ -14,6 +14,48 @@ use crate::config;
 use crate::output::sanitize_for_display;
 use crate::tools::print_tool_status;
 
+mod retention_coverage {
+    use chrono::{DateTime, Utc};
+
+    /// Hard floor below which we treat a positive lag as noise (clock skew,
+    /// the gap between an event being inserted and a job row being written).
+    /// Anything below this is reported as `Ok`.
+    const NOISE_FLOOR: chrono::TimeDelta = chrono::Duration::hours(1);
+
+    #[derive(Debug, PartialEq, Eq)]
+    pub enum CoverageStatus {
+        /// No jobs and no events, or events comfortably cover the jobs.
+        Ok,
+        /// Jobs exist but the event_log is empty.
+        EventLogEmptyButJobsExist,
+        /// Oldest event is `gap_seconds` newer than the oldest job — events
+        /// were pruned while jobs survived.
+        AsymmetryDetected { gap_seconds: i64 },
+    }
+
+    /// Pure decision function. `oldest_job` is `Some` if any job exists;
+    /// `oldest_event` is `Some` if any event_log row exists.
+    pub fn evaluate(
+        oldest_job: Option<DateTime<Utc>>,
+        oldest_event: Option<DateTime<Utc>>,
+    ) -> CoverageStatus {
+        match (oldest_job, oldest_event) {
+            (None, _) => CoverageStatus::Ok,
+            (Some(_), None) => CoverageStatus::EventLogEmptyButJobsExist,
+            (Some(j), Some(e)) => {
+                let lag = e.signed_duration_since(j);
+                if lag <= NOISE_FLOOR {
+                    CoverageStatus::Ok
+                } else {
+                    CoverageStatus::AsymmetryDetected {
+                        gap_seconds: lag.num_seconds(),
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// Dispatch health subcommands.
 pub fn run(cmd: HealthCommands) -> Result<()> {
     match cmd {
@@ -82,6 +124,41 @@ pub fn check() -> Result<()> {
             println!("{} {e}", style("ERROR").red());
             issues += 1;
         }
+    }
+
+    // 2b. Retention coverage (issue #194)
+    print!("  Retention coverage ... ");
+    if let Ok(app::BootstrapResult { store, .. }) = &kernel_result {
+        let oldest_job = store.oldest_job_created_at().ok().flatten();
+        let oldest_event = store.oldest_event_at().ok().flatten();
+        match retention_coverage::evaluate(oldest_job, oldest_event) {
+            retention_coverage::CoverageStatus::Ok => {
+                println!("{}", style("OK").green());
+            }
+            retention_coverage::CoverageStatus::EventLogEmptyButJobsExist => {
+                println!(
+                    "{} jobs table is non-empty but event_log is empty — \
+                     historical activity queries will be incomplete. \
+                     Check [retention.event_log] in config.toml.",
+                    style("WARN").yellow()
+                );
+                issues += 1;
+            }
+            retention_coverage::CoverageStatus::AsymmetryDetected { gap_seconds } => {
+                let hours = gap_seconds / 3600;
+                println!(
+                    "{} oldest event is {} hours newer than the oldest job. \
+                     event_log retention is pruning events faster than jobs \
+                     are pruned, so `voom events` and SSE history will \
+                     undercount completed work. See issue #194.",
+                    style("WARN").yellow(),
+                    hours
+                );
+                issues += 1;
+            }
+        }
+    } else {
+        println!("{} (database unavailable)", style("skipped").dim());
     }
 
     // 3. External tools
@@ -425,5 +502,55 @@ mod tests {
     fn test_parse_datetime_invalid() {
         assert!(parse_datetime("not-a-date").is_err());
         assert!(parse_datetime("2024/01/15").is_err());
+    }
+}
+
+#[cfg(test)]
+mod retention_coverage_tests {
+    use super::retention_coverage::{evaluate, CoverageStatus};
+    use chrono::{Duration, Utc};
+
+    #[test]
+    fn ok_when_no_jobs_and_no_events() {
+        assert_eq!(evaluate(None, None), CoverageStatus::Ok);
+    }
+
+    #[test]
+    fn ok_when_oldest_event_predates_oldest_job() {
+        let now = Utc::now();
+        let oldest_job = Some(now - Duration::hours(2));
+        let oldest_event = Some(now - Duration::hours(3));
+        assert_eq!(evaluate(oldest_job, oldest_event), CoverageStatus::Ok);
+    }
+
+    #[test]
+    fn ok_when_event_only_slightly_newer_than_oldest_job() {
+        let now = Utc::now();
+        let oldest_job = Some(now - Duration::hours(48));
+        let oldest_event = Some(now - Duration::hours(48) + Duration::minutes(5));
+        assert_eq!(evaluate(oldest_job, oldest_event), CoverageStatus::Ok);
+    }
+
+    #[test]
+    fn warn_when_event_log_starts_well_after_oldest_job() {
+        let now = Utc::now();
+        let oldest_job = Some(now - Duration::days(7));
+        let oldest_event = Some(now - Duration::hours(1));
+        match evaluate(oldest_job, oldest_event) {
+            CoverageStatus::AsymmetryDetected { gap_seconds } => {
+                assert!(gap_seconds >= 6 * 24 * 3600);
+            }
+            other => panic!("expected AsymmetryDetected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn warn_when_jobs_present_but_event_log_empty() {
+        let now = Utc::now();
+        let oldest_job = Some(now - Duration::days(1));
+        match evaluate(oldest_job, None) {
+            CoverageStatus::EventLogEmptyButJobsExist => {}
+            other => panic!("expected EventLogEmptyButJobsExist, got {other:?}"),
+        }
     }
 }

--- a/crates/voom-cli/src/config.rs
+++ b/crates/voom-cli/src/config.rs
@@ -369,6 +369,13 @@ retention_days = 30
 # Database retention. Bounds the size of jobs, event_log, and file_transitions
 # to keep the database from growing forever. Set keep_for_days = 0 and keep_last = 0
 # for any table to disable retention for that table.
+#
+# Invariant: event_log must outlive jobs by ~10x on both axes. Each job row
+# produces ~7 event_log rows (file.discovered, file.introspected, three
+# plan.* events, job.started, job.completed). If event_log is pruned while
+# jobs are not, `voom events` and SSE history will undercount completed
+# work. `voom health check` reports when this invariant is violated.
+# See issue #194.
 [retention]
 # How often the periodic prune runs in `serve` mode (minutes).
 schedule_interval_minutes = 60

--- a/crates/voom-cli/src/config.rs
+++ b/crates/voom-cli/src/config.rs
@@ -61,9 +61,14 @@ impl TableRetention {
         }
     }
     fn for_event_log() -> Self {
+        // event_log carries ~7 rows per process job (file.discovered,
+        // file.introspected, three plan.* events for transformed files, and
+        // job.started/completed). To preserve at least one full
+        // `jobs.keep_last` bucket of activity, keep_last must outlive jobs
+        // by roughly that ratio. See issue #194 for the diagnosis.
         Self {
-            keep_for_days: Some(30),
-            keep_last: Some(100_000),
+            keep_for_days: Some(60),
+            keep_last: Some(500_000),
         }
     }
     fn for_file_transitions() -> Self {
@@ -375,8 +380,10 @@ keep_for_days = 7
 keep_last = 50000
 
 [retention.event_log]
-keep_for_days = 30
-keep_last = 100000
+# Must outlive [retention.jobs] by ~10x: event_log carries ~7 rows per
+# process job. See issue #194.
+keep_for_days = 60
+keep_last = 500000
 
 [retention.file_transitions]
 keep_for_days = 90
@@ -813,7 +820,7 @@ keep_last = 100000
         assert_eq!(cfg.retention.jobs.keep_for_days, Some(14));
         assert_eq!(cfg.retention.jobs.keep_last, Some(100_000));
         // Tables not listed get the type defaults
-        assert_eq!(cfg.retention.event_log.keep_for_days, Some(30));
+        assert_eq!(cfg.retention.event_log.keep_for_days, Some(60));
         assert_eq!(cfg.retention.file_transitions.keep_for_days, Some(90));
     }
 
@@ -824,5 +831,10 @@ keep_last = 100000
         assert!(cfg.retention.run_after_cli);
         assert_eq!(cfg.retention.jobs.keep_for_days, Some(7));
         assert_eq!(cfg.retention.jobs.keep_last, Some(50_000));
+        // event_log must outlive jobs by ~10x to cover all events emitted by
+        // a full jobs.keep_last bucket of process jobs (~7 events each).
+        // See issue #194.
+        assert_eq!(cfg.retention.event_log.keep_for_days, Some(60));
+        assert_eq!(cfg.retention.event_log.keep_last, Some(500_000));
     }
 }

--- a/crates/voom-cli/tests/health_retention_coverage.rs
+++ b/crates/voom-cli/tests/health_retention_coverage.rs
@@ -1,0 +1,30 @@
+//! End-to-end check: `voom health check` exits 0 against a fresh data
+//! directory and reports the Retention coverage section. Issue #194.
+
+use assert_cmd::Command;
+
+#[test]
+fn health_check_runs_against_empty_data_dir() {
+    let dir = tempfile::tempdir().unwrap();
+    let cfg_dir = tempfile::tempdir().unwrap();
+    let cfg_path = cfg_dir.path().join("voom").join("config.toml");
+    std::fs::create_dir_all(cfg_path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &cfg_path,
+        format!("data_dir = \"{}\"\n", dir.path().display()),
+    )
+    .unwrap();
+
+    let out = Command::cargo_bin("voom")
+        .unwrap()
+        .env("XDG_CONFIG_HOME", cfg_dir.path())
+        .args(["health", "check"])
+        .output()
+        .expect("run voom health check");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("Retention coverage"),
+        "expected 'Retention coverage' in output, got:\n{stdout}"
+    );
+}

--- a/crates/voom-cli/tests/health_retention_coverage.rs
+++ b/crates/voom-cli/tests/health_retention_coverage.rs
@@ -4,7 +4,7 @@
 use assert_cmd::Command;
 
 #[test]
-fn health_check_runs_against_empty_data_dir() {
+fn health_check_reports_retention_coverage_section() {
     let dir = tempfile::tempdir().unwrap();
     let cfg_dir = tempfile::tempdir().unwrap();
     let cfg_path = cfg_dir.path().join("voom").join("config.toml");

--- a/crates/voom-domain/src/storage.rs
+++ b/crates/voom-domain/src/storage.rs
@@ -224,6 +224,10 @@ pub trait JobStorage: Send + Sync {
     /// Count how many terminal-state jobs would be deleted by `policy`.
     /// Mirrors `prune_old_jobs` but does not modify the database.
     fn count_old_jobs(&self, policy: RetentionPolicy) -> Result<PruneReport>;
+    /// Return the `created_at` of the oldest job row, or `None` if the table
+    /// is empty. Used by `voom health check` to compare against
+    /// `EventLogStorage::oldest_event_at` and detect retention asymmetry.
+    fn oldest_job_created_at(&self) -> Result<Option<chrono::DateTime<chrono::Utc>>>;
 }
 
 /// Plan persistence operations.
@@ -460,6 +464,9 @@ pub trait EventLogStorage: Send + Sync {
     fn count_old_event_log(&self, policy: RetentionPolicy) -> Result<PruneReport>;
     /// Return the most recent event of the given type, or None if none exist.
     fn latest_event_of_type(&self, event_type: &str) -> Result<Option<EventLogRecord>>;
+    /// Return the `created_at` of the oldest event row, or `None` if the
+    /// table is empty.
+    fn oldest_event_at(&self) -> Result<Option<chrono::DateTime<chrono::Utc>>>;
 }
 
 /// Library snapshot storage operations.

--- a/crates/voom-domain/src/test_support.rs
+++ b/crates/voom-domain/src/test_support.rs
@@ -429,6 +429,11 @@ impl JobStorage for InMemoryStore {
     ) -> crate::errors::Result<crate::storage::PruneReport> {
         Ok(crate::storage::PruneReport::default())
     }
+
+    fn oldest_job_created_at(&self) -> Result<Option<chrono::DateTime<chrono::Utc>>> {
+        let jobs = self.jobs.lock();
+        Ok(jobs.values().map(|j| j.created_at).min())
+    }
 }
 
 impl PlanStorage for InMemoryStore {
@@ -673,6 +678,11 @@ impl crate::storage::EventLogStorage for InMemoryStore {
     ) -> crate::errors::Result<Option<crate::storage::EventLogRecord>> {
         Ok(None)
     }
+
+    fn oldest_event_at(&self) -> Result<Option<chrono::DateTime<chrono::Utc>>> {
+        let events = self.event_log.lock();
+        Ok(events.iter().map(|r| r.created_at).min())
+    }
 }
 
 impl SnapshotStorage for InMemoryStore {
@@ -763,5 +773,70 @@ impl PendingOpsStorage for InMemoryStore {
         let mut ops = self.pending_ops.lock().clone();
         ops.sort_by_key(|o| o.started_at);
         Ok(ops)
+    }
+}
+
+#[cfg(test)]
+mod oldest_at_tests {
+    use super::*;
+    use crate::job::{Job, JobType};
+    use crate::storage::{EventLogRecord, EventLogStorage, JobStorage};
+
+    #[test]
+    fn oldest_job_created_at_none_when_empty() {
+        let store = InMemoryStore::new();
+        assert!(store.oldest_job_created_at().unwrap().is_none());
+    }
+
+    #[test]
+    fn oldest_job_created_at_returns_min_created_at() {
+        let store = InMemoryStore::new();
+        let mut j1 = Job::new(JobType::Process);
+        j1.created_at = chrono::Utc::now() - chrono::Duration::hours(2);
+        let mut j2 = Job::new(JobType::Process);
+        j2.created_at = chrono::Utc::now() - chrono::Duration::hours(1);
+        store.create_job(&j1).unwrap();
+        store.create_job(&j2).unwrap();
+        assert_eq!(
+            store
+                .oldest_job_created_at()
+                .unwrap()
+                .map(|t| t.timestamp_millis()),
+            Some(j1.created_at.timestamp_millis())
+        );
+    }
+
+    #[test]
+    fn oldest_event_at_none_when_empty() {
+        let store = InMemoryStore::new();
+        assert!(store.oldest_event_at().unwrap().is_none());
+    }
+
+    #[test]
+    fn oldest_event_at_returns_min_created_at() {
+        let store = InMemoryStore::new();
+        let mut a = EventLogRecord::new(
+            uuid::Uuid::new_v4(),
+            "file.discovered".into(),
+            "{}".into(),
+            "older".into(),
+        );
+        a.created_at = chrono::Utc::now() - chrono::Duration::hours(3);
+        let mut b = EventLogRecord::new(
+            uuid::Uuid::new_v4(),
+            "file.discovered".into(),
+            "{}".into(),
+            "newer".into(),
+        );
+        b.created_at = chrono::Utc::now() - chrono::Duration::hours(1);
+        store.insert_event_log(&a).unwrap();
+        store.insert_event_log(&b).unwrap();
+        assert_eq!(
+            store
+                .oldest_event_at()
+                .unwrap()
+                .map(|t| t.timestamp_millis()),
+            Some(a.created_at.timestamp_millis())
+        );
     }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -188,6 +188,26 @@ The event bus is the sole communication mechanism between plugins. It uses synch
 
 Events are published to all subscribed plugins, ordered by priority (lower = runs first). Each subscriber can optionally return an `EventResult` that may influence downstream processing.
 
+### Retention invariants
+
+`event_log` records every event dispatched on the bus, including
+`job.started` and `job.completed`. `jobs` records one row per work item the
+worker pool processed.
+
+For a single `voom process` run, the event_log gains roughly **seven rows
+per job row**: file.discovered, file.introspected, three plan.* rows for
+files that were transformed, plus job.started/completed. Default retention
+must therefore keep `event_log` at *least* `7×` longer than `jobs`, on
+both axes (`keep_last` and `keep_for_days`), or the event log will be
+pruned while jobs survive — producing the misleading appearance that jobs
+completed without announcing themselves on the bus.
+
+The shipped defaults satisfy this: `jobs.keep_last = 50_000` and
+`event_log.keep_last = 500_000`; `jobs.keep_for_days = 7` and
+`event_log.keep_for_days = 60`. Operators who tighten `event_log` in
+`config.toml` should keep the multiplier in mind — `voom health check`
+warns when the oldest event is newer than the oldest job (issue #194).
+
 ## CLI Dual-Dispatch Pattern
 
 CLI commands (`scan`, `process`) use a **hybrid approach**: direct plugin calls for CLI control flow, with event publishing for plugin coordination. This is an intentional architectural decision, not interim scaffolding.

--- a/plugins/job-manager/src/worker.rs
+++ b/plugins/job-manager/src/worker.rs
@@ -901,6 +901,12 @@ mod tests {
         ) -> voom_domain::errors::Result<voom_domain::storage::PruneReport> {
             self.inner.count_old_jobs(policy)
         }
+
+        fn oldest_job_created_at(
+            &self,
+        ) -> voom_domain::errors::Result<Option<chrono::DateTime<chrono::Utc>>> {
+            self.inner.oldest_job_created_at()
+        }
     }
 
     #[tokio::test]

--- a/plugins/sqlite-store/src/store/event_log_storage.rs
+++ b/plugins/sqlite-store/src/store/event_log_storage.rs
@@ -453,4 +453,59 @@ mod tests {
         assert_eq!(count_report.deleted, prune_report.deleted);
         assert_eq!(count_report.kept, prune_report.kept);
     }
+
+    #[test]
+    fn pruning_event_log_can_outpace_pruning_jobs_with_tight_default_ratio() {
+        use voom_domain::job::{Job, JobType};
+        use voom_domain::storage::JobStorage;
+
+        let store = test_store();
+
+        // Mimic a run where each job produces ~7 events. Insert the events first
+        // (older rowids) and then the corresponding job rows, so that pruning
+        // event_log to keep_last=100 deletes the early events while the jobs row
+        // count (50) is well under jobs.keep_last=50.
+        let job_count: usize = 50;
+        let events_per_job: usize = 7;
+        for i in 0..(job_count * events_per_job) {
+            let r = EventLogRecord::new(
+                uuid::Uuid::new_v4(),
+                "file.discovered".into(),
+                format!(r#"{{"i":{i}}}"#),
+                format!("event {i}"),
+            );
+            store.insert_event_log(&r).unwrap();
+        }
+        for _ in 0..job_count {
+            let job = Job::new(JobType::Process);
+            store.create_job(&job).unwrap();
+        }
+
+        // event_log retention: keep_last=100 (mirror of production: smaller of
+        // event_log.keep_last vs total events emitted)
+        let event_pruned = store.prune_event_log(100).unwrap();
+        assert_eq!(
+            event_pruned, 250,
+            "expected aggressive event pruning in this scenario"
+        );
+
+        // jobs retention: not run (or run with keep_last=50000 — same outcome)
+        // Surviving event_log rows
+        let kept_events = store
+            .list_event_log(&EventLogFilters::default())
+            .unwrap()
+            .len();
+        let kept_jobs = store
+            .list_jobs(&voom_domain::storage::JobFilters::default())
+            .unwrap()
+            .len();
+        assert_eq!(kept_events, 100);
+        assert_eq!(kept_jobs, 50);
+
+        // The asymmetry: jobs > number of jobs whose events still exist.
+        assert!(
+            kept_jobs * events_per_job > kept_events,
+            "this test exists to lock in the diagnosis from issue #194"
+        );
+    }
 }

--- a/plugins/sqlite-store/src/store/event_log_storage.rs
+++ b/plugins/sqlite-store/src/store/event_log_storage.rs
@@ -5,7 +5,7 @@ use voom_domain::storage::{
     EventLogFilters, EventLogRecord, EventLogStorage, PruneReport, RetentionPolicy,
 };
 
-use super::{format_datetime, storage_err, SqliteStore};
+use super::{format_datetime, other_storage_err, storage_err, SqliteStore};
 
 impl EventLogStorage for SqliteStore {
     fn insert_event_log(&self, record: &EventLogRecord) -> Result<i64> {
@@ -180,6 +180,25 @@ impl EventLogStorage for SqliteStore {
         )
         .optional()
         .map_err(storage_err("failed to query latest event"))
+    }
+
+    fn oldest_event_at(&self) -> Result<Option<chrono::DateTime<chrono::Utc>>> {
+        let conn = self.conn()?;
+        let oldest: Option<String> = conn
+            .query_row("SELECT MIN(created_at) FROM event_log", [], |row| {
+                row.get(0)
+            })
+            .optional()
+            .map_err(storage_err("failed to query oldest event"))?
+            .flatten();
+
+        match oldest {
+            None => Ok(None),
+            Some(s) => s
+                .parse::<chrono::DateTime<chrono::Utc>>()
+                .map(Some)
+                .map_err(other_storage_err("invalid created_at on event_log row")),
+        }
     }
 }
 
@@ -425,6 +444,30 @@ mod tests {
         let store = test_store();
         let got = store.latest_event_of_type("retention.completed").unwrap();
         assert!(got.is_none());
+    }
+
+    #[test]
+    fn oldest_event_at_returns_min_on_sqlite() {
+        let store = test_store();
+        let mut older = EventLogRecord::new(
+            uuid::Uuid::new_v4(),
+            "file.discovered".into(),
+            "{}".into(),
+            "x".into(),
+        );
+        older.created_at = chrono::Utc::now() - chrono::Duration::days(2);
+        store.insert_event_log(&older).unwrap();
+        let mut newer = EventLogRecord::new(
+            uuid::Uuid::new_v4(),
+            "file.discovered".into(),
+            "{}".into(),
+            "y".into(),
+        );
+        newer.created_at = chrono::Utc::now();
+        store.insert_event_log(&newer).unwrap();
+
+        let got = store.oldest_event_at().unwrap().unwrap();
+        assert_eq!(got.timestamp_millis(), older.created_at.timestamp_millis());
     }
 
     #[test]

--- a/plugins/sqlite-store/src/store/event_log_storage.rs
+++ b/plugins/sqlite-store/src/store/event_log_storage.rs
@@ -5,7 +5,7 @@ use voom_domain::storage::{
     EventLogFilters, EventLogRecord, EventLogStorage, PruneReport, RetentionPolicy,
 };
 
-use super::{format_datetime, other_storage_err, storage_err, SqliteStore};
+use super::{format_datetime, parse_datetime, storage_err, SqliteStore};
 
 impl EventLogStorage for SqliteStore {
     fn insert_event_log(&self, record: &EventLogRecord) -> Result<i64> {
@@ -192,13 +192,7 @@ impl EventLogStorage for SqliteStore {
             .map_err(storage_err("failed to query oldest event"))?
             .flatten();
 
-        match oldest {
-            None => Ok(None),
-            Some(s) => s
-                .parse::<chrono::DateTime<chrono::Utc>>()
-                .map(Some)
-                .map_err(other_storage_err("invalid created_at on event_log row")),
-        }
+        oldest.map(|s| parse_datetime(&s)).transpose()
     }
 }
 

--- a/plugins/sqlite-store/src/store/job_storage.rs
+++ b/plugins/sqlite-store/src/store/job_storage.rs
@@ -6,7 +6,10 @@ use voom_domain::errors::{Result, StorageErrorKind, VoomError};
 use voom_domain::job::{Job, JobStatus, JobUpdate};
 use voom_domain::storage::{JobFilters, JobStorage, PruneReport, RetentionPolicy};
 
-use super::{format_datetime, other_storage_err, row_to_job, storage_err, SqlQuery, SqliteStore};
+use super::{
+    format_datetime, other_storage_err, parse_datetime, row_to_job, storage_err, SqlQuery,
+    SqliteStore,
+};
 
 fn serialize_json(value: &serde_json::Value) -> Result<String> {
     serde_json::to_string(value).map_err(other_storage_err("failed to serialize JSON"))
@@ -339,13 +342,7 @@ impl JobStorage for SqliteStore {
             .map_err(storage_err("failed to query oldest job"))?
             .flatten();
 
-        match oldest {
-            None => Ok(None),
-            Some(s) => s
-                .parse::<chrono::DateTime<chrono::Utc>>()
-                .map(Some)
-                .map_err(other_storage_err("invalid created_at on jobs row")),
-        }
+        oldest.map(|s| parse_datetime(&s)).transpose()
     }
 
     fn count_jobs_by_status(&self) -> Result<Vec<(JobStatus, u64)>> {

--- a/plugins/sqlite-store/src/store/job_storage.rs
+++ b/plugins/sqlite-store/src/store/job_storage.rs
@@ -331,6 +331,23 @@ impl JobStorage for SqliteStore {
         })
     }
 
+    fn oldest_job_created_at(&self) -> Result<Option<chrono::DateTime<chrono::Utc>>> {
+        let conn = self.conn()?;
+        let oldest: Option<String> = conn
+            .query_row("SELECT MIN(created_at) FROM jobs", [], |row| row.get(0))
+            .optional()
+            .map_err(storage_err("failed to query oldest job"))?
+            .flatten();
+
+        match oldest {
+            None => Ok(None),
+            Some(s) => s
+                .parse::<chrono::DateTime<chrono::Utc>>()
+                .map(Some)
+                .map_err(other_storage_err("invalid created_at on jobs row")),
+        }
+    }
+
     fn count_jobs_by_status(&self) -> Result<Vec<(JobStatus, u64)>> {
         let conn = self.conn()?;
         let mut stmt = conn
@@ -694,6 +711,21 @@ mod tests {
         let report = store.prune_old_jobs(policy).unwrap();
         assert_eq!(report.deleted, 0);
         assert_eq!(report.kept, 0);
+    }
+
+    #[test]
+    fn oldest_job_created_at_returns_min_on_sqlite() {
+        use voom_domain::job::{Job, JobType};
+        let store = test_store();
+        let mut older = Job::new(JobType::Process);
+        older.created_at = chrono::Utc::now() - chrono::Duration::days(3);
+        store.create_job(&older).unwrap();
+        let mut newer = Job::new(JobType::Process);
+        newer.created_at = chrono::Utc::now();
+        store.create_job(&newer).unwrap();
+
+        let got = store.oldest_job_created_at().unwrap().unwrap();
+        assert_eq!(got.timestamp_millis(), older.created_at.timestamp_millis());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Diagnoses issue #194 to retention pruning of `event_log` while `jobs` is preserved (no dispatch defect).
- Bumps `[retention.event_log]` defaults so a full `jobs.keep_last` worth of process jobs (~7 events each) cannot be pruned: `keep_for_days 30→60`, `keep_last 100_000→500_000`.
- Adds `oldest_job_created_at` / `oldest_event_at` accessors and a `voom health check` section that warns when the oldest event is newer than the oldest job.
- Documents the retention invariant in `docs/architecture.md` and the embedded sample config.

## Root cause
Each `voom process` job emits ~7 `event_log` rows (file.discovered, file.introspected, three plan.* events, job.started, job.completed). The shipped defaults bounded `event_log.keep_last` at 100k while `jobs.keep_last` was 50k — only a 2× ratio. End-of-run retention pruned 71,993 events from the issue reporter's 47,410-job run while leaving every job row in place, so external observers reading historical `event_log` saw ~80% of `job.started` events instead of 100%. The bus dispatch path (`WorkerPool::run_one_job` → `EventBusReporter`) was — and is — emitting both events for every job.

The smoking gun was the last `retention.completed` row in the user's E2E export:
```
deleted=71993 kept=100000  (event_log)
deleted=0     kept=47410   (jobs)
```

## Test plan
- [x] `cargo test --workspace` — passes
- [x] `cargo test -p voom-cli --features functional -- --test-threads=4` — 119 functional tests + 4 pipeline integration + 1 health smoke pass
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] New regression test in `sqlite-store` reproduces the asymmetry deterministically
- [x] Five `retention_coverage::evaluate` unit tests + 2 boundary tests on `<=`-vs-`<` semantics
- [x] End-to-end `voom health check` smoke test verifies the new section appears in stdout

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)