### PR TITLE
feat(ffmpeg-executor): add probed hardware decode

### DIFF
--- a/crates/voom-cli/src/config.rs
+++ b/crates/voom-cli/src/config.rs
@@ -354,6 +354,10 @@ pub fn default_config_contents() -> String {
 # # Lower this to 2 on small GPUs or when CUDA OOM appears under load.
 # # Applies only when NVENC is active; 0 uses the default.
 # # nvenc_max_parallel = 4
+# # Opportunistically use hardware decode when a matching decoder was probed.
+# # Disable this if a GPU driver or source profile fails with hwaccel enabled.
+# # Defaults to true.
+# # hw_decode = false
 #
 # [plugin.tvdb-metadata]
 # api_key = "your-tvdb-api-key"

--- a/plugins/ffmpeg-executor/src/command.rs
+++ b/plugins/ffmpeg-executor/src/command.rs
@@ -3,7 +3,7 @@
 use std::path::Path;
 
 use voom_domain::errors::{Result, VoomError};
-use voom_domain::media::{Container, MediaFile};
+use voom_domain::media::{Container, MediaFile, Track, TrackType};
 use voom_domain::plan::{ActionParams, OperationType, PlannedAction, TranscodeChannels};
 use voom_domain::utils::sanitize::{validate_metadata_key, validate_metadata_value};
 
@@ -326,6 +326,15 @@ fn collect_video_filters(settings: &voom_domain::plan::TranscodeSettings) -> Vec
     filters
 }
 
+fn requires_software_video_filters(settings: &voom_domain::plan::TranscodeSettings) -> bool {
+    let scales_video = settings
+        .max_resolution
+        .as_deref()
+        .and_then(parse_max_height)
+        .is_some();
+    scales_video || settings.hdr_mode.as_deref() == Some("tonemap")
+}
+
 fn apply_transcode_video(
     mut cmd: FfmpegCommand,
     action: &PlannedAction,
@@ -439,6 +448,49 @@ fn apply_synthesize_audio(cmd: FfmpegCommand, action: &PlannedAction) -> FfmpegC
     )
 }
 
+fn source_video_track<'a>(file: &'a MediaFile, action: &PlannedAction) -> Option<&'a Track> {
+    let stream_index = action.track_index?;
+    file.tracks
+        .iter()
+        .find(|track| track.index == stream_index && track.track_type == TrackType::Video)
+}
+
+fn pixel_format_allows_direct_hw_decode(pixel_format: Option<&str>) -> bool {
+    let Some(format) = pixel_format else {
+        return true;
+    };
+    let lower = format.to_ascii_lowercase();
+    !lower.contains("alpha")
+        && !lower.contains("yuva")
+        && !lower.contains("rgba")
+        && !lower.contains("bgra")
+        && !lower.contains("gbr")
+        && !lower.contains("rgb")
+}
+
+fn action_allows_direct_hw_decode(
+    file: &MediaFile,
+    action: &PlannedAction,
+    hw_cfg: &HwAccelConfig,
+) -> Vec<String> {
+    let ActionParams::Transcode { codec, settings } = &action.parameters else {
+        return Vec::new();
+    };
+    if !hw_cfg.has_hw_encoder(codec) {
+        return Vec::new();
+    }
+    if requires_software_video_filters(settings) {
+        return Vec::new();
+    }
+    let Some(track) = source_video_track(file, action) else {
+        return Vec::new();
+    };
+    if !pixel_format_allows_direct_hw_decode(track.pixel_format.as_deref()) {
+        return Vec::new();
+    }
+    hw_cfg.decoder_input_args(&track.codec)
+}
+
 /// Build an `FFmpeg` command from a plan's actions.
 ///
 /// Groups all actions into a single `FFmpeg` invocation where possible.
