### PR TITLE
test: triage cargo-mutants survivors in voom-dsl and policy-evaluator (#236)

### DIFF
--- a/crates/voom-dsl/src/compiled.rs
+++ b/crates/voom-dsl/src/compiled.rs
@@ -517,3 +517,48 @@ pub enum CompiledValueOrField {
     Value(serde_json::Value),
     Field(Vec<String>),
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- CompiledRegex::pattern accessor (issue #236, cluster C) ----
+
+    #[test]
+    fn compiled_regex_pattern_returns_input() {
+        // Kills both `pattern -> &str` mutants ("" and "xyzzy"): the original
+        // returns the exact input string, not a constant placeholder.
+        let r = CompiledRegex::new("hello.*world").unwrap();
+        assert_eq!(r.pattern(), "hello.*world");
+    }
+
+    #[test]
+    fn compiled_regex_pattern_distinct_from_mutant_constants() {
+        // Belt-and-suspenders: explicitly assert the value is neither of the
+        // two constants cargo-mutants substitutes.
+        let r = CompiledRegex::new("commentary").unwrap();
+        let pat = r.pattern();
+        assert_ne!(pat, "");
+        assert_ne!(pat, "xyzzy");
+        assert_eq!(pat, "commentary");
+    }
+
+    #[test]
+    fn compiled_regex_serializes_as_pattern_string() {
+        // Serde uses the pattern field directly. Guards against silent drift
+        // if Serialize is ever rewritten to emit the compiled regex shape.
+        let r = CompiledRegex::new(r"\d+").unwrap();
+        let json = serde_json::to_string(&r).unwrap();
+        assert_eq!(json, r#""\\d+""#);
+    }
+
+    #[test]
+    fn compiled_regex_serde_roundtrip_preserves_pattern() {
+        let original = CompiledRegex::new(r"foo\d+bar").unwrap();
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: CompiledRegex = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.pattern(), original.pattern());
+        // Verify the regex still matches after roundtrip.
+        assert!(decoded.regex().is_match("foo42bar"));
+    }
+}

--- a/crates/voom-dsl/src/compiler.rs
+++ b/crates/voom-dsl/src/compiler.rs
@@ -1092,4 +1092,63 @@ mod tests {
         // Sanity guard that protects later refactors of `safe_u32`.
         assert_eq!(safe_u32(42.0), Some(42));
     }
+
+    // ---- parse_error_strategy / parse_default_strategy arms (issue #236, cluster B) ----
+    // Each arm needs a test that returns Some(<variant>) for the literal it
+    // matches; the cargo-mutants "delete match arm" mutation falls through
+    // to the wildcard `_ => None` arm and would fail the assertion.
+
+    #[test]
+    fn parse_error_strategy_continue() {
+        assert_eq!(
+            parse_error_strategy("continue"),
+            Some(ErrorStrategy::Continue),
+        );
+    }
+
+    #[test]
+    fn parse_error_strategy_skip() {
+        assert_eq!(parse_error_strategy("skip"), Some(ErrorStrategy::Skip));
+    }
+
+    #[test]
+    fn parse_error_strategy_abort() {
+        assert_eq!(parse_error_strategy("abort"), Some(ErrorStrategy::Abort));
+    }
+
+    #[test]
+    fn parse_error_strategy_unknown_returns_none() {
+        assert_eq!(parse_error_strategy("nonsense"), None);
+    }
+
+    #[test]
+    fn parse_default_strategy_first_per_language() {
+        assert_eq!(
+            parse_default_strategy("first_per_language"),
+            Some(DefaultStrategy::FirstPerLanguage),
+        );
+    }
+
+    #[test]
+    fn parse_default_strategy_none() {
+        assert_eq!(parse_default_strategy("none"), Some(DefaultStrategy::None));
+    }
+
+    #[test]
+    fn parse_default_strategy_first() {
+        assert_eq!(
+            parse_default_strategy("first"),
+            Some(DefaultStrategy::First)
+        );
+    }
+
+    #[test]
+    fn parse_default_strategy_all() {
+        assert_eq!(parse_default_strategy("all"), Some(DefaultStrategy::All));
+    }
+
+    #[test]
+    fn parse_default_strategy_unknown_returns_none() {
+        assert_eq!(parse_default_strategy("nonsense"), None);
+    }
 }

--- a/crates/voom-dsl/src/compiler.rs
+++ b/crates/voom-dsl/src/compiler.rs
@@ -1044,4 +1044,52 @@ mod tests {
             other => panic!("expected Conditional, got {other:?}"),
         }
     }
