### PR TITLE
test: phase 2 cargo-mutants triage (#236)

### DIFF
--- a/crates/voom-dsl/src/compiler.rs
+++ b/crates/voom-dsl/src/compiler.rs
@@ -1151,4 +1151,80 @@ mod tests {
     fn parse_default_strategy_unknown_returns_none() {
         assert_eq!(parse_default_strategy("nonsense"), None);
     }
+
+    // ---- compile_transcode setting-extraction tests (issue #236, phase 2) ----
+    // Each test exercises one match arm in compile_transcode by constructing
+    // a single-entry settings vec and asserting the resulting field. The
+    // single-entry settings also distinguish the `== to !=` mutant on the
+    // `get` closure (line 232): with one element, `find(|(k,_)| k != key)`
+    // returns None while the original returns Some.
+    fn transcode_with(key: &str, val: Value) -> CompiledTranscodeSettings {
+        let settings = vec![(key.to_string(), val)];
+        let CompiledOperation::Transcode { settings, .. } =
+            compile_transcode("video", "hevc", &settings)
+        else {
+            unreachable!("compile_transcode always returns Transcode")
+        };
+        settings
+    }
+
+    #[test]
+    fn compile_transcode_preserve_list() {
+        let s = transcode_with(
+            "preserve",
+            Value::List(vec![
+                Value::String("metadata".into()),
+                Value::String("subtitles".into()),
+            ]),
+        );
+        assert_eq!(s.preserve, vec!["metadata", "subtitles"]);
+    }
+
+    #[test]
+    fn compile_transcode_crf_number() {
+        let s = transcode_with("crf", Value::Number(23.0, "23".into()));
+        assert_eq!(s.crf, Some(23));
+    }
+
+    #[test]
+    fn compile_transcode_preset_string() {
+        let s = transcode_with("preset", Value::String("fast".into()));
+        assert_eq!(s.preset, Some("fast".into()));
+    }
+
+    #[test]
+    fn compile_transcode_bitrate_string() {
+        let s = transcode_with("bitrate", Value::String("8M".into()));
+        assert_eq!(s.bitrate, Some("8M".into()));
+    }
+
+    #[test]
+    fn compile_transcode_channels_number() {
+        let s = transcode_with("channels", Value::Number(6.0, "6".into()));
+        assert_eq!(s.channels, Some(TranscodeChannels::Count(6)));
+    }
+
+    #[test]
+    fn compile_transcode_channels_named() {
+        let s = transcode_with("channels", Value::Ident("stereo".into()));
+        assert_eq!(s.channels, Some(TranscodeChannels::Named("stereo".into())));
+    }
+
+    #[test]
+    fn compile_transcode_hw_fallback_bool() {
+        let s = transcode_with("hw_fallback", Value::Bool(true));
+        assert_eq!(s.hw_fallback, Some(true));
+    }
+
+    #[test]
+    fn compile_transcode_max_resolution_ident() {
+        let s = transcode_with("max_resolution", Value::Ident("1080p".into()));
+        assert_eq!(s.max_resolution, Some("1080p".into()));
+    }
+
+    #[test]
+    fn compile_transcode_max_resolution_number_raw() {
+        let s = transcode_with("max_resolution", Value::Number(1080.0, "1080".into()));
+        assert_eq!(s.max_resolution, Some("1080".into()));
+    }
 }

--- a/crates/voom-dsl/src/formatter.rs
+++ b/crates/voom-dsl/src/formatter.rs
@@ -978,4 +978,101 @@ mod tests {
             _ => panic!("expected When"),
         }
     }