@@ -450,20 +502,36 @@ pub fn build_ffmpeg_command(
 ) -> Result<Vec<String>> {
     let mut cmd = FfmpegCommand::new();
 
-    // NOTE: we intentionally do NOT emit `-hwaccel <backend>` input
-    // args.  That flag requests hardware-accelerated *decoding* (e.g.
-    // hevc_cuvid), which requires the matching cuvid/vaapi/qsv decoder
-    // to be compiled into ffmpeg.  When it's absent ffmpeg hard-fails
-    // instead of falling back to software decode.  HW *encoding* (e.g.
-    // av1_nvenc) works fine with software-decoded frames, so omitting
-    // the flag is safe and maximally compatible.
-
     // Inject device-targeting args (e.g. -vaapi_device, -qsv_device)
     // before the input file so ffmpeg opens the device first.
     if let Some(hw) = hw_accel {
         for arg in hw.device_args() {
             cmd = cmd.arg(&arg);
         }
+    }
+
+    // Hardware decode hard-fails if the matching decoder is missing, so
+    // only emit it after probing found a same-backend source decoder.
+    let mut hw_decode_args = Vec::new();
+    for action in actions {
+        if action.operation != OperationType::TranscodeVideo {
+            continue;
+        }
+        let ActionParams::Transcode { settings, .. } = &action.parameters else {
+            continue;
+        };
+        let mut owned_config: Option<HwAccelConfig> = None;
+        let Some(effective_hw) = resolve_effective_hw(settings, hw_accel, &mut owned_config) else {
+            continue;
+        };
+        hw_decode_args = action_allows_direct_hw_decode(file, action, effective_hw);
+        if !hw_decode_args.is_empty() {
+            break;
+        }
+    }
+
+    for arg in hw_decode_args {
+        cmd = cmd.arg(&arg);
     }
 
     cmd = cmd.input(&file.path);
@@ -609,6 +677,12 @@ mod tests {
             Track::new(1, TrackType::AudioMain, "mp3".into()),
         ];
         file
+    }
+
+    fn arg_index(args: &[String], needle: &str) -> usize {
+        args.iter()
+            .position(|arg| arg == needle)
+            .unwrap_or_else(|| panic!("{needle} not found in {args:?}"))
     }
 
     #[test]
@@ -985,6 +1059,146 @@ mod tests {
             "NVENC should not use -crf, got: {args:?}"
         );
         assert!(args.contains(&"23".to_string()));