+
+    // ---- safe_u32 boundary tests (issue #236, cluster A) ----
+    // These tests target the five cargo-mutants survivors on
+    // crates/voom-dsl/src/compiler.rs:29. Each value below is chosen so the
+    // original predicate `n >= 0.0 && n <= u32::MAX && n.fract() == 0.0`
+    // returns a different result than at least one mutant variant.
+
+    #[test]
+    fn safe_u32_accepts_zero() {
+        // Kills `>= -> <` (0.0 >= 0.0 is true; 0.0 < 0.0 is false)
+        // and `== -> !=` (0.0.fract() == 0.0 is true; != is false).
+        assert_eq!(safe_u32(0.0), Some(0));
+    }
+
+    #[test]
+    fn safe_u32_accepts_u32_max() {
+        // Kills `<= -> >` at u32::MAX (MAX <= MAX true; MAX > MAX false).
+        let n = f64::from(u32::MAX);
+        assert_eq!(safe_u32(n), Some(u32::MAX));
+    }
+
+    #[test]
+    fn safe_u32_rejects_negative() {
+        // Kills `&& -> ||` (first conjunction): with ||, -1.0 satisfies the
+        // chain via the second branch and returns Some.
+        assert_eq!(safe_u32(-1.0), None);
+    }
+
+    #[test]
+    fn safe_u32_rejects_overflow() {
+        // Kills `&& -> ||` (second conjunction): with ||, n.fract() == 0.0
+        // alone admits overflow values that should be rejected.
+        let n = f64::from(u32::MAX) + 1.0;
+        assert_eq!(safe_u32(n), None);
+    }
+
+    #[test]
+    fn safe_u32_rejects_fractional_in_range() {
+        // Reinforces both `&& -> ||` mutants and the `== -> !=` mutant.
+        assert_eq!(safe_u32(0.5), None);
+        assert_eq!(safe_u32(1.5), None);
+    }
+
+    #[test]
+    fn safe_u32_typical_value_round_trips() {
+        // Sanity guard that protects later refactors of `safe_u32`.
+        assert_eq!(safe_u32(42.0), Some(42));
+    }
 }

--- a/plugins/policy-evaluator/src/condition.rs
+++ b/plugins/policy-evaluator/src/condition.rs
@@ -618,4 +618,128 @@ mod tests {
             &ctx,
         ));
     }
