### PR TITLE
Limit NVENC plan concurrency

### DIFF
--- a/crates/voom-cli/src/commands/process/mod.rs
+++ b/crates/voom-cli/src/commands/process/mod.rs
@@ -31,6 +31,16 @@ use voom_domain::utils::format::format_size;
 use voom_job_manager::progress::{CompositeReporter, ProgressReporter};
 use voom_job_manager::worker::{JobErrorStrategy, WorkerPool, WorkerPoolConfig};
 
+fn hw_resource_for_backend(backend: &str) -> Option<&'static str> {
+    match backend {
+        "nvenc" => Some("hw:nvenc"),
+        "qsv" => Some("hw:qsv"),
+        "vaapi" => Some("hw:vaapi"),
+        "videotoolbox" => Some("hw:videotoolbox"),
+        _ => None,
+    }
+}
+
 /// Run the process command.
 ///
 /// Uses the event-driven + direct-call pattern throughout:
@@ -74,15 +84,22 @@ pub async fn run(args: ProcessArgs, quiet: bool, token: CancellationToken) -> Re
     let store_for_retention = store.clone();
     let kernel_for_retention = kernel.clone();
     let capabilities = Arc::new(collector.snapshot());
-    let plan_limiter = Arc::new(voom_job_manager::worker::PlanExecutionLimiter::from_limits(
-        ["hw:nvenc", "hw:qsv", "hw:vaapi", "hw:videotoolbox"]
-            .into_iter()
-            .filter_map(|resource| {
-                capabilities
-                    .parallel_limit(resource)
-                    .map(|limit| (resource.to_string(), limit))
-            }),
-    ));
+    let limited_hw_resources = ["hw:nvenc", "hw:qsv", "hw:vaapi", "hw:videotoolbox"]
+        .into_iter()
+        .filter_map(|resource| {
+            capabilities
+                .parallel_limit(resource)
+                .map(|limit| (resource.to_string(), limit))
+        })
+        .collect::<Vec<_>>();
+    let default_hw_resource =
+        hw_resource_for_backend(capabilities.best_hwaccel()).map(str::to_string);
+    let plan_limiter = Arc::new(
+        voom_job_manager::worker::PlanExecutionLimiter::from_limits_with_default(
+            limited_hw_resources,
+            default_hw_resource,
+        ),
+    );
 
     let paths = resolve_paths(&args.paths)?;
 
@@ -864,6 +881,19 @@ mod tests {
     };
     use super::plan_outcome::PlanOutcome;
     use super::safeguards::{check_disk_space, check_duration_shrink, check_size_increase};
+
+    #[test]
+    fn test_hw_resource_for_backend() {
+        assert_eq!(hw_resource_for_backend("nvenc"), Some("hw:nvenc"));
+        assert_eq!(hw_resource_for_backend("qsv"), Some("hw:qsv"));
+        assert_eq!(hw_resource_for_backend("vaapi"), Some("hw:vaapi"));
+        assert_eq!(
+            hw_resource_for_backend("videotoolbox"),
+            Some("hw:videotoolbox")
+        );
+        assert_eq!(hw_resource_for_backend("none"), None);
+        assert_eq!(hw_resource_for_backend("unknown"), None);
+    }
 
     /// A test plugin that counts received plan lifecycle events.
     #[allow(clippy::struct_field_names)]