+    }
+
+    #[test]
+    fn test_build_command_uses_nvenc_hw_decode_when_decoder_available() {
+        let file = sample_mp4_file();
+        let action = PlannedAction::track_op(
+            OperationType::TranscodeVideo,
+            0,
+            ActionParams::Transcode {
+                codec: "hevc".into(),
+                settings: TranscodeSettings::default().with_crf(Some(23)),
+            },
+            "Transcode with NVENC",
+        );
+        let output = Path::new("/tmp/output.mp4");
+        let hw = HwAccelConfig::with_backend(crate::hwaccel::HwAccelBackend::Nvenc)
+            .with_validated_encoders(vec!["hevc_nvenc".into()])
+            .with_hw_decoders(vec!["h264_cuvid".into()]);
+
+        let args = build_ffmpeg_command(&file, &[&action], output, Some(&hw)).unwrap();
+
+        assert_eq!(args[arg_index(&args, "-hwaccel") + 1], "cuda");
+        assert_eq!(args[arg_index(&args, "-hwaccel_output_format") + 1], "cuda");
+        assert!(arg_index(&args, "-hwaccel") < arg_index(&args, "-i"));
+        assert!(args.contains(&"hevc_nvenc".to_string()));
+    }
+
+    #[test]
+    fn test_build_command_skips_hw_decode_when_decoder_missing() {
+        let file = sample_mp4_file();
+        let action = PlannedAction::track_op(
+            OperationType::TranscodeVideo,
+            0,
+            ActionParams::Transcode {
+                codec: "hevc".into(),
+                settings: TranscodeSettings::default(),
+            },
+            "Transcode with NVENC",
+        );
+        let output = Path::new("/tmp/output.mp4");
+        let hw = HwAccelConfig::with_backend(crate::hwaccel::HwAccelBackend::Nvenc)
+            .with_validated_encoders(vec!["hevc_nvenc".into()])
+            .with_hw_decoders(vec!["hevc_cuvid".into()]);
+
+        let args = build_ffmpeg_command(&file, &[&action], output, Some(&hw)).unwrap();
+
+        assert!(!args.contains(&"-hwaccel".to_string()));
+        assert!(args.contains(&"hevc_nvenc".to_string()));
+    }
+
+    #[test]
+    fn test_build_command_skips_hw_decode_when_encoder_falls_back_to_software() {
+        let file = sample_mp4_file();
+        let action = PlannedAction::track_op(
+            OperationType::TranscodeVideo,
+            0,
+            ActionParams::Transcode {
+                codec: "av1".into(),
+                settings: TranscodeSettings::default(),
+            },
+            "Transcode AV1",
+        );
+        let output = Path::new("/tmp/output.mkv");
+        let hw = HwAccelConfig::with_backend(crate::hwaccel::HwAccelBackend::Nvenc)
+            .with_validated_encoders(vec!["h264_nvenc".into(), "hevc_nvenc".into()])
+            .with_hw_decoders(vec!["h264_cuvid".into()]);
+
+        let args = build_ffmpeg_command(&file, &[&action], output, Some(&hw)).unwrap();
+
+        assert!(!args.contains(&"-hwaccel".to_string()));
+        assert!(args.contains(&"libsvtav1".to_string()));
+    }
+
+    #[test]
+    fn test_build_command_skips_hw_decode_when_filters_require_sw_frames() {
+        let file = sample_mp4_file();
+        let action = PlannedAction::track_op(
+            OperationType::TranscodeVideo,
+            0,
+            ActionParams::Transcode {
+                codec: "hevc".into(),
+                settings: TranscodeSettings::default().with_max_resolution(Some("720p".into())),
+            },
+            "Scale and transcode",
+        );
+        let output = Path::new("/tmp/output.mp4");
+        let hw = HwAccelConfig::with_backend(crate::hwaccel::HwAccelBackend::Nvenc)
+            .with_validated_encoders(vec!["hevc_nvenc".into()])
+            .with_hw_decoders(vec!["h264_cuvid".into()]);
+
+        let args = build_ffmpeg_command(&file, &[&action], output, Some(&hw)).unwrap();
+
+        assert!(!args.contains(&"-hwaccel".to_string()));
+        assert!(args.contains(&"-vf".to_string()));
+    }
+
+    #[test]
+    fn test_build_command_allows_hw_decode_when_max_resolution_is_invalid() {
+        let file = sample_mp4_file();
+        let action = PlannedAction::track_op(
+            OperationType::TranscodeVideo,
+            0,
+            ActionParams::Transcode {
+                codec: "hevc".into(),
+                settings: TranscodeSettings::default().with_max_resolution(Some("large".into())),
+            },
+            "Transcode with ignored max resolution",
+        );
+        let output = Path::new("/tmp/output.mp4");
+        let hw = HwAccelConfig::with_backend(crate::hwaccel::HwAccelBackend::Nvenc)
+            .with_validated_encoders(vec!["hevc_nvenc".into()])
+            .with_hw_decoders(vec!["h264_cuvid".into()]);
+
+        let args = build_ffmpeg_command(&file, &[&action], output, Some(&hw)).unwrap();
+
+        assert_eq!(args[arg_index(&args, "-hwaccel") + 1], "cuda");
+        assert!(!args.contains(&"-vf".to_string()));
+    }
+
+    #[test]
+    fn test_build_command_skips_hw_decode_for_hdr_tonemap() {
+        let file = sample_mp4_file();
+        let action = PlannedAction::track_op(
+            OperationType::TranscodeVideo,
+            0,
+            ActionParams::Transcode {
+                codec: "hevc".into(),
+                settings: TranscodeSettings::default().with_hdr_mode(Some("tonemap".into())),
+            },
+            "Tonemap and transcode",
+        );
+        let output = Path::new("/tmp/output.mp4");
+        let hw = HwAccelConfig::with_backend(crate::hwaccel::HwAccelBackend::Nvenc)
+            .with_validated_encoders(vec!["hevc_nvenc".into()])
+            .with_hw_decoders(vec!["h264_cuvid".into()]);
+
+        let args = build_ffmpeg_command(&file, &[&action], output, Some(&hw)).unwrap();
+
+        assert!(!args.contains(&"-hwaccel".to_string()));
+        assert!(args.contains(&"-vf".to_string()));
     }
 
     #[test]

