### PR TITLE
feat(storage): batch due-verification lookup (closes #250)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,6 +350,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e93abca9e28e0a1b9877922aacb20576e05d4679ffa78c3d6dc22a26a216659"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -406,6 +418,33 @@ dependencies = [
  "parse-zoneinfo",
  "phf",
  "phf_codegen",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -656,6 +695,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
+dependencies = [
+ "cast",
+ "itertools 0.13.0",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,6 +774,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1169,6 +1247,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1528,6 +1617,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1814,6 +1912,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1961,6 +2065,34 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -2931,6 +3063,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3630,6 +3772,7 @@ name = "voom-sqlite-store"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "criterion",
  "insta",
  "r2d2",
  "r2d2_sqlite",
@@ -4031,7 +4174,7 @@ dependencies = [
  "cranelift-frontend",
  "cranelift-native",
  "gimli",
- "itertools",
+ "itertools 0.12.1",
  "log",
  "object 0.36.7",
  "smallvec",

--- a/crates/voom-cli/src/commands/verify.rs
+++ b/crates/voom-cli/src/commands/verify.rs
@@ -12,7 +12,7 @@ use chrono::{DateTime, Utc};
 use console::style;
 use rayon::prelude::*;
 
-use voom_domain::storage::{FileFilters, StorageTrait};
+use voom_domain::storage::StorageTrait;
 use voom_domain::verification::{
     VerificationFilters, VerificationMode, VerificationOutcome, VerificationRecord,
 };
@@ -158,26 +158,15 @@ fn resolve_due_targets(
         parse_since(&args.since).context("parsing --since")?
     };
 
-    let files = store.list_files(&FileFilters::default())?;
-    let mut out = Vec::new();
-    for f in files {
-        let mut latest_filters = VerificationFilters::default();
-        latest_filters.file_id = Some(f.id.to_string());
-        latest_filters.limit = Some(1);
-        let latest = store.list_verifications(&latest_filters)?;
-        let needs = match latest.first() {
-            Some(rec) => rec.verified_at < cutoff,
-            None => true,
-        };
-        if needs {
-            out.push(VerifyTarget {
-                file_id: f.id.to_string(),
-                path: f.path.clone(),
-                duration: Some(f.duration),
-            });
-        }
-    }
-    Ok(out)
+    Ok(store
+        .list_files_due_for_verification(cutoff)?
+        .into_iter()
+        .map(|f| VerifyTarget {
+            file_id: f.id.to_string(),
+            path: f.path,
+            duration: Some(f.duration),
+        })
+        .collect())
 }
 
 /// Minimal input for a parallel quick-verify pass.
@@ -404,4 +393,71 @@ fn run_report(args: VerifyReportArgs) -> Result<()> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use voom_domain::media::MediaFile;
+    use voom_domain::test_support::InMemoryStore;
+
+    fn verify_args() -> VerifyArgs {
+        VerifyArgs {
+            paths: Vec::new(),
+            thorough: false,
+            hash: false,
+            since: "30d".to_string(),
+            all: false,
+            workers: 0,
+            hw_accel: None,
+            format: None,
+        }
+    }
+
+    #[test]
+    fn resolve_due_targets_returns_never_verified_and_stale_files() {
+        let cutoff = Utc::now() - chrono::Duration::days(30);
+        let never_file = MediaFile::new(PathBuf::from("/media/never.mkv"));
+        let stale_file = MediaFile::new(PathBuf::from("/media/stale.mkv"));
+        let fresh_file = MediaFile::new(PathBuf::from("/media/fresh.mkv"));
+        let never_id = never_file.id.to_string();
+        let stale_id = stale_file.id.to_string();
+        let fresh_id = fresh_file.id.to_string();
+        let store: Arc<dyn StorageTrait> = Arc::new(
+            InMemoryStore::new()
+                .with_file(never_file)
+                .with_file(stale_file)
+                .with_file(fresh_file)
+                .with_verification(VerificationRecord::new(
+                    uuid::Uuid::new_v4(),
+                    stale_id.clone(),
+                    cutoff - chrono::Duration::days(1),
+                    VerificationMode::Quick,
+                    VerificationOutcome::Ok,
+                    0,
+                    0,
+                    None,
+                    None,
+                ))
+                .with_verification(VerificationRecord::new(
+                    uuid::Uuid::new_v4(),
+                    fresh_id,
+                    cutoff + chrono::Duration::days(1),
+                    VerificationMode::Quick,
+                    VerificationOutcome::Ok,
+                    0,
+                    0,
+                    None,
+                    None,
+                )),
+        );
+
+        let targets = resolve_due_targets(&store, &verify_args()).expect("resolve targets");
+        let mut target_ids: Vec<_> = targets.into_iter().map(|target| target.file_id).collect();
+        target_ids.sort();
+        let mut expected = vec![never_id, stale_id];
+        expected.sort();
+
+        assert_eq!(target_ids, expected);
+    }
 }

--- a/crates/voom-domain/src/storage.rs
+++ b/crates/voom-domain/src/storage.rs
@@ -552,6 +552,13 @@ pub trait VerificationStorage: Send + Sync {
         mode: crate::verification::VerificationMode,
     ) -> Result<Option<crate::verification::VerificationRecord>>;
 
+    /// List active files whose latest verification is older than `cutoff`, or
+    /// which have never been verified.
+    fn list_files_due_for_verification(
+        &self,
+        cutoff: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Vec<crate::media::MediaFile>>;
+
     /// Aggregate integrity summary. `since` is the cutoff for "stale" — files
     /// last verified before this timestamp are counted in `stale`.
     fn integrity_summary(

--- a/crates/voom-domain/src/test_support.rs
+++ b/crates/voom-domain/src/test_support.rs
@@ -837,6 +837,33 @@ impl crate::storage::VerificationStorage for InMemoryStore {
         Ok(self.list_verifications(&filters)?.into_iter().next())
     }
 
+    fn list_files_due_for_verification(
+        &self,
+        cutoff: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Vec<MediaFile>> {
+        let files = self.files.lock();
+        let verifications = self.verifications.lock();
+        let mut due: Vec<MediaFile> = files
+            .values()
+            .filter(|file| file.status == FileStatus::Active)
+            .filter(|file| {
+                let file_id = file.id.to_string();
+                verifications
+                    .iter()
+                    .filter(|record| record.file_id == file_id)
+                    .max_by(|a, b| {
+                        a.verified_at
+                            .cmp(&b.verified_at)
+                            .then_with(|| a.id.cmp(&b.id))
+                    })
+                    .is_none_or(|record| record.verified_at < cutoff)
+            })
+            .cloned()
+            .collect();
+        due.sort_by_key(|file| file.id);
+        Ok(due)
+    }
+
     fn integrity_summary(&self, since: chrono::DateTime<chrono::Utc>) -> Result<IntegritySummary> {
         let files = self.files.lock();
         let verifications = self.verifications.lock();
@@ -996,5 +1023,84 @@ mod oldest_at_tests {
                 .map(|t| t.timestamp_millis()),
             Some(a.created_at.timestamp_millis())
         );
+    }
+}
+
+#[cfg(test)]
+mod verification_storage_tests {
+    use super::*;
+    use crate::storage::{FileStorage, VerificationStorage};
+
+    fn media_file(path: &str) -> MediaFile {
+        MediaFile::new(PathBuf::from(path))
+    }
+
+    #[test]
+    fn list_files_due_for_verification_includes_never_verified_files() {
+        let file = media_file("/media/never.mkv");
+        let file_id = file.id;
+        let store = InMemoryStore::new().with_file(file);
+
+        let due = store
+            .list_files_due_for_verification(chrono::Utc::now())
+            .expect("due files");
+
+        assert_eq!(due.len(), 1);
+        assert_eq!(due[0].id, file_id);
+    }
+
+    #[test]
+    fn list_files_due_for_verification_filters_by_latest_verification() {
+        let cutoff = chrono::Utc::now() - chrono::Duration::days(30);
+        let stale_file = media_file("/media/stale.mkv");
+        let fresh_file = media_file("/media/fresh.mkv");
+        let stale_id = stale_file.id;
+        let fresh_id = fresh_file.id;
+        let store = InMemoryStore::new()
+            .with_file(stale_file)
+            .with_file(fresh_file)
+            .with_verification(VerificationRecord::new(
+                Uuid::new_v4(),
+                stale_id.to_string(),
+                cutoff - chrono::Duration::seconds(1),
+                VerificationMode::Quick,
+                VerificationOutcome::Ok,
+                0,
+                0,
+                None,
+                None,
+            ))
+            .with_verification(VerificationRecord::new(
+                Uuid::new_v4(),
+                fresh_id.to_string(),
+                cutoff + chrono::Duration::seconds(1),
+                VerificationMode::Quick,
+                VerificationOutcome::Ok,
+                0,
+                0,
+                None,
+                None,
+            ));
+
+        let due = store
+            .list_files_due_for_verification(cutoff)
+            .expect("due files");
+        let due_ids: Vec<_> = due.iter().map(|file| file.id).collect();
+
+        assert_eq!(due_ids, vec![stale_id]);
+    }
+
+    #[test]
+    fn list_files_due_for_verification_excludes_missing_files() {
+        let file = media_file("/media/missing.mkv");
+        let file_id = file.id;
+        let store = InMemoryStore::new().with_file(file);
+        store.mark_missing(&file_id).expect("mark missing");
+
+        let due = store
+            .list_files_due_for_verification(chrono::Utc::now())
+            .expect("due files");
+
+        assert!(due.is_empty());
     }
 }

--- a/plugins/sqlite-store/Cargo.toml
+++ b/plugins/sqlite-store/Cargo.toml
@@ -27,6 +27,11 @@ tracing = { workspace = true }
 workspace = true
 
 [dev-dependencies]
+criterion = "=0.7.0"
 insta = { workspace = true }
 tempfile = { workspace = true }
 voom-domain = { workspace = true, features = ["testing"] }
+
+[[bench]]
+name = "verification_due"
+harness = false

--- a/plugins/sqlite-store/benches/verification_due.rs
+++ b/plugins/sqlite-store/benches/verification_due.rs
@@ -1,0 +1,102 @@
+use std::path::PathBuf;
+
+use chrono::Utc;
+use criterion::{criterion_group, criterion_main, Criterion};
+use tempfile::TempDir;
+use uuid::Uuid;
+use voom_domain::media::MediaFile;
+use voom_domain::storage::{FileFilters, FileStorage, VerificationStorage};
+use voom_domain::verification::{
+    VerificationFilters, VerificationMode, VerificationOutcome, VerificationRecord,
+};
+use voom_sqlite_store::store::SqliteStore;
+
+fn seed_store(file_count: usize) -> (TempDir, SqliteStore) {
+    let dir = TempDir::new().expect("temp dir");
+    let store = SqliteStore::open(&dir.path().join("bench.sqlite")).expect("sqlite store");
+    let now = Utc::now();
+
+    for index in 0..file_count {
+        let mut file = MediaFile::new(PathBuf::from(format!("/media/file-{index:05}.mkv")));
+        file.size = index as u64;
+        file.duration = index as f64;
+        store.upsert_file(&file).expect("insert file");
+
+        if index % 2 == 0 {
+            let record = VerificationRecord::new(
+                Uuid::new_v4(),
+                file.id.to_string(),
+                now,
+                VerificationMode::Quick,
+                VerificationOutcome::Ok,
+                0,
+                0,
+                None,
+                None,
+            );
+            store
+                .insert_verification(&record)
+                .expect("insert verification");
+        }
+    }
+
+    (dir, store)
+}
+
+fn old_n_plus_one_due_files(
+    store: &SqliteStore,
+    cutoff: chrono::DateTime<Utc>,
+) -> Vec<(String, PathBuf, Option<f64>)> {
+    let files = store
+        .list_files(&FileFilters::default())
+        .expect("list files");
+    let mut due = Vec::new();
+    for file in files {
+        let mut filters = VerificationFilters::default();
+        filters.file_id = Some(file.id.to_string());
+        filters.limit = Some(1);
+        let latest = store
+            .list_verifications(&filters)
+            .expect("list verifications");
+        let needs_verification = latest
+            .first()
+            .is_none_or(|record| record.verified_at < cutoff);
+        if needs_verification {
+            due.push((file.id.to_string(), file.path, Some(file.duration)));
+        }
+    }
+    due
+}
+
+fn bench_due_file_listing(c: &mut Criterion) {
+    let (_dir, store) = seed_store(10_000);
+    let cutoff = Utc::now() - chrono::Duration::days(30);
+    let expected = old_n_plus_one_due_files(&store, cutoff).len();
+    assert_eq!(
+        expected,
+        store
+            .list_files_due_for_verification(cutoff)
+            .expect("list due files")
+            .len()
+    );
+
+    let mut group = c.benchmark_group("verification_due_10k");
+    group.sample_size(10);
+    group.bench_function("old_n_plus_one", |b| {
+        b.iter(|| {
+            old_n_plus_one_due_files(std::hint::black_box(&store), std::hint::black_box(cutoff))
+        });
+    });
+    group.bench_function("list_files_due_for_verification", |b| {
+        b.iter(|| {
+            store
+                .list_files_due_for_verification(std::hint::black_box(cutoff))
+                .expect("list due files")
+                .len()
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_due_file_listing);
+criterion_main!(benches);

--- a/plugins/sqlite-store/src/schema.rs
+++ b/plugins/sqlite-store/src/schema.rs
@@ -221,6 +221,7 @@ CREATE TABLE IF NOT EXISTS verifications (
 CREATE INDEX IF NOT EXISTS idx_verifications_file ON verifications(file_id);
 CREATE INDEX IF NOT EXISTS idx_verifications_outcome ON verifications(outcome);
 CREATE INDEX IF NOT EXISTS idx_verifications_time ON verifications(verified_at);
+CREATE INDEX IF NOT EXISTS idx_verifications_file_verified_at ON verifications(file_id, verified_at);
 ";
 
 /// Initialize the database schema.
@@ -477,7 +478,9 @@ fn migrate_missing_tables(conn: &Connection) -> rusqlite::Result<()> {
             );
             CREATE INDEX IF NOT EXISTS idx_verifications_file ON verifications(file_id);
             CREATE INDEX IF NOT EXISTS idx_verifications_outcome ON verifications(outcome);
-            CREATE INDEX IF NOT EXISTS idx_verifications_time ON verifications(verified_at);",
+            CREATE INDEX IF NOT EXISTS idx_verifications_time ON verifications(verified_at);
+            CREATE INDEX IF NOT EXISTS idx_verifications_file_verified_at \
+                ON verifications(file_id, verified_at);",
         )?;
     }
 
@@ -560,6 +563,18 @@ fn migrate_indexes_and_constraints(conn: &Connection) -> rusqlite::Result<()> {
         conn.execute_batch(
             "CREATE INDEX IF NOT EXISTS idx_transitions_created_at \
              ON file_transitions(created_at);",
+        )?;
+    }
+
+    let verifications_exists: bool = conn.query_row(
+        "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='verifications'",
+        [],
+        |row| row.get(0),
+    )?;
+    if verifications_exists && !has_index("idx_verifications_file_verified_at")? {
+        conn.execute_batch(
+            "CREATE INDEX IF NOT EXISTS idx_verifications_file_verified_at \
+             ON verifications(file_id, verified_at);",
         )?;
     }
 
@@ -1007,5 +1022,20 @@ mod tests {
             count >= 3,
             "expected at least 3 indexes on verifications, got {count}"
         );
+    }
+
+    #[test]
+    fn verification_latest_lookup_index_is_created() {
+        let conn = Connection::open_in_memory().unwrap();
+        create_schema(&conn).unwrap();
+        let exists: bool = conn
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM sqlite_master \
+                 WHERE type='index' AND name='idx_verifications_file_verified_at'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(exists);
     }
 }

--- a/plugins/sqlite-store/src/store/verification_storage.rs
+++ b/plugins/sqlite-store/src/store/verification_storage.rs
@@ -1,16 +1,18 @@
 //! `VerificationStorage` implementation backed by SQLite.
 
 use chrono::{DateTime, Utc};
-use rusqlite::params;
+use rusqlite::{params, Row};
 
 use voom_domain::errors::Result;
+use voom_domain::media::{Container, MediaFile};
 use voom_domain::storage::VerificationStorage;
+use voom_domain::transition::FileStatus;
 use voom_domain::verification::{
     IntegritySummary, VerificationFilters, VerificationMode, VerificationRecord,
 };
 
 use super::row_mappers::row_to_verification;
-use super::{format_datetime, storage_err, SqlQuery, SqliteStore};
+use super::{format_datetime, parse_datetime, storage_err, SqlQuery, SqliteStore};
 
 const SELECT_VERIFICATION: &str = "SELECT id, file_id, verified_at, mode, outcome, \
     error_count, warning_count, content_hash, details FROM verifications";
@@ -50,6 +52,41 @@ const INTEGRITY_HASH_MISMATCHES_SQL: &str = "SELECT COUNT(DISTINCT file_id) FROM
             ) AS rn \
         FROM verifications WHERE mode = 'hash' \
     ) WHERE rn = 1 AND prev_hash IS NOT NULL AND prev_hash <> content_hash";
+
+fn row_to_due_file(row: &Row<'_>) -> rusqlite::Result<MediaFile> {
+    let path: String = row.get("path")?;
+    let mut file = MediaFile::new(path.into());
+    let id: String = row.get("id")?;
+    file.id = super::parse_uuid(&id).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(
+            0,
+            rusqlite::types::Type::Text,
+            format!("invalid UUID in files: {id}: {e}").into(),
+        )
+    })?;
+    file.size = u64::try_from(row.get::<_, i64>("size")?.max(0)).unwrap_or(0);
+    file.content_hash = row
+        .get::<_, Option<String>>("content_hash")?
+        .filter(|value| !value.is_empty());
+    file.expected_hash = row.get("expected_hash")?;
+    let status: String = row.get("status")?;
+    file.status = FileStatus::parse(&status).unwrap_or_default();
+    let container: String = row.get("container")?;
+    file.container = Container::from_extension(&container);
+    file.duration = row.get::<_, Option<f64>>("duration")?.unwrap_or(0.0);
+    file.bitrate = row
+        .get::<_, Option<i32>>("bitrate")?
+        .and_then(|value| u32::try_from(value).ok());
+    let introspected_at: String = row.get("introspected_at")?;
+    file.introspected_at = parse_datetime(&introspected_at).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(
+            0,
+            rusqlite::types::Type::Text,
+            format!("corrupt datetime in files.introspected_at: {introspected_at}: {e}").into(),
+        )
+    })?;
+    Ok(file)
+}
 
 impl VerificationStorage for SqliteStore {
     fn insert_verification(&self, record: &VerificationRecord) -> Result<()> {
@@ -132,6 +169,36 @@ impl VerificationStorage for SqliteStore {
             )),
             None => Ok(None),
         }
