### PR TITLE
feat(verifier): hardware-accelerated decode for --thorough mode

### DIFF
--- a/crates/voom-cli/src/cli.rs
+++ b/crates/voom-cli/src/cli.rs
@@ -559,9 +559,49 @@ pub struct VerifyArgs {
     #[arg(short, long, default_value_t = 0)]
     pub workers: usize,
 
+    /// Hardware-accelerated decode backend for `--thorough` (default: none).
+    /// Falls back to CPU if the requested backend isn't advertised by
+    /// `ffmpeg -hwaccels`. Overrides `[plugin.verifier].thorough_hw_accel`.
+    #[arg(long, value_enum)]
+    pub hw_accel: Option<HwAccelArg>,
+
     /// Output format
     #[arg(short, long)]
     pub format: Option<OutputFormat>,
+}
+
+/// CLI surface for the `--hw-accel` flag. Decoupled from
+/// `voom_verifier::hwaccel::HwAccelMode` so the CLI doesn't pull
+/// the verifier types into its parser.
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum HwAccelArg {
+    /// CPU decode.
+    None,
+    /// Auto-detect: pick the first probed backend (NVDEC > QSV > VAAPI > VideoToolbox).
+    Auto,
+    /// NVIDIA NVDEC (`-hwaccel cuda`).
+    Nvdec,
+    /// Linux VA-API (`-hwaccel vaapi`).
+    Vaapi,
+    /// Intel QuickSync Video (`-hwaccel qsv`).
+    Qsv,
+    /// macOS VideoToolbox (`-hwaccel videotoolbox`).
+    Videotoolbox,
+}
+
+impl HwAccelArg {
+    /// Canonical name accepted by the verifier's parser.
+    #[must_use]
+    pub fn as_canonical(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::Auto => "auto",
+            Self::Nvdec => "nvdec",
+            Self::Vaapi => "vaapi",
+            Self::Qsv => "qsv",
+            Self::Videotoolbox => "videotoolbox",
+        }
+    }
 }
 
 #[derive(clap::Args)]

--- a/crates/voom-cli/src/commands/verify.rs
+++ b/crates/voom-cli/src/commands/verify.rs
@@ -16,10 +16,11 @@ use voom_domain::storage::{FileFilters, StorageTrait};
 use voom_domain::verification::{
     VerificationFilters, VerificationMode, VerificationOutcome, VerificationRecord,
 };
+use voom_verifier::hwaccel::{self as verifier_hwaccel, HwAccelMode};
 use voom_verifier::VerifierConfig;
 
 use crate::app;
-use crate::cli::{OutputFormat, VerifyArgs, VerifyCommands, VerifyReportArgs};
+use crate::cli::{HwAccelArg, OutputFormat, VerifyArgs, VerifyCommands, VerifyReportArgs};
 use crate::commands::since::parse_since;
 use crate::config::{self, AppConfig};
 