--- a/plugins/ffmpeg-executor/src/hwaccel.rs
+++ b/plugins/ffmpeg-executor/src/hwaccel.rs
@@ -21,6 +21,12 @@ pub struct HwAccelConfig {
     /// encoders in the list are used; missing ones fall back to software.
     /// `None` means no validation was performed (all are trusted).
     validated_encoders: Option<Vec<String>>,
+    /// HW decoders compiled into ffmpeg. Hardware decode is emitted only if
+    /// the source codec maps to an entry in this list.
+    hw_decoders: Vec<String>,
+    /// Enables opportunistic hardware decode. Defaults to true; config can
+    /// disable it for driver-specific failures.
+    hw_decode_enabled: bool,
     /// Target GPU/render device. NVIDIA: "0", "1", etc.
     /// VA-API/QSV: "/dev/dri/renderD128", etc.
     device: Option<String>,
@@ -33,6 +39,8 @@ impl HwAccelConfig {
         Self {
             backend: None,
             validated_encoders: None,
+            hw_decoders: Vec::new(),
+            hw_decode_enabled: true,
             device: None,
         }
     }
@@ -43,6 +51,8 @@ impl HwAccelConfig {
         Self {
             backend: Some(backend),
             validated_encoders: None,
+            hw_decoders: Vec::new(),
+            hw_decode_enabled: true,
             device: None,
         }
     }
@@ -65,6 +75,8 @@ impl HwAccelConfig {
         Self {
             backend: detect_backend_from_text(&text),
             validated_encoders: None,
+            hw_decoders: Vec::new(),
+            hw_decode_enabled: true,
             device: None,
         }
     }
@@ -76,6 +88,20 @@ impl HwAccelConfig {
     #[must_use]
     pub fn with_validated_encoders(mut self, encoders: Vec<String>) -> Self {
         self.validated_encoders = Some(encoders);
+        self
+    }
+
+    /// Set the list of HW decoders compiled into ffmpeg.
+    #[must_use]
+    pub fn with_hw_decoders(mut self, decoders: Vec<String>) -> Self {
+        self.hw_decoders = decoders;
+        self
+    }
+
+    /// Enable or disable opportunistic HW decode.
+    #[must_use]
+    pub fn with_hw_decode_enabled(mut self, enabled: bool) -> Self {
+        self.hw_decode_enabled = enabled;
         self
     }
 
@@ -181,6 +207,42 @@ impl HwAccelConfig {
         }
     }
 
+    /// Get `FFmpeg` input args for HW decoding when a matching decoder exists.
+    #[must_use]
+    pub fn decoder_input_args(&self, source_codec: &str) -> Vec<String> {
+        if !self.hw_decode_enabled {
+            return Vec::new();
+        }
+
+        let Some(backend) = self.backend else {
+            return Vec::new();
+        };
+        let Some(decoder) = hw_decoder_for_backend(backend, source_codec) else {
+            return Vec::new();
+        };
+        if !self
+            .hw_decoders
+            .iter()
+            .any(|candidate| candidate == &decoder)
+        {
+            return Vec::new();
+        }
+
+        let (hwaccel, surface) = match backend {
+            HwAccelBackend::Nvenc => ("cuda", "cuda"),
+            HwAccelBackend::Qsv => ("qsv", "qsv"),
+            HwAccelBackend::Vaapi => ("vaapi", "vaapi"),
+            HwAccelBackend::Videotoolbox => return Vec::new(),
+        };
+
+        vec![
+            "-hwaccel".to_string(),
+            hwaccel.to_string(),
+            "-hwaccel_output_format".to_string(),
+            surface.to_string(),
+        ]
+    }
+
     /// Get `FFmpeg` input args for HW acceleration (e.g., `-hwaccel cuda`).
     #[must_use]
     pub fn input_args(&self) -> Vec<String> {
@@ -212,17 +274,32 @@ fn hw_encoder_for_backend(backend: HwAccelBackend, codec: &str) -> Option<String
         HwAccelBackend::Videotoolbox => ("_videotoolbox", &["hevc", "h264"]),
     };
 
-    let canonical = match codec {
-        "h265" => "hevc",
-        "avc" => "h264",
-        other => other,
-    };
+    let canonical = canonical_video_codec(codec);
 
     if supported_codecs.contains(&canonical) {
         Some(format!("{canonical}{suffix}"))
     } else {
         None
     }
+}
+
+fn canonical_video_codec(codec: &str) -> &str {
+    match codec {
+        "h265" => "hevc",
+        "avc" => "h264",
+        "mpeg2video" => "mpeg2",
+        other => other,
+    }
+}
+
+fn hw_decoder_for_backend(backend: HwAccelBackend, codec: &str) -> Option<String> {
+    let suffix = match backend {
+        HwAccelBackend::Nvenc => "_cuvid",
+        HwAccelBackend::Qsv => "_qsv",
+        HwAccelBackend::Vaapi => "_vaapi",
+        HwAccelBackend::Videotoolbox => return None,
+    };
+    Some(format!("{}{suffix}", canonical_video_codec(codec)))
 }
 
 /// Collect all matching backends from lowercased hwaccel text, in
