### PR TITLE
Bound subprocess output capture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3547,7 +3547,6 @@ dependencies = [
  "voom-domain",
  "voom-process",
  "voom-wit",
- "wait-timeout",
  "wasmtime",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3545,6 +3545,7 @@ dependencies = [
  "ureq",
  "uuid",
  "voom-domain",
+ "voom-process",
  "voom-wit",
  "wait-timeout",
  "wasmtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3605,6 +3605,7 @@ dependencies = [
 name = "voom-process"
 version = "0.1.0"
 dependencies = [
+ "tempfile",
  "tokio",
  "tokio-util",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3651,6 +3651,7 @@ dependencies = [
  "tracing",
  "voom-domain",
  "voom-kernel",
+ "voom-process",
 ]
 
 [[package]]

--- a/crates/voom-kernel/Cargo.toml
+++ b/crates/voom-kernel/Cargo.toml
@@ -24,13 +24,12 @@ thiserror = { workspace = true }
 toml = { workspace = true }
 uuid = { workspace = true }
 ureq = { workspace = true, optional = true }
-wait-timeout = { workspace = true, optional = true }
 wasmtime = { workspace = true, optional = true }
 voom-process = { workspace = true, optional = true }
 
 [features]
 default = []
-wasm = ["dep:wasmtime", "dep:ureq", "dep:wait-timeout", "dep:voom-process"]
+wasm = ["dep:wasmtime", "dep:ureq", "dep:voom-process"]
 
 [lints]
 workspace = true

--- a/crates/voom-kernel/Cargo.toml
+++ b/crates/voom-kernel/Cargo.toml
@@ -26,10 +26,11 @@ uuid = { workspace = true }
 ureq = { workspace = true, optional = true }
 wait-timeout = { workspace = true, optional = true }
 wasmtime = { workspace = true, optional = true }
+voom-process = { workspace = true, optional = true }
 
 [features]
 default = []
-wasm = ["dep:wasmtime", "dep:ureq", "dep:wait-timeout"]
+wasm = ["dep:wasmtime", "dep:ureq", "dep:wait-timeout", "dep:voom-process"]
 
 [lints]
 workspace = true

--- a/crates/voom-kernel/src/host/functions.rs
+++ b/crates/voom-kernel/src/host/functions.rs
@@ -11,6 +11,8 @@ use wait_timeout::ChildExt;
 
 use super::{HostState, HttpResponse, ToolOutput, MAX_PLUGIN_DATA_VALUE_SIZE};
 
+const HOST_TOOL_CAPTURE_LIMIT_BYTES: usize = 1024 * 1024;
+
 /// Extract the host (domain) from a URL string.
 /// Supports `scheme://[user@]host[:port]/...` forms.
 fn extract_url_host(url: &str) -> Result<String, String> {
@@ -228,14 +230,12 @@ impl HostState {
         // deadlock when pipe buffers fill up.
         let stdout_handle = child.stdout.take().map(|mut out| {
             std::thread::spawn(move || {
-                let mut buf = Vec::new();
-                std::io::Read::read_to_end(&mut out, &mut buf).map(|_| buf)
+                voom_process::read_bounded(&mut out, HOST_TOOL_CAPTURE_LIMIT_BYTES)
             })
         });
         let stderr_handle = child.stderr.take().map(|mut err| {
             std::thread::spawn(move || {
-                let mut buf = Vec::new();
-                std::io::Read::read_to_end(&mut err, &mut buf).map(|_| buf)
+                voom_process::read_bounded(&mut err, HOST_TOOL_CAPTURE_LIMIT_BYTES)
             })
         });
 

--- a/crates/voom-kernel/src/host/functions.rs
+++ b/crates/voom-kernel/src/host/functions.rs
@@ -5,13 +5,9 @@
 
 use std::io::Read as _;
 use std::path::Path;
-use std::process::Command;
 use std::time::Duration;
-use wait_timeout::ChildExt;
 
 use super::{HostState, HttpResponse, ToolOutput, MAX_PLUGIN_DATA_VALUE_SIZE};
-
-const HOST_TOOL_CAPTURE_LIMIT_BYTES: usize = 1024 * 1024;
 
 /// Extract the host (domain) from a URL string.
 /// Supports `scheme://[user@]host[:port]/...` forms.
@@ -40,6 +36,15 @@ fn extract_url_host(url: &str) -> Result<String, String> {
 /// Check whether a string looks like a filesystem path.
 fn looks_like_path(s: &str) -> bool {
     s.starts_with('/') || s.starts_with("./") || s.starts_with("../") || s.starts_with('~')
+}
+
+fn host_tool_error(tool: &str, timeout_ms: u64, error: &voom_domain::errors::VoomError) -> String {
+    if let voom_domain::errors::VoomError::ToolExecution { message, .. } = error {
+        if message.contains("timed out") {
+            return format!("tool '{tool}' timed out after {timeout_ms}ms");
+        }
+    }
+    error.to_string()
 }
 
 impl HostState {
@@ -219,46 +224,20 @@ impl HostState {
             ));
         }
 
-        let mut child = Command::new(tool)
-            .args(args)
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped())
-            .spawn()
-            .map_err(|e| format!("failed to spawn tool '{tool}': {e}"))?;
-
-        // Read stdout/stderr on separate threads BEFORE waiting, to avoid
-        // deadlock when pipe buffers fill up.
-        let stdout_handle = child.stdout.take().map(|mut out| {
-            std::thread::spawn(move || {
-                voom_process::read_bounded(&mut out, HOST_TOOL_CAPTURE_LIMIT_BYTES)
-            })
-        });
-        let stderr_handle = child.stderr.take().map(|mut err| {
-            std::thread::spawn(move || {
-                voom_process::read_bounded(&mut err, HOST_TOOL_CAPTURE_LIMIT_BYTES)
-            })
-        });
-
         let timeout = Duration::from_millis(timeout_ms);
-        match child.wait_timeout(timeout) {
-            Ok(Some(status)) => {
-                let stdout = stdout_handle
-                    .map(|h| h.join().unwrap_or(Ok(Vec::new())))
-                    .unwrap_or(Ok(Vec::new()))
-                    .map_err(|e| format!("failed to read stdout: {e}"))?;
-                let stderr = stderr_handle
-                    .map(|h| h.join().unwrap_or(Ok(Vec::new())))
-                    .unwrap_or(Ok(Vec::new()))
-                    .map_err(|e| format!("failed to read stderr: {e}"))?;
-                Ok(ToolOutput::new(status.code().unwrap_or(-1), stdout, stderr))
-            }
-            Ok(None) => {
-                child.kill().ok();
-                child.wait().ok();
-                Err(format!("tool '{tool}' timed out after {timeout_ms}ms"))
-            }
-            Err(e) => Err(format!("error waiting for tool '{tool}': {e}")),
-        }
+        let output = voom_process::run_with_timeout_config(
+            tool,
+            args,
+            timeout,
+            voom_process::CaptureConfig::default(),
+        )
+        .map_err(|e| host_tool_error(tool, timeout_ms, &e))?;
+
+        Ok(ToolOutput::new(
+            output.status.code().unwrap_or(-1),
+            output.stdout,
+            output.stderr,
+        ))
     }
 
     /// Query transitions for a file by its UUID.

--- a/crates/voom-kernel/src/host/mod.rs
+++ b/crates/voom-kernel/src/host/mod.rs
@@ -300,6 +300,40 @@ mod tests {
         assert!(String::from_utf8_lossy(&output.stdout).contains("hello"));
     }
 
+    #[cfg(unix)]
+    fn make_executable(path: &std::path::Path) {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut perms = std::fs::metadata(path).expect("metadata").permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(path, perms).expect("chmod");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn run_tool_truncates_noisy_stdout() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let script = dir.path().join("host-stdout-flood.sh");
+        std::fs::write(
+            &script,
+            "#!/bin/sh\npython3 - <<'PY'\nimport sys\nsys.stdout.write('c' * 1200000)\nPY\n",
+        )
+        .expect("write script");
+        make_executable(&script);
+
+        let state = HostState::new("test".into())
+            .with_tools(vec![script.to_string_lossy().into_owned()])
+            .with_capabilities(HashSet::from(["execute:tool".to_string()]))
+            .with_paths(vec![dir.path().to_path_buf()]);
+
+        let output = state
+            .run_tool(script.to_str().expect("utf8 path"), &[], 5000)
+            .expect("tool output");
+
+        assert!(output.stdout.len() < 1_200_000);
+        assert!(String::from_utf8_lossy(&output.stdout).contains("...[truncated "));
+    }
+
     #[test]
     fn test_run_tool_timeout() {
         let state = HostState::new("test".into())

--- a/crates/voom-process/Cargo.toml
+++ b/crates/voom-process/Cargo.toml
@@ -18,5 +18,8 @@ tracing = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 
+[dev-dependencies]
+tempfile = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/voom-process/src/lib.rs
+++ b/crates/voom-process/src/lib.rs
@@ -258,18 +258,38 @@ pub fn stderr_tail(bytes: &[u8], max_lines: usize) -> String {
 }
 
 /// Read all bytes from an optional tokio `ChildStdout`/`ChildStderr`.
-async fn read_child_pipe<R>(pipe: Option<R>) -> Vec<u8>
+async fn read_child_pipe<R>(pipe: Option<R>, max_bytes: usize) -> Vec<u8>
 where
     R: tokio::io::AsyncReadExt + Unpin,
 {
     let Some(mut pipe) = pipe else {
         return Vec::new();
     };
-    let mut buf = Vec::new();
-    if let Err(e) = pipe.read_to_end(&mut buf).await {
-        tracing::warn!(error = %e, "failed to read child pipe");
+
+    let mut output = Vec::with_capacity(max_bytes.min(8192));
+    let mut truncated_bytes = 0usize;
+    let mut chunk = [0u8; 8192];
+
+    loop {
+        let read = match pipe.read(&mut chunk).await {
+            Ok(read) => read,
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to read child pipe");
+                break;
+            }
+        };
+        if read == 0 {
+            break;
+        }
+
+        let remaining = max_bytes.saturating_sub(output.len());
+        let retained = remaining.min(read);
+        output.extend_from_slice(&chunk[..retained]);
+        truncated_bytes = truncated_bytes.saturating_add(read - retained);
     }
-    buf
+
+    append_truncation_marker(&mut output, truncated_bytes);
+    output
 }
 
 /// Async cancellable subprocess execution via `tokio::process`.
@@ -286,7 +306,7 @@ pub async fn run_cancellable(
     timeout: Duration,
     token: &tokio_util::sync::CancellationToken,
 ) -> Result<Output> {
-    run_cancellable_env(tool, args, timeout, &[], token).await
+    run_cancellable_env_config(tool, args, timeout, &[], token, CaptureConfig::default()).await
 }
 
 /// Async cancellable subprocess with extra environment variables.
@@ -298,6 +318,41 @@ pub async fn run_cancellable_env(
     timeout: Duration,
     env_vars: &[(&str, &str)],
     token: &tokio_util::sync::CancellationToken,
+) -> Result<Output> {
+    run_cancellable_env_config(
+        tool,
+        args,
+        timeout,
+        env_vars,
+        token,
+        CaptureConfig::default(),
+    )
+    .await
+}
+
+/// Async cancellable subprocess with configured output capture limits.
+///
+/// See [`run_cancellable`] for details.
+pub async fn run_cancellable_config(
+    tool: &str,
+    args: &[impl AsRef<OsStr>],
+    timeout: Duration,
+    token: &tokio_util::sync::CancellationToken,
+    capture: CaptureConfig,
+) -> Result<Output> {
+    run_cancellable_env_config(tool, args, timeout, &[], token, capture).await
+}
+
+/// Async cancellable subprocess with extra environment variables and capture limits.
+///
+/// See [`run_cancellable`] for details.
+pub async fn run_cancellable_env_config(
+    tool: &str,
+    args: &[impl AsRef<OsStr>],
+    timeout: Duration,
+    env_vars: &[(&str, &str)],
+    token: &tokio_util::sync::CancellationToken,
+    capture: CaptureConfig,
 ) -> Result<Output> {
     use tokio::process::Command as TokioCommand;
 
@@ -322,8 +377,8 @@ pub async fn run_cancellable_env(
     tokio::select! {
         result = async {
             let (stdout, stderr, status) = tokio::join!(
-                read_child_pipe(stdout_pipe),
-                read_child_pipe(stderr_pipe),
+                read_child_pipe(stdout_pipe, capture.max_stdout_bytes),
+                read_child_pipe(stderr_pipe, capture.max_stderr_bytes),
                 child.wait(),
             );
             (stdout, stderr, status)
@@ -486,6 +541,39 @@ mod tests {
             .expect("echo should succeed");
         assert!(output.status.success());
         assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "hello");
+    }
+
+    #[tokio::test]
+    async fn run_cancellable_truncates_stdout_at_configured_limit() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let script = dir.path().join("async-stdout-flood.sh");
+        std::fs::write(
+            &script,
+            "#!/bin/sh\npython3 - <<'PY'\nimport sys\nsys.stdout.write('b' * 35)\nPY\n",
+        )
+        .expect("write script");
+        make_executable(&script);
+
+        let token = tokio_util::sync::CancellationToken::new();
+        let output = run_cancellable_env_config(
+            script.to_str().expect("utf8 path"),
+            &[] as &[&str],
+            Duration::from_secs(5),
+            &[],
+            &token,
+            CaptureConfig {
+                max_stdout_bytes: 8,
+                max_stderr_bytes: DEFAULT_CAPTURE_LIMIT_BYTES,
+            },
+        )
+        .await
+        .expect("script succeeds");
+
+        assert!(output.status.success());
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout),
+            "bbbbbbbb\n...[truncated 27 bytes]"
+        );
     }
 
     #[tokio::test]

--- a/crates/voom-process/src/lib.rs
+++ b/crates/voom-process/src/lib.rs
@@ -4,7 +4,7 @@
 //! `FFmpeg` executor plugins.
 
 use std::ffi::OsStr;
-use std::io::Read;
+use std::io::{ErrorKind, Read};
 use std::process::{Command, Output, Stdio};
 use std::time::Duration;
 
@@ -39,6 +39,34 @@ impl Default for CaptureConfig {
     }
 }
 
+struct BoundedCapture {
+    output: Vec<u8>,
+    truncated_bytes: usize,
+    max_bytes: usize,
+}
+
+impl BoundedCapture {
+    fn new(max_bytes: usize) -> Self {
+        Self {
+            output: Vec::with_capacity(max_bytes.min(8192)),
+            truncated_bytes: 0,
+            max_bytes,
+        }
+    }
+
+    fn push(&mut self, chunk: &[u8]) {
+        let remaining = self.max_bytes.saturating_sub(self.output.len());
+        let retained = remaining.min(chunk.len());
+        self.output.extend_from_slice(&chunk[..retained]);
+        self.truncated_bytes = self.truncated_bytes.saturating_add(chunk.len() - retained);
+    }
+
+    fn finish(mut self) -> Vec<u8> {
+        append_truncation_marker(&mut self.output, self.truncated_bytes);
+        self.output
+    }
+}
+
 fn append_truncation_marker(buf: &mut Vec<u8>, truncated_bytes: usize) {
     if truncated_bytes == 0 {
         return;
@@ -61,8 +89,7 @@ pub fn read_bounded<R>(reader: &mut R, max_bytes: usize) -> std::io::Result<Vec<
 where
     R: Read,
 {
-    let mut output = Vec::with_capacity(max_bytes.min(8192));
-    let mut truncated_bytes = 0usize;
+    let mut capture = BoundedCapture::new(max_bytes);
     let mut chunk = [0u8; 8192];
 
     loop {
@@ -70,15 +97,23 @@ where
         if read == 0 {
             break;
         }
-
-        let remaining = max_bytes.saturating_sub(output.len());
-        let retained = remaining.min(read);
-        output.extend_from_slice(&chunk[..retained]);
-        truncated_bytes = truncated_bytes.saturating_add(read - retained);
+        capture.push(&chunk[..read]);
     }
 
-    append_truncation_marker(&mut output, truncated_bytes);
-    Ok(output)
+    Ok(capture.finish())
+}
+
+fn spawn_error(tool: &str, error: std::io::Error) -> VoomError {
+    if error.kind() == ErrorKind::NotFound {
+        VoomError::ToolNotFound {
+            tool: tool.to_string(),
+        }
+    } else {
+        VoomError::ToolExecution {
+            tool: tool.into(),
+            message: format!("failed to spawn {tool}: {error}"),
+        }
+    }
 }
 
 /// Spawn reader threads for stdout and stderr pipes.
@@ -183,10 +218,7 @@ pub fn run_with_timeout_env_config(
     for (key, val) in env_vars {
         cmd.env(key, val);
     }
-    let mut child = cmd.spawn().map_err(|e| VoomError::ToolExecution {
-        tool: tool.into(),
-        message: format!("failed to spawn {tool}: {e}"),
-    })?;
+    let mut child = cmd.spawn().map_err(|e| spawn_error(tool, e))?;
 
     // Spawn reader threads before waiting so pipes drain concurrently.
     let (stdout_handle, stderr_handle) = spawn_pipe_readers(&mut child, capture);
@@ -227,6 +259,23 @@ pub fn run_with_timeout_env_config(
             })
         }
     }
+}
+
+/// Run a subprocess and return whether it exits successfully before the timeout.
+#[must_use]
+pub fn probe_tool_status(tool: &str, args: &[impl AsRef<OsStr>], timeout: Duration) -> bool {
+    run_with_timeout(tool, args, timeout).is_ok_and(|o| o.status.success())
+}
+
+/// Run a subprocess with extra environment variables and return whether it succeeds.
+#[must_use]
+pub fn probe_tool_status_env(
+    tool: &str,
+    args: &[impl AsRef<OsStr>],
+    timeout: Duration,
+    env_vars: &[(&str, &str)],
+) -> bool {
+    run_with_timeout_env(tool, args, timeout, env_vars).is_ok_and(|o| o.status.success())
 }
 
 /// Format a tool invocation as a shell-reproducible command string.
@@ -274,8 +323,7 @@ where
         return Vec::new();
     };
 
-    let mut output = Vec::with_capacity(max_bytes.min(8192));
-    let mut truncated_bytes = 0usize;
+    let mut capture = BoundedCapture::new(max_bytes);
     let mut chunk = [0u8; 8192];
 
     loop {
@@ -289,15 +337,10 @@ where
         if read == 0 {
             break;
         }
-
-        let remaining = max_bytes.saturating_sub(output.len());
-        let retained = remaining.min(read);
-        output.extend_from_slice(&chunk[..retained]);
-        truncated_bytes = truncated_bytes.saturating_add(read - retained);
+        capture.push(&chunk[..read]);
     }
 
-    append_truncation_marker(&mut output, truncated_bytes);
-    output
+    capture.finish()
 }
 
 /// Async cancellable subprocess execution via `tokio::process`.