+
+    // ---- format_phase indent-arithmetic tests (issue #236, phase 2) ----
+    // Each test exercises one optional section of format_phase by calling it
+    // at level=1 and asserting the inner line is indented by exactly 4
+    // spaces (two indent steps × 2 spaces). Both `+ to -` (gives 0 spaces)
+    // and `+ to *` (gives 2 spaces) mutants on each `level + 1` site fail
+    // the substring assertion.
+
+    use crate::ast::{RunIfNode, Span, SpannedOperation};
+
+    fn empty_phase(name: &str) -> PhaseNode {
+        PhaseNode {
+            name: name.into(),
+            skip_when: None,
+            depends_on: vec![],
+            run_if: None,
+            on_error: None,
+            operations: vec![],
+            span: Span {
+                start: 0,
+                end: 0,
+                line: 1,
+                col: 1,
+            },
+        }
+    }
+
+    #[test]
+    fn format_phase_depends_on_indents_one_deeper() {
+        let mut phase = empty_phase("build");
+        phase.depends_on = vec!["init".into()];
+        let mut out = String::new();
+        format_phase(&phase, &mut out, 1);
+        assert!(
+            out.contains("\n    depends_on: [init]\n"),
+            "depends_on line should be indented by 4 spaces; got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn format_phase_skip_when_indents_one_deeper() {
+        let mut phase = empty_phase("build");
+        phase.skip_when = Some(ConditionNode::IsDubbed);
+        let mut out = String::new();
+        format_phase(&phase, &mut out, 1);
+        assert!(
+            out.contains("\n    skip when "),
+            "skip when line should be indented by 4 spaces; got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn format_phase_run_if_indents_one_deeper() {
+        let mut phase = empty_phase("build");
+        phase.run_if = Some(RunIfNode {
+            phase: "init".into(),
+            trigger: "modified".into(),
+        });
+        let mut out = String::new();
+        format_phase(&phase, &mut out, 1);
+        assert!(
+            out.contains("\n    run_if init.modified\n"),
+            "run_if line should be indented by 4 spaces; got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn format_phase_on_error_indents_one_deeper() {
+        let mut phase = empty_phase("build");
+        phase.on_error = Some("skip".into());
+        let mut out = String::new();
+        format_phase(&phase, &mut out, 1);
+        assert!(
+            out.contains("\n    on_error: skip\n"),
+            "on_error line should be indented by 4 spaces; got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn format_phase_operation_indents_one_deeper() {
+        let mut phase = empty_phase("build");
+        phase.operations = vec![SpannedOperation {
+            node: OperationNode::Container("mkv".into()),
+            span: Span {
+                start: 0,
+                end: 0,
+                line: 1,
+                col: 1,
+            },
+        }];
+        let mut out = String::new();
+        format_phase(&phase, &mut out, 1);
+        assert!(
+            out.contains("\n    container mkv\n"),
+            "container operation should be indented by 4 spaces; got:\n{out}"
+        );
+    }
 }

--- a/crates/voom-dsl/src/formatter.rs
+++ b/crates/voom-dsl/src/formatter.rs
@@ -1075,4 +1075,87 @@ mod tests {
             "container operation should be indented by 4 spaces; got:\n{out}"
         );
     }
+
+    // ---- format_config indent-arithmetic tests (issue #236, phase 2) ----
+    // Mirrors the cluster 7 (format_phase) recipe: each test exercises one
+    // optional config section by calling format_config at level=1 and
+    // asserting the inner line is indented by exactly 4 spaces. Both `+ to
+    // -` (gives 0 spaces) and `+ to *` (gives 2 spaces) mutants on each
+    // `level + 1` site fail the substring check.
+
+    fn empty_config() -> ConfigNode {
+        ConfigNode {
+            audio_languages: vec![],
+            subtitle_languages: vec![],
+            on_error: None,
+            commentary_patterns: vec![],
+            keep_backups: None,
+            span: Span {
+                start: 0,
+                end: 0,
+                line: 1,
+                col: 1,
+            },
+        }
+    }
+
+    #[test]
+    fn format_config_audio_languages_indents_one_deeper() {
+        let mut config = empty_config();
+        config.audio_languages = vec!["eng".into()];
+        let mut out = String::new();
+        format_config(&config, &mut out, 1);
+        assert!(
+            out.contains("\n    languages audio: [eng]\n"),
+            "audio languages line should be indented by 4 spaces; got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn format_config_subtitle_languages_indents_one_deeper() {
+        let mut config = empty_config();
+        config.subtitle_languages = vec!["eng".into()];
+        let mut out = String::new();
+        format_config(&config, &mut out, 1);
+        assert!(
+            out.contains("\n    languages subtitle: [eng]\n"),
+            "subtitle languages line should be indented by 4 spaces; got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn format_config_commentary_patterns_indents_one_deeper() {
+        let mut config = empty_config();
+        config.commentary_patterns = vec!["commentary".into()];
+        let mut out = String::new();
+        format_config(&config, &mut out, 1);
+        assert!(
+            out.contains("\n    commentary_patterns: [\"commentary\"]\n"),
+            "commentary_patterns line should be indented by 4 spaces; got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn format_config_on_error_indents_one_deeper() {
+        let mut config = empty_config();
+        config.on_error = Some("skip".into());
+        let mut out = String::new();
+        format_config(&config, &mut out, 1);
+        assert!(
+            out.contains("\n    on_error: skip\n"),
+            "on_error line should be indented by 4 spaces; got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn format_config_keep_backups_indents_one_deeper() {
+        let mut config = empty_config();
+        config.keep_backups = Some(true);
+        let mut out = String::new();
+        format_config(&config, &mut out, 1);
+        assert!(
+            out.contains("\n    keep_backups: true\n"),
+            "keep_backups line should be indented by 4 spaces; got:\n{out}"
+        );
+    }
 }

--- a/crates/voom-dsl/src/formatter.rs
+++ b/crates/voom-dsl/src/formatter.rs
@@ -1158,4 +1158,63 @@ mod tests {
             "keep_backups line should be indented by 4 spaces; got:\n{out}"
         );
     }
+
+    // ---- format_rules indent-arithmetic tests (issue #236, phase 2) ----
+    // Calls format_rules at level=1 with a single rule and asserts each of
+    // the three indented inner lines (rule-open `rule "r1" {` at 4 spaces,
+    // the recursive `when ...` at 6 spaces, and the rule-close `}` at 4
+    // spaces) appears at the correct depth. The `+ to -` mutants on each
+    // site cause usize subtraction underflow at level=1, panicking the test
+    // before the assertion runs — that still counts as caught. The `+ to *`
+    // mutants produce wrong indentation that fails the substring check.
+
+    fn simple_rule(name: &str) -> RuleNode {
+        RuleNode {
+            name: name.into(),
+            when: WhenNode {
+                condition: ConditionNode::IsDubbed,
+                then_actions: vec![],
+                else_actions: vec![],
+                span: Span {
+                    start: 0,
+                    end: 0,
+                    line: 1,
+                    col: 1,
+                },
+            },
+        }
+    }
+
+    #[test]
+    fn format_rules_rule_open_indents_two_levels() {
+        let rules = vec![simple_rule("r1")];
+        let mut out = String::new();
+        format_rules("first_match", &rules, &mut out, 1);
+        assert!(
+            out.contains("\n    rule \"r1\" {\n"),
+            "rule-open line should be indented by 4 spaces; got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn format_rules_when_indents_three_levels() {
+        let rules = vec![simple_rule("r1")];
+        let mut out = String::new();
+        format_rules("first_match", &rules, &mut out, 1);
+        assert!(
+            out.contains("\n      when "),
+            "when line should be indented by 6 spaces; got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn format_rules_rule_close_indents_two_levels() {
+        let rules = vec![simple_rule("r1")];
+        let mut out = String::new();
+        format_rules("first_match", &rules, &mut out, 1);
+        assert!(
+            out.contains("\n    }\n"),
+            "rule-close brace should be indented by 4 spaces; got:\n{out}"
+        );
+    }
 }

--- a/crates/voom-dsl/src/validator.rs
+++ b/crates/voom-dsl/src/validator.rs
@@ -2417,4 +2417,103 @@ mod tests {
             err.errors
         );
     }
+
+    // ---- validate_filter arm-deletion tests (issue #236, phase 2) ----
+    // Each test invokes validate_filter with a focused FilterNode that the
+    // original code rejects (or accepts) and the mutated code does the
+    // opposite. For arm-deletion mutants, an invalid filter that originally
+    // emits an error becomes silent under the mutant. For the `delete !`
+    // mutant on line 735, both an invalid-language test (catches the deleted
+    // arm + flipped predicate) and a valid-language test (catches the
+    // flipped predicate alone) make the distinction explicit.
+
+    use crate::ast::CompareOp;
+
+    fn run_validate_filter(filter: FilterNode) -> (Vec<DslError>, Vec<DslWarning>) {
+        let mut errors = Vec::new();
+        let mut warnings = Vec::new();
+        validate_filter(&filter, 1, 1, &mut errors, &mut warnings);
+        (errors, warnings)
+    }
+
+    #[test]
+    fn validate_filter_lang_in_invalid_emits_error() {
+        let (errors, _) = run_validate_filter(FilterNode::LangIn(vec!["xxx".into()]));
+        assert!(
+            !errors.is_empty(),
+            "expected an error for invalid language in LangIn, got none"
+        );
+    }
+
+    #[test]
+    fn validate_filter_lang_compare_invalid_emits_error() {
+        let (errors, _) = run_validate_filter(FilterNode::LangCompare(CompareOp::Eq, "xxx".into()));
+        assert!(
+            !errors.is_empty(),
+            "expected an error for invalid language in LangCompare, got none"
+        );
+    }
+
+    #[test]
+    fn validate_filter_lang_compare_valid_emits_no_error() {
+        let (errors, _) = run_validate_filter(FilterNode::LangCompare(CompareOp::Eq, "eng".into()));
+        assert!(
+            errors.is_empty(),
+            "expected no error for valid language in LangCompare, got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_filter_codec_in_invalid_emits_error() {
+        let (errors, _) = run_validate_filter(FilterNode::CodecIn(vec!["bogus_codec".into()]));
+        assert!(
+            !errors.is_empty(),
+            "expected an error for invalid codec in CodecIn, got none"
+        );
+    }
+
+    #[test]
+    fn validate_filter_codec_compare_invalid_emits_error() {
+        let (errors, _) = run_validate_filter(FilterNode::CodecCompare(
+            CompareOp::Eq,
+            "bogus_codec".into(),
+        ));
+        assert!(
+            !errors.is_empty(),
+            "expected an error for invalid codec in CodecCompare, got none"
+        );
+    }
+
+    #[test]
+    fn validate_filter_and_recurses_into_invalid_inner() {
+        let (errors, _) =
+            run_validate_filter(FilterNode::And(vec![FilterNode::LangIn(
+                vec!["xxx".into()],
+            )]));
+        assert!(
+            !errors.is_empty(),
+            "expected And to recurse into LangIn and surface its error, got none"
+        );
+    }
+
+    #[test]
+    fn validate_filter_or_recurses_into_invalid_inner() {
+        let (errors, _) =
+            run_validate_filter(FilterNode::Or(vec![FilterNode::LangIn(vec!["xxx".into()])]));
+        assert!(
+            !errors.is_empty(),
+            "expected Or to recurse into LangIn and surface its error, got none"
+        );
+    }
+
+    #[test]
+    fn validate_filter_not_recurses_into_invalid_inner() {
+        let (errors, _) = run_validate_filter(FilterNode::Not(Box::new(FilterNode::LangIn(vec![
+            "xxx".into(),
+        ]))));
+        assert!(
+            !errors.is_empty(),
+            "expected Not to recurse into LangIn and surface its error, got none"
+        );
+    }
 }

--- a/crates/voom-dsl/src/validator.rs
+++ b/crates/voom-dsl/src/validator.rs
@@ -2516,4 +2516,103 @@ mod tests {
             "expected Not to recurse into LangIn and surface its error, got none"
         );
     }
+
+    // EQUIVALENT MUTANT (issue #236, phase 2):
+    // crates/voom-dsl/src/validator.rs:390:26: replace < with <= in check_tag_conflicts
+    //
+    // The compared values `i` and `clear_idx` both come from `enumerate()` on
+    // `phase.operations` — they are unique sequential indices into the same
+    // vec. The condition runs only when the spanned op at index `i` is a
+    // SetTag; ClearTags has its own (different) index `clear_idx`. So `i`
+    // cannot equal `clear_idx`, and `i < clear_idx` and `i <= clear_idx` are
+    // always equivalent on every reachable input.
+    //
+    // Per #236 policy: documented inline rather than suppressed in
+    // .cargo/mutants.toml so the analysis stays discoverable.
+
+    // ---- check_tag_conflicts arm-deletion + boundary tests (issue #236, phase 2) ----
+
+    fn phase_with_ops(name: &str, ops: Vec<OperationNode>) -> PhaseNode {
+        use crate::ast::{Span, SpannedOperation};
+
+        let operations = ops
+            .into_iter()
+            .enumerate()
+            .map(|(i, node)| SpannedOperation {
+                node,
+                span: Span {
+                    start: i,
+                    end: i + 1,
+                    line: i + 1,
+                    col: 1,
+                },
+            })
+            .collect();
+        PhaseNode {
+            name: name.into(),
+            skip_when: None,
+            depends_on: vec![],
+            run_if: None,
+            on_error: None,
+            operations,
+            span: Span {
+                start: 0,
+                end: 0,
+                line: 1,
+                col: 1,
+            },
+        }
+    }
+
+    #[test]
+    fn check_tag_conflicts_set_and_delete_same_tag_emits_error() {
+        let phase = phase_with_ops(
+            "p",
+            vec![
+                OperationNode::SetTag {
+                    tag: "x".into(),
+                    value: ValueOrField::Value(Value::String("dummy".into())),
+                },
+                OperationNode::DeleteTag("x".into()),
+            ],
+        );
+        let mut errors = Vec::new();
+        check_tag_conflicts(&phase, &mut errors);
+        assert_eq!(
+            errors.len(),
+            1,
+            "expected exactly one error, got {errors:?}"
+        );
+        let msg = format!("{}", errors[0]);
+        assert!(
+            msg.contains("both set and deleted"),
+            "expected 'both set and deleted' in error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn check_tag_conflicts_set_before_clear_emits_warning() {
+        let phase = phase_with_ops(
+            "p",
+            vec![
+                OperationNode::SetTag {
+                    tag: "y".into(),
+                    value: ValueOrField::Value(Value::String("dummy".into())),
+                },
+                OperationNode::ClearTags,
+            ],
+        );
+        let mut errors = Vec::new();
+        check_tag_conflicts(&phase, &mut errors);
+        assert_eq!(
+            errors.len(),
+            1,
+            "expected exactly one error, got {errors:?}"
+        );
+        let msg = format!("{}", errors[0]);
+        assert!(
+            msg.contains("appears before clear_tags"),
+            "expected 'appears before clear_tags' in error, got: {msg}"
+        );
+    }
 }

--- a/crates/voom-dsl/src/validator.rs
+++ b/crates/voom-dsl/src/validator.rs
@@ -2591,7 +2591,7 @@ mod tests {
     }
 
     #[test]
-    fn check_tag_conflicts_set_before_clear_emits_warning() {
+    fn check_tag_conflicts_set_before_clear_emits_error() {
         let phase = phase_with_ops(
             "p",
             vec![

--- a/docs/mutation-testing-baseline.md
+++ b/docs/mutation-testing-baseline.md
@@ -1,12 +1,12 @@
 # Mutation Testing Baseline
 
-This document captures the initial `cargo mutants` baseline for the three logic-dense crates targeted by issue #214. The numbers below are the reference point that follow-up triage work needs to drive down.
+This document captures the current `cargo mutants` baseline for the three logic-dense crates targeted by issue #214. The numbers below are the reference point that follow-up triage work needs to drive down. The original baseline (SHA `dd69cfa`, 2026-05-05) has been replaced in place by the post-Phase-2 numbers from issue #236; the `Source SHA` field below identifies the snapshot the counts correspond to.
 
 | | |
 |---|---|
 | **Captured** | 2026-05-05 |
-| **Workflow run** | [actions/runs/25374530315](https://github.com/randomparity/voom/actions/runs/25374530315) (`workflow_dispatch` on `main`) |
-| **Source SHA** | `dd69cfa` |
+| **Workflow run** | Local re-baseline on `homer.pdx.drc.nz` (no GitHub Actions URL) |
+| **Source SHA** | `5363860` |
 | **cargo-mutants version** | 27.0.0 |
 | **Config** | `.cargo/mutants.toml` (`exclude_globs = ["**/tests/**", "**/benches/**", "**/examples/**"]`) |
 | **Per-mutant timeout** | 300 s, passed via `--timeout 300` in the workflow |
@@ -17,48 +17,57 @@ This document captures the initial `cargo mutants` baseline for the three logic-
 
 | Crate | Total mutants | Caught | Missed | Unviable | Catch rate |
 |---|---:|---:|---:|---:|---:|
-| `voom-dsl` | 514 | 197 | 122 | 195 | 61.8 % |
-| `voom-policy-evaluator` | 265 | 74 | 73 | 118 | 50.3 % |
-| `voom-phase-orchestrator` | 11 | 5 | 0 | 6 | 100.0 % |
-| **Total** | **790** | **276** | **195** | **319** | **58.6 %** |
+| `voom-dsl` | 518 | 392 | 58 | 68 | 87.1 % |
+| `voom-policy-evaluator` | 265 | 217 | 42 | 6 | 83.8 % |
+| `voom-phase-orchestrator`* | 11 | 5 | 0 | 6 | 100.0 % |
+| **Total** | **794** | **614** | **100** | **80** | **86.0 %** |
+
+\* not re-run for Phase 2; logic unchanged since the original baseline.
 
 Catch rate is `Caught / (Caught + Missed)` — `Unviable` mutants are excluded because they never reach the test suite.
 
-`voom-phase-orchestrator` already catches every viable mutant; its 11 mutants live in a single `lib.rs` whose DAG-resolution logic is exercised by the existing depends_on / skip when / run_if test matrix. Triage work concentrates on the other two crates.
+`voom-phase-orchestrator` already catches every viable mutant; its 11 mutants live in a single `lib.rs` whose DAG-resolution logic is exercised by the existing depends_on / skip when / run_if test matrix. Triage work concentrates on the other two crates. After issue #236's Phase 2 (PR for branch `test/issue-236-mutation-triage-phase2`), both `voom-dsl` and `voom-policy-evaluator` exceed the 80% catch-rate threshold defined in #236's Definition of Done.
+
+Progression across the three baselines captured to date:
+
+| Crate | Pre-Phase-1 (`dd69cfa`) | Post-Phase-1 (`3da0275`) | Post-Phase-2 (`5363860`) |
+|---|---:|---:|---:|
+| `voom-dsl` | 61.8 % | 70.7 % | **87.1 %** |
+| `voom-policy-evaluator` | 50.3 % | 73.0 % | **83.8 %** |
 
 ## Representative surviving mutants
 
 The first 10 surviving mutants per crate, taken in declaration order from `outcomes.json`. The full lists are in each workflow run's `mutants-<crate>` artifact (90-day retention) under `mutants.out/missed.txt` and `mutants.out/outcomes.json`.
 
-### `voom-dsl` (122 surviving)
+### `voom-dsl` (58 surviving)
 
-- `crates/voom-dsl/src/compiled.rs:46:9: replace CompiledRegex::pattern -> &str with ""`
-- `crates/voom-dsl/src/compiled.rs:46:9: replace CompiledRegex::pattern -> &str with "xyzzy"`
-- `crates/voom-dsl/src/compiler.rs:29:45: replace && with || in safe_u32`
-- `crates/voom-dsl/src/compiler.rs:29:17: replace && with || in safe_u32`
-- `crates/voom-dsl/src/compiler.rs:29:10: replace >= with < in safe_u32`
-- `crates/voom-dsl/src/compiler.rs:29:22: replace <= with > in safe_u32`
-- `crates/voom-dsl/src/compiler.rs:29:58: replace == with != in safe_u32`
-- `crates/voom-dsl/src/compiler.rs:78:9: delete match arm "skip" in parse_error_strategy`
-- `crates/voom-dsl/src/compiler.rs:90:9: delete match arm "first" in parse_default_strategy`
-- `crates/voom-dsl/src/compiler.rs:91:9: delete match arm "all" in parse_default_strategy`
+- `crates/voom-dsl/src/compiled.rs:52:9: replace <impl fmt::Debug for CompiledRegex>::fmt -> fmt::Result with Ok(Default::default())`
+- `crates/voom-dsl/src/compiler.rs:171:38: replace == with != in compile_operation`
+- `crates/voom-dsl/src/compiler.rs:218:21: delete match arm "all" in compile_operation`
+- `crates/voom-dsl/src/compiler.rs:318:21: delete match arm Value::Number(n, _) in compile_synthesize`
+- `crates/voom-dsl/src/compiler.rs:319:21: delete match arm Value::Ident(s) | Value::String(s) in compile_synthesize`
+- `crates/voom-dsl/src/compiler.rs:329:38: replace == with != in compile_synthesize`
+- `crates/voom-dsl/src/compiler.rs:337:21: delete match arm Value::Number(n, _) in compile_synthesize`
+- `crates/voom-dsl/src/compiler.rs:338:21: delete match arm Value::Ident(s) in compile_synthesize`
+- `crates/voom-dsl/src/compiler.rs:541:9: delete match arm "track" in parse_track_target`
+- `crates/voom-dsl/src/compiler.rs:590:60: replace > with == in topological_sort`
 
-The cluster on `compiler.rs:29` is a single line — `safe_u32`'s range-check predicate. A handful of focused tests exercising u32 boundary values would knock out all five mutants on that line at once. `parse_error_strategy` / `parse_default_strategy` are similarly clustered: missing tests for each enum arm.
+What remains in `voom-dsl` after Phase 2 is concentrated in the formatter and the compiler's synthesize/topological-sort paths. The largest remaining clusters are `format_operation` (6 survivors) and `format_number`, `compile_synthesize`, `topological_sort`, and `validator::broad_track_category` (5 each), with `format_when` and `format_policy` trailing at 4 apiece. The formatter clusters reflect the fact that round-trip / golden-output tests cover the common cases but not every per-operation rendering branch; the `compile_synthesize` cluster is missing coverage for individual `Value::*` arms feeding the synth-track parameters.
 
-### `voom-policy-evaluator` (73 surviving)
+### `voom-policy-evaluator` (42 surviving)
 
-- `plugins/policy-evaluator/src/condition.rs:59:40: replace && with || in evaluate_condition`
-- `plugins/policy-evaluator/src/condition.rs:59:36: replace > with == in evaluate_condition`
-- `plugins/policy-evaluator/src/condition.rs:59:36: replace > with < in evaluate_condition`
-- `plugins/policy-evaluator/src/condition.rs:59:36: replace > with >= in evaluate_condition`
-- `plugins/policy-evaluator/src/condition.rs:59:43: delete ! in evaluate_condition`
-- `plugins/policy-evaluator/src/condition.rs:61:65: replace <= with > in evaluate_condition`
-- `plugins/policy-evaluator/src/condition.rs:101:9: delete match arm "hwaccels" in resolve_system_field`
-- `plugins/policy-evaluator/src/condition.rs:132:9: delete match arm "language" | "lang" in resolve_track_field`
-- `plugins/policy-evaluator/src/condition.rs:133:9: delete match arm "title" in resolve_track_field`
-- `plugins/policy-evaluator/src/condition.rs:134:9: delete match arm "channels" in resolve_track_field`
+- `plugins/policy-evaluator/src/lib.rs:71:5: replace evaluate_single_phase_with_hints -> Option<voom_domain::plan::Plan> with None`
+- `plugins/policy-evaluator/src/condition.rs:258:9: delete match arm (serde_json::Value::Number(l), serde_json::Value::Number(r)) in json_values_equal`
+- `plugins/policy-evaluator/src/condition.rs:258:84: replace == with != in json_values_equal`
+- `plugins/policy-evaluator/src/container_compat.rs:42:9: delete match arm Container::Mov | Container::Ts | Container::Flv | Container::Wmv | Container::Other in codec_supported`
+- `plugins/policy-evaluator/src/evaluator.rs:266:33: replace == with != in apply_safeguards`
+- `plugins/policy-evaluator/src/evaluator.rs:272:8: delete ! in apply_safeguards`
+- `plugins/policy-evaluator/src/evaluator.rs:386:37: replace > with == in apply_container_safeguard`
+- `plugins/policy-evaluator/src/evaluator.rs:386:37: replace > with >= in apply_container_safeguard`
+- `plugins/policy-evaluator/src/evaluator.rs:410:5: replace apply_safeguard_for_track_type with ()`
+- `plugins/policy-evaluator/src/evaluator.rs:415:14: replace == with != in apply_safeguard_for_track_type`
 
-The `evaluate_condition` cluster on lines 59 and 61 is the predicate at the heart of policy evaluation — six surviving mutants on two lines means the comparison operators and boolean composition aren't being exercised end-to-end. The `resolve_*_field` mutants are missing test coverage for individual track/system field aliases.
+The dominant remaining cluster is `apply_safeguard_for_track_type` in `evaluator.rs` with 9 survivors, followed by `is_font_attachment` in `filter.rs` (5) and the `apply_safeguards` predicate cluster in `evaluator.rs` (3). The safeguard clusters indicate that the per-track-type guard branches and their boundary comparisons aren't yet exercised end-to-end; `is_font_attachment` is a small classification helper whose individual MIME/extension branches are uncovered.
 
 ### `voom-phase-orchestrator`
 
@@ -66,14 +75,14 @@ No surviving mutants.
 
 ## Triage
 
-A single tracking issue gathers follow-up work to drive surviving-mutant counts down: see [#236 — track triage of cargo-mutants survivors](https://github.com/randomparity/voom/issues/236).
+Issue [#236 — track triage of cargo-mutants survivors](https://github.com/randomparity/voom/issues/236) drove the Phase 1 and Phase 2 work that produced the catch rates above and was closed alongside this re-baseline. The clusters listed above are candidates for a follow-up triage issue if the project decides to push catch rates further.
 
 The general approach for triaging a survivor:
 
 1. Read the survivor's `name` field — it includes the file, line, and the exact mutation cargo-mutants applied.
 2. Write a focused unit test that distinguishes the original code from the mutant. If the mutation is a comparison operator flip, the test should hit the boundary value; if it is a deleted match arm, the test should pass that arm's input.
 3. Verify locally with `cargo mutants -p <crate> --file <relative-path> --regex <fragment of the mutation name>`.
-4. Group several survivors into a single PR when they touch related code (e.g. the five `safe_u32` mutants in `voom-dsl/compiler.rs:29` belong together).
+4. Group several survivors into a single PR when they touch related code (e.g. the nine `apply_safeguard_for_track_type` mutants in `policy-evaluator/src/evaluator.rs` belong together).
 
 If a mutant is provably equivalent (no observable behavior change), document the reasoning in the test file rather than suppressing it via `cargo-mutants` config — that keeps the analysis reviewable and discoverable.
 

--- a/plugins/policy-evaluator/src/condition.rs
+++ b/plugins/policy-evaluator/src/condition.rs
@@ -1109,4 +1109,85 @@ mod tests {
             &ctx,
         ));
     }
+
+    // ---- compare_json comparison-operator tests (issue #236, phase 2) ----
+    // Each test calls compare_json directly via super::* so we don't have to
+    // route String/Bool fixtures through FieldCompare. The String tests use
+    // single-character strings to make the lexicographic ordering obvious;
+    // the Bool test exercises the only valid bool comparison op (Ne) since
+    // ordering ops fall through to `_ => false` regardless.
+
+    #[test]
+    fn compare_json_returns_false_for_type_mismatch() {
+        // Kills `replace compare_json -> bool with true`: the type-mismatch
+        // fallback must return false, not true.
+        let left = serde_json::Value::String("a".into());
+        let right = serde_json::json!(1);
+        assert!(!compare_json(&left, CompiledCompareOp::Eq, &right));
+    }
+
+    #[test]
+    fn compare_json_string_ne_different() {
+        // Kills String Ne `!= -> ==`: distinct strings should be Ne-true.
+        let left = serde_json::Value::String("a".into());
+        let right = serde_json::Value::String("b".into());
+        assert!(compare_json(&left, CompiledCompareOp::Ne, &right));
+    }
+
+    #[test]
+    fn compare_json_string_lt_equal_inputs() {
+        // Kills String Lt `< -> ==` and `< -> <=`: equal strings are not Lt.
+        let left = serde_json::Value::String("a".into());
+        let right = serde_json::Value::String("a".into());
+        assert!(!compare_json(&left, CompiledCompareOp::Lt, &right));
+    }
+
+    #[test]
+    fn compare_json_string_lt_less() {
+        // Kills String Lt `< -> >`: "a" < "b" is true; "a" > "b" is false.
+        let left = serde_json::Value::String("a".into());
+        let right = serde_json::Value::String("b".into());
+        assert!(compare_json(&left, CompiledCompareOp::Lt, &right));
+    }
+
+    #[test]
+    fn compare_json_string_le_equal_inputs() {
+        // Kills String Le `<= -> >`: equal strings are Le-true, not Gt.
+        let left = serde_json::Value::String("a".into());
+        let right = serde_json::Value::String("a".into());
+        assert!(compare_json(&left, CompiledCompareOp::Le, &right));
+    }
+
+    #[test]
+    fn compare_json_string_gt_equal_inputs() {
+        // Kills String Gt `> -> ==` and `> -> >=`: equal strings are not Gt.
+        let left = serde_json::Value::String("a".into());
+        let right = serde_json::Value::String("a".into());
+        assert!(!compare_json(&left, CompiledCompareOp::Gt, &right));
+    }
+
+    #[test]
+    fn compare_json_string_gt_greater() {
+        // Kills String Gt `> -> <`: "b" > "a" is true; "b" < "a" is false.
+        let left = serde_json::Value::String("b".into());
+        let right = serde_json::Value::String("a".into());
+        assert!(compare_json(&left, CompiledCompareOp::Gt, &right));
+    }
+
+    #[test]
+    fn compare_json_string_ge_equal_inputs() {
+        // Kills String Ge `>= -> <`: equal strings are Ge-true, not Lt.
+        let left = serde_json::Value::String("a".into());
+        let right = serde_json::Value::String("a".into());
+        assert!(compare_json(&left, CompiledCompareOp::Ge, &right));
+    }
+
+    #[test]
+    fn compare_json_bool_ne_different() {
+        // Kills both Bool Ne mutants: `delete match arm Ne` (would fall through
+        // to `_ => false`) and `!= -> ==` (would yield `true == false` = false).
+        let left = serde_json::Value::Bool(true);
+        let right = serde_json::Value::Bool(false);
+        assert!(compare_json(&left, CompiledCompareOp::Ne, &right));
+    }
 }

--- a/plugins/policy-evaluator/src/condition.rs
+++ b/plugins/policy-evaluator/src/condition.rs
@@ -1007,4 +1007,106 @@ mod tests {
             &ctx,
         ));
     }
+
+    // ---- resolve_file_field arms (issue #236, phase 2) ----
+    // Each test targets a single match arm in resolve_file_field. Seeding the
+    // field with a known non-default value and asserting FieldCompare(Eq)
+    // succeeds means deleting the arm — which makes resolve_file_field fall
+    // through to the tag-lookup `_` branch (which finds nothing because the
+    // helper leaves `tags` empty) — flips the assertion to false. The same
+    // assertions also kill the function-level `replace -> None` and
+    // `replace -> Some(Default::default())` (Value::Null) mutants because
+    // each compares against a specific, non-null expected value.
+
+    fn file_with_seeded_file_fields() -> MediaFile {
+        // container=Mkv (as_str() = "mkv"), size=12_345_678, duration=90.5,
+        // path=/movies/test.mkv (filename "test.mkv"), tags empty.
+        use voom_domain::media::Container;
+        let mut file = MediaFile::new(PathBuf::from("/movies/test.mkv"));
+        file.container = Container::Mkv;
+        file.size = 12_345_678;
+        file.duration = 90.5;
+        file
+    }
+
+    #[test]
+    fn resolve_file_field_container() {
+        // Kills `delete match arm "container"`.
+        let file = file_with_seeded_file_fields();
+        let ctx = no_ctx();
+        assert!(evaluate_condition(
+            &CompiledCondition::FieldCompare {
+                path: vec!["file".into(), "container".into()],
+                op: CompiledCompareOp::Eq,
+                value: serde_json::Value::String("mkv".into()),
+            },
+            &file,
+            &ctx,
+        ));
+    }
+
+    #[test]
+    fn resolve_file_field_size() {
+        // Kills `delete match arm "size"`.
+        let file = file_with_seeded_file_fields();
+        let ctx = no_ctx();
+        assert!(evaluate_condition(
+            &CompiledCondition::FieldCompare {
+                path: vec!["file".into(), "size".into()],
+                op: CompiledCompareOp::Eq,
+                value: serde_json::json!(12_345_678u64),
+            },
+            &file,
+            &ctx,
+        ));
+    }
+
+    #[test]
+    fn resolve_file_field_duration() {
+        // Kills `delete match arm "duration"`. 90.5 is exactly representable
+        // in f64 to avoid equality flakes.
+        let file = file_with_seeded_file_fields();
+        let ctx = no_ctx();
+        assert!(evaluate_condition(
+            &CompiledCondition::FieldCompare {
+                path: vec!["file".into(), "duration".into()],
+                op: CompiledCompareOp::Eq,
+                value: serde_json::json!(90.5),
+            },
+            &file,
+            &ctx,
+        ));
+    }
+
+    #[test]
+    fn resolve_file_field_path() {
+        // Kills `delete match arm "path"`.
+        let file = file_with_seeded_file_fields();
+        let ctx = no_ctx();
+        assert!(evaluate_condition(
+            &CompiledCondition::FieldCompare {
+                path: vec!["file".into(), "path".into()],
+                op: CompiledCompareOp::Eq,
+                value: serde_json::Value::String("/movies/test.mkv".into()),
+            },
+            &file,
+            &ctx,
+        ));
+    }
+
+    #[test]
+    fn resolve_file_field_filename() {
+        // Kills `delete match arm "filename"`.
+        let file = file_with_seeded_file_fields();
+        let ctx = no_ctx();
+        assert!(evaluate_condition(
+            &CompiledCondition::FieldCompare {
+                path: vec!["file".into(), "filename".into()],
+                op: CompiledCompareOp::Eq,
+                value: serde_json::Value::String("test.mkv".into()),
+            },
+            &file,
+            &ctx,
+        ));
+    }
 }

--- a/plugins/policy-evaluator/src/condition.rs
+++ b/plugins/policy-evaluator/src/condition.rs
@@ -1019,13 +1019,19 @@ mod tests {
     // each compares against a specific, non-null expected value.
 
     fn file_with_seeded_file_fields() -> MediaFile {
-        // container=Mkv (as_str() = "mkv"), size=12_345_678, duration=90.5,
-        // path=/movies/test.mkv (filename "test.mkv"), tags empty.
         use voom_domain::media::Container;
         let mut file = MediaFile::new(PathBuf::from("/movies/test.mkv"));
         file.container = Container::Mkv;
         file.size = 12_345_678;
         file.duration = 90.5;
+        // The cluster's tests rely on `tags` being empty so that the `_` arm of
+        // resolve_file_field cannot accidentally satisfy a built-in field name.
+        // Assert the precondition so a future change to MediaFile::new defaults
+        // surfaces here instead of silently weakening the mutant kills.
+        assert!(
+            file.tags.is_empty(),
+            "fixture precondition: tags must be empty"
+        );
         file
     }
 

--- a/plugins/policy-evaluator/src/filter.rs
+++ b/plugins/policy-evaluator/src/filter.rs
@@ -461,4 +461,61 @@ mod tests {
         // track_matches (no context) should return false for field refs
         assert!(!track_matches(&track, &filter));
     }
+
+    // ---- compare_f64 boundary tests (issue #236, phase 2) ----
+    // Each test targets specific surviving mutants on lines 131–134. The
+    // EPSILON-boundary tests use input pairs whose absolute difference is
+    // exactly f64::EPSILON, the only inputs that distinguish `<` from `<=`
+    // (or `>=` from `<`) on that branch. The Ne `replace - with +/replace -
+    // with /` mutants need inputs where (left-right), (left+right), and
+    // (left/right) all give different absolute values, which is why we use
+    // `(1.0, -1.0)` and `(2.0, 2.0)`.
+
+    #[test]
+    fn compare_f64_eq_at_epsilon_boundary() {
+        // |0 - EPSILON| = EPSILON. EPSILON < EPSILON is false, but the
+        // `< to <=` mutant would flip this to true.
+        assert!(!compare_f64(0.0, CompiledCompareOp::Eq, f64::EPSILON));
+    }
+
+    #[test]
+    fn compare_f64_ne_at_epsilon_boundary() {
+        // |0 - EPSILON| = EPSILON. EPSILON >= EPSILON is true, but the
+        // `>= to <` mutant would flip this to false.
+        assert!(compare_f64(0.0, CompiledCompareOp::Ne, f64::EPSILON));
+    }
+
+    #[test]
+    fn compare_f64_ne_subtraction_distinguishes_addition() {
+        // |1 - (-1)| = 2 (>= EPSILON, true). The `- to +` mutant computes
+        // |1 + (-1)| = 0 (< EPSILON, false), so the result flips.
+        assert!(compare_f64(1.0, CompiledCompareOp::Ne, -1.0));
+    }
+
+    #[test]
+    fn compare_f64_ne_subtraction_distinguishes_division() {
+        // |2 - 2| = 0 (< EPSILON, false). The `- to /` mutant computes
+        // |2 / 2| = 1 (>= EPSILON, true), so the result flips.
+        assert!(!compare_f64(2.0, CompiledCompareOp::Ne, 2.0));
+    }
+
+    #[test]
+    fn compare_f64_lt_equal_inputs() {
+        // 1 < 1 is false. Both `< to ==` (1 == 1 = true) and `< to <=`
+        // (1 <= 1 = true) mutants flip the result, so this single test
+        // kills two surviving mutants on line 133.
+        assert!(!compare_f64(1.0, CompiledCompareOp::Lt, 1.0));
+    }
+
+    #[test]
+    fn compare_f64_lt_left_less() {
+        // 1 < 2 is true. The `< to >` mutant (1 > 2 = false) flips it.
+        assert!(compare_f64(1.0, CompiledCompareOp::Lt, 2.0));
+    }
+
+    #[test]
+    fn compare_f64_le_equal_inputs() {
+        // 1 <= 1 is true. The `<= to >` mutant (1 > 1 = false) flips it.
+        assert!(compare_f64(1.0, CompiledCompareOp::Le, 1.0));
+    }
 }


### PR DESCRIPTION
## Summary

- Drives cargo-mutants catch rates above the 80% Definition-of-Done threshold for both targeted crates: `voom-dsl` 70.7% → 87.1%, `voom-policy-evaluator` 73.0% → 83.8%.
- 9 cluster-killing test commits + 1 doc refresh + 1 review-cleanup commit.
- 77 surviving mutants killed (78 attempted; 1 documented as a provably-equivalent mutant in `crates/voom-dsl/src/validator.rs` per the issue's in-source-comment policy).
- No production code changed; all changes are tests + the baseline doc.

## Status of #236 Definition of Done

Both clauses now met:

- "Every cluster listed above is closed" — met in Phase 1 (PRs #239, #241, #242).
- "Catch rate ≥ 80 % on each crate" — met by this PR.

## Cluster commits

| # | Cluster | Mutants killed | SHA |
|--:|---|--:|---|
| 1 | `resolve_file_field` arms (policy-evaluator) | 7 | `e3ff2d7` |
| 2 | `compare_f64` boundary (policy-evaluator) | 8 | `4449a97` |
| 3 | `compare_json` operators (policy-evaluator) | 12 | `34fb468` |
| 4 | `compile_transcode` setting arms (voom-dsl) | 11 | `45062bd` |
| 5 | `validate_filter` arms (voom-dsl) | 7 | `f9f846c` |
| 6 | `check_tag_conflicts` + 1 equivalent (voom-dsl) | 6 (+1 doc) | `70ca666` |
| 7 | `format_phase` indent arithmetic (voom-dsl) | 10 | `22d2cb2` |
| 8 | `format_config` indent arithmetic (voom-dsl) | 10 | `b72accf` |
| 9 | `format_rules` indent arithmetic (voom-dsl) | 6 | `5363860` |
| - | docs: refresh baseline | - | `ff29d25` |
| - | post-review cleanup (test rename + fixture assert) | - | `708ae3f` |

## Test plan

- [x] `cargo test --workspace` passes (59 test result blocks, 0 failures)
- [x] `cargo test -p voom-cli --features functional -- --test-threads=4` passes (6 blocks, 0 failures)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Each cluster verified locally with scoped `cargo mutants -p <crate> --file <file> --regex '<function>'` — every targeted mutant now caught
- [x] Final re-baseline at SHA `5363860` (pre-doc-commit): voom-dsl 87.1 %, voom-policy-evaluator 83.8 %