### PR TITLE
test(policy-evaluator): generate predicate shapes in algebra tests (#229)

### DIFF
--- a/plugins/policy-evaluator/tests/proptest_invariants.rs
+++ b/plugins/policy-evaluator/tests/proptest_invariants.rs
@@ -330,15 +330,23 @@ proptest! {
         );
     }
 
-    /// De Morgan's law: `not (A and B) ≡ (not A) or (not B)`.
+    /// De Morgan's law: `not (A and B) ≡ (not A) or (not B)` for any A, B
+    /// drawn from `condition_dsl_strategy`.
     #[test]
-    fn de_morgan_and(audio in vec(audio_track_strategy(), 0..=4)) {
+    fn de_morgan_and(
+        audio in vec(audio_track_strategy(), 0..=4),
+        a in condition_dsl_strategy(),
+        b in condition_dsl_strategy(),
+    ) {
         let file = build_file(&audio);
-        let a = "exists(audio where lang in [eng])";
-        let b = "exists(audio where codec in [aac])";
         let lhs = skip_fires(&file, &format!("not (({a}) and ({b}))"));
         let rhs = skip_fires(&file, &format!("(not ({a})) or (not ({b}))"));
-        prop_assert_eq!(lhs, rhs);
+        // Positional arg: prop_assert_eq! routes through concat!, which rejects {capture}.
+        prop_assert_eq!(
+            lhs, rhs,
+            "De Morgan (and) broke for predicates a=`{}` b=`{}`",
+            a, b,
+        );
     }
 
     /// De Morgan's law: `not (A or B) ≡ (not A) and (not B)`.

--- a/plugins/policy-evaluator/tests/proptest_invariants.rs
+++ b/plugins/policy-evaluator/tests/proptest_invariants.rs
@@ -166,6 +166,130 @@ fn skip_fires(file: &MediaFile, condition_dsl: &str) -> bool {
     result.plans[0].is_skipped()
 }
 
+/// Strategy for a grammar-valid DSL `condition_atom` string.
+///
+/// Covers the shapes called out in issue #229:
+/// - plain atoms: `is_dubbed`, `is_original`, `audio_is_multi_language`
+/// - `exists(<target> [where <filter_atom>])`
+/// - `count(<target> [where <filter_atom>]) <op> <number>`
+/// - `<field_access> <op> <value>`
+/// - `<field_access> exists`
+///
+/// Excludes `in` from comparison ops in field-compare and count variants
+/// (it requires a list RHS, which is handled by dedicated list-shaped
+/// variants in the filter sub-strategy). Field paths are restricted to
+/// `audio.*` and `video.*`, which the evaluator's `resolve_field` knows
+/// how to look up; unresolvable paths still produce deterministic
+/// `false`, but keeping the strategy on resolvable paths exercises more
+/// of the evaluator.
+#[allow(dead_code)] // wired into algebra tests in Task 3; remove then.
+fn condition_dsl_strategy() -> impl Strategy<Value = String> {
+    // Scalars used inside generated strings.
+    let lang = prop_oneof![
+        Just("eng"),
+        Just("jpn"),
+        Just("fre"),
+        Just("spa"),
+        Just("ger"),
+    ];
+    let codec = prop_oneof![
+        Just("aac"),
+        Just("ac3"),
+        Just("dts"),
+        Just("flac"),
+        Just("opus"),
+    ];
+    let target = prop_oneof![Just("audio"), Just("subtitle"), Just("video")];
+    // Comparison ops that take scalar RHS (no `in`).
+    let scalar_cmp = prop_oneof![
+        Just("=="),
+        Just("!="),
+        Just("<"),
+        Just("<="),
+        Just(">"),
+        Just(">="),
+    ];
+    let small_num = 0u32..=8u32;
+
+    // ----- filter_atom variants used inside `where` clauses -----
+
+    let lang_in_list = lang.clone().prop_map(|l| format!("lang in [{l}]"));
+    let codec_in_list = codec.clone().prop_map(|c| format!("codec in [{c}]"));
+    let channels_cmp =
+        (scalar_cmp.clone(), small_num.clone()).prop_map(|(op, n)| format!("channels {op} {n}"));
+    let bare_filter = prop_oneof![
+        Just("commentary".to_string()),
+        Just("forced".to_string()),
+        Just("default".to_string()),
+    ];
+    let filter_atom = prop_oneof![lang_in_list, codec_in_list, channels_cmp, bare_filter];
+
+    // Optional ` where <filter_atom>` suffix (or empty).
+    let where_clause = proptest::option::of(filter_atom)
+        .prop_map(|f| f.map_or(String::new(), |s| format!(" where {s}")));
+
+    // ----- condition_atom variants -----
+
+    let plain = prop_oneof![
+        Just("is_dubbed".to_string()),
+        Just("is_original".to_string()),
+        Just("audio_is_multi_language".to_string()),
+    ];
+
+    let exists_atom =
+        (target.clone(), where_clause.clone()).prop_map(|(t, w)| format!("exists({t}{w})"));
+
+    let count_atom = (
+        target.clone(),
+        where_clause.clone(),
+        scalar_cmp.clone(),
+        small_num.clone(),
+    )
+        .prop_map(|(t, w, op, n)| format!("count({t}{w}) {op} {n}"));
+
+    // Field-access compare with a string RHS (codec/language fields).
+    let field_string_cmp = (
+        prop_oneof![
+            Just("audio.codec"),
+            Just("audio.language"),
+            Just("audio.title"),
+        ],
+        scalar_cmp.clone(),
+        prop_oneof![
+            codec.clone().prop_map(|c| format!("\"{c}\"")),
+            lang.clone().prop_map(|l| format!("\"{l}\"")),
+        ],
+    )
+        .prop_map(|(f, op, v)| format!("{f} {op} {v}"));
+
+    // Field-access compare with a numeric RHS (channels/width/height).
+    let field_num_cmp = (
+        prop_oneof![
+            Just("audio.channels"),
+            Just("video.width"),
+            Just("video.height"),
+        ],
+        scalar_cmp,
+        small_num,
+    )
+        .prop_map(|(f, op, n)| format!("{f} {op} {n}"));
+
+    let field_exists = prop_oneof![
+        Just("audio.codec exists".to_string()),
+        Just("audio.language exists".to_string()),
+        Just("video.codec exists".to_string()),
+    ];
+
+    prop_oneof![
+        plain,
+        exists_atom,
+        count_atom,
+        field_string_cmp,
+        field_num_cmp,
+        field_exists,
+    ]
+}
+
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(256))]
 

