### PR TITLE
ci: nightly scoped mutation testing with cargo-mutants

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,0 +1,24 @@
+# cargo-mutants configuration for the VOOM workspace.
+#
+# Scope: only the logic-dense crates carry mutation-testing budget. The matrix
+# in .github/workflows/mutants.yml selects packages via `cargo mutants -p ...`;
+# this file applies workspace-wide exclusions and per-mutant timeouts that are
+# safe regardless of which package is being mutated.
+#
+# See: https://mutants.rs/
+
+# Skip non-source paths. Tests and benchmarks are not interesting targets —
+# mutating them produces noise (a "passing" mutated test that still tested
+# nothing useful). Examples follow the same logic.
+exclude_globs = [
+    "**/tests/**",
+    "**/benches/**",
+    "**/examples/**",
+]
+
+# Maximum wall-clock per cargo command (build + test) for a single mutant.
+# Mutants that exceed this are recorded as "timeout" rather than "missed", so
+# they do not falsely inflate the survived count when the test suite gets
+# pathologically slow on a particular mutation. 300s comfortably covers the
+# slowest expected single-package cargo test.
+timeout = 300

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -2,8 +2,10 @@
 #
 # Scope: only the logic-dense crates carry mutation-testing budget. The matrix
 # in .github/workflows/mutants.yml selects packages via `cargo mutants -p ...`;
-# this file applies workspace-wide exclusions and per-mutant timeouts that are
-# safe regardless of which package is being mutated.
+# this file applies workspace-wide exclusions that are safe regardless of which
+# package is being mutated. The per-mutant timeout (300s) is applied via the
+# `--timeout 300` CLI flag in the workflow because cargo-mutants 27 does not
+# expose a `timeout` key in its config schema.
 #
 # See: https://mutants.rs/
 
@@ -15,10 +17,3 @@ exclude_globs = [
     "**/benches/**",
     "**/examples/**",
 ]