--- a/crates/voom-cli/src/commands/process/mod.rs
+++ b/crates/voom-cli/src/commands/process/mod.rs
@@ -961,13 +961,17 @@ mod tests {
     }
 
     pub(super) fn test_plan_with_transcode_hw(phase: &str, hw: &str) -> Plan {
+        test_plan_with_optional_transcode_hw(phase, Some(hw))
+    }
+
+    pub(super) fn test_plan_with_optional_transcode_hw(phase: &str, hw: Option<&str>) -> Plan {
         let mut plan = test_plan(phase, false);
         plan.actions = vec![PlannedAction::track_op(
             OperationType::TranscodeVideo,
             0,
             ActionParams::Transcode {
                 codec: "hevc".into(),
-                settings: TranscodeSettings::default().with_hw(Some(hw.to_string())),
+                settings: TranscodeSettings::default().with_hw(hw.map(str::to_string)),
             },
             "Transcode video",
         )];

--- a/crates/voom-cli/src/commands/process/mod.rs
+++ b/crates/voom-cli/src/commands/process/mod.rs
@@ -74,6 +74,15 @@ pub async fn run(args: ProcessArgs, quiet: bool, token: CancellationToken) -> Re
     let store_for_retention = store.clone();
     let kernel_for_retention = kernel.clone();
     let capabilities = Arc::new(collector.snapshot());
+    let plan_limiter = Arc::new(voom_job_manager::worker::PlanExecutionLimiter::from_limits(
+        ["hw:nvenc", "hw:qsv", "hw:vaapi", "hw:videotoolbox"]
+            .into_iter()
+            .filter_map(|resource| {
+                capabilities
+                    .parallel_limit(resource)
+                    .map(|limit| (resource.to_string(), limit))
+            }),
+    ));
 
     let paths = resolve_paths(&args.paths)?;
 
@@ -223,6 +232,7 @@ pub async fn run(args: ProcessArgs, quiet: bool, token: CancellationToken) -> Re
                     let token = token_for_workers.clone();
                     let ffprobe_path = ffprobe_path.clone();
                     let capabilities = capabilities.clone();
+                    let plan_limiter = plan_limiter.clone();
                     let counters = counters.clone();
                     async move {
                         let ctx = ProcessContext {
@@ -237,6 +247,7 @@ pub async fn run(args: ProcessArgs, quiet: bool, token: CancellationToken) -> Re
                             token: &token,
                             ffprobe_path: ffprobe_path.as_deref(),
                             capabilities: &capabilities,
+                            plan_limiter,
                             counters: &counters,
                         };
                         process_single_file(job, &ctx).await
@@ -688,6 +699,7 @@ pub(super) struct ProcessContext<'a> {
     pub(super) token: &'a CancellationToken,
     pub(super) ffprobe_path: Option<&'a str>,
     pub(super) capabilities: &'a voom_domain::CapabilityMap,
+    pub(super) plan_limiter: Arc<voom_job_manager::worker::PlanExecutionLimiter>,
     pub(super) counters: &'a RunCounters,
 }
 
@@ -845,7 +857,7 @@ mod tests {
         EventResult, FileDiscoveredEvent, FileIntrospectedEvent, PlanCreatedEvent, PlanSkippedEvent,
     };
     use voom_domain::media::MediaFile;
-    use voom_domain::plan::{ActionParams, OperationType, Plan, PlannedAction};
+    use voom_domain::plan::{ActionParams, OperationType, Plan, PlannedAction, TranscodeSettings};
 
     use super::pipeline::{
         apply_detected_languages, execute_single_plan, AUDIO_LANGUAGE_DETECTOR_PLUGIN,
@@ -948,11 +960,26 @@ mod tests {
         plan
     }
 
+    pub(super) fn test_plan_with_transcode_hw(phase: &str, hw: &str) -> Plan {
+        let mut plan = test_plan(phase, false);
+        plan.actions = vec![PlannedAction::track_op(
+            OperationType::TranscodeVideo,
+            0,
+            ActionParams::Transcode {
+                codec: "hevc".into(),
+                settings: TranscodeSettings::default().with_hw(Some(hw.to_string())),
+            },
+            "Transcode video",
+        )];
+        plan
+    }
+
     /// Bundle of long-lived test fixtures shared across `ProcessContext`
     /// construction sites. Owns the `TempDir` so the resolver's working path
     /// stays valid for the test's lifetime.
     pub(super) struct TestFixture {
         capabilities: voom_domain::CapabilityMap,
+        plan_limiter: Arc<voom_job_manager::worker::PlanExecutionLimiter>,
         counters: RunCounters,
         token: CancellationToken,
         resolver: PolicyResolver,
@@ -977,6 +1004,7 @@ mod tests {
             );
             Self {
                 capabilities: voom_domain::CapabilityMap::new(),
+                plan_limiter: Arc::new(voom_job_manager::worker::PlanExecutionLimiter::default()),
                 counters: RunCounters::new(),
                 token: CancellationToken::new(),
                 resolver,
@@ -1022,6 +1050,7 @@ mod tests {
                 token: &self.token,
                 ffprobe_path: None,
                 capabilities: &self.capabilities,
+                plan_limiter: self.plan_limiter.clone(),
                 counters: &self.counters,
             }
         }

--- a/crates/voom-cli/src/commands/process/pipeline.rs
+++ b/crates/voom-cli/src/commands/process/pipeline.rs
@@ -861,9 +861,12 @@ mod tests {
     async fn process_pipeline_limits_transcode_without_per_action_hw() {
         let policy = global_hw_policy();
         let fixture = process_tests::TestFixture::with_policy(policy);
-        let limiter = Arc::new(voom_job_manager::worker::PlanExecutionLimiter::from_limits(
-            vec![("hw:nvenc".to_string(), 1)],
-        ));
+        let limiter = Arc::new(
+            voom_job_manager::worker::PlanExecutionLimiter::from_limits_with_default(
+                vec![("hw:nvenc".to_string(), 1)],
+                Some("hw:nvenc".to_string()),
+            ),
+        );
         let held = limiter
             .acquire_for_plan(&process_tests::test_plan_with_optional_transcode_hw(
                 "transcode-video",

--- a/crates/voom-cli/src/commands/process/pipeline.rs
+++ b/crates/voom-cli/src/commands/process/pipeline.rs
@@ -781,6 +781,14 @@ mod tests {
             }"#
     }
 
+    fn global_hw_policy() -> &'static str {
+        r#"policy "test" {
+                phase transcode-video {
+                    transcode video to hevc
+                }
+            }"#
+    }
+
     fn h264_file(path: std::path::PathBuf) -> MediaFile {
         MediaFile::new(path)
             .with_container(Container::Mkv)
@@ -837,6 +845,62 @@ mod tests {
         assert!(
             matches!(entered_rx.try_recv(), Err(mpsc::TryRecvError::Empty)),
             "executor must not receive PlanCreated while the nvenc permit is held"
+        );
+
+        drop(held);
+        tokio::time::timeout(Duration::from_secs(1), &mut processing)
+            .await
+            .expect("processing should continue after the limiter permit is released")
+            .expect("processing should complete without execution errors");
+        entered_rx
+            .try_recv()
+            .expect("executor should receive PlanCreated after permit release");
+    }
+
+    #[tokio::test]
+    async fn process_pipeline_limits_transcode_without_per_action_hw() {
+        let policy = global_hw_policy();
+        let fixture = process_tests::TestFixture::with_policy(policy);
+        let limiter = Arc::new(voom_job_manager::worker::PlanExecutionLimiter::from_limits(
+            vec![("hw:nvenc".to_string(), 1)],
+        ));
+        let held = limiter
+            .acquire_for_plan(&process_tests::test_plan_with_optional_transcode_hw(
+                "transcode-video",
+                None,
+            ))
+            .await;
+
+        let path = fixture.dir_path().join("movie.mkv");
+        std::fs::write(&path, vec![0u8; 1024]).unwrap();
+        let file = h264_file(path);
+        let compiled = voom_dsl::compile_policy(policy).unwrap();
+
+        let (entered_tx, entered_rx) = mpsc::channel();
+        let mut kernel = voom_kernel::Kernel::new();
+        kernel
+            .register_plugin(Arc::new(RecordingExecutor { entered_tx }), 50)
+            .unwrap();
+        let ctx = ProcessContext {
+            plan_limiter: limiter,
+            ..fixture.make_ctx(
+                Arc::new(kernel),
+                Arc::new(voom_domain::test_support::InMemoryStore::new()),
+            )
+        };
+
+        let processing = process_single_file_execute(&file, &compiled, &ctx);
+        tokio::pin!(processing);
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), &mut processing)
+                .await
+                .is_err(),
+            "global/default hw transcode should wait for the default limited resource"
+        );
+        assert!(
+            matches!(entered_rx.try_recv(), Err(mpsc::TryRecvError::Empty)),
+            "executor must not receive PlanCreated while the default nvenc permit is held"
         );
 
         drop(held);

--- a/crates/voom-cli/src/commands/process/pipeline.rs
+++ b/crates/voom-cli/src/commands/process/pipeline.rs
@@ -280,6 +280,7 @@ async fn process_single_file_execute(
         }
 
         // Execute this plan
+        let permit = ctx.plan_limiter.acquire_for_plan(&plan).await;
         let plan_clone = plan.clone();
         let file_clone = current_file.clone();
         let kernel_clone = ctx.kernel.clone();
@@ -289,6 +290,7 @@ async fn process_single_file_execute(
         })
         .await
         .map_err(|e| format!("plan execution join error: {e}"))?;
+        drop(permit);
         let elapsed_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
 
         match exec_outcome {
@@ -720,4 +722,145 @@ pub(super) fn execute_single_plan(
 ) -> PlanOutcome {
     let results = PlanDispatcher::new(kernel).begin(plan, file);
     PlanOutcome::from_event_result(&results, plan, file)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::mpsc;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use voom_domain::capabilities::Capability;
+    use voom_domain::events::{Event, EventResult};
+    use voom_domain::media::{Container, MediaFile, Track, TrackType};
+
+    use super::super::tests as process_tests;
+    use super::*;
+
+    struct RecordingExecutor {
+        entered_tx: mpsc::Sender<()>,
+    }
+
+    impl voom_kernel::Plugin for RecordingExecutor {
+        fn name(&self) -> &'static str {
+            "recording-executor"
+        }
+
+        fn version(&self) -> &'static str {
+            "0.1.0"
+        }
+
+        fn capabilities(&self) -> &[Capability] {
+            &[]
+        }
+
+        fn handles(&self, event_type: &str) -> bool {
+            event_type == Event::PLAN_CREATED
+        }
+
+        fn on_event(&self, event: &Event) -> voom_domain::errors::Result<Option<EventResult>> {
+            if let Event::PlanCreated(_) = event {
+                let _ = self.entered_tx.send(());
+                return Ok(Some(EventResult::plan_succeeded(self.name(), None)));
+            }
+            Ok(None)
+        }
+    }
+
+    #[tokio::test]
+    async fn test_process_plan_limiter_serializes_nvenc_plans() {
+        let limiter = voom_job_manager::worker::PlanExecutionLimiter::from_limits(vec![(
+            "hw:nvenc".to_string(),
+            1,
+        )]);
+        let plan = process_tests::test_plan_with_transcode_hw("transcode-video", "nvenc");
+
+        let first = limiter.acquire_for_plan(&plan).await;
+        let limiter_clone = limiter.clone();
+        let plan_clone = plan.clone();
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+
+        let waiting = tokio::spawn(async move {
+            let _permit = limiter_clone.acquire_for_plan(&plan_clone).await;
+            let _ = entered_tx.send(());
+            true
+        });
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), entered_rx)
+                .await
+                .is_err(),
+            "second nvenc plan must wait while the first permit is held"
+        );
+
+        drop(first);
+        assert!(tokio::time::timeout(Duration::from_secs(1), waiting)
+            .await
+            .expect("waiting plan should acquire permit after release")
+            .expect("waiting task should complete"));
+    }
+
+    #[tokio::test]
+    async fn process_pipeline_respects_plan_limiter() {
+        let policy = r#"policy "test" {
+                phase transcode-video {
+                    transcode video to hevc {
+                        hw: nvenc
+                    }
+                }
+            }"#;
+        let fixture = process_tests::TestFixture::with_policy(policy);
+        let limiter = Arc::new(voom_job_manager::worker::PlanExecutionLimiter::from_limits(
+            vec![("hw:nvenc".to_string(), 1)],
+        ));
+        let held = limiter
+            .acquire_for_plan(&process_tests::test_plan_with_transcode_hw(
+                "transcode-video",
+                "nvenc",
+            ))
+            .await;
+
+        let path = fixture.dir_path().join("movie.mkv");
+        std::fs::write(&path, vec![0u8; 1024]).unwrap();
+        let file = MediaFile::new(path.clone())
+            .with_container(Container::Mkv)
+            .with_tracks(vec![Track::new(0, TrackType::Video, "h264".into())]);
+        let compiled = voom_dsl::compile_policy(policy).unwrap();
+
+        let (entered_tx, entered_rx) = mpsc::channel();
+        let mut kernel = voom_kernel::Kernel::new();
+        kernel
+            .register_plugin(Arc::new(RecordingExecutor { entered_tx }), 50)
+            .unwrap();
+        let ctx = ProcessContext {
+            plan_limiter: limiter,
+            ..fixture.make_ctx(
+                Arc::new(kernel),
+                Arc::new(voom_domain::test_support::InMemoryStore::new()),
+            )
+        };
+
+        let processing = process_single_file_execute(&file, &compiled, &ctx);
+        tokio::pin!(processing);
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), &mut processing)
+                .await
+                .is_err(),
+            "processing must wait for the plan limiter before executor dispatch"
+        );
+        assert!(
+            matches!(entered_rx.try_recv(), Err(mpsc::TryRecvError::Empty)),
+            "executor must not receive PlanCreated while the nvenc permit is held"
+        );
+
+        drop(held);
+        tokio::time::timeout(Duration::from_secs(1), &mut processing)
+            .await
+            .expect("processing should continue after the limiter permit is released")
+            .expect("processing should complete without execution errors");
+        entered_rx
+            .try_recv()
+            .expect("executor should receive PlanCreated after permit release");
+    }
 }

