### PR TITLE
ci+docs: cargo-mutants baseline and workflow jq fix

### DIFF
--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -69,13 +69,17 @@ jobs:
             echo "::warning::no outcomes.json produced — cargo mutants exited before generating results"
             exit 0
           fi
-          # outcomes.json is a list of objects each with a `summary` field
-          # ("caught", "missed", "timeout", "unviable", "success").
-          caught=$(jq '[.outcomes[] | select(.summary == "caught")] | length' "$out")
-          missed=$(jq '[.outcomes[] | select(.summary == "missed")] | length' "$out")
-          timeout=$(jq '[.outcomes[] | select(.summary == "timeout")] | length' "$out")
-          unviable=$(jq '[.outcomes[] | select(.summary == "unviable")] | length' "$out")
-          total=$(jq '.outcomes | length' "$out")
+          # outcomes.json: each entry has a `summary` field whose value is one
+          # of "CaughtMutant" / "MissedMutant" / "Timeout" / "Unviable" /
+          # "Success". "Success" is the baseline (unmutated) sanity run that
+          # cargo-mutants does once per invocation; it is not a mutant outcome
+          # and is excluded from the per-mutant total below. Mutant data lives
+          # under .scenario.Mutant (capital M).
+          caught=$(jq '[.outcomes[] | select(.summary == "CaughtMutant")] | length' "$out")
+          missed=$(jq '[.outcomes[] | select(.summary == "MissedMutant")] | length' "$out")
+          timeout=$(jq '[.outcomes[] | select(.summary == "Timeout")] | length' "$out")
+          unviable=$(jq '[.outcomes[] | select(.summary == "Unviable")] | length' "$out")
+          total=$((caught + missed + timeout + unviable))
           {
             echo "## cargo mutants — ${{ matrix.package }}"
             echo
@@ -85,11 +89,11 @@ jobs:
             echo "| Missed   | $missed |"
             echo "| Timeout  | $timeout |"
             echo "| Unviable | $unviable |"
-            echo "| **Total** | **$total** |"
+            echo "| **Total mutants** | **$total** |"
             echo
             echo "Surviving mutants (first 10):"
             echo
-            jq -r '.outcomes[] | select(.summary == "missed") | "- `\(.scenario.mutant.package_name)` \(.scenario.mutant.source_file.tree_relative_slashes):\(.scenario.mutant.span.start.line) — \(.scenario.mutant.replacement)"' "$out" | head -10
+            jq -r '.outcomes[] | select(.summary == "MissedMutant") | "- \(.scenario.Mutant.name)"' "$out" | head -10
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload mutants.out artifact

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -8,6 +8,7 @@
 | [dsl-reference.md](dsl-reference.md) | DSL language reference for `.voom` policy files |
 | [quickstart.md](quickstart.md) | Getting started guide |
 | [../CONTRIBUTING.md](../CONTRIBUTING.md) | Local development, coverage, and CI workflow notes |
+| [mutation-testing-baseline.md](mutation-testing-baseline.md) | Initial cargo-mutants baseline counts and triage guidance for logic-dense crates |
 | [plugin-development.md](plugin-development.md) | Guide for writing native and WASM plugins |
 | [functional-test-plan.md](functional-test-plan.md) | QA test plan covering all user-facing features |
 | [troubleshooting.md](troubleshooting.md) | Troubleshooting guide for common issues |

--- a/docs/mutation-testing-baseline.md
+++ b/docs/mutation-testing-baseline.md
@@ -66,7 +66,7 @@ No surviving mutants.
 
 ## Triage
 
-A single tracking issue gathers follow-up work to drive surviving-mutant counts down: see [#TBD — track triage of cargo-mutants survivors](https://github.com/randomparity/voom/issues/TBD). Update the issue number once it is opened.
+A single tracking issue gathers follow-up work to drive surviving-mutant counts down: see [#236 — track triage of cargo-mutants survivors](https://github.com/randomparity/voom/issues/236).
 
 The general approach for triaging a survivor:
 

--- a/docs/mutation-testing-baseline.md
+++ b/docs/mutation-testing-baseline.md
@@ -1,0 +1,82 @@
+# Mutation Testing Baseline
+
+This document captures the initial `cargo mutants` baseline for the three logic-dense crates targeted by issue #214. The numbers below are the reference point that follow-up triage work needs to drive down.
+
+| | |
+|---|---|
+| **Captured** | 2026-05-05 |
+| **Workflow run** | [actions/runs/25374530315](https://github.com/randomparity/voom/actions/runs/25374530315) (`workflow_dispatch` on `main`) |
+| **Source SHA** | `dd69cfa` |
+| **cargo-mutants version** | 27.0.0 |
+| **Config** | `.cargo/mutants.toml` (`exclude_globs = ["**/tests/**", "**/benches/**", "**/examples/**"]`) |
+| **Per-mutant timeout** | 300 s, passed via `--timeout 300` in the workflow |
+
+## Per-crate counts
+
+`Caught` mutants were detected by the test suite. `Missed` mutants survived all tests — these are the targets for triage. `Unviable` mutants failed to compile (cargo-mutants writes them out, the test suite never sees them). `Success` is the unmutated-tree sanity run; it is not a mutant outcome and is excluded from the totals.
+
+| Crate | Total mutants | Caught | Missed | Unviable | Catch rate |
+|---|---:|---:|---:|---:|---:|
+| `voom-dsl` | 514 | 197 | 122 | 195 | 61.8 % |
+| `voom-policy-evaluator` | 265 | 74 | 73 | 118 | 50.3 % |
+| `voom-phase-orchestrator` | 11 | 5 | 0 | 6 | 100.0 % |
+| **Total** | **790** | **276** | **195** | **319** | **58.6 %** |
+
+Catch rate is `Caught / (Caught + Missed)` — `Unviable` mutants are excluded because they never reach the test suite.
+
+`voom-phase-orchestrator` already catches every viable mutant; its 11 mutants live in a single `lib.rs` whose DAG-resolution logic is exercised by the existing depends_on / skip when / run_if test matrix. Triage work concentrates on the other two crates.
+
+## Representative surviving mutants
+
+The first 10 surviving mutants per crate, taken in declaration order from `outcomes.json`. The full lists are in each workflow run's `mutants-<crate>` artifact (90-day retention) under `mutants.out/missed.txt` and `mutants.out/outcomes.json`.
+
+### `voom-dsl` (122 surviving)
+
+- `crates/voom-dsl/src/compiled.rs:46:9: replace CompiledRegex::pattern -> &str with ""`
+- `crates/voom-dsl/src/compiled.rs:46:9: replace CompiledRegex::pattern -> &str with "xyzzy"`
+- `crates/voom-dsl/src/compiler.rs:29:45: replace && with || in safe_u32`
+- `crates/voom-dsl/src/compiler.rs:29:17: replace && with || in safe_u32`
+- `crates/voom-dsl/src/compiler.rs:29:10: replace >= with < in safe_u32`
+- `crates/voom-dsl/src/compiler.rs:29:22: replace <= with > in safe_u32`
+- `crates/voom-dsl/src/compiler.rs:29:58: replace == with != in safe_u32`
+- `crates/voom-dsl/src/compiler.rs:78:9: delete match arm "skip" in parse_error_strategy`
+- `crates/voom-dsl/src/compiler.rs:90:9: delete match arm "first" in parse_default_strategy`
+- `crates/voom-dsl/src/compiler.rs:91:9: delete match arm "all" in parse_default_strategy`
+
+The cluster on `compiler.rs:29` is a single line — `safe_u32`'s range-check predicate. A handful of focused tests exercising u32 boundary values would knock out all five mutants on that line at once. `parse_error_strategy` / `parse_default_strategy` are similarly clustered: missing tests for each enum arm.
+
+### `voom-policy-evaluator` (73 surviving)
+
+- `plugins/policy-evaluator/src/condition.rs:59:40: replace && with || in evaluate_condition`
+- `plugins/policy-evaluator/src/condition.rs:59:36: replace > with == in evaluate_condition`
+- `plugins/policy-evaluator/src/condition.rs:59:36: replace > with < in evaluate_condition`
+- `plugins/policy-evaluator/src/condition.rs:59:36: replace > with >= in evaluate_condition`
+- `plugins/policy-evaluator/src/condition.rs:59:43: delete ! in evaluate_condition`
+- `plugins/policy-evaluator/src/condition.rs:61:65: replace <= with > in evaluate_condition`
+- `plugins/policy-evaluator/src/condition.rs:101:9: delete match arm "hwaccels" in resolve_system_field`
+- `plugins/policy-evaluator/src/condition.rs:132:9: delete match arm "language" | "lang" in resolve_track_field`
+- `plugins/policy-evaluator/src/condition.rs:133:9: delete match arm "title" in resolve_track_field`
+- `plugins/policy-evaluator/src/condition.rs:134:9: delete match arm "channels" in resolve_track_field`
+
+The `evaluate_condition` cluster on lines 59 and 61 is the predicate at the heart of policy evaluation — six surviving mutants on two lines means the comparison operators and boolean composition aren't being exercised end-to-end. The `resolve_*_field` mutants are missing test coverage for individual track/system field aliases.
+
+### `voom-phase-orchestrator`
+
+No surviving mutants.
+
+## Triage
+
+A single tracking issue gathers follow-up work to drive surviving-mutant counts down: see [#TBD — track triage of cargo-mutants survivors](https://github.com/randomparity/voom/issues/TBD). Update the issue number once it is opened.
+
+The general approach for triaging a survivor:
+
+1. Read the survivor's `name` field — it includes the file, line, and the exact mutation cargo-mutants applied.
+2. Write a focused unit test that distinguishes the original code from the mutant. If the mutation is a comparison operator flip, the test should hit the boundary value; if it is a deleted match arm, the test should pass that arm's input.
+3. Verify locally with `cargo mutants -p <crate> --file <relative-path> --regex <fragment of the mutation name>`.
+4. Group several survivors into a single PR when they touch related code (e.g. the five `safe_u32` mutants in `voom-dsl/compiler.rs:29` belong together).
+
+If a mutant is provably equivalent (no observable behavior change), document the reasoning in the test file rather than suppressing it via `cargo-mutants` config — that keeps the analysis reviewable and discoverable.
+
+## Refreshing the baseline
+
+The numbers above will drift as code changes. Tomorrow's nightly run will already have a different `Source SHA`. Update this document only when meaningful work has shifted the numbers (e.g. a triage PR that catches a cluster of survivors). For day-to-day reference, prefer the latest run on the [Actions / Mutants page](https://github.com/randomparity/voom/actions/workflows/mutants.yml).


### PR DESCRIPTION
## Summary

Closes #214 (the Tasks 4–5 deferred from #226).

- **Workflow fix** in `.github/workflows/mutants.yml`: cargo-mutants 27 emits PascalCase enum variants in `outcomes.json` (`CaughtMutant`/`MissedMutant`/`Timeout`/`Unviable`/`Success`) and nests mutant data under `.scenario.Mutant` (capital `M`). The original workflow used lowercase enum strings and lowercase paths, so yesterday's first nightly run produced correct artifacts but reported all-zero counts in the GitHub Step Summary. This PR corrects every jq filter and switches the survivor list to `.scenario.Mutant.name` (which cargo-mutants pre-formats as `file:line: replace X -> ... with Y`). The `Success` baseline run is now excluded from the displayed total.
- **Baseline doc** at `docs/mutation-testing-baseline.md`: per-crate counts and 10 representative survivors per crate from a `workflow_dispatch` run on `main` ([run 25374530315](https://github.com/randomparity/voom/actions/runs/25374530315), source SHA `dd69cfa`). Catch rates: voom-dsl 61.8%, voom-policy-evaluator 50.3%, voom-phase-orchestrator 100%.
- **Docs index** updated to surface the new baseline page.
- **Triage tracking issue** opened as #236 with the high-leverage clusters identified in the baseline.

## Per-crate baseline

| Crate | Total mutants | Caught | Missed | Unviable | Catch rate |
|---|---:|---:|---:|---:|---:|
| `voom-dsl` | 514 | 197 | 122 | 195 | 61.8 % |
| `voom-policy-evaluator` | 265 | 74 | 73 | 118 | 50.3 % |
| `voom-phase-orchestrator` | 11 | 5 | 0 | 6 | 100.0 % |

`voom-phase-orchestrator` is already at 100% catch rate — out of scope for #236. The other two crates have visible clusters (e.g. five mutants on a single line of `safe_u32`'s range-check predicate) where one targeted test removes several survivors at once.

## Test plan

- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --workspace -- -D warnings` clean.
- [x] `cargo test --workspace` passes.
- [x] `actionlint .github/workflows/mutants.yml` clean.
- [x] `zizmor .github/workflows/mutants.yml` clean.
- [x] Workflow run `25374530315` produced `mutants.out/outcomes.json` with the expected schema (all sample survivors taken from this run).
- [ ] After merge: confirm the next nightly's GitHub Step Summary populates the count tables and the survivor list with non-zero values (validates the jq fix end-to-end on the schedule trigger).

Refs #214, #236.