--- a/plugins/policy-evaluator/tests/proptest_invariants.rs
+++ b/plugins/policy-evaluator/tests/proptest_invariants.rs
@@ -182,6 +182,11 @@ fn skip_fires(file: &MediaFile, condition_dsl: &str) -> bool {
 /// how to look up; unresolvable paths still produce deterministic
 /// `false`, but keeping the strategy on resolvable paths exercises more
 /// of the evaluator.
+///
+/// Lives here (string-emitting, local) rather than in
+/// `voom_dsl::testing::strategies` because issue #229 scoped this work to
+/// raw DSL strings; an AST-level `condition_strategy` paired with
+/// `format_policy` is the right home if/when this is hoisted.
 fn condition_dsl_strategy() -> impl Strategy<Value = String> {
     // Scalars used inside generated strings.
     let lang = prop_oneof![

--- a/plugins/policy-evaluator/tests/proptest_invariants.rs
+++ b/plugins/policy-evaluator/tests/proptest_invariants.rs
@@ -293,6 +293,26 @@ fn condition_dsl_strategy() -> impl Strategy<Value = String> {
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(256))]
 
+    /// Every string emitted by `condition_dsl_strategy` must compile as a
+    /// `skip when <p>` policy. This catches grammar-violating shapes in
+    /// the strategy itself before the algebra tests would notice.
+    #[test]
+    fn condition_dsl_strategy_emits_compilable_predicates(
+        p in condition_dsl_strategy(),
+    ) {
+        let src = format!("policy \"p\" {{ phase init {{ skip when {p} container mkv }} }}");
+        let res = compile_policy(&src);
+        prop_assert!(
+            res.is_ok(),
+            "strategy emitted non-compilable predicate `{p}`: {:?}",
+            res.err(),
+        );
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
     /// Identity: `not (not P) ≡ P`.
     #[test]
     fn double_negation_identity(audio in vec(audio_track_strategy(), 0..=4)) {

--- a/plugins/policy-evaluator/tests/proptest_invariants.rs
+++ b/plugins/policy-evaluator/tests/proptest_invariants.rs
@@ -349,14 +349,22 @@ proptest! {
         );
     }
 
-    /// De Morgan's law: `not (A or B) ≡ (not A) and (not B)`.
+    /// De Morgan's law: `not (A or B) ≡ (not A) and (not B)` for any A, B
+    /// drawn from `condition_dsl_strategy`.
     #[test]
-    fn de_morgan_or(audio in vec(audio_track_strategy(), 0..=4)) {
+    fn de_morgan_or(
+        audio in vec(audio_track_strategy(), 0..=4),
+        a in condition_dsl_strategy(),
+        b in condition_dsl_strategy(),
+    ) {
         let file = build_file(&audio);
-        let a = "exists(audio where lang in [eng])";
-        let b = "exists(audio where codec in [aac])";
         let lhs = skip_fires(&file, &format!("not (({a}) or ({b}))"));
         let rhs = skip_fires(&file, &format!("(not ({a})) and (not ({b}))"));
-        prop_assert_eq!(lhs, rhs);
+        // Positional arg: prop_assert_eq! routes through concat!, which rejects {capture}.
+        prop_assert_eq!(
+            lhs, rhs,
+            "De Morgan (or) broke for predicates a=`{}` b=`{}`",
+            a, b,
+        );
     }
 }

--- a/plugins/policy-evaluator/tests/proptest_invariants.rs
+++ b/plugins/policy-evaluator/tests/proptest_invariants.rs
@@ -182,7 +182,6 @@ fn skip_fires(file: &MediaFile, condition_dsl: &str) -> bool {
 /// how to look up; unresolvable paths still produce deterministic
 /// `false`, but keeping the strategy on resolvable paths exercises more
 /// of the evaluator.
-#[allow(dead_code)] // wired into algebra tests in Task 3; remove then.
 fn condition_dsl_strategy() -> impl Strategy<Value = String> {
     // Scalars used inside generated strings.
     let lang = prop_oneof![
@@ -313,14 +312,22 @@ proptest! {
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(256))]
 
-    /// Identity: `not (not P) ≡ P`.
+    /// Identity: `not (not P) ≡ P` for any predicate P drawn from
+    /// `condition_dsl_strategy`.
     #[test]
-    fn double_negation_identity(audio in vec(audio_track_strategy(), 0..=4)) {
+    fn double_negation_identity(
+        audio in vec(audio_track_strategy(), 0..=4),
+        p in condition_dsl_strategy(),
+    ) {
         let file = build_file(&audio);
-        let p = "exists(audio where lang in [eng])";
-        let direct = skip_fires(&file, p);
+        let direct = skip_fires(&file, &p);
         let double_neg = skip_fires(&file, &format!("not (not ({p}))"));
-        prop_assert_eq!(direct, double_neg);
+        // Positional arg: prop_assert_eq! routes through concat!, which rejects {capture}.
+        prop_assert_eq!(
+            direct, double_neg,
+            "double-negation broke for predicate `{}`",
+            p,
+        );
     }
 
     /// De Morgan's law: `not (A and B) ≡ (not A) or (not B)`.


### PR DESCRIPTION
## Summary

Closes #229.

Strengthens the three predicate-algebra property tests in `plugins/policy-evaluator/tests/proptest_invariants.rs` by quantifying them over generated DSL predicate strings, not just over `MediaFile` inputs.

- New `condition_dsl_strategy()` emits grammar-valid `condition_atom` strings: plain atoms (`is_dubbed`, `is_original`, `audio_is_multi_language`), `exists(<target> [where <filter>])`, `count(...) <op> <n>`, field-access compares (string and numeric RHS), and `<field> exists`.
- New canary property test `condition_dsl_strategy_emits_compilable_predicates` asserts every emitted string compiles via `compile_policy`. If the strategy ever drifts from the grammar, this test fails first with a small shrunk counterexample, before the algebra tests are confused by it.
- `double_negation_identity`, `de_morgan_and`, `de_morgan_or` now draw their predicates from the strategy in addition to the existing audio-track strategy.

Test-only change. No production code touched. Single file modified.

## Test plan

- [x] `cargo test -p voom-policy-evaluator --test proptest_invariants` — all 6 tests pass at 256 cases each
- [x] `cargo test -p voom-policy-evaluator` — 119 unit/integration + 6 proptest + 2 doctests pass
- [x] `cargo test` (full workspace) — pass
- [x] `cargo test -p voom-cli --features functional -- --test-threads=4` — pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean