### PR TITLE
test(policy-evaluator): assert end-state of defaults first_per_language (#227)

### DIFF
--- a/plugins/policy-evaluator/tests/proptest_invariants.rs
+++ b/plugins/policy-evaluator/tests/proptest_invariants.rs
@@ -109,16 +109,13 @@ proptest! {
         let mut updated = file.clone();
         apply_default_actions(&mut updated, &first.plans[0]);
 
-        // End-state witness: after one pass, every language that had any
-        // AudioMain track must have exactly one default AudioMain track.
-        // This is the actual fixpoint semantics of `first_per_language`;
-        // the "second pass emits zero actions" check below is its
-        // downstream consequence. We assert both so that an evaluator that
-        // produced no second-pass actions for the wrong reason (e.g. by
-        // short-circuiting) cannot pass.
+        // Asserted alongside the idempotence check below: a short-circuiting
+        // evaluator could emit zero second-pass actions without actually
+        // reaching the `first_per_language` fixpoint, so we witness the
+        // end-state directly here.
         let mut counts: HashMap<&str, u32> = HashMap::new();
         for t in &updated.tracks {
-            if matches!(t.track_type, TrackType::AudioMain) && t.is_default {
+            if t.track_type == TrackType::AudioMain && t.is_default {
                 *counts.entry(t.language.as_str()).or_default() += 1;
             }
         }

--- a/plugins/policy-evaluator/tests/proptest_invariants.rs
+++ b/plugins/policy-evaluator/tests/proptest_invariants.rs
@@ -1,6 +1,7 @@
 //! Property-based invariants for the policy evaluator: sort stability,
 //! dedup idempotence, and predicate algebra (double-negation, De Morgan).
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 use proptest::collection::vec;
@@ -107,6 +108,23 @@ proptest! {
 
         let mut updated = file.clone();
         apply_default_actions(&mut updated, &first.plans[0]);
+
+        // End-state witness: after one pass, every language that had any
+        // AudioMain track must have exactly one default AudioMain track.
+        // This is the actual fixpoint semantics of `first_per_language`;
+        // the "second pass emits zero actions" check below is its
+        // downstream consequence. We assert both so that an evaluator that
+        // produced no second-pass actions for the wrong reason (e.g. by
+        // short-circuiting) cannot pass.
+        let mut counts: HashMap<&str, u32> = HashMap::new();
+        for t in &updated.tracks {
+            if matches!(t.track_type, TrackType::AudioMain) && t.is_default {
+                *counts.entry(t.language.as_str()).or_default() += 1;
+            }
+        }
+        for (lang, n) in &counts {
+            prop_assert_eq!(*n, 1, "lang {} has {} default audio tracks after pass 1", lang, n);
+        }
 
         let second = evaluate(&policy, &updated);
         prop_assert_eq!(second.plans.len(), 1);


### PR DESCRIPTION
## Summary

Strengthens `defaults_first_per_language_is_idempotent` (in `plugins/policy-evaluator/tests/proptest_invariants.rs`) so it directly witnesses the fixpoint property of `defaults audio first_per_language`, instead of asserting only the downstream "second pass emits zero actions" consequence.

Closes #227.

## Changes

- After applying the first plan's actions, the test now also counts default-flagged `AudioMain` tracks per language and asserts every counted language has exactly one default. The pre-existing zero-actions check is retained — together they fully witness the fixpoint property.
- Added `use std::collections::HashMap;` (only new dependency on the test).

Two commits:
1. `test(policy-evaluator): assert end-state of defaults first_per_language (#227)` — the strengthening itself, matching the issue's proposal.
2. `test(policy-evaluator): prefer == over matches!, tighten end-state comment` — follow-up polish per project conventions (avoid `matches!`, keep WHY-only comments).

## Testing

- All five `proptest_invariants.rs` properties pass (`cargo test -p voom-policy-evaluator --test proptest_invariants`): `keep_audio_preserves_track_order`, `defaults_first_per_language_is_idempotent`, `double_negation_identity`, `de_morgan_and`, `de_morgan_or`.
- Mutation sanity check (not committed): temporarily stripped the language-dedup from `emit_defaults_first_per_language`. The new end-state assertion fired first with `lang jpn has 2 default audio tracks after pass 1`, confirming the strengthening is load-bearing rather than a downstream consequence of the existing check. Evaluator was restored before commit.
- `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` all green.
- Proptest case budget unchanged at `with_cases(256)` per the issue's acceptance criteria.

## Notes

- Test-only change; no production code touched.
- Format args use the positional form (`"lang {} has {} ...", lang, n`) rather than Rust 2021 inlined captures because `prop_assert_eq!` builds its format string via `concat!`, and `format_args!` will not capture identifiers across that macro expansion.
- The proptest run can regenerate `plugins/policy-evaluator/tests/proptest_invariants.proptest-regressions` when a failure is observed (e.g. during the mutation check above). The workspace `.gitignore` does not currently exclude `*.proptest-regressions`. Out of scope here; will file a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