--- a/crates/voom-cli/src/commands/process/pipeline.rs
+++ b/crates/voom-cli/src/commands/process/pipeline.rs
@@ -280,7 +280,11 @@ async fn process_single_file_execute(
         }
 
         // Execute this plan
-        let permit = ctx.plan_limiter.acquire_for_plan(&plan).await;
+        let permit = tokio::select! {
+            biased;
+            () = ctx.token.cancelled() => break,
+            permit = ctx.plan_limiter.acquire_for_plan(&plan) => permit,
+        };
         let plan_clone = plan.clone();
         let file_clone = current_file.clone();
         let kernel_clone = ctx.kernel.clone();
@@ -767,64 +771,45 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn test_process_plan_limiter_serializes_nvenc_plans() {
-        let limiter = voom_job_manager::worker::PlanExecutionLimiter::from_limits(vec![(
-            "hw:nvenc".to_string(),
-            1,
-        )]);
-        let plan = process_tests::test_plan_with_transcode_hw("transcode-video", "nvenc");
-
-        let first = limiter.acquire_for_plan(&plan).await;
-        let limiter_clone = limiter.clone();
-        let plan_clone = plan.clone();
-        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
-
-        let waiting = tokio::spawn(async move {
-            let _permit = limiter_clone.acquire_for_plan(&plan_clone).await;
-            let _ = entered_tx.send(());
-            true
-        });
-
-        assert!(
-            tokio::time::timeout(Duration::from_millis(20), entered_rx)
-                .await
-                .is_err(),
-            "second nvenc plan must wait while the first permit is held"
-        );
-
-        drop(first);
-        assert!(tokio::time::timeout(Duration::from_secs(1), waiting)
-            .await
-            .expect("waiting plan should acquire permit after release")
-            .expect("waiting task should complete"));
-    }
-
-    #[tokio::test]
-    async fn process_pipeline_respects_plan_limiter() {
-        let policy = r#"policy "test" {
+    fn nvenc_policy() -> &'static str {
+        r#"policy "test" {
                 phase transcode-video {
                     transcode video to hevc {
                         hw: nvenc
                     }
                 }
-            }"#;
-        let fixture = process_tests::TestFixture::with_policy(policy);
-        let limiter = Arc::new(voom_job_manager::worker::PlanExecutionLimiter::from_limits(
-            vec![("hw:nvenc".to_string(), 1)],
-        ));
-        let held = limiter
+            }"#
+    }
+
+    fn h264_file(path: std::path::PathBuf) -> MediaFile {
+        MediaFile::new(path)
+            .with_container(Container::Mkv)
+            .with_tracks(vec![Track::new(0, TrackType::Video, "h264".into())])
+    }
+
+    async fn held_nvenc_permit(
+        limiter: &voom_job_manager::worker::PlanExecutionLimiter,
+    ) -> voom_job_manager::worker::PlanExecutionPermit {
+        limiter
             .acquire_for_plan(&process_tests::test_plan_with_transcode_hw(
                 "transcode-video",
                 "nvenc",
             ))
-            .await;
+            .await
+    }
+
+    #[tokio::test]
+    async fn process_pipeline_respects_plan_limiter() {
+        let policy = nvenc_policy();
+        let fixture = process_tests::TestFixture::with_policy(policy);
+        let limiter = Arc::new(voom_job_manager::worker::PlanExecutionLimiter::from_limits(
+            vec![("hw:nvenc".to_string(), 1)],
+        ));
+        let held = held_nvenc_permit(&limiter).await;
 
         let path = fixture.dir_path().join("movie.mkv");
         std::fs::write(&path, vec![0u8; 1024]).unwrap();
-        let file = MediaFile::new(path.clone())
-            .with_container(Container::Mkv)
-            .with_tracks(vec![Track::new(0, TrackType::Video, "h264".into())]);
+        let file = h264_file(path);
         let compiled = voom_dsl::compile_policy(policy).unwrap();
 
         let (entered_tx, entered_rx) = mpsc::channel();
@@ -862,5 +847,59 @@ mod tests {
         entered_rx
             .try_recv()
             .expect("executor should receive PlanCreated after permit release");
+    }
+
+    #[tokio::test]
+    async fn process_pipeline_cancellation_stops_waiting_for_plan_limiter() {
+        let policy = nvenc_policy();
+        let fixture = process_tests::TestFixture::with_policy(policy);
+        let limiter = Arc::new(voom_job_manager::worker::PlanExecutionLimiter::from_limits(
+            vec![("hw:nvenc".to_string(), 1)],
+        ));
+        let held = held_nvenc_permit(&limiter).await;
+
+        let path = fixture.dir_path().join("movie.mkv");
+        std::fs::write(&path, vec![0u8; 1024]).unwrap();
+        let file = h264_file(path);
+        let compiled = voom_dsl::compile_policy(policy).unwrap();
+
+        let (entered_tx, entered_rx) = mpsc::channel();
+        let mut kernel = voom_kernel::Kernel::new();
+        kernel
+            .register_plugin(Arc::new(RecordingExecutor { entered_tx }), 50)
+            .unwrap();
+        let ctx = ProcessContext {
+            plan_limiter: limiter,
+            ..fixture.make_ctx(
+                Arc::new(kernel),
+                Arc::new(voom_domain::test_support::InMemoryStore::new()),
+            )
+        };
+
+        let processing = process_single_file_execute(&file, &compiled, &ctx);
+        tokio::pin!(processing);
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), &mut processing)
+                .await
+                .is_err(),
+            "processing must wait for the plan limiter before cancellation"
+        );
+        assert!(
+            matches!(entered_rx.try_recv(), Err(mpsc::TryRecvError::Empty)),
+            "executor must not receive PlanCreated while the nvenc permit is held"
+        );
+
+        fixture.cancel();
+        drop(held);
+
+        tokio::time::timeout(Duration::from_secs(1), &mut processing)
+            .await
+            .expect("processing should stop after cancellation")
+            .expect("processing should return without execution errors");
+        assert!(
+            matches!(entered_rx.try_recv(), Err(mpsc::TryRecvError::Empty)),
+            "executor must not receive PlanCreated after cancellation"
+        );
     }
 }

