### PR TITLE
docs(contributing): document proptest regressions policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,3 +42,11 @@ cargo mutants -p voom-dsl
 Surviving mutants and per-mutant outcomes land in `mutants.out/`. The workspace config at `.cargo/mutants.toml` excludes tests and benches and the workflow caps each cargo command at 300 seconds via `--timeout 300` — pass `--timeout <seconds>` to override locally.
 
 The current baseline counts per crate are recorded in `docs/mutation-testing-baseline.md`; new code in the targeted crates should aim to keep the missed-mutant count flat or drive it down.
+
+## Property-based testing
+
+Several crates use [`proptest`](https://docs.rs/proptest) for property-based tests. When proptest finds a failing case it shrinks it and writes the seed to a sibling `*.proptest-regressions` file (for example, `crates/voom-dsl/tests/proptest_roundtrip.proptest-regressions`).
+
+**Commit these files.** This matches proptest's own recommendation in the auto-generated header of each file and ensures every developer and every CI run benefits from previously-found shrunk failures. New crates that adopt proptest should commit their regressions file alongside the test once the first useful seed exists.
+
+Do not add `*.proptest-regressions` to `.gitignore`.


### PR DESCRIPTION
## Summary
- Closes #232 by recording the workspace policy that `*.proptest-regressions` files are committed to source control.
- Adds a new `## Property-based testing` section to `CONTRIBUTING.md` after `## Mutation testing` explaining the policy and its rationale (proptest's own recommendation; CI replay of previously-found shrunk failures).
- Documentation only. No `.gitignore` change. No code change. Both existing regressions files (`crates/voom-dsl/tests/proptest_roundtrip.proptest-regressions`, `plugins/policy-evaluator/tests/proptest_invariants.proptest-regressions`) are already tracked.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo test -p voom-cli --features functional -- --test-threads=4`
- [x] Manual read of the rendered `CONTRIBUTING.md` to confirm the new section reads cleanly in context.