-
-# Maximum wall-clock per cargo command (build + test) for a single mutant.
-# Mutants that exceed this are recorded as "timeout" rather than "missed", so
-# they do not falsely inflate the survived count when the test suite gets
-# pathologically slow on a particular mutation. 300s comfortably covers the
-# slowest expected single-package cargo test.
-timeout = 300

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -1,0 +1,102 @@
+name: Mutants
+
+on:
+  schedule:
+    # Nightly at 03:00 UTC. Off-hours for the maintainer's timezone and well
+    # away from the weekly fuzz sweep at 06:00 UTC Mondays.
+    - cron: '0 3 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  mutants:
+    name: Mutants ${{ matrix.package }}
+    runs-on: ubuntu-latest
+    # Hard ceiling per matrix job. Mutation testing is slow; 6 hours matches
+    # the GitHub-hosted runner cap. If any package consistently approaches
+    # this limit, shard with `cargo mutants --shard N/M` instead of raising.
+    timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - voom-dsl
+          - voom-policy-evaluator
+          - voom-phase-orchestrator
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9  # v1.12.0
+
+      - name: Cache cargo build artifacts
+        uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2.8.0
+        with:
+          # Per-package cache key so the three matrix jobs don't fight over
+          # the same target/ snapshot.
+          key: mutants-${{ matrix.package }}
+
+      - name: Install cargo-mutants
+        uses: taiki-e/install-action@9ca1734d8940023f074414ee621fd530c4ce10f2  # v2.55.3
+        with:
+          tool: cargo-mutants
+
+      - name: Run cargo mutants
+        # Surviving mutants are the steady-state signal, not a regression. Let
+        # cargo-mutants exit 2 ("some mutants missed") without failing the job.
+        # Real failures (config errors, baseline test failures, exit 1/3/4)
+        # will still show up in the summary step's parsed counts.
+        continue-on-error: true
+        run: |
+          cargo mutants \
+            --package ${{ matrix.package }} \
+            --output mutants.out \
+            --timeout 300 \
+            --no-shuffle \
+            --colors=never
+
+      - name: Summarize outcomes
+        if: always()
+        run: |
+          set -euo pipefail
+          out=mutants.out/outcomes.json
+          if [ ! -f "$out" ]; then
+            echo "::warning::no outcomes.json produced — cargo mutants exited before generating results"
+            exit 0
+          fi
+          # outcomes.json is a list of objects each with a `summary` field
+          # ("caught", "missed", "timeout", "unviable", "success").
+          caught=$(jq '[.outcomes[] | select(.summary == "caught")] | length' "$out")
+          missed=$(jq '[.outcomes[] | select(.summary == "missed")] | length' "$out")
+          timeout=$(jq '[.outcomes[] | select(.summary == "timeout")] | length' "$out")
+          unviable=$(jq '[.outcomes[] | select(.summary == "unviable")] | length' "$out")
+          total=$(jq '.outcomes | length' "$out")
+          {
+            echo "## cargo mutants — ${{ matrix.package }}"
+            echo
+            echo "| Outcome  | Count |"
+            echo "|----------|-------|"
+            echo "| Caught   | $caught |"
+            echo "| Missed   | $missed |"
+            echo "| Timeout  | $timeout |"
+            echo "| Unviable | $unviable |"
+            echo "| **Total** | **$total** |"
+            echo
+            echo "Surviving mutants (first 10):"
+            echo
+            jq -r '.outcomes[] | select(.summary == "missed") | "- `\(.scenario.mutant.package_name)` \(.scenario.mutant.source_file.tree_relative_slashes):\(.scenario.mutant.span.start.line) — \(.scenario.mutant.replacement)"' "$out" | head -10
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload mutants.out artifact
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: mutants-${{ matrix.package }}
+          path: mutants.out/
+          retention-days: 90
+          if-no-files-found: warn

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,3 +29,16 @@ The CI invocation lives in `.github/workflows/sonarcloud.yml`. The path `lcov.in
 ## Fuzzing the DSL
 
 The `voom-dsl` parser and compiler have fuzz harnesses under `crates/voom-dsl/fuzz/`. See `crates/voom-dsl/fuzz/README.md` for instructions on running locally and triaging crashes. The harnesses also run weekly in CI via `.github/workflows/fuzz.yml`.
+
+## Mutation testing
+
+The `voom-dsl`, `voom-policy-evaluator`, and `voom-phase-orchestrator` crates run nightly mutation testing in CI via `.github/workflows/mutants.yml`. To reproduce a single-crate run locally:
+
+```bash
+cargo install cargo-mutants --locked
+cargo mutants -p voom-dsl
+```
+
+Surviving mutants and per-mutant outcomes land in `mutants.out/`. The workspace config at `.cargo/mutants.toml` excludes tests and benches and the workflow caps each cargo command at 300 seconds via `--timeout 300` — pass `--timeout <seconds>` to override locally.
+
+The current baseline counts per crate are recorded in `docs/mutation-testing-baseline.md`; new code in the targeted crates should aim to keep the missed-mutant count flat or drive it down.


### PR DESCRIPTION
## Summary

- Adds `.cargo/mutants.toml` excluding `**/tests/**`, `**/benches/**`, `**/examples/**` (verified via `cargo mutants --list-files -p voom-dsl`).
- Adds `.github/workflows/mutants.yml` running `cargo mutants` nightly at 03:00 UTC against `voom-dsl`, `voom-policy-evaluator`, and `voom-phase-orchestrator`. Per-package matrix, per-package rust-cache key, 6-hour `timeout-minutes` ceiling, 90-day artifact retention. Non-blocking: `continue-on-error: true` on the cargo step + `if: always()` on the summary and artifact-upload steps so surviving mutants do not redden the workflow. The summary step parses `mutants.out/outcomes.json` into the GitHub Step Summary (caught/missed/timeout/unviable counts plus the first 10 missed mutants).
- Documents the local invocation (`cargo install cargo-mutants --locked` + `cargo mutants -p <crate>`) in `CONTRIBUTING.md`.

## Deviation from #214

Issue #214 suggested the config snippet `timeout = "300s"`. cargo-mutants 27 has no `timeout` key in its config schema (verified via `cargo mutants --emit-schema=config` — the only related keys are `minimum_test_timeout` and `timeout_multiplier`, which have different semantics). The 300-second hard cap is preserved by passing `--timeout 300` on the CLI in the workflow.

## Deferred to a follow-up PR (issue #214 stays open)

- `docs/mutation-testing-baseline.md` — captured from the artifacts of the first nightly run after this PR lands.
- Triage tracking issue — opened once the baseline numbers are known.

Splitting was the cleaner option because the baseline doc derives from CI output: cargo-mutants on three logic-dense crates can take hours per matrix job, so writing the baseline in this same session would have meant babysitting a long CI run.

## Test plan

- [x] `cargo fmt --all -- --check` passes.
- [x] `cargo clippy --workspace -- -D warnings` passes.
- [x] `cargo test --workspace` matches `main` (no Rust code changed in this PR).
- [x] `actionlint .github/workflows/mutants.yml` is clean.
- [x] `zizmor .github/workflows/mutants.yml` is clean.
- [ ] After merge: workflow_dispatch the new `mutants.yml` to capture the baseline; follow-up PR consumes the artifacts.

Refs #214.