@@ -66,6 +67,7 @@ fn run_verify(args: VerifyArgs) -> Result<()> {
 
     match mode {
         VerificationMode::Thorough => {
+            let hw_accel = resolve_thorough_hw_accel(&verifier_cfg, args.hw_accel);
             // Serial: ffmpeg saturates cores already.
             for tgt in &targets {
                 let timeout = compute_thorough_timeout(&verifier_cfg, tgt.duration);
@@ -74,6 +76,7 @@ fn run_verify(args: VerifyArgs) -> Result<()> {
                     &tgt.path,
                     &verifier_cfg.ffmpeg_path,
                     timeout,
+                    hw_accel,
                 )?;
                 store.insert_verification(&rec)?;
                 print_record(&rec, &tgt.path);
@@ -206,6 +209,44 @@ fn compute_thorough_timeout(cfg: &VerifierConfig, duration: Option<f64>) -> Dura
         cfg.thorough_timeout_multiplier,
         cfg.thorough_timeout_floor_secs,
     )
+}
+
+/// Resolve the effective HW decode backend for `voom verify run --thorough`.
+///
+/// Precedence: explicit `--hw-accel` flag → `[plugin.verifier]
+/// thorough_hw_accel` config → `none`. Probes `ffmpeg -hwaccels` once and
+/// falls back to CPU when the requested backend is missing.
+fn resolve_thorough_hw_accel(
+    verifier_cfg: &VerifierConfig,
+    flag: Option<HwAccelArg>,
+) -> Option<HwAccelMode> {
+    let raw = flag
+        .map(|f| f.as_canonical().to_string())
+        .unwrap_or_else(|| verifier_cfg.thorough_hw_accel.clone());
+    let mode = HwAccelMode::parse(&raw).unwrap_or_else(|| {
+        eprintln!(
+            "warning: unrecognised hw-accel value '{raw}'; \
+             valid: none, auto, nvdec, vaapi, qsv, videotoolbox. Using CPU."
+        );
+        HwAccelMode::None
+    });
+    if matches!(mode, HwAccelMode::None) {
+        return None;
+    }
+    let probed = verifier_hwaccel::probe_hwaccels(&verifier_cfg.ffmpeg_path);
+    let resolved = verifier_hwaccel::resolve(mode, &probed);
+    match resolved {
+        Some(m) => {
+            eprintln!("Using hw-accel decode: {} (probed: {probed:?})", m.as_str());
+        }
+        None => {
+            eprintln!(
+                "Requested hw-accel '{raw}' not available on this ffmpeg \
+                 (probed: {probed:?}); falling back to CPU decode."
+            );
+        }
+    }
+    resolved
 }
 
 fn read_verifier_config(cfg: &AppConfig) -> VerifierConfig {

--- a/plugins/verifier/src/config.rs
+++ b/plugins/verifier/src/config.rs
@@ -21,6 +21,12 @@ pub struct VerifierConfig {
     pub ffprobe_path: String,
     /// Path to ffmpeg (defaults to "ffmpeg" on PATH).
     pub ffmpeg_path: String,
+    /// Hardware-accelerated decode mode for thorough verification.
+    /// Recognised: `none` (default — CPU), `auto`, `nvdec`, `vaapi`,
+    /// `qsv`, `videotoolbox`. Falls back to CPU if the requested
+    /// backend is not advertised by `ffmpeg -hwaccels` on this host.
+    /// Unrecognised values warn and use CPU.
+    pub thorough_hw_accel: String,
 }
 
 impl Default for VerifierConfig {
@@ -32,6 +38,7 @@ impl Default for VerifierConfig {
             quarantine_dir: None,
             ffprobe_path: "ffprobe".into(),
             ffmpeg_path: "ffmpeg".into(),
+            thorough_hw_accel: "none".into(),
         }
     }
 }

--- a/plugins/verifier/src/hwaccel.rs
+++ b/plugins/verifier/src/hwaccel.rs
@@ -1,0 +1,394 @@
+//! Hardware-accelerated decode helpers for thorough verification.
+//!
+//! `voom verify --thorough` runs `ffmpeg -i <file> -f null -` end-to-end on
+//! every file in the library. On large libraries this pass is the dominant
+//! cost. This module lets the caller request a HW decode backend (NVDEC,
+//! VAAPI, QSV, VideoToolbox), probes whether ffmpeg actually supports it on
+//! this host, and falls back to CPU if not.
+//!
+//! Decode-only by design — the verifier never re-encodes, so no encoder
+//! mapping or device targeting is required. Encoder-side hwaccel logic
+//! lives in `voom-ffmpeg-executor::hwaccel`.
+
+use std::time::Duration;
+
+use voom_process::run_with_timeout;
+
+/// User-facing HW decode mode.
+///
+/// `Auto` picks the first probed backend; `None` forces CPU. Other variants
+/// pin a specific backend, falling back to CPU if it isn't available.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum HwAccelMode {
+    /// CPU decode (default).
+    #[default]
+    None,
+    /// Probe `ffmpeg -hwaccels` and pick the first supported backend.
+    Auto,
+    /// NVIDIA NVDEC (`-hwaccel cuda`).
+    Nvdec,
+    /// Linux VA-API (`-hwaccel vaapi`).
+    Vaapi,
+    /// Intel `QuickSync` Video (`-hwaccel qsv`).
+    Qsv,
+    /// macOS `VideoToolbox` (`-hwaccel videotoolbox`).
+    Videotoolbox,
+}
+
+impl HwAccelMode {
+    /// Parse a canonical name as accepted by the CLI flag and config key.
+    /// Recognised: `none`, `auto`, `nvdec`, `vaapi`, `qsv`, `videotoolbox`.
+    /// Case-insensitive; surrounding whitespace is ignored.
+    #[must_use]
+    pub fn parse(name: &str) -> Option<Self> {
+        match name.trim().to_ascii_lowercase().as_str() {
+            "none" | "" => Some(Self::None),
+            "auto" => Some(Self::Auto),
+            "nvdec" | "cuda" | "nvenc" => Some(Self::Nvdec),
+            "vaapi" => Some(Self::Vaapi),
+            "qsv" => Some(Self::Qsv),
+            "videotoolbox" => Some(Self::Videotoolbox),
+            _ => None,
+        }
+    }
+
+    /// Canonical, user-visible name (mirrors the CLI flag values).
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::Auto => "auto",
+            Self::Nvdec => "nvdec",
+            Self::Vaapi => "vaapi",
+            Self::Qsv => "qsv",
+            Self::Videotoolbox => "videotoolbox",
+        }
+    }
+
+    /// The `-hwaccel` argument value ffmpeg expects for this backend.
+    /// Returns `None` for `None`/`Auto` (the latter is resolved separately).
+    #[must_use]
+    pub fn ffmpeg_name(self) -> Option<&'static str> {
+        match self {
+            Self::None | Self::Auto => None,
+            Self::Nvdec => Some("cuda"),
+            Self::Vaapi => Some("vaapi"),
+            Self::Qsv => Some("qsv"),
+            Self::Videotoolbox => Some("videotoolbox"),
+        }
+    }
+}
+
+/// Pin a concrete backend to use for decode, or `None` if CPU.
+///
+/// Resolution rules:
+/// - `HwAccelMode::None` → `None`.
+/// - `HwAccelMode::Auto` → first probed backend in priority order, or `None`.
+/// - Any explicit backend → that backend if `probed` contains its ffmpeg
+///   name, else `None` with a warning logged.
+///
+/// `probed` is the list returned by `ffmpeg -hwaccels` (lower-cased,
+/// trimmed). Auto-probe order matches `voom-ffmpeg-executor`: NVDEC, QSV,
+/// VAAPI, VideoToolbox.
+#[must_use]
+pub fn resolve(mode: HwAccelMode, probed: &[String]) -> Option<HwAccelMode> {
+    let lower: Vec<String> = probed.iter().map(|s| s.to_ascii_lowercase()).collect();
+    match mode {
+        HwAccelMode::None => None,
+        HwAccelMode::Auto => auto_pick(&lower),
+        explicit => {
+            let want = explicit.ffmpeg_name()?;
+            if lower.iter().any(|s| s == want) {
+                Some(explicit)
+            } else {
+                tracing::warn!(
+                    backend = explicit.as_str(),
+                    probed = ?lower,
+                    "configured hw_accel backend not supported by this ffmpeg \
+                     build; falling back to CPU decode"
+                );
+                None
+            }
+        }
+    }
+}
+
+fn auto_pick(lower: &[String]) -> Option<HwAccelMode> {
+    if lower.iter().any(|s| s == "cuda") {
+        return Some(HwAccelMode::Nvdec);
+    }
+    if lower.iter().any(|s| s == "qsv") {
+        return Some(HwAccelMode::Qsv);
+    }
+    if lower.iter().any(|s| s == "vaapi") {
+        return Some(HwAccelMode::Vaapi);
+    }
+    if lower.iter().any(|s| s == "videotoolbox") {
+        return Some(HwAccelMode::Videotoolbox);
+    }
+    None
+}
+
+/// Probe `ffmpeg -hwaccels`, returning the lower-cased backend names that
+/// the binary advertises. Spawn errors, non-zero exits, and timeouts all
+/// degrade silently to an empty `Vec` — the caller treats that as "no HW
+/// support" and falls back to CPU.
+#[must_use]
+pub fn probe_hwaccels(ffmpeg_path: &str) -> Vec<String> {
+    let args = [std::ffi::OsString::from("-hwaccels")];
+    match run_with_timeout(ffmpeg_path, &args, Duration::from_secs(5)) {
+        Ok(output) if output.status.success() => parse_hwaccels(&output.stdout),
+        Ok(_) | Err(_) => Vec::new(),
+    }
+}
+
+fn parse_hwaccels(stdout: &[u8]) -> Vec<String> {
+    let text = String::from_utf8_lossy(stdout);
+    text.lines()
+        .skip_while(|l| !l.contains("Hardware acceleration methods"))
+        .skip(1)
+        .filter_map(|l| {
+            let t = l.trim();
+            if t.is_empty() {
+                None
+            } else {
+                Some(t.to_ascii_lowercase())
+            }
+        })
+        .collect()
+}
+
+/// Return ffmpeg input args for a resolved backend (`-hwaccel <name>`),
+/// or an empty list for CPU decode. Always emitted before `-i`.
+#[must_use]
+pub fn input_args(resolved: Option<HwAccelMode>) -> Vec<String> {
+    let Some(mode) = resolved else {
+        return Vec::new();
+    };
+    let Some(name) = mode.ffmpeg_name() else {
+        return Vec::new();
+    };
+    vec!["-hwaccel".to_string(), name.to_string()]
+}
+
+/// Return true if `line` is benign HW-vendor diagnostic output that should
+/// not count as a verification error.
+///
+/// Hardware decoders surface a handful of `-v error` level messages that
+/// don't indicate corruption — context-init churn, fallback notices,
+/// per-frame format warnings. Counting these as decode errors would turn
+/// every HW-accelerated thorough run into a false-positive. The list
+/// below is intentionally conservative: only patterns that are
+/// independent of the file under test are filtered.
+#[must_use]
+pub fn is_hwaccel_noise(line: &str) -> bool {
+    let l = line.trim();
+    if l.is_empty() {
+        return true;
+    }
+    // Common HW-init diagnostics that ffmpeg emits before transparent
+    // CPU fallback.  None of these indicate a corrupt source.
+    const NOISE_FRAGMENTS: &[&str] = &[
+        "Failed setup for format",
+        "hwaccel initialisation returned error",
+        "No device available for decoder",
+        "Cannot load nvcuvid",
+        "Cannot load libcuda",
+        "Cannot allocate memory in static TLS block",
+        "Could not dynamically load CUDA",
+        "vaapi_hwaccel: Failed to initialise",
+        "qsv_hwaccel: Failed to initialise",
+        "Hardware does not support accelerated",
+    ];
+    NOISE_FRAGMENTS.iter().any(|frag| l.contains(frag))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_none_and_auto() {
+        assert_eq!(HwAccelMode::parse("none"), Some(HwAccelMode::None));
+        assert_eq!(HwAccelMode::parse(""), Some(HwAccelMode::None));
+        assert_eq!(HwAccelMode::parse("auto"), Some(HwAccelMode::Auto));
+        assert_eq!(HwAccelMode::parse("AUTO"), Some(HwAccelMode::Auto));
+        assert_eq!(HwAccelMode::parse(" auto "), Some(HwAccelMode::Auto));
+    }
+
+    #[test]
+    fn parse_explicit_backends() {
+        assert_eq!(HwAccelMode::parse("nvdec"), Some(HwAccelMode::Nvdec));
+        assert_eq!(HwAccelMode::parse("cuda"), Some(HwAccelMode::Nvdec));
+        assert_eq!(HwAccelMode::parse("VAAPI"), Some(HwAccelMode::Vaapi));
+        assert_eq!(HwAccelMode::parse("qsv"), Some(HwAccelMode::Qsv));
+        assert_eq!(
+            HwAccelMode::parse("videotoolbox"),
+            Some(HwAccelMode::Videotoolbox)
+        );
+    }
+
+    #[test]
+    fn parse_unknown_returns_none() {
+        assert_eq!(HwAccelMode::parse("d3d11va"), None);
+        assert_eq!(HwAccelMode::parse("opencl"), None);
+    }
+
+    #[test]
+    fn ffmpeg_name_maps_correctly() {
+        assert_eq!(HwAccelMode::Nvdec.ffmpeg_name(), Some("cuda"));
+        assert_eq!(HwAccelMode::Vaapi.ffmpeg_name(), Some("vaapi"));
+        assert_eq!(HwAccelMode::Qsv.ffmpeg_name(), Some("qsv"));
+        assert_eq!(
+            HwAccelMode::Videotoolbox.ffmpeg_name(),
+            Some("videotoolbox")
+        );
+        assert!(HwAccelMode::None.ffmpeg_name().is_none());
+        assert!(HwAccelMode::Auto.ffmpeg_name().is_none());
+    }
+
+    #[test]
+    fn resolve_none_disables() {
+        let probed = vec!["cuda".into(), "vaapi".into()];
+        assert!(resolve(HwAccelMode::None, &probed).is_none());
+    }
+
+    #[test]
+    fn resolve_auto_prefers_cuda() {
+        let probed = vec!["cuda".into(), "vaapi".into()];
+        assert_eq!(
+            resolve(HwAccelMode::Auto, &probed),
+            Some(HwAccelMode::Nvdec)
+        );
+    }
+
+    #[test]
+    fn resolve_auto_falls_through_priority() {
+        let probed = vec!["vaapi".into(), "qsv".into()];
+        assert_eq!(resolve(HwAccelMode::Auto, &probed), Some(HwAccelMode::Qsv));
+    }
+
+    #[test]
+    fn resolve_auto_picks_videotoolbox() {
+        let probed = vec!["videotoolbox".into()];
+        assert_eq!(
+            resolve(HwAccelMode::Auto, &probed),
+            Some(HwAccelMode::Videotoolbox)
+        );
+    }
+
+    #[test]
+    fn resolve_auto_empty_returns_none() {
+        let probed: Vec<String> = vec![];
+        assert!(resolve(HwAccelMode::Auto, &probed).is_none());
+    }
+
+    #[test]
+    fn resolve_explicit_match_returns_self() {
+        let probed = vec!["cuda".into()];
+        assert_eq!(
+            resolve(HwAccelMode::Nvdec, &probed),
+            Some(HwAccelMode::Nvdec)
+        );
+    }
+
+    #[test]
+    fn resolve_explicit_missing_falls_back_to_cpu() {
+        let probed = vec!["vaapi".into()];
+        // User asked for nvdec but ffmpeg has only vaapi → CPU.
+        assert!(resolve(HwAccelMode::Nvdec, &probed).is_none());
+    }
+
+    #[test]
+    fn resolve_is_case_insensitive_against_probed_list() {
+        let probed = vec!["CUDA".into()];
+        assert_eq!(
+            resolve(HwAccelMode::Nvdec, &probed),
+            Some(HwAccelMode::Nvdec)
+        );
+    }
+
+    #[test]
+    fn parse_hwaccels_handles_typical_output() {
+        let stdout = b"Hardware acceleration methods:\ncuda\nvaapi\nvideotoolbox\n";
+        let parsed = parse_hwaccels(stdout);
+        assert_eq!(parsed, vec!["cuda", "vaapi", "videotoolbox"]);
+    }
+
+    #[test]
+    fn parse_hwaccels_lower_cases() {
+        let stdout = b"Hardware acceleration methods:\nCUDA\nVAAPI\n";
+        let parsed = parse_hwaccels(stdout);
+        assert_eq!(parsed, vec!["cuda", "vaapi"]);
+    }
+
+    #[test]
+    fn parse_hwaccels_skips_blank_lines() {
+        let stdout = b"Hardware acceleration methods:\n\ncuda\n\nvaapi\n";
+        let parsed = parse_hwaccels(stdout);
+        assert_eq!(parsed, vec!["cuda", "vaapi"]);
+    }
+
+    #[test]
+    fn parse_hwaccels_without_header_is_empty() {
+        let stdout = b"unrelated banner\nstuff\n";
+        assert!(parse_hwaccels(stdout).is_empty());
+    }
+
+    #[test]
+    fn input_args_for_cpu_is_empty() {
+        assert!(input_args(None).is_empty());
+        assert!(input_args(Some(HwAccelMode::None)).is_empty());
+        assert!(input_args(Some(HwAccelMode::Auto)).is_empty());
+    }
+
+    #[test]
+    fn input_args_emit_hwaccel_flag() {
+        assert_eq!(
+            input_args(Some(HwAccelMode::Nvdec)),
+            vec!["-hwaccel", "cuda"]
+        );
+        assert_eq!(
+            input_args(Some(HwAccelMode::Vaapi)),
+            vec!["-hwaccel", "vaapi"]
+        );
+        assert_eq!(input_args(Some(HwAccelMode::Qsv)), vec!["-hwaccel", "qsv"]);
+        assert_eq!(
+            input_args(Some(HwAccelMode::Videotoolbox)),
+            vec!["-hwaccel", "videotoolbox"]
+        );
+    }
+
+    #[test]
+    fn noise_filter_matches_known_patterns() {
+        assert!(is_hwaccel_noise(
+            "[h264 @ 0x55] Failed setup for format cuda: hwaccel initialisation returned error"
+        ));
+        assert!(is_hwaccel_noise("Cannot load nvcuvid"));
+        assert!(is_hwaccel_noise(
+            "[hevc @ 0x42] No device available for decoder"
+        ));
+        assert!(is_hwaccel_noise(
+            "Hardware does not support accelerated decoding"
+        ));
+    }
+
+    #[test]
+    fn noise_filter_rejects_real_decode_errors() {
+        assert!(!is_hwaccel_noise(
+            "[matroska,webm @ 0x55] Truncated packet, error in reference frame"
+        ));
+        assert!(!is_hwaccel_noise(
+            "[h264 @ 0x42] error while decoding MB 100 50, bytestream"
+        ));
+        assert!(!is_hwaccel_noise(
+            "Invalid data found when processing input"
+        ));
+    }
+
+    #[test]
+    fn noise_filter_treats_blank_lines_as_noise() {
+        assert!(is_hwaccel_noise(""));
+        assert!(is_hwaccel_noise("   "));
+    }
+}