+
+    // ---- IsDubbed / IsOriginal predicate tests (issue #236, cluster D) ----
+    // Targets the six surviving mutants on condition.rs:59 and :61. The four
+    // IsDubbed cases pick boundary corners so each operator flip changes the
+    // boolean output.
+
+    fn file_with_audio_langs(langs: &[&str]) -> MediaFile {
+        let mut file = MediaFile::new(PathBuf::from("/test.mkv"));
+        file.tracks = langs
+            .iter()
+            .enumerate()
+            .map(|(i, lang)| {
+                let mut t = Track::new(
+                    i as u32,
+                    if i == 0 {
+                        TrackType::AudioMain
+                    } else {
+                        TrackType::AudioAlternate
+                    },
+                    "aac".into(),
+                );
+                t.language = (*lang).into();
+                t
+            })
+            .collect();
+        file
+    }
+
+    fn add_subtitle(file: &mut MediaFile, lang: &str) {
+        let next_idx = file.tracks.len() as u32;
+        let mut sub = Track::new(next_idx, TrackType::SubtitleMain, "srt".into());
+        sub.language = lang.into();
+        file.tracks.push(sub);
+    }
+
+    #[test]
+    fn is_dubbed_true_when_multi_lang_with_subtitles() {
+        // count=2, !empty=true → original true. Kills `> -> <` (2<1 false).
+        let mut file = file_with_audio_langs(&["eng", "jpn"]);
+        add_subtitle(&mut file, "eng");
+        let ctx = no_ctx();
+        assert!(evaluate_condition(
+            &CompiledCondition::IsDubbed,
+            &file,
+            &ctx
+        ));
+    }
+
+    #[test]
+    fn is_dubbed_false_when_single_lang_with_subtitles() {
+        // count=1, !empty=true → original false.
+        // Kills `> -> ==` (1==1 true), `> -> >=` (1>=1 true), and
+        // `&& -> ||` first form (false || true = true).
+        let mut file = file_with_audio_langs(&["eng"]);
+        add_subtitle(&mut file, "eng");
+        let ctx = no_ctx();
+        assert!(!evaluate_condition(
+            &CompiledCondition::IsDubbed,
+            &file,
+            &ctx
+        ));
+    }
+
+    #[test]
+    fn is_dubbed_false_when_multi_lang_no_subtitles() {
+        // count=2, !empty=false → original false.
+        // Kills `delete !` (count>1 true && empty=true → mutant true) and
+        // reinforces the `&& -> ||` second form (true || false = true).
+        let file = file_with_audio_langs(&["eng", "jpn"]);
+        let ctx = no_ctx();
+        assert!(!evaluate_condition(
+            &CompiledCondition::IsDubbed,
+            &file,
+            &ctx
+        ));
+    }
+
+    #[test]
+    fn is_dubbed_false_when_no_audio_no_subtitles() {
+        // count=0, no subs → original false. Sanity baseline.
+        let file = MediaFile::new(PathBuf::from("/test.mkv"));
+        let ctx = no_ctx();
+        assert!(!evaluate_condition(
+            &CompiledCondition::IsDubbed,
+            &file,
+            &ctx
+        ));
+    }
+
+    #[test]
+    fn is_original_true_with_one_audio_lang() {
+        // count=1 → original `1 <= 1` true. Kills `<= -> >` (1>1 false).
+        let file = file_with_audio_langs(&["eng"]);
+        let ctx = no_ctx();
+        assert!(evaluate_condition(
+            &CompiledCondition::IsOriginal,
+            &file,
+            &ctx
+        ));
+    }
+
+    #[test]
+    fn is_original_true_with_zero_audio_langs() {
+        // count=0 → original true. Reinforces the boundary direction.
+        let file = MediaFile::new(PathBuf::from("/test.mkv"));
+        let ctx = no_ctx();
+        assert!(evaluate_condition(
+            &CompiledCondition::IsOriginal,
+            &file,
+            &ctx
+        ));
+    }
+
+    #[test]
+    fn is_original_false_with_multi_audio_langs() {
+        // count=2 → original false. Confirms `<= -> >` direction (2>1 true).
+        let file = file_with_audio_langs(&["eng", "jpn"]);
+        let ctx = no_ctx();
+        assert!(!evaluate_condition(
+            &CompiledCondition::IsOriginal,
+            &file,
+            &ctx
+        ));
+    }
 }

--- a/plugins/policy-evaluator/src/condition.rs
+++ b/plugins/policy-evaluator/src/condition.rs
@@ -742,4 +742,115 @@ mod tests {
             &ctx
         ));
     }
