### PR TITLE
feat(domain): lift parse_since to voom-domain (closes #249)

### DIFF
--- a/crates/voom-cli/src/commands/env.rs
+++ b/crates/voom-cli/src/commands/env.rs
@@ -9,10 +9,10 @@ use voom_ffmpeg_executor::probe::{
 
 use crate::app;
 use crate::cli::{EnvCommands, OutputFormat};
-use crate::commands::since::parse_absolute_since;
 use crate::config;
 use crate::output::sanitize_for_display;
 use crate::tools::print_tool_status;
+use voom_domain::utils::since::parse_since;
 
 mod retention_coverage {
     use chrono::{DateTime, Duration, Utc};
@@ -417,7 +417,7 @@ fn history(
     limit: u32,
     format: OutputFormat,
 ) -> Result<()> {
-    let since_dt = since.map(|s| parse_absolute_since(&s)).transpose()?;
+    let since_dt = since.map(|s| parse_since(&s)).transpose()?;
 
     let mut filters = HealthCheckFilters::default();
     filters.check_name = check_name;

--- a/crates/voom-cli/src/commands/mod.rs
+++ b/crates/voom-cli/src/commands/mod.rs
@@ -16,6 +16,5 @@ pub mod process;
 pub mod report;
 pub mod scan;
 pub mod serve;
-pub mod since;
 pub mod tools;
 pub mod verify;

--- a/crates/voom-cli/src/commands/verify.rs
+++ b/crates/voom-cli/src/commands/verify.rs
@@ -21,8 +21,8 @@ use voom_verifier::VerifierConfig;
 
 use crate::app;
 use crate::cli::{HwAccelArg, OutputFormat, VerifyArgs, VerifyCommands, VerifyReportArgs};
-use crate::commands::since::parse_since;
 use crate::config::{self, AppConfig};
+use voom_domain::utils::since::parse_since;
 
 /// Top-level dispatcher for `voom verify <subcommand>`.
 ///

--- a/crates/voom-cli/tests/functional_tests.rs
+++ b/crates/voom-cli/tests/functional_tests.rs
@@ -1761,6 +1761,18 @@ mod test_health {
                 "No environment check records found.",
             ));
     }
+
+    #[test]
+    fn health_history_accepts_relative_since() {
+        let env = TestEnv::new();
+        env.voom()
+            .args(["env", "history", "--since", "7d"])
+            .assert()
+            .success()
+            .stderr(predicate::str::contains(
+                "No environment check records found.",
+            ));
+    }
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/crates/voom-domain/src/utils/mod.rs
+++ b/crates/voom-domain/src/utils/mod.rs
@@ -4,3 +4,4 @@ pub mod format;
 pub mod language;
 pub mod normalize;
 pub mod sanitize;
+pub mod since;

--- a/crates/voom-domain/src/utils/since.rs
+++ b/crates/voom-domain/src/utils/since.rs
@@ -1,36 +1,42 @@
-//! Parse `--since` arguments — relative durations or absolute datetimes.
+//! Parse `--since` arguments as relative durations or absolute datetimes.
 
-use anyhow::{anyhow, Result};
 use chrono::{DateTime, Duration, NaiveDate, NaiveDateTime, TimeZone, Utc};
+
+#[derive(Debug, thiserror::Error)]
+pub enum SinceParseError {
+    #[error("invalid --since '{0}': expected 30d, 4w, 12h, or YYYY-MM-DD")]
+    Invalid(String),
+    #[error("invalid datetime '{0}': expected YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS")]
+    InvalidAbsolute(String),
+}
 
 /// Parse `30d` / `4w` / `12h` / `2026-01-15` / `2026-01-15T10:30:00`
 /// into a UTC `DateTime`. Relative forms are subtracted from "now".
 ///
 /// # Errors
 /// Returns an error if the input doesn't match any supported format.
-pub fn parse_since(s: &str) -> Result<DateTime<Utc>> {
+pub fn parse_since(s: &str) -> Result<DateTime<Utc>, SinceParseError> {
     if let Some(dt) = parse_relative(s) {
         return Ok(dt);
     }
-    parse_absolute_since(s)
-        .map_err(|_| anyhow!("invalid --since '{s}': expected `30d`, `4w`, `12h`, or YYYY-MM-DD"))
+    parse_absolute_since(s).map_err(|_| SinceParseError::Invalid(s.to_string()))
 }
 
 /// Parse `2026-01-15` / `2026-01-15T10:30:00` into a UTC `DateTime`.
 ///
 /// # Errors
 /// Returns an error if the input is not an absolute date or datetime.
-pub fn parse_absolute_since(s: &str) -> Result<DateTime<Utc>> {
+pub fn parse_absolute_since(s: &str) -> Result<DateTime<Utc>, SinceParseError> {
     if let Ok(ndt) = NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S") {
         return Ok(Utc.from_utc_datetime(&ndt));
     }
     if let Ok(nd) = NaiveDate::parse_from_str(s, "%Y-%m-%d") {
-        let ndt = nd.and_hms_opt(0, 0, 0).expect("midnight is always valid");
+        let Some(ndt) = nd.and_hms_opt(0, 0, 0) else {
+            return Err(SinceParseError::InvalidAbsolute(s.to_string()));
+        };
         return Ok(Utc.from_utc_datetime(&ndt));
     }
-    Err(anyhow!(
-        "invalid datetime '{s}': expected YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS"
-    ))
+    Err(SinceParseError::InvalidAbsolute(s.to_string()))
 }
 
 fn parse_relative(s: &str) -> Option<DateTime<Utc>> {
@@ -96,6 +102,6 @@ mod tests {
     fn rejects_garbage() {
         assert!(parse_since("nonsense").is_err());
         assert!(parse_since("").is_err());
-        assert!(parse_since("d30").is_err()); // unit before number
+        assert!(parse_since("d30").is_err());
     }
 }

--- a/plugins/web-server/src/api/verify.rs
+++ b/plugins/web-server/src/api/verify.rs
@@ -4,6 +4,7 @@ use axum::extract::{Path, Query, State};
 use axum::Json;
 use serde::Deserialize;
 
+use voom_domain::utils::since::parse_since;
 use voom_domain::verification::{
     IntegritySummary, VerificationFilters, VerificationMode, VerificationOutcome,
     VerificationRecord,
@@ -24,6 +25,7 @@ const INTEGRITY_STALE_DAYS: i64 = 30;
 pub struct VerifyQueryParams {
     pub mode: Option<String>,
     pub outcome: Option<String>,
+    pub since: Option<String>,
     pub limit: Option<u32>,
 }
 
@@ -32,9 +34,8 @@ pub struct VerifyQueryParams {
 /// Query parameters:
 /// - `mode` -- one of `quick`, `thorough`, `hash`
 /// - `outcome` -- one of `ok`, `warning`, `error`
+/// - `since` -- `30d`, `4w`, `12h`, `YYYY-MM-DD`, or `YYYY-MM-DDTHH:MM:SS`
 /// - `limit` -- max records to return (default 100, capped at 10_000)
-///
-/// `since`-style filtering is not yet exposed via the web API; see issue #196.
 #[tracing::instrument(skip(state))]
 pub async fn list_verifications(
     State(state): State<AppState>,
@@ -60,10 +61,17 @@ pub async fn list_verifications(
     let limit = params
         .limit
         .map_or(DEFAULT_VERIFY_LIMIT, |l| l.min(MAX_VERIFY_LIMIT));
+    let since = params
+        .since
+        .as_deref()
+        .map(parse_since)
+        .transpose()
+        .map_err(|e| WebError::BadRequest(e.to_string()))?;
 
     let mut filters = VerificationFilters::default();
     filters.mode = mode;
     filters.outcome = outcome;
+    filters.since = since;
     filters.limit = Some(limit);
 
     let records = spawn_store_op(move || store.list_verifications(&filters)).await?;
@@ -107,15 +115,18 @@ mod tests {
         let params: VerifyQueryParams = serde_json::from_str("{}").unwrap();
         assert!(params.mode.is_none());
         assert!(params.outcome.is_none());
+        assert!(params.since.is_none());
         assert!(params.limit.is_none());
     }
 
     #[test]
     fn verify_query_params_deserialize_with_values() {
         let params: VerifyQueryParams =
-            serde_json::from_str(r#"{"mode":"hash","outcome":"ok","limit":50}"#).unwrap();
+            serde_json::from_str(r#"{"mode":"hash","outcome":"ok","since":"7d","limit":50}"#)
+                .unwrap();
         assert_eq!(params.mode.as_deref(), Some("hash"));
         assert_eq!(params.outcome.as_deref(), Some("ok"));
+        assert_eq!(params.since.as_deref(), Some("7d"));
         assert_eq!(params.limit, Some(50));
     }
 }

--- a/plugins/web-server/tests/api_tests.rs
+++ b/plugins/web-server/tests/api_tests.rs
@@ -34,6 +34,24 @@ fn make_verification(file_id: Uuid, outcome: VerificationOutcome) -> Verificatio
     )
 }
 
+fn make_verification_at(
+    file_id: Uuid,
+    outcome: VerificationOutcome,
+    verified_at: chrono::DateTime<chrono::Utc>,
+) -> VerificationRecord {
+    VerificationRecord::new(
+        Uuid::new_v4(),
+        file_id.to_string(),
+        verified_at,
+        VerificationMode::Hash,
+        outcome,
+        u32::from(outcome == VerificationOutcome::Error),
+        0,
+        Some("abc123".into()),
+        Some("verification details".into()),
+    )
+}
+
 fn make_server(store: InMemoryStore) -> TestServer {
     make_server_with_auth(store, None)
 }
@@ -815,6 +833,41 @@ async fn test_list_verifications_accepts_valid_filters() {
     resp.assert_status_ok();
     let body: serde_json::Value = resp.json();
     assert_eq!(body, json!([]));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_verifications_filters_by_relative_since() {
+    let recent_id = Uuid::new_v4();
+    let old_id = Uuid::new_v4();
+    let store = InMemoryStore::new()
+        .with_verification(make_verification_at(
+            recent_id,
+            VerificationOutcome::Ok,
+            chrono::Utc::now() - chrono::Duration::days(2),
+        ))
+        .with_verification(make_verification_at(
+            old_id,
+            VerificationOutcome::Ok,
+            chrono::Utc::now() - chrono::Duration::days(10),
+        ));
+    let server = make_server(store);
+
+    let resp = server.get("/api/verify?since=7d").await;
+
+    resp.assert_status_ok();
+    let body: serde_json::Value = resp.json();
+    let records = body.as_array().unwrap();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0]["file_id"], recent_id.to_string());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_verifications_rejects_invalid_since() {
+    let server = make_server(InMemoryStore::new());
+
+    let resp = server.get("/api/verify?since=garbage").await;
+
+    resp.assert_status_bad_request();
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Summary

Lifts `parse_since` (and `parse_absolute_since`) into `voom-domain::utils::since` so both `voom-cli` and `voom-web-server` can share it. Wires `/api/verify?since=…` and gives `voom env history --since 30d` the relative-duration support that previously only worked in CLI verify.

- New `crates/voom-domain/src/utils/since.rs` exporting `parse_since`, `parse_absolute_since`, and a `SinceParseError` thiserror enum (replaces the old `anyhow::Result` shape so non-CLI callers can map to their own error type)
- `crates/voom-cli/src/commands/verify.rs` and `env.rs` updated to import from `voom_domain::utils::since`; old `voom-cli/src/commands/since.rs` removed
- `plugins/web-server/src/api/verify.rs` adds `since: Option<String>` to `VerifyQueryParams`, parses it, maps `SinceParseError → WebError::BadRequest`, sets `filters.since`
- Tests: parser tests live with the parser in voom-domain; new web integration test for `/api/verify?since=…` (good + bad input); new CLI test for `voom env history --since 30d`

Closes #249

## Test plan

- [ ] `cargo test -p voom-domain -p voom-cli -p voom-web-server` passes
- [ ] `curl /api/verify?since=7d` returns only records newer than the cutoff; `curl /api/verify?since=garbage` returns 400
- [ ] `voom env history --since 30d` and `voom env history --since 2026-01-15` both work

---

Recovery context: opened by the Mayor — Codex polecat (voom/obsidian) implemented the plan and committed `4b53c7e` but its session ended before `gt done` ran (push/PR/MQ chain). Mayor pushed the branch via SSH, submitted MR `vo-wisp-47m`, and opened this PR. Branch and commit are unmodified from the polecat's work.