--- a/plugins/verifier/src/lib.rs
+++ b/plugins/verifier/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub mod config;
 pub mod hash;
+pub mod hwaccel;
 pub mod quarantine;
 pub mod quick;
 pub mod thorough;
@@ -70,6 +71,27 @@ impl VerifierPlugin {
         &self.config
     }
 
+    /// Resolve `thorough_hw_accel` from config to a concrete decode backend.
+    ///
+    /// Returns `None` for CPU decode (default, unrecognised values, or
+    /// when the configured backend isn't advertised by the local ffmpeg).
+    fn resolve_thorough_hw_accel(&self) -> Option<hwaccel::HwAccelMode> {
+        let mode =
+            hwaccel::HwAccelMode::parse(&self.config.thorough_hw_accel).unwrap_or_else(|| {
+                tracing::warn!(
+                    value = self.config.thorough_hw_accel.as_str(),
+                    "unrecognised thorough_hw_accel value (valid: none, auto, nvdec, \
+                     vaapi, qsv, videotoolbox); falling back to CPU"
+                );
+                hwaccel::HwAccelMode::None
+            });
+        if matches!(mode, hwaccel::HwAccelMode::None) {
+            return None;
+        }
+        let probed = hwaccel::probe_hwaccels(&self.config.ffmpeg_path);
+        hwaccel::resolve(mode, &probed)
+    }
+
     fn handle_verify_plan(&self, plan: &Plan) -> Result<Option<EventResult>> {
         let Some(action) = plan.actions.first() else {
             return Ok(None);
@@ -99,7 +121,14 @@ impl VerifierPlugin {
                     self.config.thorough_timeout_multiplier,
                     self.config.thorough_timeout_floor_secs,
                 );
-                thorough::run_thorough(&file_id, &path, &self.config.ffmpeg_path, timeout)?
+                let hw_accel = self.resolve_thorough_hw_accel();
+                thorough::run_thorough(
+                    &file_id,
+                    &path,
+                    &self.config.ffmpeg_path,
+                    timeout,
+                    hw_accel,
+                )?
             }
             VerificationMode::Hash => {
                 let prior = store.latest_verification(&file_id, VerificationMode::Hash)?;
@@ -261,6 +290,22 @@ mod tests {
         assert_eq!(cfg.ffprobe_path, "ffprobe");
         assert_eq!(cfg.ffmpeg_path, "ffmpeg");
         assert!(cfg.quarantine_dir.is_none());
+        assert_eq!(cfg.thorough_hw_accel, "none");
+    }
+
+    #[test]
+    fn resolve_thorough_hw_accel_none_short_circuits() {
+        // Default config carries thorough_hw_accel = "none"; resolving
+        // must not invoke ffmpeg (which may be absent in the test env).
+        let p = VerifierPlugin::new();
+        assert!(p.resolve_thorough_hw_accel().is_none());
+    }
+
+    #[test]
+    fn resolve_thorough_hw_accel_invalid_falls_back_to_cpu() {
+        let mut p = VerifierPlugin::new();
+        p.config.thorough_hw_accel = "garbage".into();
+        assert!(p.resolve_thorough_hw_accel().is_none());
     }
 
     #[test]

--- a/plugins/verifier/src/thorough.rs
+++ b/plugins/verifier/src/thorough.rs
@@ -2,6 +2,12 @@
 //!
 //! Runs `ffmpeg -v error -i <file> -f null -` and counts error/warning lines
 //! on stderr. Detects truncated streams, packet errors, decode failures.
+//!
+//! Optionally accepts a resolved HW decode backend (NVDEC/VAAPI/QSV/
+//! VideoToolbox) which prepends `-hwaccel <name>` before `-i`. When HW
+//! decode is in use, vendor diagnostic lines are filtered out before
+//! counting errors so transparent CPU fallback inside ffmpeg doesn't show
+//! up as decode failures.
 
 use std::path::Path;
 use std::time::Duration;
@@ -12,9 +18,15 @@ use uuid::Uuid;
 use voom_domain::errors::{Result, VoomError};
 use voom_domain::verification::{VerificationMode, VerificationOutcome, VerificationRecord};
 
+use crate::hwaccel::{self, HwAccelMode};
 use crate::util::truncate;
 
 /// Run thorough verification on `path`. `timeout` is the absolute kill-after.
+///
+/// `hw_accel` pins a resolved decode backend (`None` ⇒ CPU). The caller is
+/// responsible for resolving the backend against `ffmpeg -hwaccels`; this
+/// function trusts the input and only emits the corresponding `-hwaccel`
+/// arg.
 ///
 /// # Errors
 /// Returns an error if the tool cannot be invoked or times out.
@@ -23,15 +35,24 @@ pub fn run_thorough(
     path: &Path,
     ffmpeg_path: &str,
     timeout: Duration,
+    hw_accel: Option<HwAccelMode>,
 ) -> Result<VerificationRecord> {
     let path_str = path.to_str().ok_or_else(|| VoomError::ToolExecution {
         tool: "ffmpeg".into(),
         message: format!("path is not valid UTF-8: {}", path.display()),
     })?;
-    let args: Vec<std::ffi::OsString> = ["-v", "error", "-i", path_str, "-f", "null", "-"]
-        .iter()
-        .map(std::ffi::OsString::from)
-        .collect();
+
+    let mut args: Vec<std::ffi::OsString> = Vec::with_capacity(8);
+    args.push("-v".into());
+    args.push("error".into());
+    for arg in hwaccel::input_args(hw_accel) {
+        args.push(arg.into());
+    }
+    args.push("-i".into());
+    args.push(path_str.into());
+    args.push("-f".into());
+    args.push("null".into());
+    args.push("-".into());
 
     let started = Utc::now();
     let output = voom_process::run_with_timeout(ffmpeg_path, &args, timeout).map_err(|e| {
@@ -42,7 +63,8 @@ pub fn run_thorough(
     })?;
 
     let stderr = String::from_utf8_lossy(&output.stderr);
-    let (error_count, warning_count) = classify_lines(&stderr);
+    let hw_active = hw_accel.is_some();
+    let (error_count, warning_count) = classify_lines(&stderr, hw_active);
     let outcome = if !output.status.success() || error_count > 0 {
         VerificationOutcome::Error
     } else if warning_count > 0 {
@@ -74,10 +96,18 @@ pub fn run_thorough(
 /// line per problem. We treat every non-empty line as an error; `-v error`
 /// already filters out warnings, so the warning count is zero unless the
 /// caller bumps verbosity. (Kept for symmetry with the schema.)
-fn classify_lines(stderr: &str) -> (u32, u32) {
-    let errors: u32 =
-        u32::try_from(stderr.lines().filter(|l| !l.trim().is_empty()).count()).unwrap_or(u32::MAX);
-    (errors, 0)
+///
+/// When `hw_active` is true, lines matching known HW-vendor diagnostic
+/// patterns (init churn, transparent CPU fallback notices) are dropped
+/// before counting so a successful HW-accelerated decode isn't reported
+/// as an error.
+fn classify_lines(stderr: &str, hw_active: bool) -> (u32, u32) {
+    let errors = stderr
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .filter(|l| !(hw_active && hwaccel::is_hwaccel_noise(l)))
+        .count();
+    (u32::try_from(errors).unwrap_or(u32::MAX), 0)
 }
 
 /// Compute a thorough-mode timeout from a known duration.
@@ -105,15 +135,32 @@ mod tests {
 
     #[test]
     fn classify_counts_lines() {
-        let (e, w) = classify_lines("a\nb\nc\n");
+        let (e, w) = classify_lines("a\nb\nc\n", false);
         assert_eq!(e, 3);
         assert_eq!(w, 0);
     }
 
     #[test]
     fn classify_ignores_blank_lines() {
-        let (e, _) = classify_lines("\n\n");
+        let (e, _) = classify_lines("\n\n", false);
         assert_eq!(e, 0);
+    }
+
+    #[test]
+    fn classify_filters_hw_noise_when_active() {
+        let stderr = "Failed setup for format cuda: hwaccel initialisation returned error\n\
+                      [matroska,webm @ 0x55] Truncated packet\n";
+        let (e_hw, _) = classify_lines(stderr, true);
+        let (e_cpu, _) = classify_lines(stderr, false);
+        assert_eq!(e_hw, 1, "hw-active mode drops the init-error line");
+        assert_eq!(e_cpu, 2, "cpu mode counts both lines");
+    }
+
+    #[test]
+    fn classify_keeps_real_errors_under_hw() {
+        let stderr = "[h264 @ 0x42] error while decoding MB 100 50, bytestream\n";
+        let (e_hw, _) = classify_lines(stderr, true);
+        assert_eq!(e_hw, 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds opt-in HW decode (NVDEC, VAAPI, QSV, VideoToolbox) to `voom verify run --thorough`, gated behind `--hw-accel` and the `[plugin.verifier] thorough_hw_accel` config key. Default remains CPU.
- Probes `ffmpeg -hwaccels` once per run; backends configured but not advertised by local ffmpeg fall back to CPU with a user-visible warning.
- Thorough-mode error classifier filters known HW-vendor diagnostic patterns so clean files don't report as errors during HW-accelerated decode.

Decode-only logic lives in the verifier crate to avoid coupling to voom-ffmpeg-executor (encoder-side). The module is small and self-contained — can move to a shared crate later if other consumers need it.

Closes #246

## Test plan

- [ ] `cargo test -p voom-verifier` passes
- [ ] `voom verify run --thorough --hw-accel` falls back gracefully on hosts without HW decode support
- [ ] Existing CPU-only thorough mode unchanged when `--hw-accel` is not set

---

Recovery context: this PR was opened by the Mayor after polecat/quartz hit a credential gap during `gt done`. Commit and branch are unmodified from the polecat's work.