+    }
+
+    fn list_files_due_for_verification(&self, cutoff: DateTime<Utc>) -> Result<Vec<MediaFile>> {
+        let conn = self.conn()?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT f.id, f.path, f.size, f.content_hash, f.expected_hash, f.status, \
+                    f.container, f.duration, f.bitrate, f.tags, f.plugin_metadata, \
+                    f.introspected_at \
+                 FROM files f \
+                 LEFT JOIN ( \
+                     SELECT file_id, MAX(verified_at) AS latest \
+                     FROM verifications \
+                     GROUP BY file_id \
+                 ) v ON v.file_id = f.id \
+                 WHERE f.status = 'active' \
+                   AND f.path IS NOT NULL \
+                   AND (v.latest IS NULL OR v.latest < ?1) \
+                 ORDER BY f.id",
+            )
+            .map_err(storage_err(
+                "failed to prepare files due for verification query",
+            ))?;
+
+        let files = stmt
+            .query_map(params![format_datetime(&cutoff)], row_to_due_file)
+            .map_err(storage_err("failed to query files due for verification"))?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(storage_err("failed to read files due for verification"))?;
+        Ok(files)
     }
 
     fn integrity_summary(&self, since: DateTime<Utc>) -> Result<IntegritySummary> {
@@ -497,6 +564,77 @@ mod tests {
             )
             .expect("file aggregate counts");
         assert_eq!(counts, (3, 1, 1));
+    }
+
+    #[test]
+    fn list_files_due_for_verification_includes_never_verified_files() {
+        let (store, file_id) = store_with_file();
+
+        let due = store
+            .list_files_due_for_verification(Utc::now() - chrono::Duration::days(30))
+            .expect("due files");
+
+        assert_eq!(due.len(), 1);
+        assert_eq!(due[0].id.to_string(), file_id);
+    }
+
+    #[test]
+    fn list_files_due_for_verification_filters_by_latest_verification() {
+        let store = SqliteStore::in_memory().expect("in-memory store");
+        let cutoff = Utc::now() - chrono::Duration::days(30);
+        let mut stale_file = MediaFile::new(PathBuf::from("/media/stale.mkv"));
+        let mut fresh_file = MediaFile::new(PathBuf::from("/media/fresh.mkv"));
+        store.upsert_file(&stale_file).expect("insert stale file");
+        store.upsert_file(&fresh_file).expect("insert fresh file");
+
+        stale_file.content_hash = Some("stale".into());
+        fresh_file.content_hash = Some("fresh".into());
+        store
+            .insert_verification(&VerificationRecord::new(
+                Uuid::new_v4(),
+                stale_file.id.to_string(),
+                cutoff - chrono::Duration::seconds(1),
+                VerificationMode::Quick,
+                VerificationOutcome::Ok,
+                0,
+                0,
+                None,
+                None,
+            ))
+            .expect("insert stale verification");
+        store
+            .insert_verification(&VerificationRecord::new(
+                Uuid::new_v4(),
+                fresh_file.id.to_string(),
+                cutoff + chrono::Duration::seconds(1),
+                VerificationMode::Quick,
+                VerificationOutcome::Ok,
+                0,
+                0,
+                None,
+                None,
+            ))
+            .expect("insert fresh verification");
+
+        let due = store
+            .list_files_due_for_verification(cutoff)
+            .expect("due files");
+        let due_ids: Vec<_> = due.iter().map(|file| file.id).collect();
+
+        assert_eq!(due_ids, vec![stale_file.id]);
+    }
+
+    #[test]
+    fn list_files_due_for_verification_excludes_missing_files() {
+        let (store, file_id) = store_with_file();
+        let file_uuid = Uuid::parse_str(&file_id).expect("uuid");
+        store.mark_missing(&file_uuid).expect("mark missing");
+
+        let due = store
+            .list_files_due_for_verification(Utc::now())
+            .expect("due files");
+
+        assert!(due.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Replaces the N+1 query pattern in `voom verify run` (no PATH) with a single combined query.

- New trait method `VerificationStorage::list_files_due_for_verification(cutoff)` returning `Vec<MediaFile>`
- SQLite impl: `LEFT JOIN` on `MAX(verified_at)` per file, filtered to `status='active'` with the `(latest IS NULL OR latest < ?)` predicate so never-verified files are included
- InMemoryStore stub impl for parity
- `crates/voom-cli/src/commands/verify.rs::resolve_due_targets` rewritten to call the new method (was: list_files + per-file list_verifications)
- Migration: composite index on `verifications(file_id, verified_at)` to keep the new query fast on large libraries
- Criterion benchmark in `plugins/sqlite-store/benches/verification_due.rs` measuring before/after on a seeded fixture

Closes #250

## Test plan

- [ ] `cargo test -p voom-sqlite-store -p voom-domain -p voom-cli` passes
- [ ] Benchmark on 10k files shows >10× speedup over the old N+1 path (per AC)
- [ ] `voom verify run` (no PATH) returns the same set of files as before
- [ ] `voom verify run --all` still verifies all active files

---

Recovery context: opened by the Mayor — Codex polecat (voom/quartz) ran `gt done` partially (push + MQ submit succeeded, MR `vo-wisp-lik` is `ready`/`GIT OK`) but `gh pr create` did not fire. Same partial-chain shape as vo-687/#252 earlier this cycle; tracked under hq-59z. May require rebase since #252 (also touching `verification_storage.rs`) merged just before this PR was opened.