+
+    // ---- resolve_track_field / resolve_system_field aliases (issue #236, cluster E) ----
+    // Each test targets a single match arm. Deleting the arm makes resolve_*
+    // return None, which flips FieldExists from true to false (or makes
+    // FieldCompare unable to find a value, returning false).
+
+    fn file_with_seeded_audio() -> MediaFile {
+        // First audio track has language=eng, channels=6, title="Director's Cut".
+        let mut file = MediaFile::new(PathBuf::from("/test.mkv"));
+        file.tracks = vec![{
+            let mut t = Track::new(0, TrackType::AudioMain, "aac".into());
+            t.language = "eng".into();
+            t.title = "Director's Cut".into();
+            t.channels = Some(6);
+            t
+        }];
+        file
+    }
+
+    #[test]
+    fn resolve_track_field_language_alias_long_form() {
+        // Kills `delete match arm "language" | "lang"` via the long form.
+        let file = file_with_seeded_audio();
+        let ctx = no_ctx();
+        assert!(evaluate_condition(
+            &CompiledCondition::FieldCompare {
+                path: vec!["audio".into(), "language".into()],
+                op: CompiledCompareOp::Eq,
+                value: serde_json::Value::String("eng".into()),
+            },
+            &file,
+            &ctx,
+        ));
+    }
+
+    #[test]
+    fn resolve_track_field_language_alias_short_form() {
+        // Reinforces the same arm via the `lang` literal.
+        let file = file_with_seeded_audio();
+        let ctx = no_ctx();
+        assert!(evaluate_condition(
+            &CompiledCondition::FieldCompare {
+                path: vec!["audio".into(), "lang".into()],
+                op: CompiledCompareOp::Eq,
+                value: serde_json::Value::String("eng".into()),
+            },
+            &file,
+            &ctx,
+        ));
+    }
+
+    #[test]
+    fn resolve_track_field_title() {
+        // Kills `delete match arm "title"`.
+        let file = file_with_seeded_audio();
+        let ctx = no_ctx();
+        assert!(evaluate_condition(
+            &CompiledCondition::FieldCompare {
+                path: vec!["audio".into(), "title".into()],
+                op: CompiledCompareOp::Eq,
+                value: serde_json::Value::String("Director's Cut".into()),
+            },
+            &file,
+            &ctx,
+        ));
+    }
+
+    #[test]
+    fn resolve_track_field_channels() {
+        // Kills `delete match arm "channels"`.
+        let file = file_with_seeded_audio();
+        let ctx = no_ctx();
+        assert!(evaluate_condition(
+            &CompiledCondition::FieldCompare {
+                path: vec!["audio".into(), "channels".into()],
+                op: CompiledCompareOp::Eq,
+                value: serde_json::json!(6),
+            },
+            &file,
+            &ctx,
+        ));
+    }
+
+    #[test]
+    fn resolve_system_field_hwaccels_array() {
+        // Kills `delete match arm "hwaccels"` in resolve_system_field.
+        // FieldExists is sufficient: deleting the arm makes the function
+        // fall through to `_ => None`, flipping the assertion.
+        use voom_domain::capability_map::CapabilityMap;
+        use voom_domain::events::{CodecCapabilities, ExecutorCapabilitiesEvent};
+
+        let file = file_with_seeded_audio();
+        let mut map = CapabilityMap::new();
+        map.register(ExecutorCapabilitiesEvent::new(
+            "ffmpeg",
+            CodecCapabilities::empty(),
+            vec![],
+            vec!["cuda".into(), "vaapi".into()],
+        ));
+        let ctx = EvalContext {
+            capabilities: Some(&map),
+        };
+
+        assert!(evaluate_condition(
+            &CompiledCondition::FieldExists {
+                path: vec!["system".into(), "hwaccels".into()],
+            },
+            &file,
+            &ctx,
+        ));
+    }
 }


### PR DESCRIPTION
## Summary

Closes the five mutant clusters listed in `docs/mutation-testing-baseline.md` for `voom-dsl` and `voom-policy-evaluator`:

- `voom-dsl/compiler.rs:29` — `safe_u32` boundary predicate (5 in-scope mutants)
- `voom-dsl/compiler.rs:78,90,91` — `parse_error_strategy` / `parse_default_strategy` arms (3 explicit + remaining arms)
- `voom-dsl/compiled.rs:46` — `CompiledRegex::pattern` accessor (2 mutants)
- `policy-evaluator/condition.rs:59,61` — `IsDubbed` / `IsOriginal` predicates (6 mutants)
- `policy-evaluator/condition.rs:101,132–134` — `resolve_*_field` aliases (4 mutants)

All changes are test-only. No production code is touched.

Per-task local cargo-mutants verification (each captured during task implementation):

| Cluster | mutants in scope | caught | missed |
|---|---:|---:|---:|
| A — `safe_u32` | 8 | 8 | 0 |
| B — `parse_*_strategy` arms | 11 (9 viable) | 9 | 0 |
| C — `CompiledRegex::pattern` | 2 | 2 | 0 |
| D — `IsDubbed` / `IsOriginal` | 13 | 13 | 0 |
| E — `resolve_*_field` aliases | 19 (within scope: 4) | 4 in-scope (+7 adjacent) | 0 in-scope |

Refs #236.

## Out of scope / follow-up

Task E's cargo-mutants run surfaced 8 additional surviving arm-deletion mutants in `resolve_track_field` on lines 135–142 (`width`, `height`, `frame_rate`, `is_default`, `is_forced`, `is_hdr`, `is_vfr`, `hdr_format`). These are different arms not listed in #236's clusters. Tracked in **#240**.

## Test plan

- [x] `cargo test` (full workspace) passes
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` is clean
- [x] `cargo fmt --all -- --check` is clean
- [x] Local `cargo mutants` runs report each cluster's mutants caught (per-task numbers in commit messages and the table above)