@@ -392,10 +435,7 @@ pub async fn run_cancellable_env_config(
     for (key, val) in options.env_vars {
         cmd.env(key, val);
     }
-    let mut child = cmd.spawn().map_err(|e| VoomError::ToolExecution {
-        tool: tool.into(),
-        message: format!("failed to spawn {tool}: {e}"),
-    })?;
+    let mut child = cmd.spawn().map_err(|e| spawn_error(tool, e))?;
 
     // Take pipes before waiting so they drain concurrently with the
     // child, avoiding deadlock when output exceeds the OS pipe buffer.
@@ -454,11 +494,10 @@ mod tests {
         let err =
             run_with_timeout("nonexistent_tool_xyz", &["-v"], Duration::from_secs(5)).unwrap_err();
         match &err {
-            VoomError::ToolExecution { tool, message } => {
+            VoomError::ToolNotFound { tool } => {
                 assert_eq!(tool, "nonexistent_tool_xyz");
-                assert!(message.contains("failed to spawn"));
             }
-            other => panic!("expected ToolExecution, got: {other}"),
+            other => panic!("expected ToolNotFound, got: {other}"),
         }
     }
 

--- a/crates/voom-process/src/lib.rs
+++ b/crates/voom-process/src/lib.rs
@@ -450,9 +450,10 @@ mod tests {
         )
         .expect("script succeeds");
 
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        assert!(stderr.contains("...[truncated "));
-        assert!(stderr_tail(&output.stderr, 2).contains("...[truncated "));
+        assert_eq!(
+            String::from_utf8_lossy(&output.stderr),
+            "first\nsecond\n...[truncated 13 bytes]"
+        );
     }
 
     #[cfg(unix)]

--- a/crates/voom-process/src/lib.rs
+++ b/crates/voom-process/src/lib.rs
@@ -12,6 +12,67 @@ use wait_timeout::ChildExt;
 
 use voom_domain::errors::{Result, VoomError};
 
+/// Default maximum bytes retained from each captured process stream.
+pub const DEFAULT_CAPTURE_LIMIT_BYTES: usize = 1024 * 1024;
+
+/// Per-stream subprocess output capture limits.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CaptureConfig {
+    pub max_stdout_bytes: usize,
+    pub max_stderr_bytes: usize,
+}
+
+impl Default for CaptureConfig {
+    fn default() -> Self {
+        Self {
+            max_stdout_bytes: DEFAULT_CAPTURE_LIMIT_BYTES,
+            max_stderr_bytes: DEFAULT_CAPTURE_LIMIT_BYTES,
+        }
+    }
+}
+
+fn append_truncation_marker(buf: &mut Vec<u8>, truncated_bytes: usize) {
+    if truncated_bytes == 0 {
+        return;
+    }
+    if !buf.is_empty() && !buf.ends_with(b"\n") {
+        buf.push(b'\n');
+    }
+    buf.extend_from_slice(format!("...[truncated {truncated_bytes} bytes]").as_bytes());
+}
+
+/// Read a stream to EOF while retaining at most `max_bytes` of original data.
+///
+/// The returned buffer includes a truncation marker when bytes were discarded.
+/// Prefer `run_with_timeout*` for subprocess execution; this helper exists for
+/// integrations that already own process lifecycle management.
+///
+/// # Errors
+/// Returns any I/O error produced while reading from `reader`.
+pub fn read_bounded<R>(reader: &mut R, max_bytes: usize) -> std::io::Result<Vec<u8>>
+where
+    R: Read,
+{
+    let mut output = Vec::with_capacity(max_bytes.min(8192));
+    let mut truncated_bytes = 0usize;
+    let mut chunk = [0u8; 8192];
+
+    loop {
+        let read = reader.read(&mut chunk)?;
+        if read == 0 {
+            break;
+        }
+
+        let remaining = max_bytes.saturating_sub(output.len());
+        let retained = remaining.min(read);
+        output.extend_from_slice(&chunk[..retained]);
+        truncated_bytes = truncated_bytes.saturating_add(read - retained);
+    }
+
+    append_truncation_marker(&mut output, truncated_bytes);
+    Ok(output)
+}
+
 /// Spawn reader threads for stdout and stderr pipes.
 ///
 /// Returns join handles that yield the collected bytes. Threads are
