### PR TITLE
Fix e2e audit phase failure summary

### DIFF
--- a/scripts/e2e-policy-audit/README.md
+++ b/scripts/e2e-policy-audit/README.md
@@ -7,8 +7,8 @@ the operator uses to judge policy correctness.
 
 The harness is policy-agnostic: it does not parse `.voom` files and does not
 encode any expected outcomes. **Pipeline correctness** (build, scan, jobs reach
-a terminal state, no data loss, web endpoints up, no phase that produced 100%
-job failures) is gated by the harness; **semantic correctness** ("did the
+a terminal state, no data loss, web endpoints up, no failed plans in any phase)
+is gated by the harness; **semantic correctness** ("did the
 policy do what I wanted") is the operator's judgment from the diffs.
 
 ## Usage

--- a/scripts/e2e-policy-audit/lib/build-summary.sh
+++ b/scripts/e2e-policy-audit/lib/build-summary.sh
@@ -124,7 +124,7 @@ fi
         echo '```'
     else
         echo
-        echo "(jobs report not parseable per-phase)"
+        echo "(plans.tsv not available or not parseable per-phase)"
     fi
     echo
     echo "## Anomaly section"

--- a/scripts/e2e-policy-audit/lib/build-summary.sh
+++ b/scripts/e2e-policy-audit/lib/build-summary.sh
@@ -13,23 +13,23 @@ hard_fails=()
 soft_warns=()
 
 note_fail() {
-    hard_fails+=("$1")
-    verdict="FAIL"
+  hard_fails+=("$1")
+  verdict="FAIL"
 }
 note_warn() {
-    soft_warns+=("$1")
-    [[ "${verdict}" == "PASS" ]] && verdict="WARN"
+  soft_warns+=("$1")
+  [[ "${verdict}" == "PASS" ]] && verdict="WARN"
 }
 
 # Hard checks on logged exit codes
 for log_name in doctor policy-validate scan; do
-    rc_file="${run}/logs/${log_name}.log.rc"
-    if [[ ! -f "${rc_file}" ]]; then
-        note_fail "missing ${log_name}.log.rc"
-        continue
-    fi
-    rc=$(cat "${rc_file}")
-    [[ "${rc}" != "0" ]] && note_fail "${log_name} exit code ${rc}"
+  rc_file="${run}/logs/${log_name}.log.rc"
+  if [[ ! -f "${rc_file}" ]]; then
+    note_fail "missing ${log_name}.log.rc"
+    continue
+  fi
+  rc=$(cat "${rc_file}")
+  [[ "${rc}" != "0" ]] && note_fail "${log_name} exit code ${rc}"
 done
 
 # diff-snapshots data-loss check
@@ -38,16 +38,16 @@ missing_bak=0
 disappeared=0
 size_changed=0
 if [[ -f "${diff_md}" ]]; then
-    missing_bak=$(awk '/Missing backup post-run:/ {print $NF}' "${diff_md}")
-    [[ -z "${missing_bak}" ]] && missing_bak=0
-    disappeared=$(awk -F'\\| ' '/Disappeared/ {print $3}' "${diff_md}" | tr -dc '0-9')
-    [[ -z "${disappeared}" ]] && disappeared=0
-    size_changed=$(awk -F'\\| ' '/size-changed/ {print $3}' "${diff_md}" | tr -dc '0-9')
-    [[ -z "${size_changed}" ]] && size_changed=0
-    ((missing_bak > 0)) && note_fail "${missing_bak} disappeared source(s) lack a backup under .voom-backup/"
-    ((size_changed > 0)) && note_warn "${size_changed} common path(s) changed size"
+  missing_bak=$(awk '/Missing backup post-run:/ {print $NF}' "${diff_md}")
+  [[ -z "${missing_bak}" ]] && missing_bak=0
+  disappeared=$(awk -F'\\| ' '/Disappeared/ {print $3}' "${diff_md}" | tr -dc '0-9')
+  [[ -z "${disappeared}" ]] && disappeared=0
+  size_changed=$(awk -F'\\| ' '/size-changed/ {print $3}' "${diff_md}" | tr -dc '0-9')
+  [[ -z "${size_changed}" ]] && size_changed=0
+  ((missing_bak > 0)) && note_fail "${missing_bak} disappeared source(s) lack a backup under .voom-backup/"
+  ((size_changed > 0)) && note_warn "${size_changed} common path(s) changed size"
 else
-    note_fail "files-summary.md not generated"
+  note_fail "files-summary.md not generated"
 fi
 
 ((post_count < pre_count)) && note_warn "post file count (${post_count}) < pre (${pre_count})"
@@ -55,22 +55,22 @@ fi
 # Web smoke
 statuses="${run}/web-smoke/statuses.tsv"
 if [[ -f "${statuses}" ]]; then
-    while IFS=$'\t' read -r ep st; do
-        [[ "${ep}" == "endpoint" ]] && continue
-        if [[ "${ep}" == *"(sse)"* ]]; then
-            [[ ! "${st}" =~ ^2[0-9][0-9]$ ]] && note_warn "SSE smoke ${ep} returned ${st}"
-            continue
-        fi
-        [[ ! "${st}" =~ ^2[0-9][0-9]$ ]] && note_fail "web smoke ${ep} returned ${st}"
-    done <"${statuses}"
+  while IFS=$'\t' read -r ep st; do
+    [[ "${ep}" == "endpoint" ]] && continue
+    if [[ "${ep}" == *"(sse)"* ]]; then
+      [[ ! "${st}" =~ ^2[0-9][0-9]$ ]] && note_warn "SSE smoke ${ep} returned ${st}"
+      continue
+    fi
+    [[ ! "${st}" =~ ^2[0-9][0-9]$ ]] && note_fail "web smoke ${ep} returned ${st}"
+  done <"${statuses}"
 fi
 
 # Job stragglers
 jobs_report="${run}/reports/jobs.txt"
 if [[ -f "${jobs_report}" ]]; then
-    if grep -Eqi '\b(running|pending)\b' "${jobs_report}"; then
-        note_fail "jobs report contains non-terminal states (running/pending)"
-    fi
+  if grep -Eqi '\b(running|pending)\b' "${jobs_report}"; then
+    note_fail "jobs report contains non-terminal states (running/pending)"
+  fi
 fi
 
 # Per-phase plan summary from db-export/plans.tsv.
@@ -78,91 +78,91 @@ phase_summary="${run}/diffs/phase-summary.tsv"
 failed_plans="${run}/diffs/failed-plans.tsv"
 plans_tsv="${run}/db-export/plans.tsv"
 if [[ -f "${plans_tsv}" ]]; then
-    "${script_dir}/plan-phase-summary.py" "${plans_tsv}" "${phase_summary}" "${failed_plans}"
+  "${script_dir}/plan-phase-summary.py" "${plans_tsv}" "${phase_summary}" "${failed_plans}"
 
-    while IFS=$'\t' read -r phase total _completed _skipped failed; do
-        [[ "${phase}" == "phase" ]] && continue
-        if ((failed > 0)); then
-            note_fail "phase ${phase}: ${failed}/${total} plans failed"
-        fi
-    done <"${phase_summary}"
+  while IFS=$'\t' read -r phase total _completed _skipped failed; do
+    [[ "${phase}" == "phase" ]] && continue
+    if ((failed > 0)); then
+      note_fail "phase ${phase}: ${failed}/${total} plans failed"
+    fi
+  done <"${phase_summary}"
 fi
 
 # Render
 {
-    echo "# E2E Run Summary — ${verdict}"
+  echo "# E2E Run Summary — ${verdict}"
+  echo
+  echo "Run dir: \`${run}\`"
+  date -Iseconds | sed 's/^/Generated: /'
+  echo
+  echo "## Counts"
+  echo
+  echo "- Pre-run files: ${pre_count}"
+  echo "- Post-run files: ${post_count}"
+  echo
+  echo "## Hard criteria"
+  echo
+  if ((${#hard_fails[@]} == 0)); then
+    echo "All passed."
+  else
+    for f in "${hard_fails[@]}"; do echo "- FAIL: ${f}"; done
+  fi
+  echo
+  echo "## Soft criteria"
+  echo
+  if ((${#soft_warns[@]} == 0)); then
+    echo "No warnings."
+  else
+    for w in "${soft_warns[@]}"; do echo "- WARN: ${w}"; done
+  fi
+  echo
+  echo "## Per-phase plan summary"
+  if [[ -s "${phase_summary}" ]]; then
     echo
-    echo "Run dir: \`${run}\`"
-    date -Iseconds | sed 's/^/Generated: /'
-    echo
-    echo "## Counts"
-    echo
-    echo "- Pre-run files: ${pre_count}"
-    echo "- Post-run files: ${post_count}"
-    echo
-    echo "## Hard criteria"
-    echo
-    if ((${#hard_fails[@]} == 0)); then
-        echo "All passed."
-    else
-        for f in "${hard_fails[@]}"; do echo "- FAIL: ${f}"; done
-    fi
-    echo
-    echo "## Soft criteria"
-    echo
-    if ((${#soft_warns[@]} == 0)); then
-        echo "No warnings."
-    else
-        for w in "${soft_warns[@]}"; do echo "- WARN: ${w}"; done
-    fi
-    echo
-    echo "## Per-phase plan summary"
-    if [[ -s "${phase_summary}" ]]; then
-        echo
-        echo '```'
-        cat "${phase_summary}"
-        echo '```'
-    else
-        echo
-        echo "(plans.tsv not available or not parseable per-phase)"
-    fi
-    echo
-    echo "## Anomaly section"
-    echo
-    echo "### Failed plans (first 50)"
     echo '```'
-    if [[ -f "${failed_plans}" ]] && [[ $(awk 'END {print NR}' "${failed_plans}") -gt 1 ]]; then
-        head -51 "${failed_plans}"
-    else
-        echo "(none)"
-    fi
+    cat "${phase_summary}"
     echo '```'
+  else
     echo
-    echo "### Top 10 longest jobs"
-    if [[ -f "${run}/db-export/jobs.tsv" ]]; then
-        echo '```'
-        awk -F'\t' 'NR==1 {for(i=1;i<=NF;i++) h[$i]=i} NR>1 {
+    echo "(plans.tsv not available or not parseable per-phase)"
+  fi
+  echo
+  echo "## Anomaly section"
+  echo
+  echo "### Failed plans (first 50)"
+  echo '```'
+  if [[ -f "${failed_plans}" ]] && [[ $(awk 'END {print NR}' "${failed_plans}") -gt 1 ]]; then
+    head -51 "${failed_plans}"
+  else
+    echo "(none)"
+  fi
+  echo '```'
+  echo
+  echo "### Top 10 longest jobs"
+  if [[ -f "${run}/db-export/jobs.tsv" ]]; then
+    echo '```'
+    awk -F'\t' 'NR==1 {for(i=1;i<=NF;i++) h[$i]=i} NR>1 {
             d = ($h["completed_at"] - $h["started_at"]);
             print d "\t" $h["id"] "\t" $h["status"];
         }' "${run}/db-export/jobs.tsv" 2>/dev/null |
-            sort -rn | head -10 || echo "(jobs.tsv missing expected columns)"
-        echo '```'
-    fi
-    echo
-    echo "### First 50 db-vs-ffprobe-post divergences (introspection bugs)"
-    if [[ -f "${run}/diffs/db-vs-ffprobe-post.tsv" ]]; then
-        echo '```'
-        head -51 "${run}/diffs/db-vs-ffprobe-post.tsv"
-        echo '```'
-    fi
-    echo
-    echo "## Linked artifacts"
-    echo
-    echo "- [diffs/](diffs/)"
-    echo "- [logs/](logs/)"
-    echo "- [reports/](reports/)"
-    echo "- [db-export/](db-export/)"
-    echo "- [web-smoke/](web-smoke/)"
+      sort -rn | head -10 || echo "(jobs.tsv missing expected columns)"
+    echo '```'
+  fi
+  echo
+  echo "### First 50 db-vs-ffprobe-post divergences (introspection bugs)"
+  if [[ -f "${run}/diffs/db-vs-ffprobe-post.tsv" ]]; then
+    echo '```'
+    head -51 "${run}/diffs/db-vs-ffprobe-post.tsv"
+    echo '```'
+  fi
+  echo
+  echo "## Linked artifacts"
+  echo
+  echo "- [diffs/](diffs/)"
+  echo "- [logs/](logs/)"
+  echo "- [reports/](reports/)"
+  echo "- [db-export/](db-export/)"
+  echo "- [web-smoke/](web-smoke/)"
 } >"${run}/summary.md"
 
 echo "build-summary: ${verdict} — see ${run}/summary.md"

--- a/scripts/e2e-policy-audit/lib/build-summary.sh
+++ b/scripts/e2e-policy-audit/lib/build-summary.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 run="${1:?run dir required}"
 pre_count="${2:?pre file count required}"
 post_count="${3:?post file count required}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 verdict="PASS"
 hard_fails=()
@@ -64,46 +65,25 @@ if [[ -f "${statuses}" ]]; then
     done <"${statuses}"
 fi
 
-# Job stragglers + per-phase failure rate
+# Job stragglers
 jobs_report="${run}/reports/jobs.txt"
-failed_jobs=0
 if [[ -f "${jobs_report}" ]]; then
     if grep -Eqi '\b(running|pending)\b' "${jobs_report}"; then
         note_fail "jobs report contains non-terminal states (running/pending)"
     fi
-    failed_jobs=$(grep -Ec '\bfailed\b' "${jobs_report}" || true)
-    ((failed_jobs > 0)) && note_warn "${failed_jobs} job(s) reported as failed"
 fi
 
-# Per-phase 100%-failure check from db-export/jobs.tsv (header-driven column
-# lookup so the script doesn't break if column order changes). Phase is
-# extracted from the JSON payload column via jq.
+# Per-phase plan summary from db-export/plans.tsv.
 phase_summary="${run}/diffs/phase-summary.tsv"
-jobs_tsv="${run}/db-export/jobs.tsv"
-if [[ -f "${jobs_tsv}" ]]; then
-    awk -F'\t' '
-        NR==1 { for (i=1; i<=NF; i++) h[$i]=i; next }
-        {
-            payload = $h["payload"]; status = $h["status"]
-            print payload "\t" status
-        }
-    ' "${jobs_tsv}" |
-        while IFS=$'\t' read -r payload status; do
-            phase=$(printf '%s' "${payload}" | jq -r '.phase_name // .phase // "unknown"' 2>/dev/null || echo "unknown")
-            printf '%s\t%s\n' "${phase}" "${status}"
-        done |
-        awk -F'\t' '
-            { tot[$1]++; if ($2=="failed") fails[$1]++ }
-            END {
-                print "phase\ttotal\tfailed"
-                for (p in tot) printf "%s\t%d\t%d\n", p, tot[p], fails[p]+0
-            }
-        ' >"${phase_summary}"
+failed_plans="${run}/diffs/failed-plans.tsv"
+plans_tsv="${run}/db-export/plans.tsv"
+if [[ -f "${plans_tsv}" ]]; then
+    "${script_dir}/plan-phase-summary.py" "${plans_tsv}" "${phase_summary}" "${failed_plans}"
 
-    while IFS=$'\t' read -r p tot fail; do
-        [[ "${p}" == "phase" ]] && continue
-        if ((tot > 0 && fail == tot)); then
-            note_fail "phase ${p}: 100% (${fail}/${tot}) jobs failed"
+    while IFS=$'\t' read -r phase total _completed _skipped failed; do
+        [[ "${phase}" == "phase" ]] && continue
+        if ((failed > 0)); then
+            note_fail "phase ${phase}: ${failed}/${total} plans failed"
         fi
     done <"${phase_summary}"
 fi
@@ -136,7 +116,7 @@ fi
         for w in "${soft_warns[@]}"; do echo "- WARN: ${w}"; done
     fi
     echo
-    echo "## Per-phase job summary"
+    echo "## Per-phase plan summary"
     if [[ -s "${phase_summary}" ]]; then
         echo
         echo '```'
@@ -149,12 +129,14 @@ fi
     echo
     echo "## Anomaly section"
     echo
-    if [[ -f "${jobs_report}" ]]; then
-        echo "### Failed jobs (first 50)"
-        echo '```'
-        grep -E '\bfailed\b' "${jobs_report}" | head -50 || echo "(none)"
-        echo '```'
+    echo "### Failed plans (first 50)"
+    echo '```'
+    if [[ -f "${failed_plans}" ]] && [[ $(awk 'END {print NR}' "${failed_plans}") -gt 1 ]]; then
+        head -51 "${failed_plans}"
+    else
+        echo "(none)"
     fi
+    echo '```'
     echo
     echo "### Top 10 longest jobs"
     if [[ -f "${run}/db-export/jobs.tsv" ]]; then

--- a/scripts/e2e-policy-audit/lib/plan-phase-summary.py
+++ b/scripts/e2e-policy-audit/lib/plan-phase-summary.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Summarize plan outcomes by phase from a db-export plans.tsv file."""
+
+from __future__ import annotations
+
+import csv
+import sys
+from collections import OrderedDict
+from pathlib import Path
+
+REQUIRED_COLUMNS = {"id", "file_id", "phase_name", "status", "result"}
+COUNTED_STATUSES = {"completed", "skipped", "failed"}
+
+
+def usage() -> str:
+    return "usage: plan-phase-summary.py <plans.tsv> <phase-summary.tsv> <failed-plans.tsv>"
+
+
+def require_columns(fieldnames: list[str] | None, plans_path: Path) -> None:
+    if fieldnames is None:
+        raise SystemExit(f"{plans_path}: missing TSV header")
+
+    missing = sorted(REQUIRED_COLUMNS.difference(fieldnames))
+    if missing:
+        joined = ", ".join(missing)
+        raise SystemExit(f"{plans_path}: missing required column(s): {joined}")
+
+
+def summarize(
+    plans_path: Path,
+    phase_summary_path: Path,
+    failed_plans_path: Path,
+) -> None:
+    phases: OrderedDict[str, dict[str, int]] = OrderedDict()
+    failed_plans: list[dict[str, str]] = []
+
+    with plans_path.open(newline="") as plans_file:
+        reader = csv.DictReader(plans_file, delimiter="\t")
+        require_columns(reader.fieldnames, plans_path)
+
+        for row in reader:
+            phase = row["phase_name"] or "unknown"
+            status = row["status"]
+            if phase not in phases:
+                phases[phase] = {"total": 0, "completed": 0, "skipped": 0, "failed": 0}
+
+            phases[phase]["total"] += 1
+            if status in COUNTED_STATUSES:
+                phases[phase][status] += 1
+
+            if status == "failed":
+                failed_plans.append(
+                    {
+                        "plan_id": row["id"],
+                        "file_id": row["file_id"],
+                        "phase": phase,
+                        "result": row["result"],
+                    }
+                )
+
+    with phase_summary_path.open("w", newline="") as phase_summary_file:
+        writer = csv.writer(phase_summary_file, delimiter="\t", lineterminator="\n")
+        writer.writerow(["phase", "total", "completed", "skipped", "failed"])
+        for phase, counts in phases.items():
+            writer.writerow(
+                [
+                    phase,
+                    counts["total"],
+                    counts["completed"],
+                    counts["skipped"],
+                    counts["failed"],
+                ]
+            )
+
+    with failed_plans_path.open("w") as failed_plans_file:
+        failed_plans_file.write("plan_id\tfile_id\tphase\tresult\n")
+        for failed_plan in failed_plans:
+            failed_plans_file.write(
+                "\t".join(
+                    [
+                        failed_plan["plan_id"],
+                        failed_plan["file_id"],
+                        failed_plan["phase"],
+                        failed_plan["result"],
+                    ]
+                )
+                + "\n"
+            )
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 4:
+        print(usage(), file=sys.stderr)
+        return 2
+
+    summarize(Path(argv[1]), Path(argv[2]), Path(argv[3]))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/e2e-policy-audit/tests/expected/summary-failed-phase/phase-summary.tsv
+++ b/scripts/e2e-policy-audit/tests/expected/summary-failed-phase/phase-summary.tsv
@@ -1,0 +1,3 @@
+phase	total	completed	skipped	failed
+containerize	1	1	0	0
+transcode-video	3	1	1	1

--- a/scripts/e2e-policy-audit/tests/expected/summary-failed-phase/summary.md
+++ b/scripts/e2e-policy-audit/tests/expected/summary-failed-phase/summary.md
@@ -1,0 +1,49 @@
+# E2E Run Summary — FAIL
+
+Run dir: `<RUN_DIR>`
+Generated: <GENERATED_AT>
+
+## Counts
+
+- Pre-run files: 4
+- Post-run files: 4
+
+## Hard criteria
+
+- FAIL: phase transcode-video: 1/3 plans failed
+
+## Soft criteria
+
+No warnings.
+
+## Per-phase plan summary
+
+```
+phase	total	completed	skipped	failed
+containerize	1	1	0	0
+transcode-video	3	1	1	1
+```
+
+## Anomaly section
+
+### Failed plans (first 50)
+```
+plan_id	file_id	phase	result
+plan-4	file-4	transcode-video	{"error":"encoder failed"}
+```
+
+### Top 10 longest jobs
+```
+10	job-2	completed
+5	job-1	completed
+```
+
+### First 50 db-vs-ffprobe-post divergences (introspection bugs)
+
+## Linked artifacts
+
+- [diffs/](diffs/)
+- [logs/](logs/)
+- [reports/](reports/)
+- [db-export/](db-export/)
+- [web-smoke/](web-smoke/)

--- a/scripts/e2e-policy-audit/tests/test.sh
+++ b/scripts/e2e-policy-audit/tests/test.sh
@@ -8,53 +8,53 @@ fixtures=(transcode)
 fail=0
 
 assert_match() {
-    local actual="$1"
-    local expected="$2"
-    if ! diff -u "${expected}" "${actual}"; then
-        echo "FAIL: ${actual} differs from ${expected}" >&2
-        fail=1
-    fi
+  local actual="$1"
+  local expected="$2"
+  if ! diff -u "${expected}" "${actual}"; then
+    echo "FAIL: ${actual} differs from ${expected}" >&2
+    fail=1
+  fi
 }
 
 run_summary_failed_phase_test() {
-    local actual
-    local normalized
-    local expected
+  local actual
+  local normalized
+  local expected
 
-    expected="tests/expected/summary-failed-phase"
-    actual=$(mktemp -d)
-    normalized=$(mktemp -d)
-    trap 'rm -R "${actual}" "${normalized}"' EXIT
+  expected="tests/expected/summary-failed-phase"
+  actual=$(mktemp -d)
+  normalized=$(mktemp -d)
+  trap 'rm -R "${actual}" "${normalized}"' EXIT
 
-    mkdir -p \
-        "${actual}/logs" \
-        "${actual}/reports" \
-        "${actual}/db-export" \
-        "${actual}/diffs"
+  mkdir -p \
+    "${actual}/logs" \
+    "${actual}/reports" \
+    "${actual}/db-export" \
+    "${actual}/diffs"
 
-    for log_name in doctor policy-validate scan; do
-        printf '0\n' >"${actual}/logs/${log_name}.log.rc"
-    done
+  for log_name in doctor policy-validate scan; do
+    printf '0\n' >"${actual}/logs/${log_name}.log.rc"
+  done
 
-    cat >"${actual}/diffs/files-summary.md" <<'EOF'
+  cat >"${actual}/diffs/files-summary.md" <<'EOF'
 # Snapshot Diff Summary
 
 Disappeared paths: 0
 Missing backup post-run: 0
 EOF
 
-    cat >"${actual}/reports/jobs.txt" <<'EOF'
+  cat >"${actual}/reports/jobs.txt" <<'EOF'
 job-1 completed
 job-2 completed
 EOF
 
-    cat >"${actual}/db-export/jobs.tsv" <<'EOF'
+  cat >"${actual}/db-export/jobs.tsv" <<'EOF'
 id	status	payload	started_at	completed_at
 job-1	completed	{"job":"process"}	10	15
 job-2	completed	{"job":"process"}	20	30
 EOF
 
-    cat >"${actual}/db-export/plans.tsv" <<'EOF'
+  cat >"${actual}/db-export/plans.tsv" <<'EOF'
 id	file_id	phase_name	status	result
 plan-1	file-1	containerize	completed	{"ok":true}
 plan-2	file-2	transcode-video	completed	{"ok":true}
@@ -62,65 +62,65 @@ plan-3	file-3	transcode-video	skipped	{"reason":"already-compatible"}
 plan-4	file-4	transcode-video	failed	{"error":"encoder failed"}
 EOF
 
-    "lib/build-summary.sh" "${actual}" 4 4
+  "lib/build-summary.sh" "${actual}" 4 4
 
-    assert_match "${actual}/diffs/phase-summary.tsv" "${expected}/phase-summary.tsv"
+  assert_match "${actual}/diffs/phase-summary.tsv" "${expected}/phase-summary.tsv"
 
-    sed \
-        -e "s|Run dir: \`${actual}\`|Run dir: \`<RUN_DIR>\`|" \
-        -e 's/^Generated: .*/Generated: <GENERATED_AT>/' \
-        "${actual}/summary.md" >"${normalized}/summary.md"
-    assert_match "${normalized}/summary.md" "${expected}/summary.md"
+  sed \
+    -e "s|Run dir: \`${actual}\`|Run dir: \`<RUN_DIR>\`|" \
+    -e 's/^Generated: .*/Generated: <GENERATED_AT>/' \
+    "${actual}/summary.md" >"${normalized}/summary.md"
+  assert_match "${normalized}/summary.md" "${expected}/summary.md"
 
-    rm -R "${actual}" "${normalized}"
-    trap - EXIT
+  rm -R "${actual}" "${normalized}"
+  trap - EXIT
 }
 
 run_summary_failed_phase_test
 
 for scenario in "${fixtures[@]}"; do
-    pre="tests/fixtures/${scenario}/pre"
-    post="tests/fixtures/${scenario}/post"
-    expected="tests/expected/${scenario}"
-    actual=$(mktemp -d)
-    trap 'rm -rf "${actual}"' EXIT
+  pre="tests/fixtures/${scenario}/pre"
+  post="tests/fixtures/${scenario}/post"
+  expected="tests/expected/${scenario}"
+  actual=$(mktemp -d)
+  trap 'rm -rf "${actual}"' EXIT
 
-    "lib/diff-snapshots.sh" "${pre}" "${post}" "${actual}/files-summary.md"
-    assert_match "${actual}/files-summary.md" "${expected}/files-summary.md"
+  "lib/diff-snapshots.sh" "${pre}" "${post}" "${actual}/files-summary.md"
+  assert_match "${actual}/files-summary.md" "${expected}/files-summary.md"
 
-    ignore="lib/ndjson-ignore.txt"
-    for combo in \
-        "pre/voom-db.ndjson:pre/ffprobe.ndjson:db-vs-ffprobe-pre.tsv" \
-        "post/voom-db.ndjson:post/ffprobe.ndjson:db-vs-ffprobe-post.tsv" \
-        "pre/voom-db.ndjson:post/voom-db.ndjson:voom-db-pre-vs-post.tsv" \
-        "pre/ffprobe.ndjson:post/ffprobe.ndjson:ffprobe-pre-vs-post.tsv"; do
-        IFS=: read -r left right out <<<"${combo}"
-        "lib/diff-ndjson.py" \
-            "tests/fixtures/${scenario}/${left}" \
-            "tests/fixtures/${scenario}/${right}" \
-            "${actual}/${out}" \
-            --ignore-file "${ignore}"
-        assert_match "${actual}/${out}" "${expected}/${out}"
-    done
+  ignore="lib/ndjson-ignore.txt"
+  for combo in \
+    "pre/voom-db.ndjson:pre/ffprobe.ndjson:db-vs-ffprobe-pre.tsv" \
+    "post/voom-db.ndjson:post/ffprobe.ndjson:db-vs-ffprobe-post.tsv" \
+    "pre/voom-db.ndjson:post/voom-db.ndjson:voom-db-pre-vs-post.tsv" \
+    "pre/ffprobe.ndjson:post/ffprobe.ndjson:ffprobe-pre-vs-post.tsv"; do
+    IFS=: read -r left right out <<<"${combo}"
+    "lib/diff-ndjson.py" \
+      "tests/fixtures/${scenario}/${left}" \
+      "tests/fixtures/${scenario}/${right}" \
+      "${actual}/${out}" \
+      --ignore-file "${ignore}"
+    assert_match "${actual}/${out}" "${expected}/${out}"
+  done
 
-    "lib/codec-pivot.py" \
-        "tests/fixtures/${scenario}/pre/ffprobe.ndjson" \
-        "tests/fixtures/${scenario}/post/ffprobe.ndjson" \
-        "${actual}/codec-pivot.md"
-    assert_match "${actual}/codec-pivot.md" "${expected}/codec-pivot.md"
+  "lib/codec-pivot.py" \
+    "tests/fixtures/${scenario}/pre/ffprobe.ndjson" \
+    "tests/fixtures/${scenario}/post/ffprobe.ndjson" \
+    "${actual}/codec-pivot.md"
+  assert_match "${actual}/codec-pivot.md" "${expected}/codec-pivot.md"
 
-    "lib/tracks-pivot.py" \
-        "tests/fixtures/${scenario}/pre/ffprobe.ndjson" \
-        "tests/fixtures/${scenario}/post/ffprobe.ndjson" \
-        "${actual}/tracks-pivot.md"
-    assert_match "${actual}/tracks-pivot.md" "${expected}/tracks-pivot.md"
+  "lib/tracks-pivot.py" \
+    "tests/fixtures/${scenario}/pre/ffprobe.ndjson" \
+    "tests/fixtures/${scenario}/post/ffprobe.ndjson" \
+    "${actual}/tracks-pivot.md"
+  assert_match "${actual}/tracks-pivot.md" "${expected}/tracks-pivot.md"
 
-    rm -rf "${actual}"
-    trap - EXIT
+  rm -rf "${actual}"
+  trap - EXIT
 done
 
 if ((fail)); then
-    echo "TESTS FAILED" >&2
-    exit 1
+  echo "TESTS FAILED" >&2
+  exit 1
 fi
 echo "TESTS PASSED"

--- a/scripts/e2e-policy-audit/tests/test.sh
+++ b/scripts/e2e-policy-audit/tests/test.sh
@@ -16,6 +16,66 @@ assert_match() {
     fi
 }
 
+run_summary_failed_phase_test() {
+    local actual
+    local normalized
+    local expected
+
+    expected="tests/expected/summary-failed-phase"
+    actual=$(mktemp -d)
+    normalized=$(mktemp -d)
+    trap 'rm -R "${actual}" "${normalized}"' EXIT
+
+    mkdir -p \
+        "${actual}/logs" \
+        "${actual}/reports" \
+        "${actual}/db-export" \
+        "${actual}/diffs"
+
+    for log_name in doctor policy-validate scan; do
+        printf '0\n' >"${actual}/logs/${log_name}.log.rc"
+    done
+
+    cat >"${actual}/diffs/files-summary.md" <<'EOF'
+# Snapshot Diff Summary
+
+Disappeared paths: 0
+Missing backup post-run: 0
+EOF
+
+    cat >"${actual}/reports/jobs.txt" <<'EOF'
+job-1 completed
+job-2 completed
+EOF
+
+    cat >"${actual}/db-export/jobs.tsv" <<'EOF'
+id	status	payload	started_at	completed_at
+job-1	completed	{"job":"process"}	10	15
+job-2	completed	{"job":"process"}	20	30
+EOF
+
+    cat >"${actual}/db-export/plans.tsv" <<'EOF'
+id	file_id	phase_name	status	result
+plan-1	file-1	containerize	completed	{"ok":true}
+plan-2	file-2	transcode-video	completed	{"ok":true}
+plan-3	file-3	transcode-video	skipped	{"reason":"already-compatible"}
+plan-4	file-4	transcode-video	failed	{"error":"encoder failed"}
+EOF
+
+    "lib/build-summary.sh" "${actual}" 4 4
+
+    assert_match "${actual}/diffs/phase-summary.tsv" "${expected}/phase-summary.tsv"
+
+    sed \
+        -e "s|Run dir: \`${actual}\`|Run dir: \`<RUN_DIR>\`|" \
+        -e 's/^Generated: .*/Generated: <GENERATED_AT>/' \
+        "${actual}/summary.md" >"${normalized}/summary.md"
+    assert_match "${normalized}/summary.md" "${expected}/summary.md"
+
+    rm -R "${actual}" "${normalized}"
+    trap - EXIT
+}
+
 for scenario in "${fixtures[@]}"; do
     pre="tests/fixtures/${scenario}/pre"
     post="tests/fixtures/${scenario}/post"
@@ -56,6 +116,8 @@ for scenario in "${fixtures[@]}"; do
     rm -rf "${actual}"
     trap - EXIT
 done
+
+run_summary_failed_phase_test
 
 if ((fail)); then
     echo "TESTS FAILED" >&2

--- a/scripts/e2e-policy-audit/tests/test.sh
+++ b/scripts/e2e-policy-audit/tests/test.sh
@@ -76,6 +76,8 @@ EOF
     trap - EXIT
 }
 
+run_summary_failed_phase_test
+
 for scenario in "${fixtures[@]}"; do
     pre="tests/fixtures/${scenario}/pre"
     post="tests/fixtures/${scenario}/post"
@@ -116,8 +118,6 @@ for scenario in "${fixtures[@]}"; do
     rm -rf "${actual}"
     trap - EXIT
 done
-
-run_summary_failed_phase_test
 
 if ((fail)); then
     echo "TESTS FAILED" >&2


### PR DESCRIPTION
## Summary
- derive e2e audit phase summary and hard-fail criteria from `db-export/plans.tsv`
- add `plan-phase-summary.py` plus a regression fixture for completed jobs with a failed phase plan
- update audit summary wording and README hard-gate description

## Test Plan
- focused issue #256 fixture matched expected `phase-summary.tsv` and normalized `summary.md`
- `bash -n scripts/e2e-policy-audit/tests/test.sh && bash -n scripts/e2e-policy-audit/lib/build-summary.sh && python3 -m py_compile scripts/e2e-policy-audit/lib/plan-phase-summary.py`
- `shellcheck scripts/e2e-policy-audit/lib/build-summary.sh scripts/e2e-policy-audit/tests/test.sh`
- `shfmt -i 2 -d scripts/e2e-policy-audit/lib/build-summary.sh scripts/e2e-policy-audit/tests/test.sh`
- `ruff check scripts/e2e-policy-audit/lib/plan-phase-summary.py`
- `prek run`

## Known limitation
- `bash scripts/e2e-policy-audit/tests/test.sh` reaches the new regression first, then stops on the existing macOS Bash 3.2 blocker: `declare: -A: invalid option` in `lib/diff-snapshots.sh`.

Fixes #256