--- a/crates/voom-cli/src/config.rs
+++ b/crates/voom-cli/src/config.rs
@@ -352,6 +352,7 @@ pub fn default_config_contents() -> String {
 # # gpu_device = "0"
 # # Maximum simultaneous NVENC encode sessions. Default: 4.
 # # Lower this to 2 on small GPUs or when CUDA OOM appears under load.
+# # Applies only when NVENC is active; 0 uses the default.
 # # nvenc_max_parallel = 4
 #
 # [plugin.tvdb-metadata]

--- a/crates/voom-cli/src/config.rs
+++ b/crates/voom-cli/src/config.rs
@@ -350,6 +350,9 @@ pub fn default_config_contents() -> String {
 # # GPU device for HW encoding. NVIDIA: "0", "1". VA-API/QSV: "/dev/dri/renderD128".
 # # Omit to use system default.
 # # gpu_device = "0"
+# # Maximum simultaneous NVENC encode sessions. Default: 4.
+# # Lower this to 2 on small GPUs or when CUDA OOM appears under load.
+# # nvenc_max_parallel = 4
 #
 # [plugin.tvdb-metadata]
 # api_key = "your-tvdb-api-key"

--- a/crates/voom-domain/src/capability_map.rs
+++ b/crates/voom-domain/src/capability_map.rs
@@ -62,6 +62,16 @@ impl CapabilityMap {
         self.executors.get(name)
     }
 
+    #[must_use]
+    pub fn parallel_limit(&self, resource: &str) -> Option<usize> {
+        self.executors
+            .values()
+            .flat_map(|event| &event.parallel_limits)
+            .filter(|limit| limit.resource == resource && limit.max_parallel > 0)
+            .map(|limit| limit.max_parallel)
+            .min()
+    }
+
     /// Deduplicated list of hardware acceleration backends across
     /// all executors, normalized to canonical names.
     #[must_use]
@@ -201,6 +211,36 @@ mod tests {
         let caps = map.executor_capabilities("ffmpeg-executor").unwrap();
         assert_eq!(caps.hw_accels, vec!["cuda"]);
         assert!(map.executor_capabilities("other").is_none());
+    }
+
+    #[test]
+    fn test_parallel_limit_lookup_uses_lowest_positive_limit() {
+        let mut map = CapabilityMap::new();
+        map.register(
+            ExecutorCapabilitiesEvent::new(
+                "exec-a",
+                CodecCapabilities::empty(),
+                vec![],
+                vec!["cuda".into()],
+            )
+            .with_parallel_limits(vec![crate::events::ExecutorParallelLimit::new(
+                "hw:nvenc", 4,
+            )]),
+        );
+        map.register(
+            ExecutorCapabilitiesEvent::new(
+                "exec-b",
+                CodecCapabilities::empty(),
+                vec![],
+                vec!["cuda".into()],
+            )
+            .with_parallel_limits(vec![crate::events::ExecutorParallelLimit::new(
+                "hw:nvenc", 2,
+            )]),
+        );
+
+        assert_eq!(map.parallel_limit("hw:nvenc"), Some(2));
+        assert_eq!(map.parallel_limit("hw:qsv"), None);
     }
 
     #[test]

--- a/crates/voom-domain/src/events.rs
+++ b/crates/voom-domain/src/events.rs
@@ -772,12 +772,31 @@ impl CodecCapabilities {
 }
 
 #[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExecutorParallelLimit {
+    pub resource: String,
+    pub max_parallel: usize,
+}
+
+impl ExecutorParallelLimit {
+    #[must_use]
+    pub fn new(resource: impl Into<String>, max_parallel: usize) -> Self {
+        Self {
+            resource: resource.into(),
+            max_parallel,
+        }
+    }
+}
+
+#[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExecutorCapabilitiesEvent {
     pub plugin_name: String,
     pub codecs: CodecCapabilities,
     pub formats: Vec<String>,
     pub hw_accels: Vec<String>,
+    #[serde(default)]
+    pub parallel_limits: Vec<ExecutorParallelLimit>,
 }
 
 impl ExecutorCapabilitiesEvent {
@@ -793,7 +812,14 @@ impl ExecutorCapabilitiesEvent {
             codecs,
             formats,
             hw_accels,
+            parallel_limits: vec![],
         }
+    }
+
+    #[must_use]
+    pub fn with_parallel_limits(mut self, limits: Vec<ExecutorParallelLimit>) -> Self {
+        self.parallel_limits = limits;
+        self
     }
 }
 
@@ -1257,6 +1283,29 @@ mod tests {
         let bytes = rmp_serde::to_vec(&event).unwrap();
         let deserialized: Event = rmp_serde::from_slice(&bytes).unwrap();
         assert_eq!(deserialized.event_type(), "executor.capabilities");
+    }
+
+    #[test]
+    fn test_executor_capabilities_parallel_limits_serde_roundtrip() {
+        let event = Event::ExecutorCapabilities(
+            ExecutorCapabilitiesEvent::new(
+                "ffmpeg-executor",
+                CodecCapabilities::empty(),
+                vec![],
+                vec!["cuda".into()],
+            )
+            .with_parallel_limits(vec![ExecutorParallelLimit::new("hw:nvenc", 4)]),
+        );
+
+        let json = serde_json::to_string(&event).unwrap();
+        let restored: Event = serde_json::from_str(&json).unwrap();
+
+        let Event::ExecutorCapabilities(restored) = restored else {
+            panic!("expected executor capabilities");
+        };
+        assert_eq!(restored.parallel_limits.len(), 1);
+        assert_eq!(restored.parallel_limits[0].resource, "hw:nvenc");
+        assert_eq!(restored.parallel_limits[0].max_parallel, 4);
     }
 
     #[test]

--- a/crates/voom-domain/src/events.rs
+++ b/crates/voom-domain/src/events.rs
@@ -1309,6 +1309,29 @@ mod tests {
     }
 
     #[test]
+    fn test_executor_capabilities_legacy_payload_defaults_parallel_limits() {
+        let json = r#"{
+            "ExecutorCapabilities": {
+                "plugin_name": "ffmpeg-executor",
+                "codecs": {
+                    "decoders": [],
+                    "encoders": [],
+                    "hw_decoders": [],
+                    "hw_encoders": []
+                },
+                "formats": [],
+                "hw_accels": ["cuda"]
+            }
+        }"#;
+
+        let restored: Event = serde_json::from_str(json).unwrap();
+        let Event::ExecutorCapabilities(restored) = restored else {
+            panic!("expected executor capabilities");
+        };
+        assert!(restored.parallel_limits.is_empty());
+    }
+
+    #[test]
     fn test_executor_capabilities_empty_codecs() {
         let caps = CodecCapabilities::empty();
         assert!(caps.decoders.is_empty());

--- a/crates/voom-wit/src/convert.rs
+++ b/crates/voom-wit/src/convert.rs
@@ -435,6 +435,13 @@ mod tests {
 
         let restored = event_from_wasm(&event_type, &payload).unwrap();
         assert_eq!(restored.event_type(), "executor.capabilities");
+
+        let Event::ExecutorCapabilities(restored) = restored else {
+            panic!("expected executor capabilities");
+        };
+        assert_eq!(restored.parallel_limits.len(), 1);
+        assert_eq!(restored.parallel_limits[0].resource, "hw:nvenc");
+        assert_eq!(restored.parallel_limits[0].max_parallel, 4);
     }
 
     #[test]

--- a/crates/voom-wit/src/convert.rs
+++ b/crates/voom-wit/src/convert.rs
@@ -401,12 +401,10 @@ mod tests {
                 e
             }),
             Event::PlanCreated(PlanCreatedEvent::new(plan)),