@@ -19,6 +80,7 @@ use voom_domain::errors::{Result, VoomError};
 /// avoiding deadlock when output exceeds the OS pipe buffer.
 fn spawn_pipe_readers(
     child: &mut std::process::Child,
+    capture: CaptureConfig,
 ) -> (
     std::thread::JoinHandle<Vec<u8>>,
     std::thread::JoinHandle<Vec<u8>>,
@@ -27,19 +89,17 @@ fn spawn_pipe_readers(
     let mut stderr = child.stderr.take().expect("stderr piped");
 
     let stdout_handle = std::thread::spawn(move || {
-        let mut buf = Vec::new();
-        if let Err(e) = stdout.read_to_end(&mut buf) {
+        read_bounded(&mut stdout, capture.max_stdout_bytes).unwrap_or_else(|e| {
             tracing::warn!(error = %e, "failed to read child stdout");
-        }
-        buf
+            Vec::new()
+        })
     });
 
     let stderr_handle = std::thread::spawn(move || {
-        let mut buf = Vec::new();
-        if let Err(e) = stderr.read_to_end(&mut buf) {
+        read_bounded(&mut stderr, capture.max_stderr_bytes).unwrap_or_else(|e| {
             tracing::warn!(error = %e, "failed to read child stderr");
-        }
-        buf
+            Vec::new()
+        })
     });
 
     (stdout_handle, stderr_handle)
@@ -70,7 +130,7 @@ pub fn run_with_timeout(
     args: &[impl AsRef<OsStr>],
     timeout: Duration,
 ) -> Result<Output> {
-    run_with_timeout_env(tool, args, timeout, &[])
+    run_with_timeout_env_config(tool, args, timeout, &[], CaptureConfig::default())
 }
 
 /// Run a subprocess with a timeout and extra environment variables.
@@ -83,6 +143,33 @@ pub fn run_with_timeout_env(
     timeout: Duration,
     env_vars: &[(&str, &str)],
 ) -> Result<Output> {
+    run_with_timeout_env_config(tool, args, timeout, env_vars, CaptureConfig::default())
+}
+
+/// Run a subprocess with a timeout and configured output capture limits.
+///
+/// # Errors
+/// Returns `VoomError::ToolExecution` if the process fails or times out.
+pub fn run_with_timeout_config(
+    tool: &str,
+    args: &[impl AsRef<OsStr>],
+    timeout: Duration,
+    capture: CaptureConfig,
+) -> Result<Output> {
+    run_with_timeout_env_config(tool, args, timeout, &[], capture)
+}
+
+/// Run a subprocess with a timeout, extra environment variables, and capture limits.
+///
+/// # Errors
+/// Returns `VoomError::ToolExecution` if the process fails or times out.
+pub fn run_with_timeout_env_config(
+    tool: &str,
+    args: &[impl AsRef<OsStr>],
+    timeout: Duration,
+    env_vars: &[(&str, &str)],
+    capture: CaptureConfig,
+) -> Result<Output> {
     let mut cmd = Command::new(tool);
     cmd.args(args).stdout(Stdio::piped()).stderr(Stdio::piped());
     for (key, val) in env_vars {
@@ -94,7 +181,7 @@ pub fn run_with_timeout_env(
     })?;
 
     // Spawn reader threads before waiting so pipes drain concurrently.
-    let (stdout_handle, stderr_handle) = spawn_pipe_readers(&mut child);
+    let (stdout_handle, stderr_handle) = spawn_pipe_readers(&mut child, capture);
 
     match child.wait_timeout(timeout) {
         Ok(Some(status)) => {
@@ -307,6 +394,74 @@ mod tests {
             stdout.contains("VOOM_TEST_VAR=hello_gpu"),
             "env output should contain the set var, got: {stdout}"
         );
+    }
+
+    #[test]
+    fn run_with_timeout_truncates_stdout_at_configured_limit() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let script = dir.path().join("stdout-flood.sh");
+        std::fs::write(
+            &script,
+            "#!/bin/sh\npython3 - <<'PY'\nimport sys\nsys.stdout.write('a' * 40)\nPY\n",
+        )
+        .expect("write script");
+        make_executable(&script);
+
+        let output = run_with_timeout_env_config(
+            script.to_str().expect("utf8 path"),
+            &[] as &[&str],
+            Duration::from_secs(5),
+            &[],
+            CaptureConfig {
+                max_stdout_bytes: 10,
+                max_stderr_bytes: DEFAULT_CAPTURE_LIMIT_BYTES,
+            },
+        )
+        .expect("script succeeds");
+
+        assert!(output.status.success());
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout),
+            "aaaaaaaaaa\n...[truncated 30 bytes]"
+        );
+        assert!(output.stderr.is_empty());
+    }
+
+    #[test]
+    fn run_with_timeout_truncates_stderr_at_configured_limit() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let script = dir.path().join("stderr-flood.sh");
+        std::fs::write(
+            &script,
+            "#!/bin/sh\npython3 - <<'PY'\nimport sys\nsys.stderr.write('first\\nsecond\\nthird\\nfourth\\n')\nPY\n",
+        )
+        .expect("write script");
+        make_executable(&script);
+
+        let output = run_with_timeout_env_config(
+            script.to_str().expect("utf8 path"),
+            &[] as &[&str],
+            Duration::from_secs(5),
+            &[],
+            CaptureConfig {
+                max_stdout_bytes: DEFAULT_CAPTURE_LIMIT_BYTES,
+                max_stderr_bytes: 13,
+            },
+        )
+        .expect("script succeeds");
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(stderr.contains("...[truncated "));
+        assert!(stderr_tail(&output.stderr, 2).contains("...[truncated "));
+    }
+
+    #[cfg(unix)]
+    fn make_executable(path: &std::path::Path) {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut perms = std::fs::metadata(path).expect("metadata").permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(path, perms).expect("chmod");
     }
 
     #[test]

--- a/crates/voom-process/src/lib.rs
+++ b/crates/voom-process/src/lib.rs
@@ -22,6 +22,14 @@ pub struct CaptureConfig {
     pub max_stderr_bytes: usize,
 }
 
+/// Options for cancellable subprocess execution.
+#[derive(Clone, Copy, Debug)]
+pub struct CancellableOptions<'a> {
+    pub env_vars: &'a [(&'a str, &'a str)],
+    pub token: &'a tokio_util::sync::CancellationToken,
+    pub capture: CaptureConfig,
+}
+
 impl Default for CaptureConfig {
     fn default() -> Self {
         Self {
@@ -306,7 +314,17 @@ pub async fn run_cancellable(
     timeout: Duration,
     token: &tokio_util::sync::CancellationToken,
 ) -> Result<Output> {
-    run_cancellable_env_config(tool, args, timeout, &[], token, CaptureConfig::default()).await
+    run_cancellable_env_config(
+        tool,
+        args,
+        timeout,
+        CancellableOptions {
+            env_vars: &[],
+            token,
+            capture: CaptureConfig::default(),
+        },
+    )
+    .await
 }
 
 /// Async cancellable subprocess with extra environment variables.
@@ -323,9 +341,11 @@ pub async fn run_cancellable_env(
         tool,
         args,
         timeout,
-        env_vars,
-        token,
-        CaptureConfig::default(),
+        CancellableOptions {
+            env_vars,
+            token,
+            capture: CaptureConfig::default(),
+        },
     )
     .await
 }
@@ -340,7 +360,17 @@ pub async fn run_cancellable_config(
     token: &tokio_util::sync::CancellationToken,
     capture: CaptureConfig,
 ) -> Result<Output> {
-    run_cancellable_env_config(tool, args, timeout, &[], token, capture).await
+    run_cancellable_env_config(
+        tool,
+        args,
+        timeout,
+        CancellableOptions {
+            env_vars: &[],
+            token,
+            capture,
+        },
+    )
+    .await
 }
 
 /// Async cancellable subprocess with extra environment variables and capture limits.
@@ -350,9 +380,7 @@ pub async fn run_cancellable_env_config(
     tool: &str,
     args: &[impl AsRef<OsStr>],
     timeout: Duration,
-    env_vars: &[(&str, &str)],
-    token: &tokio_util::sync::CancellationToken,
-    capture: CaptureConfig,
+    options: CancellableOptions<'_>,
 ) -> Result<Output> {
     use tokio::process::Command as TokioCommand;
 
@@ -361,7 +389,7 @@ pub async fn run_cancellable_env_config(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .kill_on_drop(true);
-    for (key, val) in env_vars {
+    for (key, val) in options.env_vars {
         cmd.env(key, val);
     }
     let mut child = cmd.spawn().map_err(|e| VoomError::ToolExecution {
@@ -377,8 +405,8 @@ pub async fn run_cancellable_env_config(
     tokio::select! {
         result = async {
             let (stdout, stderr, status) = tokio::join!(
-                read_child_pipe(stdout_pipe, capture.max_stdout_bytes),
-                read_child_pipe(stderr_pipe, capture.max_stderr_bytes),
+                read_child_pipe(stdout_pipe, options.capture.max_stdout_bytes),
+                read_child_pipe(stderr_pipe, options.capture.max_stderr_bytes),
                 child.wait(),
             );
             (stdout, stderr, status)
@@ -400,7 +428,7 @@ pub async fn run_cancellable_env_config(
                 ),
             })
         }
-        () = token.cancelled() => {
+        () = options.token.cancelled() => {
             let _ = child.kill().await;
             Err(VoomError::ToolExecution {
                 tool: tool.into(),
@@ -559,11 +587,13 @@ mod tests {
             script.to_str().expect("utf8 path"),
             &[] as &[&str],
             Duration::from_secs(5),
-            &[],
-            &token,
-            CaptureConfig {
-                max_stdout_bytes: 8,
-                max_stderr_bytes: DEFAULT_CAPTURE_LIMIT_BYTES,
+            CancellableOptions {
+                env_vars: &[],
+                token: &token,
+                capture: CaptureConfig {
+                    max_stdout_bytes: 8,
+                    max_stderr_bytes: DEFAULT_CAPTURE_LIMIT_BYTES,
+                },
             },
         )
         .await

--- a/crates/voom-process/src/lib.rs
+++ b/crates/voom-process/src/lib.rs
@@ -539,6 +539,16 @@ mod tests {
         );
     }
 
+    #[test]
+    fn stderr_tail_keeps_truncation_marker_visible() {
+        let mut stderr = b"line1\nline2\nline3".to_vec();
+        append_truncation_marker(&mut stderr, 25);
+
+        let tail = stderr_tail(&stderr, 2);
+
+        assert_eq!(tail, "line3\n...[truncated 25 bytes]");
+    }
+
     #[cfg(unix)]
     fn make_executable(path: &std::path::Path) {
         use std::os::unix::fs::PermissionsExt;

--- a/plugins/ffmpeg-executor/src/probe.rs
+++ b/plugins/ffmpeg-executor/src/probe.rs
@@ -168,9 +168,7 @@ pub fn probe_hw_capabilities(tool: &str) -> HwCapabilities {
 /// before `timeout`. Spawn errors, non-zero exits, and timeouts all yield
 /// `false`. Pass `&[]` for `env` when no extra variables are needed.
 fn probe_tool_status(tool: &str, args: &[&str], timeout: Duration, env: &[(&str, &str)]) -> bool {
-    voom_process::run_with_timeout_env(tool, args, timeout, env)
-        .map(|o| o.status.success())
-        .unwrap_or(false)
+    voom_process::probe_tool_status_env(tool, args, timeout, env)
 }
 
 /// Run `tool` with `args`, returning captured stdout only if it exits 0

--- a/plugins/ffprobe-introspector/src/ffprobe.rs
+++ b/plugins/ffprobe-introspector/src/ffprobe.rs
@@ -1,5 +1,4 @@
 use std::path::Path;
-use std::process::Command;
 use std::time::Duration;
 
 use voom_domain::errors::{Result, VoomError};
@@ -66,21 +65,19 @@ pub fn run_ffprobe(
 
 /// Check if ffprobe is available and return its version.
 pub fn detect_ffprobe(ffprobe_path: &str) -> Result<String> {
-    let output = Command::new(ffprobe_path)
-        .args(["-version"])
-        .output()
-        .map_err(|e| {
-            if e.kind() == std::io::ErrorKind::NotFound {
-                VoomError::ToolNotFound {
-                    tool: ffprobe_path.to_string(),
+    let output =
+        voom_process::run_with_timeout(ffprobe_path, &["-version"], Duration::from_secs(10))
+            .map_err(|e| match &e {
+                VoomError::ToolExecution { message, .. }
+                    if message.contains("No such file or directory")
+                        || message.contains("os error 2") =>
+                {
+                    VoomError::ToolNotFound {
+                        tool: ffprobe_path.to_string(),
+                    }
                 }
-            } else {
-                VoomError::ToolExecution {
-                    tool: "ffprobe".into(),
-                    message: e.to_string(),
-                }
-            }
-        })?;
+                _ => e,
+            })?;
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     // First line is typically: "ffprobe version N.N.N ..."

--- a/plugins/ffprobe-introspector/src/ffprobe.rs
+++ b/plugins/ffprobe-introspector/src/ffprobe.rs
@@ -28,18 +28,7 @@ pub fn run_ffprobe(
     .chain(std::iter::once(file_arg))
     .collect();
 
-    let output =
-        voom_process::run_with_timeout(ffprobe_path, &args, timeout).map_err(|e| match &e {
-            VoomError::ToolExecution { message, .. }
-                if message.contains("No such file or directory")
-                    || message.contains("os error 2") =>
-            {
-                VoomError::ToolNotFound {
-                    tool: ffprobe_path.to_string(),
-                }
-            }
-            _ => e,
-        })?;
+    let output = voom_process::run_with_timeout(ffprobe_path, &args, timeout)?;
 
     if !output.status.success() {
         let stderr_text = String::from_utf8_lossy(&output.stderr);
@@ -66,18 +55,7 @@ pub fn run_ffprobe(
 /// Check if ffprobe is available and return its version.
 pub fn detect_ffprobe(ffprobe_path: &str) -> Result<String> {
     let output =
-        voom_process::run_with_timeout(ffprobe_path, &["-version"], Duration::from_secs(10))
-            .map_err(|e| match &e {
-                VoomError::ToolExecution { message, .. }
-                    if message.contains("No such file or directory")
-                        || message.contains("os error 2") =>
-                {
-                    VoomError::ToolNotFound {
-                        tool: ffprobe_path.to_string(),
-                    }
-                }
-                _ => e,
-            })?;
+        voom_process::run_with_timeout(ffprobe_path, &["-version"], Duration::from_secs(10))?;
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     // First line is typically: "ffprobe version N.N.N ..."

--- a/plugins/ffprobe-introspector/src/lib.rs
+++ b/plugins/ffprobe-introspector/src/lib.rs
@@ -50,8 +50,7 @@ impl FfprobeIntrospectorPlugin {
 
     /// Probe whether the configured `ffprobe` binary is callable.
     fn detect_available(ffprobe_path: &str) -> bool {
-        voom_process::run_with_timeout(ffprobe_path, &["-version"], Duration::from_secs(10))
-            .is_ok_and(|o| o.status.success())
+        voom_process::probe_tool_status(ffprobe_path, &["-version"], Duration::from_secs(10))
     }
 
     /// Set a custom path to the ffprobe binary.

--- a/plugins/ffprobe-introspector/src/lib.rs
+++ b/plugins/ffprobe-introspector/src/lib.rs
@@ -8,7 +8,6 @@
 pub mod ffprobe;
 pub mod parser;
 
-use std::process::Command;
 use std::time::Duration;
 
 use voom_domain::capabilities::Capability;
@@ -51,11 +50,8 @@ impl FfprobeIntrospectorPlugin {
 
     /// Probe whether the configured `ffprobe` binary is callable.
     fn detect_available(ffprobe_path: &str) -> bool {
-        Command::new(ffprobe_path)
-            .arg("-version")
-            .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false)
+        voom_process::run_with_timeout(ffprobe_path, &["-version"], Duration::from_secs(10))
+            .is_ok_and(|o| o.status.success())
     }
 
     /// Set a custom path to the ffprobe binary.

--- a/plugins/mkvtoolnix-executor/src/lib.rs
+++ b/plugins/mkvtoolnix-executor/src/lib.rs
@@ -436,8 +436,7 @@ impl Plugin for MkvtoolnixExecutorPlugin {
 
     fn init(&mut self, _ctx: &PluginContext) -> Result<Vec<Event>> {
         let available =
-            voom_process::run_with_timeout("mkvmerge", &["--version"], Duration::from_secs(10))
-                .is_ok_and(|o| o.status.success());
+            voom_process::probe_tool_status("mkvmerge", &["--version"], Duration::from_secs(10));
 
         self.available = available;
 

--- a/plugins/mkvtoolnix-executor/src/lib.rs
+++ b/plugins/mkvtoolnix-executor/src/lib.rs
@@ -5,7 +5,6 @@ pub mod propedit;
 #[cfg(test)]
 pub(crate) mod test_helpers;
 
-use std::process::Command;
 use std::time::Duration;
 
 use voom_domain::capabilities::Capability;
@@ -436,10 +435,9 @@ impl Plugin for MkvtoolnixExecutorPlugin {
     }
 
     fn init(&mut self, _ctx: &PluginContext) -> Result<Vec<Event>> {
-        let available = Command::new("mkvmerge")
-            .arg("--version")
-            .output()
-            .is_ok_and(|o| o.status.success());
+        let available =
+            voom_process::run_with_timeout("mkvmerge", &["--version"], Duration::from_secs(10))
+                .is_ok_and(|o| o.status.success());
 
         self.available = available;
 

--- a/plugins/tool-detector/Cargo.toml
+++ b/plugins/tool-detector/Cargo.toml
@@ -14,6 +14,7 @@ description = "Tool detection plugin for VOOM — finds and verifies external to
 [dependencies]
 voom-domain = { workspace = true }
 voom-kernel = { workspace = true }
+voom-process = { workspace = true }
 tracing = { workspace = true }
 
 [lints]

--- a/plugins/tool-detector/src/lib.rs
+++ b/plugins/tool-detector/src/lib.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::process::Command;
+use std::time::Duration;
 
 use voom_domain::capabilities::Capability;
 use voom_domain::errors::{Result, VoomError};
@@ -141,7 +142,7 @@ impl Plugin for ToolDetectorPlugin {
 
 /// Detect a tool by running it and parsing the version output.
 fn detect_tool(name: &str, args: &[&str]) -> Option<DetectedTool> {
-    let output = Command::new(name).args(args).output().ok()?;
+    let output = voom_process::run_with_timeout(name, args, Duration::from_secs(10)).ok()?;
     if !output.status.success() {
         return None;
     }

--- a/plugins/tool-detector/src/lib.rs
+++ b/plugins/tool-detector/src/lib.rs
@@ -1,7 +1,8 @@
 //! Tool detector plugin: discovers and caches external tool availability and versions.
 
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::env;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use voom_domain::capabilities::Capability;
@@ -215,22 +216,52 @@ fn parse_version(tool_name: &str, output: &str) -> String {
     }
 }
 
-/// Find the full path to a tool using `which`.
+/// Find the full path to a tool by scanning `PATH`.
 fn find_tool_path(name: &str) -> Option<PathBuf> {
-    voom_process::run_with_timeout("which", &[name], Duration::from_secs(10))
-        .ok()
-        .and_then(|o| {
-            if o.status.success() {
-                let path = String::from_utf8_lossy(&o.stdout).trim().to_string();
-                if path.is_empty() {
-                    None
-                } else {
-                    Some(PathBuf::from(path))
-                }
-            } else {
-                None
-            }
-        })
+    let paths = env::var_os("PATH")?;
+    find_tool_path_in_paths(name, env::split_paths(&paths))
+}
+
+fn find_tool_path_in_paths(
+    name: &str,
+    paths: impl IntoIterator<Item = PathBuf>,
+) -> Option<PathBuf> {
+    paths
+        .into_iter()
+        .flat_map(|path| candidate_paths(&path, name))
+        .find(|path| is_executable_file(path))
+}
+
+fn candidate_paths(path: &Path, name: &str) -> Vec<PathBuf> {
+    if cfg!(windows) && Path::new(name).extension().is_none() {
+        let extensions = env::var_os("PATHEXT")
+            .map(|value| {
+                env::split_paths(&value)
+                    .map(|ext| ext.to_string_lossy().into_owned())
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_else(|| vec![".COM".into(), ".EXE".into(), ".BAT".into(), ".CMD".into()]);
+
+        extensions
+            .into_iter()
+            .map(|ext| path.join(format!("{name}{ext}")))
+            .collect()
+    } else {
+        vec![path.join(name)]
+    }
+}
+
+#[cfg(unix)]
+fn is_executable_file(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+
+    path.metadata()
+        .is_ok_and(|meta| meta.is_file() && meta.permissions().mode() & 0o111 != 0)
+}
+
+#[cfg(not(unix))]
+fn is_executable_file(path: &Path) -> bool {
+    path.is_file()
 }
 
 #[cfg(test)]
@@ -318,6 +349,30 @@ mod tests {
     #[test]
     fn test_parse_version_empty() {
         assert_eq!(parse_version("ffprobe", ""), "unknown");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn find_tool_path_in_paths_requires_executable_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let tool = dir.path().join("fake-tool");
+        std::fs::write(&tool, "#!/bin/sh\n").expect("write tool");
+
+        assert_eq!(
+            find_tool_path_in_paths("fake-tool", [dir.path().to_path_buf()]),
+            None
+        );
+
+        let mut perms = std::fs::metadata(&tool).expect("metadata").permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&tool, perms).expect("chmod");
+
+        assert_eq!(
+            find_tool_path_in_paths("fake-tool", [dir.path().to_path_buf()]),
+            Some(tool)
+        );
     }
 
     #[test]

--- a/plugins/tool-detector/src/lib.rs
+++ b/plugins/tool-detector/src/lib.rs
@@ -2,7 +2,6 @@
 
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::process::Command;
 use std::time::Duration;
 
 use voom_domain::capabilities::Capability;
@@ -218,18 +217,20 @@ fn parse_version(tool_name: &str, output: &str) -> String {
 
 /// Find the full path to a tool using `which`.
 fn find_tool_path(name: &str) -> Option<PathBuf> {
-    Command::new("which").arg(name).output().ok().and_then(|o| {
-        if o.status.success() {
-            let path = String::from_utf8_lossy(&o.stdout).trim().to_string();
-            if path.is_empty() {
-                None
+    voom_process::run_with_timeout("which", &[name], Duration::from_secs(10))
+        .ok()
+        .and_then(|o| {
+            if o.status.success() {
+                let path = String::from_utf8_lossy(&o.stdout).trim().to_string();
+                if path.is_empty() {
+                    None
+                } else {
+                    Some(PathBuf::from(path))
+                }
             } else {
-                Some(PathBuf::from(path))
+                None
             }
-        } else {
-            None
-        }
-    })
+        })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- bounds sync and async subprocess output capture in voom-process while preserving truncation markers
- routes plugin and WASM host tool execution through bounded process helpers
- removes duplicated tool probe and missing-tool handling logic
- replaces tool-detector which subprocess lookup with an in-process PATH scan

Fixes #253

## Verification
- cargo test
- cargo test -p voom-process -p voom-tool-detector -p voom-ffprobe-introspector -p voom-mkvtoolnix-executor -p voom-kernel --features voom-kernel/wasm
- cargo clippy --all-targets --all-features -- -D warnings
- git diff --check