### PR TITLE
test(policy-evaluator): track proptest regressions seed file (#234)

### DIFF
--- a/plugins/policy-evaluator/tests/proptest_invariants.proptest-regressions
+++ b/plugins/policy-evaluator/tests/proptest_invariants.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 075abebfab4de3736b0b579c62e1d5ab61e3545ace589ff52eb8558843cd9c3d # shrinks to audio = [("eng", "aac", 2), ("eng", "aac", 2)]


### PR DESCRIPTION
## Summary
- Tracks `plugins/policy-evaluator/tests/proptest_invariants.proptest-regressions` so the existing seed replays for every contributor, matching the convention already used for `crates/voom-dsl/tests/proptest_roundtrip.proptest-regressions`.
- No `.gitignore` change needed — nothing was suppressing the file.

Closes #234.

## Test plan
- [x] `cargo test -p voom-policy-evaluator --test proptest_invariants` passes locally with the checked-in seed replayed (6/6 tests green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)