-            Event::ExecutorCapabilities(ExecutorCapabilitiesEvent::new(
-                "test",
-                CodecCapabilities::empty(),
-                vec![],
-                vec![],
-            )),
+            Event::ExecutorCapabilities(
+                ExecutorCapabilitiesEvent::new("test", CodecCapabilities::empty(), vec![], vec![])
+                    .with_parallel_limits(vec![ExecutorParallelLimit::new("hw:nvenc", 4)]),
+            ),
         ];
 
         for event in &events {
@@ -418,15 +416,18 @@ mod tests {
 
     #[test]
     fn test_executor_capabilities_event_roundtrip() {
-        let event = Event::ExecutorCapabilities(ExecutorCapabilitiesEvent::new(
-            "ffmpeg-executor",
-            CodecCapabilities::new(
-                vec!["h264".into(), "hevc".into(), "aac".into()],
-                vec!["libx264".into(), "libx265".into(), "aac".into()],
-            ),
-            vec!["matroska".into(), "mp4".into(), "avi".into()],
-            vec!["videotoolbox".into(), "cuda".into()],
-        ));
+        let event = Event::ExecutorCapabilities(
+            ExecutorCapabilitiesEvent::new(
+                "ffmpeg-executor",
+                CodecCapabilities::new(
+                    vec!["h264".into(), "hevc".into(), "aac".into()],
+                    vec!["libx264".into(), "libx265".into(), "aac".into()],
+                ),
+                vec!["matroska".into(), "mp4".into(), "avi".into()],
+                vec!["videotoolbox".into(), "cuda".into()],
+            )
+            .with_parallel_limits(vec![ExecutorParallelLimit::new("hw:nvenc", 4)]),
+        );
 
         let (event_type, payload) = event_to_wasm(&event).unwrap();
         assert_eq!(event_type, "executor.capabilities");

--- a/plugins/ffmpeg-executor/src/lib.rs
+++ b/plugins/ffmpeg-executor/src/lib.rs
@@ -37,6 +37,17 @@ struct FfmpegExecutorConfig {
     hw_accel: Option<String>,
     #[serde(default)]
     gpu_device: Option<String>,
+    #[serde(default)]
+    nvenc_max_parallel: Option<usize>,
+}
+
+const DEFAULT_NVENC_MAX_PARALLEL_PER_GPU: usize = 4;
+
+fn positive_or_default(value: Option<usize>, default: usize) -> usize {
+    match value {
+        Some(0) | None => default,
+        Some(value) => value,
+    }
 }
 
 pub(crate) fn plugin_err(message: impl Into<String>) -> VoomError {
@@ -577,9 +588,23 @@ impl Plugin for FfmpegExecutorPlugin {
             "validated HW encoders"
         );
 
+        let mut parallel_limits = Vec::new();
+        if hw_config.backend == Some(crate::hwaccel::HwAccelBackend::Nvenc)
+            && !validated_encoders.is_empty()
+        {
+            parallel_limits.push(voom_domain::events::ExecutorParallelLimit::new(
+                "hw:nvenc",
+                positive_or_default(
+                    plugin_config.nvenc_max_parallel,
+                    DEFAULT_NVENC_MAX_PARALLEL_PER_GPU,
+                ),
+            ));
+        }
+
         self.hw_accel = hw_config.with_validated_encoders(validated_encoders);
 
-        let event = ExecutorCapabilitiesEvent::new("ffmpeg-executor", codecs, formats, hw_accels);
+        let event = ExecutorCapabilitiesEvent::new("ffmpeg-executor", codecs, formats, hw_accels)
+            .with_parallel_limits(parallel_limits);
 
         Ok(vec![Event::ExecutorCapabilities(event)])
     }
@@ -1071,6 +1096,19 @@ mod tests {
         let config: FfmpegExecutorConfig = serde_json::from_value(json).unwrap();
         assert_eq!(config.gpu_device.as_deref(), Some("1"));
         assert!(config.hw_accel.is_none());
+    }
+
+    #[test]
+    fn test_ffmpeg_executor_config_nvenc_max_parallel() {
+        let json = serde_json::json!({
+            "hw_accel": "nvenc",
+            "gpu_device": "0",
+            "nvenc_max_parallel": 3
+        });
+        let config: FfmpegExecutorConfig = serde_json::from_value(json).unwrap();
+        assert_eq!(config.hw_accel.as_deref(), Some("nvenc"));
+        assert_eq!(config.gpu_device.as_deref(), Some("0"));
+        assert_eq!(config.nvenc_max_parallel, Some(3));
     }
 
     #[test]

--- a/plugins/ffmpeg-executor/src/lib.rs
+++ b/plugins/ffmpeg-executor/src/lib.rs
@@ -14,8 +14,8 @@ use std::time::Duration;
 use voom_domain::capabilities::Capability;
 use voom_domain::errors::{Result, VoomError};
 use voom_domain::events::{
-    CodecCapabilities, Event, EventResult, ExecutorCapabilitiesEvent, PlanCreatedEvent,
-    PlanExecutingEvent,
+    CodecCapabilities, Event, EventResult, ExecutorCapabilitiesEvent, ExecutorParallelLimit,
+    PlanCreatedEvent, PlanExecutingEvent,
 };
 use voom_domain::media::Container;
 use voom_domain::plan::{ActionParams, OperationType, Plan, PlannedAction};
@@ -24,7 +24,7 @@ use voom_domain::utils::language::is_valid_language;
 use voom_domain::utils::sanitize::validate_metadata_value;
 use voom_kernel::{Plugin, PluginContext};
 
-use crate::hwaccel::{resolve_hw_config, HwAccelConfig};
+use crate::hwaccel::{resolve_hw_config, HwAccelBackend, HwAccelConfig};
 use crate::probe::{
     enumerate_gpus, probe_capabilities, validate_hw_encoder, validate_hw_encoder_on_device,
     validate_hw_encoders_parallel, GpuDevice,
@@ -48,6 +48,25 @@ fn positive_or_default(value: Option<usize>, default: usize) -> usize {
         Some(0) | None => default,
         Some(value) => value,
     }
+}
+
+fn nvenc_parallel_limits(
+    backend: Option<HwAccelBackend>,
+    validated_encoders: &[String],
+    nvenc_max_parallel: Option<usize>,
+) -> Vec<ExecutorParallelLimit> {
+    if backend != Some(HwAccelBackend::Nvenc)
+        || !validated_encoders
+            .iter()
+            .any(|encoder| encoder.ends_with("_nvenc"))
+    {
+        return Vec::new();
+    }
+
+    vec![ExecutorParallelLimit::new(
+        "hw:nvenc",
+        positive_or_default(nvenc_max_parallel, DEFAULT_NVENC_MAX_PARALLEL_PER_GPU),
+    )]
 }
 
 pub(crate) fn plugin_err(message: impl Into<String>) -> VoomError {
@@ -588,18 +607,11 @@ impl Plugin for FfmpegExecutorPlugin {
             "validated HW encoders"
         );
 
-        let mut parallel_limits = Vec::new();
-        if hw_config.backend == Some(crate::hwaccel::HwAccelBackend::Nvenc)
-            && !validated_encoders.is_empty()
-        {
-            parallel_limits.push(voom_domain::events::ExecutorParallelLimit::new(
-                "hw:nvenc",
-                positive_or_default(
-                    plugin_config.nvenc_max_parallel,
-                    DEFAULT_NVENC_MAX_PARALLEL_PER_GPU,
-                ),
-            ));
-        }
+        let parallel_limits = nvenc_parallel_limits(
+            hw_config.backend,
+            &validated_encoders,
+            plugin_config.nvenc_max_parallel,
+        );
 
         self.hw_accel = hw_config.with_validated_encoders(validated_encoders);
 
@@ -1124,6 +1136,73 @@ mod tests {
         let config = FfmpegExecutorConfig::default();
         assert!(config.gpu_device.is_none());
         assert!(config.hw_accel.is_none());
+    }
+
+    #[test]
+    fn test_config_nvenc_parallel_limits_use_configured_capacity() {
+        let limits = nvenc_parallel_limits(
+            Some(crate::hwaccel::HwAccelBackend::Nvenc),
+            &["h264_nvenc".to_string()],
+            Some(3),
+        );
+
+        assert_eq!(limits.len(), 1);
+        assert_eq!(limits[0].resource, "hw:nvenc");
+        assert_eq!(limits[0].max_parallel, 3);
+    }
+
+    #[test]
+    fn test_config_nvenc_parallel_limits_default_missing_capacity() {
+        let limits = nvenc_parallel_limits(
+            Some(crate::hwaccel::HwAccelBackend::Nvenc),
+            &["h264_nvenc".to_string()],
+            None,
+        );
+
+        assert_eq!(limits.len(), 1);
+        assert_eq!(limits[0].max_parallel, DEFAULT_NVENC_MAX_PARALLEL_PER_GPU);
+    }
+
+    #[test]
+    fn test_config_nvenc_parallel_limits_default_zero_capacity() {
+        let limits = nvenc_parallel_limits(
+            Some(crate::hwaccel::HwAccelBackend::Nvenc),
+            &["h264_nvenc".to_string()],
+            Some(0),
+        );
+
+        assert_eq!(limits.len(), 1);
+        assert_eq!(limits[0].max_parallel, DEFAULT_NVENC_MAX_PARALLEL_PER_GPU);
+    }
+
+    #[test]
+    fn test_config_nvenc_parallel_limits_skip_empty_encoders() {
+        let limits =
+            nvenc_parallel_limits(Some(crate::hwaccel::HwAccelBackend::Nvenc), &[], Some(3));
+
+        assert!(limits.is_empty());
+    }
+
+    #[test]
+    fn test_config_nvenc_parallel_limits_skip_non_nvenc_encoder() {
+        let limits = nvenc_parallel_limits(
+            Some(crate::hwaccel::HwAccelBackend::Nvenc),
+            &["h264_vaapi".to_string()],
+            Some(3),
+        );
+
+        assert!(limits.is_empty());
+    }
+
+    #[test]
+    fn test_config_nvenc_parallel_limits_skip_non_nvenc_backend() {
+        let limits = nvenc_parallel_limits(
+            Some(crate::hwaccel::HwAccelBackend::Vaapi),
+            &["h264_nvenc".to_string()],
+            Some(3),
+        );
+
+        assert!(limits.is_empty());
     }
 
     #[test]

--- a/plugins/job-manager/src/worker.rs
+++ b/plugins/job-manager/src/worker.rs
@@ -86,10 +86,24 @@ impl PlanParallelResource {
     /// Return the plan-level hardware resource for the first matching video transcode.
     ///
     /// Only `TranscodeVideo` actions with known hardware encoder names classify
-    /// a plan. Software, `auto`, `none`, unknown values, and non-video actions
-    /// return `None`.
+    /// a plan. Software, `auto`, missing hardware, unknown values, and non-video
+    /// actions return `None`.
     #[must_use]
     pub fn from_plan(plan: &voom_domain::plan::Plan) -> Option<&'static str> {
+        Self::from_plan_with_default(plan, None)
+    }
+
+    /// Return the plan-level hardware resource, using `default_resource` for
+    /// video transcodes with `hw: auto` or no per-action hardware setting.
+    ///
+    /// This mirrors ffmpeg-executor's global hardware config: explicit backend
+    /// names win, `hw: none` stays software, and unspecified/`auto` plans use
+    /// the active executor-level hardware backend when one has a limit.
+    #[must_use]
+    pub fn from_plan_with_default<'a>(
+        plan: &voom_domain::plan::Plan,
+        default_resource: Option<&'a str>,
+    ) -> Option<&'a str> {
         for action in &plan.actions {
             if action.operation != voom_domain::plan::OperationType::TranscodeVideo {
                 continue;
@@ -98,14 +112,16 @@ impl PlanParallelResource {
             else {
                 continue;
             };
-            let Some(hw) = settings.hw.as_deref() else {
-                continue;
-            };
-            match hw {
-                "nvenc" => return Some("hw:nvenc"),
-                "qsv" => return Some("hw:qsv"),
-                "vaapi" => return Some("hw:vaapi"),
-                "videotoolbox" => return Some("hw:videotoolbox"),
+            match settings.hw.as_deref() {
+                Some("nvenc") => return Some("hw:nvenc"),
+                Some("qsv") => return Some("hw:qsv"),
+                Some("vaapi") => return Some("hw:vaapi"),
+                Some("videotoolbox") => return Some("hw:videotoolbox"),
+                Some("auto") | None => {
+                    if let Some(resource) = default_resource {
+                        return Some(resource);
+                    }
+                }
                 _ => {}
             }
         }
@@ -117,10 +133,13 @@ impl PlanParallelResource {
 ///
 /// This bounds concurrent plan executions that use a classified hardware video
 /// encoder resource. It does not count individual tracks or exact encoder
-/// sessions within a plan.
+/// sessions within a plan. The first positive resource limit is also used as
+/// the default active hardware resource for plans with `hw: auto` or no
+/// per-action hardware setting.
 #[derive(Clone, Default)]
 pub struct PlanExecutionLimiter {
     semaphores: Arc<HashMap<String, Arc<Semaphore>>>,
+    default_resource: Option<String>,
 }
 
 /// RAII permit for a classified plan resource.
@@ -135,16 +154,24 @@ impl PlanExecutionLimiter {
     /// Create a limiter from resource limits.
     ///
     /// Positive limits create semaphores. Zero limits are ignored, leaving that
-    /// resource unlimited.
+    /// resource unlimited. The first positive limit becomes the default
+    /// hardware resource used for `hw: auto` or missing per-action hardware.
     #[must_use]
     pub fn from_limits(limits: impl IntoIterator<Item = (String, usize)>) -> Self {
-        let semaphores = limits
-            .into_iter()
-            .filter(|(_, limit)| *limit > 0)
-            .map(|(resource, limit)| (resource, Arc::new(Semaphore::new(limit))))
-            .collect();
+        let mut semaphores = HashMap::new();
+        let mut default_resource = None;
+        for (resource, limit) in limits {
+            if limit == 0 {
+                continue;
+            }
+            if default_resource.is_none() {
+                default_resource = Some(resource.clone());
+            }
+            semaphores.insert(resource, Arc::new(Semaphore::new(limit)));
+        }
         Self {
             semaphores: Arc::new(semaphores),
+            default_resource,
         }
     }
 
@@ -154,7 +181,9 @@ impl PlanExecutionLimiter {
     /// resource or with no configured limit for that resource. Otherwise, this
     /// waits for capacity and holds it until the returned permit is dropped.
     pub async fn acquire_for_plan(&self, plan: &voom_domain::plan::Plan) -> PlanExecutionPermit {
-        let Some(resource) = PlanParallelResource::from_plan(plan) else {
+        let Some(resource) =
+            PlanParallelResource::from_plan_with_default(plan, self.default_resource.as_deref())
+        else {
             return PlanExecutionPermit { _permit: None };
         };
         let Some(semaphore) = self.semaphores.get(resource) else {
@@ -647,12 +676,67 @@ mod tests {
     }
 
     #[test]
+    fn test_plan_parallel_resource_uses_default_for_auto_and_missing_hw() {
+        for hw in [Some("auto"), None] {
+            let plan = test_transcode_plan(hw);
+            assert_eq!(
+                PlanParallelResource::from_plan_with_default(&plan, Some("hw:nvenc")),
+                Some("hw:nvenc"),
+                "hw={hw:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_plan_parallel_resource_default_does_not_override_none() {
+        let plan = test_transcode_plan(Some("none"));
+        assert_eq!(
+            PlanParallelResource::from_plan_with_default(&plan, Some("hw:nvenc")),
+            None
+        );
+    }
+
+    #[test]
     fn test_plan_parallel_resource_ignores_audio_transcode_hw() {
         let plan = test_transcode_plan_with_operation(
             Some("nvenc"),
             voom_domain::plan::OperationType::TranscodeAudio,
         );
         assert_eq!(PlanParallelResource::from_plan(&plan), None);
+    }
+
+    #[tokio::test]
+    async fn test_plan_execution_limiter_blocks_missing_hw_on_default_resource() {
+        use std::time::Duration;
+
+        let limiter = PlanExecutionLimiter::from_limits(vec![("hw:nvenc".to_string(), 1)]);
+        let plan = test_transcode_plan(None);
+        let first = limiter.acquire_for_plan(&plan).await;
+
+        let limiter_clone = limiter.clone();
+        let plan_clone = plan.clone();
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+        let third = tokio::spawn(async move {
+            let _permit = limiter_clone.acquire_for_plan(&plan_clone).await;
+            let _ = entered_tx.send(());
+            "entered"
+        });
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), entered_rx)
+                .await
+                .is_err(),
+            "missing per-action hw should wait on the default limited resource"
+        );
+
+        drop(first);
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(1), third)
+                .await
+                .expect("task should enter after permit release")
+                .unwrap(),
+            "entered"
+        );
     }
 
     #[tokio::test]

--- a/plugins/job-manager/src/worker.rs
+++ b/plugins/job-manager/src/worker.rs
@@ -75,12 +75,25 @@ fn num_cpus() -> usize {
         .unwrap_or(4)
 }
 
+/// Canonical plan-level hardware resource classification.
+///
+/// Classification is intentionally plan-level: the first matching hardware
+/// video transcode action determines the resource for the whole plan. Audio
+/// transcodes and unknown hardware values do not consume video encoder permits.
 pub struct PlanParallelResource;
 
 impl PlanParallelResource {
+    /// Return the plan-level hardware resource for the first matching video transcode.
+    ///
+    /// Only `TranscodeVideo` actions with known hardware encoder names classify
+    /// a plan. Software, `auto`, `none`, unknown values, and non-video actions
+    /// return `None`.
     #[must_use]
     pub fn from_plan(plan: &voom_domain::plan::Plan) -> Option<&'static str> {
         for action in &plan.actions {
+            if action.operation != voom_domain::plan::OperationType::TranscodeVideo {
+                continue;
+            }
             let voom_domain::plan::ActionParams::Transcode { settings, .. } = &action.parameters
             else {
                 continue;
@@ -100,16 +113,29 @@ impl PlanParallelResource {
     }
 }
 
+/// Plan-level concurrency limiter for resources announced by executor capabilities.
+///
+/// This bounds concurrent plan executions that use a classified hardware video
+/// encoder resource. It does not count individual tracks or exact encoder
+/// sessions within a plan.
 #[derive(Clone, Default)]
 pub struct PlanExecutionLimiter {
     semaphores: Arc<HashMap<String, Arc<Semaphore>>>,
 }
 
+/// RAII permit for a classified plan resource.
+///
+/// Dropping the permit releases the resource. Permits may be no-ops when the
+/// plan has no classified resource or no configured limit.
 pub struct PlanExecutionPermit {
     _permit: Option<tokio::sync::OwnedSemaphorePermit>,
 }
 
 impl PlanExecutionLimiter {
+    /// Create a limiter from resource limits.
+    ///
+    /// Positive limits create semaphores. Zero limits are ignored, leaving that
+    /// resource unlimited.
     #[must_use]
     pub fn from_limits(limits: impl IntoIterator<Item = (String, usize)>) -> Self {
         let semaphores = limits
@@ -122,6 +148,11 @@ impl PlanExecutionLimiter {
         }
     }
 
+    /// Acquire a plan-level resource permit for a plan.
+    ///
+    /// This is a no-op for plans without a classified hardware video transcode
+    /// resource or with no configured limit for that resource. Otherwise, this
+    /// waits for capacity and holds it until the returned permit is dropped.
     pub async fn acquire_for_plan(&self, plan: &voom_domain::plan::Plan) -> PlanExecutionPermit {
         let Some(resource) = PlanParallelResource::from_plan(plan) else {
             return PlanExecutionPermit { _permit: None };
@@ -558,10 +589,17 @@ mod tests {
     }
 
     fn test_transcode_plan(hw: Option<&str>) -> voom_domain::plan::Plan {
+        test_transcode_plan_with_operation(hw, voom_domain::plan::OperationType::TranscodeVideo)
+    }
+
+    fn test_transcode_plan_with_operation(
+        hw: Option<&str>,
+        operation: voom_domain::plan::OperationType,
+    ) -> voom_domain::plan::Plan {
         let file = voom_domain::media::MediaFile::new(std::path::PathBuf::from("/test.mkv"));
         voom_domain::plan::Plan::new(file, "test-policy", "test-phase").with_action(
             voom_domain::plan::PlannedAction::track_op(
-                voom_domain::plan::OperationType::TranscodeVideo,
+                operation,
                 0,
                 voom_domain::plan::ActionParams::Transcode {
                     codec: "hevc".to_string(),
@@ -585,8 +623,42 @@ mod tests {
         assert_eq!(PlanParallelResource::from_plan(&plan), None);
     }
 
+    #[test]
+    fn test_plan_parallel_resource_classifies_known_video_hw() {
+        let cases = [
+            (Some("nvenc"), Some("hw:nvenc")),
+            (Some("qsv"), Some("hw:qsv")),
+            (Some("vaapi"), Some("hw:vaapi")),
+            (Some("videotoolbox"), Some("hw:videotoolbox")),
+            (Some("none"), None),
+            (Some("auto"), None),
+            (Some("mysteryhw"), None),
+            (None, None),
+        ];
+
+        for (hw, expected) in cases {
+            let plan = test_transcode_plan(hw);
+            assert_eq!(
+                PlanParallelResource::from_plan(&plan),
+                expected,
+                "hw={hw:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_plan_parallel_resource_ignores_audio_transcode_hw() {
+        let plan = test_transcode_plan_with_operation(
+            Some("nvenc"),
+            voom_domain::plan::OperationType::TranscodeAudio,
+        );
+        assert_eq!(PlanParallelResource::from_plan(&plan), None);
+    }
+
     #[tokio::test]
     async fn test_plan_execution_limiter_blocks_above_limit() {
+        use std::time::Duration;
+
         let limiter = PlanExecutionLimiter::from_limits(vec![("hw:nvenc".to_string(), 2)]);
         let plan = test_transcode_plan(Some("nvenc"));
 
@@ -595,16 +667,25 @@ mod tests {
 
         let limiter_clone = limiter.clone();
         let plan_clone = plan.clone();
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
         let third = tokio::spawn(async move {
             let _permit = limiter_clone.acquire_for_plan(&plan_clone).await;
+            let _ = entered_tx.send("entered");
             "entered"
         });
 
-        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
-        assert!(!third.is_finished());
+        assert!(tokio::time::timeout(Duration::from_millis(20), entered_rx)
+            .await
+            .is_err());
 
         drop(first);
-        assert_eq!(third.await.unwrap(), "entered");
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(1), third)
+                .await
+                .unwrap()
+                .unwrap(),
+            "entered"
+        );
         drop(second);
     }
 

--- a/plugins/job-manager/src/worker.rs
+++ b/plugins/job-manager/src/worker.rs
@@ -80,19 +80,9 @@ fn num_cpus() -> usize {
 /// Classification is intentionally plan-level: the first matching hardware
 /// video transcode action determines the resource for the whole plan. Audio
 /// transcodes and unknown hardware values do not consume video encoder permits.
-pub struct PlanParallelResource;
+struct PlanParallelResource;
 
 impl PlanParallelResource {
-    /// Return the plan-level hardware resource for the first matching video transcode.
-    ///
-    /// Only `TranscodeVideo` actions with known hardware encoder names classify
-    /// a plan. Software, `auto`, missing hardware, unknown values, and non-video
-    /// actions return `None`.
-    #[must_use]
-    pub fn from_plan(plan: &voom_domain::plan::Plan) -> Option<&'static str> {
-        Self::from_plan_with_default(plan, None)
-    }
-
     /// Return the plan-level hardware resource, using `default_resource` for
     /// video transcodes with `hw: auto` or no per-action hardware setting.
     ///
@@ -133,9 +123,9 @@ impl PlanParallelResource {
 ///
 /// This bounds concurrent plan executions that use a classified hardware video
 /// encoder resource. It does not count individual tracks or exact encoder
-/// sessions within a plan. The first positive resource limit is also used as
-/// the default active hardware resource for plans with `hw: auto` or no
-/// per-action hardware setting.
+/// sessions within a plan. Callers that need executor-level hardware limits to
+/// apply to plans with `hw: auto` or no per-action hardware should use
+/// [`PlanExecutionLimiter::from_limits_with_default`].
 #[derive(Clone, Default)]
 pub struct PlanExecutionLimiter {
     semaphores: Arc<HashMap<String, Arc<Semaphore>>>,
@@ -154,21 +144,33 @@ impl PlanExecutionLimiter {
     /// Create a limiter from resource limits.
     ///
     /// Positive limits create semaphores. Zero limits are ignored, leaving that
-    /// resource unlimited. The first positive limit becomes the default
-    /// hardware resource used for `hw: auto` or missing per-action hardware.
+    /// resource unlimited. Plans with `hw: auto` or missing per-action hardware
+    /// are not limited unless callers use
+    /// [`PlanExecutionLimiter::from_limits_with_default`].
     #[must_use]
     pub fn from_limits(limits: impl IntoIterator<Item = (String, usize)>) -> Self {
+        Self::from_limits_with_default(limits, None)
+    }
+
+    /// Create a limiter from resource limits and an explicit default resource.
+    ///
+    /// Positive limits create semaphores. Zero limits are ignored, leaving that
+    /// resource unlimited. `default_resource` is used for `hw: auto` or missing
+    /// per-action hardware only when it matches a positive configured limit.
+    #[must_use]
+    pub fn from_limits_with_default(
+        limits: impl IntoIterator<Item = (String, usize)>,
+        default_resource: Option<String>,
+    ) -> Self {
         let mut semaphores = HashMap::new();
-        let mut default_resource = None;
         for (resource, limit) in limits {
             if limit == 0 {
                 continue;
             }
-            if default_resource.is_none() {
-                default_resource = Some(resource.clone());
-            }
             semaphores.insert(resource, Arc::new(Semaphore::new(limit)));
         }
+        let default_resource =
+            default_resource.filter(|resource| semaphores.contains_key(resource));
         Self {
             semaphores: Arc::new(semaphores),
             default_resource,
@@ -643,13 +645,19 @@ mod tests {
     #[test]
     fn test_plan_parallel_resource_detects_nvenc_transcode() {
         let plan = test_transcode_plan(Some("nvenc"));
-        assert_eq!(PlanParallelResource::from_plan(&plan), Some("hw:nvenc"));
+        assert_eq!(
+            PlanParallelResource::from_plan_with_default(&plan, None),
+            Some("hw:nvenc")
+        );
     }
 
     #[test]
     fn test_plan_parallel_resource_ignores_software_transcode() {
         let plan = test_transcode_plan(None);
-        assert_eq!(PlanParallelResource::from_plan(&plan), None);
+        assert_eq!(
+            PlanParallelResource::from_plan_with_default(&plan, None),
+            None
+        );
     }
 
     #[test]
@@ -668,7 +676,7 @@ mod tests {
         for (hw, expected) in cases {
             let plan = test_transcode_plan(hw);
             assert_eq!(
-                PlanParallelResource::from_plan(&plan),
+                PlanParallelResource::from_plan_with_default(&plan, None),
                 expected,
                 "hw={hw:?}"
             );
@@ -702,14 +710,20 @@ mod tests {
             Some("nvenc"),
             voom_domain::plan::OperationType::TranscodeAudio,
         );
-        assert_eq!(PlanParallelResource::from_plan(&plan), None);
+        assert_eq!(
+            PlanParallelResource::from_plan_with_default(&plan, None),
+            None
+        );
     }
 
     #[tokio::test]
     async fn test_plan_execution_limiter_blocks_missing_hw_on_default_resource() {
         use std::time::Duration;
 
-        let limiter = PlanExecutionLimiter::from_limits(vec![("hw:nvenc".to_string(), 1)]);
+        let limiter = PlanExecutionLimiter::from_limits_with_default(
+            vec![("hw:nvenc".to_string(), 1)],
+            Some("hw:nvenc".to_string()),
+        );
         let plan = test_transcode_plan(None);
         let first = limiter.acquire_for_plan(&plan).await;
 
@@ -737,6 +751,32 @@ mod tests {
                 .unwrap(),
             "entered"
         );
+    }
+
+    #[tokio::test]
+    async fn test_plan_execution_limiter_does_not_default_without_explicit_resource() {
+        use std::time::Duration;
+
+        let limiter = PlanExecutionLimiter::from_limits(vec![("hw:nvenc".to_string(), 1)]);
+        let limited_plan = test_transcode_plan(Some("nvenc"));
+        let implicit_plan = test_transcode_plan(None);
+        let first = limiter.acquire_for_plan(&limited_plan).await;
+
+        let limiter_clone = limiter.clone();
+        let plan_clone = implicit_plan.clone();
+        let task = tokio::spawn(async move {
+            let _permit = limiter_clone.acquire_for_plan(&plan_clone).await;
+            "entered"
+        });
+
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(1), task)
+                .await
+                .expect("implicit plan should not wait without explicit default")
+                .unwrap(),
+            "entered"
+        );
+        drop(first);
     }
 
     #[tokio::test]

--- a/plugins/job-manager/src/worker.rs
+++ b/plugins/job-manager/src/worker.rs
@@ -1,5 +1,6 @@
 //! Worker pool for concurrent job processing using tokio tasks.
 
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
@@ -72,6 +73,71 @@ fn num_cpus() -> usize {
     std::thread::available_parallelism()
         .map(std::num::NonZeroUsize::get)
         .unwrap_or(4)
+}
+
+pub struct PlanParallelResource;
+
+impl PlanParallelResource {
+    #[must_use]
+    pub fn from_plan(plan: &voom_domain::plan::Plan) -> Option<&'static str> {
+        for action in &plan.actions {
+            let voom_domain::plan::ActionParams::Transcode { settings, .. } = &action.parameters
+            else {
+                continue;
+            };
+            let Some(hw) = settings.hw.as_deref() else {
+                continue;
+            };
+            match hw {
+                "nvenc" => return Some("hw:nvenc"),
+                "qsv" => return Some("hw:qsv"),
+                "vaapi" => return Some("hw:vaapi"),
+                "videotoolbox" => return Some("hw:videotoolbox"),
+                _ => {}
+            }
+        }
+        None
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct PlanExecutionLimiter {
+    semaphores: Arc<HashMap<String, Arc<Semaphore>>>,
+}
+
+pub struct PlanExecutionPermit {
+    _permit: Option<tokio::sync::OwnedSemaphorePermit>,
+}
+
+impl PlanExecutionLimiter {
+    #[must_use]
+    pub fn from_limits(limits: impl IntoIterator<Item = (String, usize)>) -> Self {
+        let semaphores = limits
+            .into_iter()
+            .filter(|(_, limit)| *limit > 0)
+            .map(|(resource, limit)| (resource, Arc::new(Semaphore::new(limit))))
+            .collect();
+        Self {
+            semaphores: Arc::new(semaphores),
+        }
+    }
+
+    pub async fn acquire_for_plan(&self, plan: &voom_domain::plan::Plan) -> PlanExecutionPermit {
+        let Some(resource) = PlanParallelResource::from_plan(plan) else {
+            return PlanExecutionPermit { _permit: None };
+        };
+        let Some(semaphore) = self.semaphores.get(resource) else {
+            return PlanExecutionPermit { _permit: None };
+        };
+        let permit = semaphore
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("plan execution semaphore closed");
+        PlanExecutionPermit {
+            _permit: Some(permit),
+        }
+    }
 }
 
 /// Outcome of a single job execution.
@@ -489,6 +555,57 @@ mod tests {
     fn test_queue() -> Arc<JobQueue> {
         let store = Arc::new(InMemoryStore::new());
         Arc::new(JobQueue::new(store))
+    }
+
+    fn test_transcode_plan(hw: Option<&str>) -> voom_domain::plan::Plan {
+        let file = voom_domain::media::MediaFile::new(std::path::PathBuf::from("/test.mkv"));
+        voom_domain::plan::Plan::new(file, "test-policy", "test-phase").with_action(
+            voom_domain::plan::PlannedAction::track_op(
+                voom_domain::plan::OperationType::TranscodeVideo,
+                0,
+                voom_domain::plan::ActionParams::Transcode {
+                    codec: "hevc".to_string(),
+                    settings: voom_domain::plan::TranscodeSettings::default()
+                        .with_hw(hw.map(str::to_string)),
+                },
+                "transcode video",
+            ),
+        )
+    }
+
+    #[test]
+    fn test_plan_parallel_resource_detects_nvenc_transcode() {
+        let plan = test_transcode_plan(Some("nvenc"));
+        assert_eq!(PlanParallelResource::from_plan(&plan), Some("hw:nvenc"));
+    }
+
+    #[test]
+    fn test_plan_parallel_resource_ignores_software_transcode() {
+        let plan = test_transcode_plan(None);
+        assert_eq!(PlanParallelResource::from_plan(&plan), None);
+    }
+
+    #[tokio::test]
+    async fn test_plan_execution_limiter_blocks_above_limit() {
+        let limiter = PlanExecutionLimiter::from_limits(vec![("hw:nvenc".to_string(), 2)]);
+        let plan = test_transcode_plan(Some("nvenc"));
+
+        let first = limiter.acquire_for_plan(&plan).await;
+        let second = limiter.acquire_for_plan(&plan).await;
+
+        let limiter_clone = limiter.clone();
+        let plan_clone = plan.clone();
+        let third = tokio::spawn(async move {
+            let _permit = limiter_clone.acquire_for_plan(&plan_clone).await;
+            "entered"
+        });
+
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        assert!(!third.is_finished());
+
+        drop(first);
+        assert_eq!(third.await.unwrap(), "entered");
+        drop(second);
     }
 
     #[tokio::test]

--- a/plugins/web-server/src/api/tools.rs
+++ b/plugins/web-server/src/api/tools.rs
@@ -43,6 +43,8 @@ pub struct ExecutorCapabilitiesResponse {
     pub codecs: CodecCapabilitiesDto,
     pub formats: Vec<String>,
     pub hw_accels: Vec<String>,
+    #[serde(default)]
+    pub parallel_limits: Vec<voom_domain::events::ExecutorParallelLimit>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -189,12 +191,17 @@ mod tests {
             },
             formats: vec!["matroska".into(), "mp4".into()],
             hw_accels: vec!["videotoolbox".into()],
+            parallel_limits: vec![voom_domain::events::ExecutorParallelLimit::new(
+                "hw:nvenc", 4,
+            )],
         };
         let json = serde_json::to_value(&response).unwrap();
         assert_eq!(json["plugin_name"], "ffmpeg-executor");
         assert_eq!(json["codecs"]["decoders"][0], "h264");
         assert_eq!(json["formats"][0], "matroska");
         assert_eq!(json["hw_accels"][0], "videotoolbox");
+        assert_eq!(json["parallel_limits"][0]["resource"], "hw:nvenc");
+        assert_eq!(json["parallel_limits"][0]["max_parallel"], 4);
     }
 
     #[test]
@@ -206,11 +213,16 @@ mod tests {
             voom_domain::events::CodecCapabilities::new(vec!["aac".into()], vec!["aac".into()]),
             vec!["mp4".into()],
             vec![],
-        );
+        )
+        .with_parallel_limits(vec![voom_domain::events::ExecutorParallelLimit::new(
+            "hw:nvenc", 4,
+        )]);
         let bytes = serde_json::to_vec(&domain_event).unwrap();
         let dto: ExecutorCapabilitiesResponse = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(dto.plugin_name, "ffmpeg-executor");
         assert_eq!(dto.codecs.decoders, vec!["aac"]);
+        assert_eq!(dto.parallel_limits.len(), 1);
+        assert_eq!(dto.parallel_limits[0].resource, "hw:nvenc");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- announce executor parallel limits for NVENC capacity
- add a public plan execution limiter and wire it into `voom process`
- make the process limiter default backend explicit via `CapabilityMap::best_hwaccel()`

## Test Plan
- [x] cargo test -p voom-job-manager plan_
- [x] cargo test -p voom-cli process_pipeline
- [x] cargo test -p voom-cli test_hw_resource_for_backend
- [x] cargo fmt --check
- [x] cargo clippy -p voom-cli -p voom-job-manager --all-targets -- -D warnings
- [x] cargo test