@@ -290,6 +367,8 @@ pub fn config_from_backend_name(name: &str) -> HwAccelConfig {
     HwAccelConfig {
         backend,
         validated_encoders: None,
+        hw_decoders: Vec::new(),
+        hw_decode_enabled: true,
         device: None,
     }
 }
@@ -352,6 +431,8 @@ pub fn config_from_backend_with_system(
     if let (Some(override_be), Some(sys)) = (config.backend, system) {
         if sys.backend == Some(override_be) {
             config.validated_encoders = sys.validated_encoders.clone();
+            config.hw_decoders = sys.hw_decoders.clone();
+            config.hw_decode_enabled = sys.hw_decode_enabled;
             config.device = sys.device.clone();
         }
     }
@@ -555,6 +636,78 @@ mod tests {
     fn test_has_hw_encoder_disabled() {
         let config = HwAccelConfig::new();
         assert!(!config.has_hw_encoder("h264"));
+    }
+
+    // decoder input args
+
+    #[test]
+    fn test_hw_decoder_input_args_nvenc_match() {
+        let config = HwAccelConfig::with_backend(HwAccelBackend::Nvenc)
+            .with_hw_decoders(vec!["h264_cuvid".into(), "hevc_cuvid".into()]);
+
+        assert_eq!(
+            config.decoder_input_args("h264"),
+            vec!["-hwaccel", "cuda", "-hwaccel_output_format", "cuda"]
+        );
+        assert_eq!(
+            config.decoder_input_args("h265"),
+            vec!["-hwaccel", "cuda", "-hwaccel_output_format", "cuda"]
+        );
+    }
+
+    #[test]
+    fn test_hw_decoder_input_args_missing_decoder_returns_empty() {
+        let config = HwAccelConfig::with_backend(HwAccelBackend::Nvenc)
+            .with_hw_decoders(vec!["hevc_cuvid".into()]);
+
+        assert!(config.decoder_input_args("h264").is_empty());
+    }
+
+    #[test]
+    fn test_hw_decoder_input_args_empty_decoder_list_returns_empty() {
+        let config =
+            HwAccelConfig::with_backend(HwAccelBackend::Nvenc).with_hw_decoders(Vec::new());
+
+        assert!(config.decoder_input_args("h264").is_empty());
+    }
+
+    #[test]
+    fn test_hw_decoder_input_args_qsv_and_vaapi_match_backend() {
+        let qsv = HwAccelConfig::with_backend(HwAccelBackend::Qsv)
+            .with_hw_decoders(vec!["h264_qsv".into()]);
+        let vaapi = HwAccelConfig::with_backend(HwAccelBackend::Vaapi)
+            .with_hw_decoders(vec!["h264_vaapi".into()]);
+
+        assert_eq!(
+            qsv.decoder_input_args("h264"),
+            vec!["-hwaccel", "qsv", "-hwaccel_output_format", "qsv"]
+        );
+        assert_eq!(
+            vaapi.decoder_input_args("h264"),
+            vec!["-hwaccel", "vaapi", "-hwaccel_output_format", "vaapi"]
+        );
+    }
+
+    #[test]
+    fn test_hw_decoder_input_args_uses_probed_decoder_as_source_of_truth() {
+        let config = HwAccelConfig::with_backend(HwAccelBackend::Vaapi)
+            .with_hw_decoders(vec!["vc1_vaapi".into()]);
+
+        assert_eq!(
+            config.decoder_input_args("vc1"),
+            vec!["-hwaccel", "vaapi", "-hwaccel_output_format", "vaapi"]
+        );
+    }
+
+    #[test]
+    fn test_hw_override_inherits_decoders_and_decode_flag() {
+        let system = HwAccelConfig::with_backend(HwAccelBackend::Nvenc)
+            .with_hw_decoders(vec!["h264_cuvid".into()])
+            .with_hw_decode_enabled(false);
+
+        let override_config = config_from_backend_with_system("nvenc", Some(&system));
+
+        assert!(override_config.decoder_input_args("h264").is_empty());
     }
 
     // ── config_from_backend_with_system ────────────────────────

--- a/plugins/ffmpeg-executor/src/lib.rs
+++ b/plugins/ffmpeg-executor/src/lib.rs
@@ -39,6 +39,8 @@ struct FfmpegExecutorConfig {
     gpu_device: Option<String>,
     #[serde(default)]
     nvenc_max_parallel: Option<usize>,
+    #[serde(default)]
+    hw_decode: Option<bool>,
 }
 
 const DEFAULT_NVENC_MAX_PARALLEL_PER_GPU: usize = 4;
@@ -613,7 +615,10 @@ impl Plugin for FfmpegExecutorPlugin {
             plugin_config.nvenc_max_parallel,
         );
 
-        self.hw_accel = hw_config.with_validated_encoders(validated_encoders);
+        self.hw_accel = hw_config
+            .with_validated_encoders(validated_encoders)
+            .with_hw_decoders(codecs.hw_decoders.clone())
+            .with_hw_decode_enabled(plugin_config.hw_decode.unwrap_or(true));
 
         let event = ExecutorCapabilitiesEvent::new("ffmpeg-executor", codecs, formats, hw_accels)
             .with_parallel_limits(parallel_limits);
@@ -1129,6 +1134,14 @@ mod tests {
         let config: FfmpegExecutorConfig = serde_json::from_value(json).unwrap();
         assert_eq!(config.hw_accel.as_deref(), Some("vaapi"));
         assert_eq!(config.gpu_device.as_deref(), Some("/dev/dri/renderD128"));
+    }
+
+    #[test]
+    fn test_ffmpeg_executor_config_hw_decode() {
+        let json = serde_json::json!({"hw_decode": false});
+        let config: FfmpegExecutorConfig = serde_json::from_value(json).unwrap();
+
+        assert_eq!(config.hw_decode, Some(false));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Use probed hardware decoder capabilities to add same-backend ffmpeg hwaccel input args for eligible hardware video transcodes.
- Keep compatibility fallbacks: no hw decode when the decoder is not probed, encoder falls back to software, software filters are needed, or hw_decode is disabled.
- Document the plugin-level `hw_decode = false` opt-out in the default config sample.

## Test Plan
- [x] `cargo test -p voom-ffmpeg-executor`
- [x] `cargo clippy -p voom-ffmpeg-executor --all-targets --all-features -- -D warnings`
- [x] commit hook: `cargo fmt`
- [x] commit hook: `cargo clippy`

Closes #259.