### PR TITLE
test: property-based tests for DSL roundtrip and policy-evaluator (#216)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3590,6 +3590,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "insta",
+ "proptest",
  "serde",
  "serde_json",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,6 +276,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2049,6 +2064,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "proptest-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c57924a81864dddafba92e1bf92f9bf82f97096c44489548a60e888e1547549b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "psm"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2084,6 +2129,12 @@ dependencies = [
  "web-sys",
  "winapi",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -2203,6 +2254,15 @@ name = "rand_core"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "raw-cpuid"
@@ -2446,6 +2506,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -3135,6 +3207,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3375,11 +3453,14 @@ dependencies = [
  "insta",
  "pest",
  "pest_derive",
+ "proptest",
+ "proptest-derive",
  "regex",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "voom-domain",
+ "voom-dsl",
  "xxhash-rust",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,4 +140,7 @@ governor = "0.10"
 
 # Testing
 insta = { version = "1", features = ["yaml"] }
+# Property-based testing
+proptest = "1.11"
+proptest-derive = "0.8"
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,7 +140,6 @@ governor = "0.10"
 
 # Testing
 insta = { version = "1", features = ["yaml"] }
-# Property-based testing
-proptest = "1.11"
+proptest = "1"
 proptest-derive = "0.8"
 tempfile = "3"

--- a/crates/voom-dsl/Cargo.toml
+++ b/crates/voom-dsl/Cargo.toml
@@ -11,6 +11,11 @@ keywords.workspace = true
 categories.workspace = true
 description = "DSL parser and compiler for VOOM policy files"
 
+[features]
+# Exposes `voom_dsl::testing` strategies for downstream proptest consumers.
+# Enabled by integration tests via dev-dependencies on this crate with features = ["proptest"].
+proptest = ["dep:proptest", "dep:proptest-derive"]
+
 [dependencies]
 pest = "2"
 pest_derive = "2"
@@ -20,9 +25,14 @@ regex = { workspace = true }
 thiserror = { workspace = true }
 voom-domain = { workspace = true }
 xxhash-rust = { workspace = true }
+proptest = { workspace = true, optional = true }
+proptest-derive = { workspace = true, optional = true }
 
 [lints]
 workspace = true
 
 [dev-dependencies]
 insta = { workspace = true }
+proptest = { workspace = true }
+proptest-derive = { workspace = true }
+voom-dsl = { path = ".", features = ["proptest"] }

--- a/crates/voom-dsl/src/lib.rs
+++ b/crates/voom-dsl/src/lib.rs
@@ -28,6 +28,9 @@ pub mod parser;
 pub mod service;
 pub mod validator;
 
+#[cfg(any(test, feature = "proptest"))]
+pub mod testing;
+
 pub use ast::{
     ActionNode, CompareOp, ConditionNode, ConfigNode, FilterNode, OperationNode, PhaseNode,
     PolicyAst, RuleNode, RunIfNode, Span, SpannedOperation, SynthSetting, TrackQueryNode,

--- a/crates/voom-dsl/src/testing/mod.rs
+++ b/crates/voom-dsl/src/testing/mod.rs
@@ -1,0 +1,6 @@
+//! Test-only strategies for property-based testing of the DSL.
+//!
+//! Only available when the `proptest` cargo feature is enabled or when
+//! compiling tests for this crate.
+
+pub mod strategies;

--- a/crates/voom-dsl/src/testing/strategies.rs
+++ b/crates/voom-dsl/src/testing/strategies.rs
@@ -1,1 +1,211 @@
-//! `proptest` strategies for AST nodes. Filled in by Task 3 of issue #216.
+//! `proptest` strategies for AST nodes. Strategies are intentionally bounded
+//! in depth and width to keep test runtime tractable — the goal is to catch
+//! parser/formatter drift, not to enumerate the entire grammar.
+//!
+//! Scope is deliberately narrow: only the operations called out in issue #216
+//! (`Container`, `Keep`, `Remove`, `Order`, `Defaults`). Other variants of
+//! `OperationNode` will be added in follow-up tasks.
+
+use proptest::collection::vec;
+use proptest::prelude::*;
+use proptest::string::string_regex;
+
+use crate::ast::{
+    CompareOp, ConfigNode, FilterNode, OperationNode, PhaseNode, PolicyAst, Span, SpannedOperation,
+};
+
+/// Dummy span used for generated ASTs. The parser overwrites spans on the
+/// roundtrip; the test strips spans before comparing.
+fn dummy_span() -> Span {
+    Span::new(0, 0, 1, 1)
+}
+
+fn ident_strategy() -> impl Strategy<Value = String> {
+    string_regex("[a-z][a-z0-9_]{0,15}").expect("ident regex compiles")
+}
+
+fn policy_name_strategy() -> impl Strategy<Value = String> {
+    // Match the grammar's string literal contents — printable ASCII without
+    // `"` or `\`. Non-empty so we don't lose the field on reparse.
+    string_regex("[A-Za-z0-9 _\\-]{1,32}").expect("policy name regex compiles")
+}
+
+fn language_strategy() -> impl Strategy<Value = String> {
+    string_regex("[a-z]{2,3}").expect("language regex compiles")
+}
+
+fn codec_strategy() -> impl Strategy<Value = String> {
+    prop_oneof![
+        Just("aac".to_string()),
+        Just("ac3".to_string()),
+        Just("dts".to_string()),
+        Just("flac".to_string()),
+        Just("h264".to_string()),
+        Just("h265".to_string()),
+        Just("opus".to_string()),
+    ]
+}
+
+/// Numeric comparison operators — used for `channels` filters where the full
+/// range of operators is accepted by the parser.
+fn numeric_compare_op_strategy() -> impl Strategy<Value = CompareOp> {
+    prop_oneof![
+        Just(CompareOp::Eq),
+        Just(CompareOp::Ne),
+        Just(CompareOp::Lt),
+        Just(CompareOp::Le),
+        Just(CompareOp::Gt),
+        Just(CompareOp::Ge),
+    ]
+}
+
+fn track_target_strategy() -> impl Strategy<Value = String> {
+    prop_oneof![
+        Just("audio".to_string()),
+        Just("subtitle".to_string()),
+        Just("subtitles".to_string()),
+        Just("video".to_string()),
+        Just("attachment".to_string()),
+        Just("attachments".to_string()),
+    ]
+}
+
+/// Atomic `FilterNode` leaves — no logical connectives. The parser rewrites
+/// `lang == X` and `codec == X` into `LangIn`/`CodecIn` singleton lists, so
+/// generating `Eq` for `LangCompare`/`CodecCompare` would not round-trip.
+/// Only `Ne` survives as `LangCompare`/`CodecCompare`; other operators are
+/// rejected by the parser entirely.
+fn filter_leaf_strategy() -> impl Strategy<Value = FilterNode> {
+    prop_oneof![
+        vec(language_strategy(), 1..=3).prop_map(FilterNode::LangIn),
+        vec(codec_strategy(), 1..=3).prop_map(FilterNode::CodecIn),
+        language_strategy().prop_map(|l| FilterNode::LangCompare(CompareOp::Ne, l)),
+        codec_strategy().prop_map(|c| FilterNode::CodecCompare(CompareOp::Ne, c)),
+        (
+            numeric_compare_op_strategy(),
+            (1u32..=8).prop_map(f64::from)
+        )
+            .prop_map(|(op, ch)| FilterNode::Channels(op, ch)),
+        Just(FilterNode::Commentary),
+        Just(FilterNode::Forced),
+        Just(FilterNode::Default),
+    ]
+}
+
+/// Strategy for [`FilterNode`] expressions. Generated trees are normalized so
+/// that the format/parse roundtrip preserves structure:
+///
+/// * `And` children are never `And` (parser flattens `A and (B and C)` to
+///   `And([A, B, C])`).
+/// * `Or` children are never `Or` (same flattening for `or`).
+/// * `Not` children are never `Not` (`not not X` does not parse).
+///
+/// The strategy enforces these invariants by post-processing recursive
+/// subtrees to wrap forbidden children in `Not(...)` (or unwrap a leading
+/// `Not`).
+pub fn filter_strategy() -> impl Strategy<Value = FilterNode> {
+    filter_leaf_strategy().prop_recursive(3, 16, 3, |inner| {
+        let and_child = inner.clone().prop_map(|f| match f {
+            FilterNode::And(_) => FilterNode::Not(Box::new(f)),
+            other => other,
+        });
+        let or_child = inner.clone().prop_map(|f| match f {
+            FilterNode::Or(_) => FilterNode::Not(Box::new(f)),
+            other => other,
+        });
+        let not_child = inner.prop_map(|f| match f {
+            // `not not X` does not parse, so unwrap a leading Not.
+            FilterNode::Not(inner) => *inner,
+            other => other,
+        });
+        prop_oneof![
+            vec(and_child, 2..=3).prop_map(FilterNode::And),
+            vec(or_child, 2..=3).prop_map(FilterNode::Or),
+            not_child.prop_map(|f| FilterNode::Not(Box::new(f))),
+        ]
+    })
+}
+
+/// Strategy for the focused subset of [`OperationNode`] called out in #216.
+pub fn operation_strategy() -> impl Strategy<Value = OperationNode> {
+    prop_oneof![
+        Just(OperationNode::Container("mkv".to_string())),
+        Just(OperationNode::Container("mp4".to_string())),
+        (
+            track_target_strategy(),
+            proptest::option::of(filter_strategy())
+        )
+            .prop_map(|(target, filter)| OperationNode::Keep { target, filter }),
+        (
+            track_target_strategy(),
+            proptest::option::of(filter_strategy())
+        )
+            .prop_map(|(target, filter)| OperationNode::Remove { target, filter }),
+        vec(language_strategy(), 1..=4).prop_map(OperationNode::Order),
+        vec(
+            (
+                // Grammar accepts only "audio" or "subtitle" as the kind in
+                // `default_item`, even though the parser normalizes
+                // "subtitles" to "subtitle" elsewhere.
+                prop_oneof![Just("audio".to_string()), Just("subtitle".to_string())],
+                prop_oneof![
+                    Just("first".to_string()),
+                    Just("first_per_language".to_string()),
+                    Just("none".to_string()),
+                    Just("all".to_string()),
+                ],
+            ),
+            1..=2,
+        )
+        .prop_map(OperationNode::Defaults),
+    ]
+}
+
+fn spanned_op_strategy() -> impl Strategy<Value = SpannedOperation> {
+    operation_strategy().prop_map(|node| SpannedOperation {
+        node,
+        span: dummy_span(),
+    })
+}
+
+fn phase_strategy() -> impl Strategy<Value = PhaseNode> {
+    (ident_strategy(), vec(spanned_op_strategy(), 0..=4)).prop_map(|(name, operations)| PhaseNode {
+        name,
+        skip_when: None,
+        depends_on: Vec::new(),
+        run_if: None,
+        on_error: None,
+        operations,
+        span: dummy_span(),
+    })
+}
+
+fn config_strategy() -> impl Strategy<Value = ConfigNode> {
+    (
+        vec(language_strategy(), 0..=3),
+        vec(language_strategy(), 0..=3),
+    )
+        .prop_map(|(audio_languages, subtitle_languages)| ConfigNode {
+            audio_languages,
+            subtitle_languages,
+            on_error: None,
+            commentary_patterns: Vec::new(),
+            keep_backups: None,
+            span: dummy_span(),
+        })
+}
+
+/// Top-level strategy that builds a complete [`PolicyAst`] for roundtrip tests.
+pub fn policy_ast_strategy() -> impl Strategy<Value = PolicyAst> {
+    (
+        policy_name_strategy(),
+        proptest::option::of(config_strategy()),
+        vec(phase_strategy(), 1..=3),
+    )
+        .prop_map(|(name, config, phases)| PolicyAst {
+            name,
+            config,
+            phases,
+            span: dummy_span(),
+        })
+}

--- a/crates/voom-dsl/src/testing/strategies.rs
+++ b/crates/voom-dsl/src/testing/strategies.rs
@@ -2,9 +2,9 @@
 //! in depth and width to keep test runtime tractable — the goal is to catch
 //! parser/formatter drift, not to enumerate the entire grammar.
 //!
-//! Scope is deliberately narrow: only the operations called out in issue #216
-//! (`Container`, `Keep`, `Remove`, `Order`, `Defaults`). Other variants of
-//! `OperationNode` will be added in follow-up tasks.
+//! Scope is deliberately narrow: only the operations `Container`, `Keep`,
+//! `Remove`, `Order`, `Defaults`. Other `OperationNode` variants are not
+//! generated yet — extend the strategies as new variants gain coverage.
 
 use proptest::collection::vec;
 use proptest::prelude::*;
@@ -126,7 +126,7 @@ pub fn filter_strategy() -> impl Strategy<Value = FilterNode> {
     })
 }
 
-/// Strategy for the focused subset of [`OperationNode`] called out in #216.
+/// Strategy for the focused subset of [`OperationNode`] currently covered.
 pub fn operation_strategy() -> impl Strategy<Value = OperationNode> {
     prop_oneof![
         Just(OperationNode::Container("mkv".to_string())),

--- a/crates/voom-dsl/src/testing/strategies.rs
+++ b/crates/voom-dsl/src/testing/strategies.rs
@@ -1,0 +1,1 @@
+//! `proptest` strategies for AST nodes. Filled in by Task 3 of issue #216.

--- a/crates/voom-dsl/tests/proptest_roundtrip.proptest-regressions
+++ b/crates/voom-dsl/tests/proptest_roundtrip.proptest-regressions
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 805245950aae0a5bd5b4ea0633c028a1aa244400b6555eaf02150e9a20d1be57 # shrinks to ast = PolicyAst { name: "a", config: None, phases: [PhaseNode { name: "a", skip_when: None, depends_on: [], run_if: None, on_error: None, operations: [SpannedOperation { node: Keep { target: "audio", filter: Some(LangCompare(Lt, "aa")) }, span: Span { start: 0, end: 0, line: 1, col: 1 } }], span: Span { start: 0, end: 0, line: 1, col: 1 } }], span: Span { start: 0, end: 0, line: 1, col: 1 } }
+cc 807203a8e5759f2c31aa339a1e48b628c21274e66cb406ecb27e28f07cb08998 # shrinks to ast = PolicyAst { name: " ", config: None, phases: [PhaseNode { name: "a", skip_when: None, depends_on: [], run_if: None, on_error: None, operations: [SpannedOperation { node: Remove { target: "audio", filter: Some(And([CodecCompare(Ne, "ac3"), And([Commentary, CodecCompare(Ne, "opus")])])) }, span: Span { start: 0, end: 0, line: 1, col: 1 } }], span: Span { start: 0, end: 0, line: 1, col: 1 } }], span: Span { start: 0, end: 0, line: 1, col: 1 } }

--- a/crates/voom-dsl/tests/proptest_roundtrip.rs
+++ b/crates/voom-dsl/tests/proptest_roundtrip.rs
@@ -29,7 +29,7 @@ fn strip_spans(value: &mut serde_json::Value) {
 }
 
 proptest! {
-    #![proptest_config(ProptestConfig::with_cases(64))]
+    #![proptest_config(ProptestConfig::with_cases(256))]
 
     #[test]
     fn format_parse_roundtrip(ast in policy_ast_strategy()) {
@@ -38,5 +38,6 @@ proptest! {
             panic!("failed to reparse formatted output:\n---\n{source}\n---\nerror: {e:?}")
         });
         prop_assert_eq!(normalize(&ast), normalize(&reparsed));
+        prop_assert_eq!(format_policy(&ast), format_policy(&reparsed));
     }
 }

--- a/crates/voom-dsl/tests/proptest_roundtrip.rs
+++ b/crates/voom-dsl/tests/proptest_roundtrip.rs
@@ -1,0 +1,42 @@
+//! Property-based test: format/parse roundtrip preserves AST semantics.
+
+use proptest::prelude::*;
+use voom_dsl::testing::strategies::policy_ast_strategy;
+use voom_dsl::{format_policy, parse_policy};
+
+/// Strip `span` fields so two ASTs that differ only in source positions compare equal.
+fn normalize(ast: &voom_dsl::PolicyAst) -> serde_json::Value {
+    let mut json = serde_json::to_value(ast).expect("AST is serializable");
+    strip_spans(&mut json);
+    json
+}
+
+fn strip_spans(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Object(map) => {
+            map.remove("span");
+            for v in map.values_mut() {
+                strip_spans(v);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for v in items {
+                strip_spans(v);
+            }
+        }
+        _ => {}
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    #[test]
+    fn format_parse_roundtrip(ast in policy_ast_strategy()) {
+        let source = format_policy(&ast);
+        let reparsed = parse_policy(&source).unwrap_or_else(|e| {
+            panic!("failed to reparse formatted output:\n---\n{source}\n---\nerror: {e:?}")
+        });
+        prop_assert_eq!(normalize(&ast), normalize(&reparsed));
+    }
+}

--- a/plugins/policy-evaluator/Cargo.toml
+++ b/plugins/policy-evaluator/Cargo.toml
@@ -25,5 +25,6 @@ workspace = true
 
 [dev-dependencies]
 insta = { workspace = true }
+proptest = { workspace = true }
 voom-dsl = { workspace = true }
 voom-domain = { workspace = true, features = ["testing"] }

--- a/plugins/policy-evaluator/tests/proptest_invariants.rs
+++ b/plugins/policy-evaluator/tests/proptest_invariants.rs
@@ -1,0 +1,89 @@
+//! Property-based invariants for the policy evaluator. See issue #216.
+
+use std::path::PathBuf;
+
+use proptest::collection::vec;
+use proptest::prelude::*;
+
+use voom_domain::media::{MediaFile, Track, TrackType};
+use voom_dsl::compile_policy;
+use voom_policy_evaluator::evaluate;
+
+/// Strategy for an audio Track: (language, codec, channels) tuple.
+fn audio_track_strategy() -> impl Strategy<Value = (String, String, u32)> {
+    (
+        prop_oneof![
+            Just("eng"),
+            Just("jpn"),
+            Just("fre"),
+            Just("spa"),
+            Just("ger")
+        ]
+        .prop_map(str::to_string),
+        prop_oneof![
+            Just("aac"),
+            Just("ac3"),
+            Just("dts"),
+            Just("flac"),
+            Just("opus")
+        ]
+        .prop_map(str::to_string),
+        prop_oneof![Just(2u32), Just(6), Just(8)],
+    )
+}
+
+/// Build a `MediaFile` with one fixed video track at index 0 and the given
+/// audio tracks at sequential indices starting at 1.
+fn build_file(audio: &[(String, String, u32)]) -> MediaFile {
+    let mut file = MediaFile::new(PathBuf::from("/test/movie.mkv"));
+    let mut next_index = 0u32;
+
+    let mut video = Track::new(next_index, TrackType::Video, "h264".into());
+    video.language = "und".into();
+    file.tracks.push(video);
+    next_index += 1;
+
+    for (lang, codec, channels) in audio {
+        let mut t = Track::new(next_index, TrackType::AudioMain, codec.clone());
+        t.language = lang.clone();
+        t.channels = Some(*channels);
+        file.tracks.push(t);
+        next_index += 1;
+    }
+    file
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    /// Sort stability: when `keep audio where lang in [...]` selects a subset
+    /// of tracks, the resulting Plan emits actions referencing tracks in
+    /// monotonically-increasing index order. Two tracks A and B that both
+    /// pass the filter must appear in the plan in the same relative order
+    /// as in the input file.
+    #[test]
+    fn keep_audio_preserves_track_order(audio in vec(audio_track_strategy(), 1..=8)) {
+        let file = build_file(&audio);
+        let policy = compile_policy(
+            r#"policy "test" { phase init { keep audio where lang in [eng, jpn, fre] } }"#,
+        ).unwrap();
+
+        let result = evaluate(&policy, &file);
+        // Phase 'init' produces exactly one Plan.
+        prop_assert_eq!(result.plans.len(), 1);
+
+        // Extract the track indices the plan touches, in emission order.
+        let touched: Vec<u32> = result.plans[0]
+            .actions
+            .iter()
+            .filter_map(|a| a.track_index)
+            .collect();
+
+        // The indices must be strictly increasing — equivalent to "preserves
+        // original file order" since file indices are assigned sequentially
+        // in insertion order.
+        for w in touched.windows(2) {
+            prop_assert!(w[0] < w[1], "Plan emitted indices out of order: {touched:?}");
+        }
+    }
+}

--- a/plugins/policy-evaluator/tests/proptest_invariants.rs
+++ b/plugins/policy-evaluator/tests/proptest_invariants.rs
@@ -147,3 +147,49 @@ fn apply_default_actions(file: &mut MediaFile, plan: &Plan) {
         }
     }
 }
+
+/// Build a `skip when <condition>` policy and return whether the skip fires
+/// (i.e., whether the condition evaluates to true) when applied to `file`.
+fn skip_fires(file: &MediaFile, condition_dsl: &str) -> bool {
+    let src =
+        format!("policy \"p\" {{ phase init {{ skip when {condition_dsl} container mkv }} }}");
+    let policy = compile_policy(&src).unwrap_or_else(|e| panic!("dsl: {src}\nerr: {e:?}"));
+    let result = evaluate(&policy, file);
+    result.plans[0].is_skipped()
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    /// Identity: `not (not P) ≡ P`.
+    #[test]
+    fn double_negation_identity(audio in vec(audio_track_strategy(), 0..=4)) {
+        let file = build_file(&audio);
+        let p = "exists(audio where lang in [eng])";
+        let direct = skip_fires(&file, p);
+        let double_neg = skip_fires(&file, &format!("not (not ({p}))"));
+        prop_assert_eq!(direct, double_neg);
+    }
+
+    /// De Morgan's law: `not (A and B) ≡ (not A) or (not B)`.
+    #[test]
+    fn de_morgan_and(audio in vec(audio_track_strategy(), 0..=4)) {
+        let file = build_file(&audio);
+        let a = "exists(audio where lang in [eng])";
+        let b = "exists(audio where codec in [aac])";
+        let lhs = skip_fires(&file, &format!("not (({a}) and ({b}))"));
+        let rhs = skip_fires(&file, &format!("(not ({a})) or (not ({b}))"));
+        prop_assert_eq!(lhs, rhs);
+    }
+
+    /// De Morgan's law: `not (A or B) ≡ (not A) and (not B)`.
+    #[test]
+    fn de_morgan_or(audio in vec(audio_track_strategy(), 0..=4)) {
+        let file = build_file(&audio);
+        let a = "exists(audio where lang in [eng])";
+        let b = "exists(audio where codec in [aac])";
+        let lhs = skip_fires(&file, &format!("not (({a}) or ({b}))"));
+        let rhs = skip_fires(&file, &format!("(not ({a})) and (not ({b}))"));
+        prop_assert_eq!(lhs, rhs);
+    }
+}

--- a/plugins/policy-evaluator/tests/proptest_invariants.rs
+++ b/plugins/policy-evaluator/tests/proptest_invariants.rs
@@ -1,4 +1,5 @@
-//! Property-based invariants for the policy evaluator. See issue #216.
+//! Property-based invariants for the policy evaluator: sort stability,
+//! dedup idempotence, and predicate algebra (double-negation, De Morgan).
 
 use std::path::PathBuf;
 
@@ -37,19 +38,17 @@ fn audio_track_strategy() -> impl Strategy<Value = (String, String, u32)> {
 /// audio tracks at sequential indices starting at 1.
 fn build_file(audio: &[(String, String, u32)]) -> MediaFile {
     let mut file = MediaFile::new(PathBuf::from("/test/movie.mkv"));
-    let mut next_index = 0u32;
 
-    let mut video = Track::new(next_index, TrackType::Video, "h264".into());
+    let mut video = Track::new(0, TrackType::Video, "h264".into());
     video.language = "und".into();
     file.tracks.push(video);
-    next_index += 1;
 
-    for (lang, codec, channels) in audio {
-        let mut t = Track::new(next_index, TrackType::AudioMain, codec.clone());
+    for (i, (lang, codec, channels)) in audio.iter().enumerate() {
+        let idx = u32::try_from(i + 1).expect("audio count fits in u32");
+        let mut t = Track::new(idx, TrackType::AudioMain, codec.clone());
         t.language = lang.clone();
         t.channels = Some(*channels);
         file.tracks.push(t);
-        next_index += 1;
     }
     file
 }
@@ -70,19 +69,16 @@ proptest! {
         ).unwrap();
 
         let result = evaluate(&policy, &file);
-        // Phase 'init' produces exactly one Plan.
         prop_assert_eq!(result.plans.len(), 1);
 
-        // Extract the track indices the plan touches, in emission order.
         let touched: Vec<u32> = result.plans[0]
             .actions
             .iter()
             .filter_map(|a| a.track_index)
             .collect();
 
-        // The indices must be strictly increasing — equivalent to "preserves
-        // original file order" since file indices are assigned sequentially
-        // in insertion order.
+        // Strictly increasing indices ⇔ original file order preserved, because
+        // file indices are assigned sequentially in insertion order.
         for w in touched.windows(2) {
             prop_assert!(w[0] < w[1], "Plan emitted indices out of order: {touched:?}");
         }
@@ -106,15 +102,12 @@ proptest! {
             r#"policy "test" { phase init { defaults { audio: first_per_language } } }"#,
         ).unwrap();
 
-        // First evaluation produces the (set_default, clear_default) actions.
         let first = evaluate(&policy, &file);
         prop_assert_eq!(first.plans.len(), 1);
 
-        // Apply the default-flag actions to a mutable clone of the file.
         let mut updated = file.clone();
         apply_default_actions(&mut updated, &first.plans[0]);
 
-        // Second evaluation against the updated file must be a no-op.
         let second = evaluate(&policy, &updated);
         prop_assert_eq!(second.plans.len(), 1);
         prop_assert_eq!(

--- a/plugins/policy-evaluator/tests/proptest_invariants.rs
+++ b/plugins/policy-evaluator/tests/proptest_invariants.rs
@@ -87,3 +87,60 @@ proptest! {
         }
     }
 }
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    /// Dedup idempotence: applying `defaults audio first_per_language` and
+    /// then mutating the file in place to reflect those default-flag changes
+    /// must leave no further work for a second evaluation. Equivalently:
+    /// `defaults first_per_language` is a fixpoint operator on the
+    /// `is_default` flag set.
+    #[test]
+    fn defaults_first_per_language_is_idempotent(
+        audio in proptest::collection::vec(audio_track_strategy(), 1..=6),
+    ) {
+        let file = build_file(&audio);
+        let policy = voom_dsl::compile_policy(
+            r#"policy "test" { phase init { defaults { audio: first_per_language } } }"#,
+        ).unwrap();
+
+        // First evaluation produces the (set_default, clear_default) actions.
+        let first = evaluate(&policy, &file);
+        prop_assert_eq!(first.plans.len(), 1);
+
+        // Apply the default-flag actions to a mutable clone of the file.
+        let mut updated = file.clone();
+        apply_default_actions(&mut updated, &first.plans[0]);
+
+        // Second evaluation against the updated file must be a no-op.
+        let second = evaluate(&policy, &updated);
+        prop_assert_eq!(
+            second.plans[0].actions.len(),
+            0,
+            "second pass emitted actions: {:?}",
+            second.plans[0].actions,
+        );
+    }
+}
+
+/// Apply `SetDefault` / `ClearDefault` actions from a Plan to a MediaFile,
+/// mirroring what an executor would do at run-time. Lives in this test file
+/// because no production code performs this in-place mutation.
+fn apply_default_actions(file: &mut voom_domain::media::MediaFile, plan: &voom_domain::plan::Plan) {
+    use voom_domain::plan::OperationType;
+
+    for action in &plan.actions {
+        let Some(idx) = action.track_index else {
+            continue;
+        };
+        let Some(track) = file.tracks.iter_mut().find(|t| t.index == idx) else {
+            continue;
+        };
+        match action.operation {
+            OperationType::SetDefault => track.is_default = true,
+            OperationType::ClearDefault => track.is_default = false,
+            _ => {}
+        }
+    }
+}

--- a/plugins/policy-evaluator/tests/proptest_invariants.rs
+++ b/plugins/policy-evaluator/tests/proptest_invariants.rs
@@ -6,6 +6,7 @@ use proptest::collection::vec;
 use proptest::prelude::*;
 
 use voom_domain::media::{MediaFile, Track, TrackType};
+use voom_domain::plan::{OperationType, Plan};
 use voom_dsl::compile_policy;
 use voom_policy_evaluator::evaluate;
 
@@ -98,10 +99,10 @@ proptest! {
     /// `is_default` flag set.
     #[test]
     fn defaults_first_per_language_is_idempotent(
-        audio in proptest::collection::vec(audio_track_strategy(), 1..=6),
+        audio in vec(audio_track_strategy(), 1..=6),
     ) {
         let file = build_file(&audio);
-        let policy = voom_dsl::compile_policy(
+        let policy = compile_policy(
             r#"policy "test" { phase init { defaults { audio: first_per_language } } }"#,
         ).unwrap();
 
@@ -115,6 +116,7 @@ proptest! {
 
         // Second evaluation against the updated file must be a no-op.
         let second = evaluate(&policy, &updated);
+        prop_assert_eq!(second.plans.len(), 1);
         prop_assert_eq!(
             second.plans[0].actions.len(),
             0,
@@ -127,9 +129,7 @@ proptest! {
 /// Apply `SetDefault` / `ClearDefault` actions from a Plan to a MediaFile,
 /// mirroring what an executor would do at run-time. Lives in this test file
 /// because no production code performs this in-place mutation.
-fn apply_default_actions(file: &mut voom_domain::media::MediaFile, plan: &voom_domain::plan::Plan) {
-    use voom_domain::plan::OperationType;
-
+fn apply_default_actions(file: &mut MediaFile, plan: &Plan) {
     for action in &plan.actions {
         let Some(idx) = action.track_index else {
             continue;
@@ -140,7 +140,10 @@ fn apply_default_actions(file: &mut voom_domain::media::MediaFile, plan: &voom_d
         match action.operation {
             OperationType::SetDefault => track.is_default = true,
             OperationType::ClearDefault => track.is_default = false,
-            _ => {}
+            other => panic!(
+                "apply_default_actions only models SetDefault/ClearDefault; got {other:?} \
+                 — extend the helper or narrow the policy"
+            ),
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds `proptest`-based property tests covering the two areas called out in #216:

- **DSL parse/format roundtrip** (`crates/voom-dsl/tests/proptest_roundtrip.rs`) — for AST shapes generated by a `proptest::Strategy`, asserts both `parse(format(ast)) ≡ ast` (modulo spans, via JSON normalization) and the format-fixpoint `format(ast) == format(parse(format(ast)))`. 256 cases.
- **Policy-evaluator invariants** (`plugins/policy-evaluator/tests/proptest_invariants.rs`) — five properties at 256 cases each:
  - `keep_audio_preserves_track_order` — sort stability of `keep audio where lang in [...]`.
  - `defaults_first_per_language_is_idempotent` — dedup idempotence (re-evaluation after applying actions emits no further work).
  - `double_negation_identity`, `de_morgan_and`, `de_morgan_or` — predicate algebra over `skip when` conditions.

## Implementation notes

- AST `Arbitrary` strategies live inside `voom-dsl` behind a `proptest` cargo feature, since AST nodes are `#[non_exhaustive]` and cannot be constructed externally. Integration tests in `crates/voom-dsl/tests/` activate the feature via the standard self-referential dev-dep idiom.
- Roundtrip strategies were narrowed to match real parser normalisations, each documented at the call site:
  - `lang ==`/`codec ==` is rewritten by the parser to `LangIn(vec![v])` / `CodecIn(vec![v])`, so only `Ne` survives as `LangCompare`/`CodecCompare`.
  - PEG flattens `And`-in-`And` and `Or`-in-`Or`; the strategy wraps such children to preserve hierarchy through the roundtrip.
  - Grammar rejects `not not X`; the strategy unwraps double-`Not`.
  - Grammar's `default_item` accepts only `audio`/`subtitle` keys for `defaults`.
- Predicate-algebra tests use a `skip_fires(file, condition_dsl) -> bool` helper that compiles a `skip when <cond>` policy, evaluates it, and returns whether the plan was skipped — letting us compare two equivalent forms (`P` vs `not (not P)`, etc.) on the same file.
- `apply_default_actions` in the dedup test panics on unexpected `OperationType` variants so future evaluator changes surface loudly rather than passing silently.
- No production code modified. Only `Cargo.toml` files, a `pub mod testing;` declaration in `crates/voom-dsl/src/lib.rs` (gated behind the `proptest` feature), and the two new test files.

## Test plan

- [x] `cargo test -p voom-dsl --test proptest_roundtrip` — 1 test, 256 cases, passes.
- [x] `cargo test -p voom-policy-evaluator --test proptest_invariants` — 5 tests, 256 cases each, passes.
- [x] `cargo test --workspace` — all crates pass, no regressions.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo test -p voom-cli --features functional -- --test-threads=4` — 124 functional tests pass.
- [x] CI: existing `.github/workflows/ci.yml:32` invokes `cargo test --workspace` which picks up both new test targets — no workflow changes needed.

## Follow-ups

Filed during review:
- #227 — strengthen `defaults_first_per_language_is_idempotent` with explicit end-state assertion.
- #228 — extend roundtrip strategy coverage to remaining `OperationNode`/`FilterNode` variants.
- #229 — generate predicate shapes (rather than fixed strings) in the algebra tests.

Closes #216.