### PR TITLE
feat(storage): transcode_outcomes table + storage trait (E5 of #200)

### DIFF
--- a/crates/voom-domain/src/lib.rs
+++ b/crates/voom-domain/src/lib.rs
@@ -21,6 +21,7 @@ pub mod temp_file;
     clippy::return_self_not_must_use
 )]
 pub mod test_support;
+pub mod transcode;
 pub mod transition;
 pub mod utils;
 pub mod verification;
@@ -47,8 +48,9 @@ pub use storage::{
     BadFileFilters, BadFileStorage, EventLogFilters, EventLogRecord, EventLogStorage, FileFilters,
     FileStorage, FileTransitionStorage, HealthCheckFilters, HealthCheckRecord, HealthCheckStorage,
     JobFilters, JobStorage, MaintenanceStorage, PlanStorage, PlanSummary, PluginDataStorage,
-    SnapshotStorage, StorageTrait,
+    SnapshotStorage, StorageTrait, TranscodeOutcomeFilters, TranscodeOutcomeStorage,
 };
+pub use transcode::TranscodeOutcome;
 pub use transition::{
     DiscoveredFile, FileStatus, FileTransition, ReconcileResult, TransitionSource,
 };

--- a/crates/voom-domain/src/storage.rs
+++ b/crates/voom-domain/src/storage.rs
@@ -10,6 +10,7 @@ use crate::job::{Job, JobStatus, JobUpdate};
 use crate::media::{Container, MediaFile, StoredFingerprint};
 use crate::plan::Plan;
 use crate::stats::{LibrarySnapshot, SavingsReport, SnapshotTrigger, TimePeriod};
+use crate::transcode::TranscodeOutcome;
 use crate::transition::{DiscoveredFile, FileTransition, ReconcileResult, TransitionSource};
 
 /// Row retention policy for time- or count-based pruning.
@@ -91,6 +92,14 @@ pub struct FileFilters {
     pub offset: Option<u32>,
     /// When `true`, include files with `Missing` status. Default: `false`.
     pub include_missing: bool,
+}
+
+/// Filters for querying persisted transcode outcomes.
+#[non_exhaustive]
+#[derive(Debug, Clone, Default)]
+pub struct TranscodeOutcomeFilters {
+    pub file_id: Option<String>,
+    pub limit: Option<u32>,
 }
 
 // --- Focused sub-traits ---
@@ -567,6 +576,25 @@ pub trait VerificationStorage: Send + Sync {
     ) -> Result<crate::verification::IntegritySummary>;
 }
 
+/// Transcode outcome persistence.
+///
+/// # Errors
+/// Implementations return [`VoomError::Storage`](crate::errors::VoomError::Storage)
+/// for any underlying database failure.
+pub trait TranscodeOutcomeStorage: Send + Sync {
+    /// Insert a completed transcode outcome.
+    fn insert_transcode_outcome(&self, outcome: &TranscodeOutcome) -> Result<()>;
+
+    /// Query transcode outcomes newest first, breaking timestamp ties by ID.
+    fn list_transcode_outcomes(
+        &self,
+        filters: &TranscodeOutcomeFilters,
+    ) -> Result<Vec<TranscodeOutcome>>;
+
+    /// Most recent transcode outcome for a file, if any.
+    fn latest_outcome_for_file(&self, file_id: &str) -> Result<Option<TranscodeOutcome>>;
+}
+
 /// Composed storage interface encompassing all sub-traits.
 ///
 /// All methods are synchronous (blocking) since rusqlite is synchronous.
@@ -588,6 +616,7 @@ pub trait StorageTrait:
     + SnapshotStorage
     + PendingOpsStorage
     + VerificationStorage
+    + TranscodeOutcomeStorage
 {
 }
 
@@ -605,6 +634,7 @@ impl<T> StorageTrait for T where
         + SnapshotStorage
         + PendingOpsStorage
         + VerificationStorage
+        + TranscodeOutcomeStorage
 {
 }
 

--- a/crates/voom-domain/src/test_support.rs
+++ b/crates/voom-domain/src/test_support.rs
@@ -26,8 +26,9 @@ use crate::storage::{
     BadFileFilters, BadFileStorage, FileFilters, FileStorage, FileTransitionStorage,
     HealthCheckFilters, HealthCheckRecord, HealthCheckStorage, JobFilters, JobStorage,
     MaintenanceStorage, PageStats, PendingOperation, PendingOpsStorage, PlanStorage, PlanSummary,
-    PluginDataStorage, SnapshotStorage,
+    PluginDataStorage, SnapshotStorage, TranscodeOutcomeFilters, TranscodeOutcomeStorage,
 };
+use crate::transcode::TranscodeOutcome;
 use crate::transition::{
     DiscoveredFile, FileStatus, FileTransition, ReconcileResult, TransitionSource,
 };
@@ -110,6 +111,7 @@ pub struct InMemoryStore {
     snapshots: Mutex<Vec<LibrarySnapshot>>,
     event_log: Mutex<Vec<crate::storage::EventLogRecord>>,
     pub pending_ops: Mutex<Vec<PendingOperation>>,
+    pub transcode_outcomes: Mutex<Vec<TranscodeOutcome>>,
     pub transitions: Mutex<Vec<FileTransition>>,
     pub verifications: Mutex<Vec<VerificationRecord>>,
     plugin_data: Mutex<HashMap<(String, String), Vec<u8>>>,
@@ -123,6 +125,7 @@ impl InMemoryStore {
             snapshots: Mutex::new(Vec::new()),
             event_log: Mutex::new(Vec::new()),
             pending_ops: Mutex::new(Vec::new()),
+            transcode_outcomes: Mutex::new(Vec::new()),
             transitions: Mutex::new(Vec::new()),
             verifications: Mutex::new(Vec::new()),
             plugin_data: Mutex::new(HashMap::new()),
@@ -150,6 +153,12 @@ impl InMemoryStore {
     /// Builder: seed the store with a verification record.
     pub fn with_verification(self, verification: VerificationRecord) -> Self {
         self.verifications.lock().push(verification);
+        self
+    }
+
+    /// Builder: seed the store with a transcode outcome.
+    pub fn with_transcode_outcome(self, outcome: TranscodeOutcome) -> Self {
+        self.transcode_outcomes.lock().push(outcome);
         self
     }
 }
@@ -1026,6 +1035,55 @@ mod oldest_at_tests {
     }
 }
 
+impl TranscodeOutcomeStorage for InMemoryStore {
+    fn insert_transcode_outcome(&self, outcome: &TranscodeOutcome) -> Result<()> {
+        self.transcode_outcomes.lock().push(outcome.clone());
+        Ok(())
+    }
+
+    fn list_transcode_outcomes(
+        &self,
+        filters: &TranscodeOutcomeFilters,
+    ) -> Result<Vec<TranscodeOutcome>> {
+        let mut outcomes: Vec<TranscodeOutcome> = self
+            .transcode_outcomes
+            .lock()
+            .iter()
+            .filter(|outcome| matches_transcode_outcome_filter(outcome, filters))
+            .cloned()
+            .collect();
+        outcomes.sort_by(|a, b| {
+            b.completed_at
+                .cmp(&a.completed_at)
+                .then_with(|| b.id.cmp(&a.id))
+        });
+        if let Some(limit) = filters.limit {
+            outcomes.truncate(limit as usize);
+        }
+        Ok(outcomes)
+    }
+
+    fn latest_outcome_for_file(&self, file_id: &str) -> Result<Option<TranscodeOutcome>> {
+        let filters = TranscodeOutcomeFilters {
+            file_id: Some(file_id.to_string()),
+            limit: Some(1),
+        };
+        Ok(self.list_transcode_outcomes(&filters)?.into_iter().next())
+    }
+}
+
+fn matches_transcode_outcome_filter(
+    outcome: &TranscodeOutcome,
+    filters: &TranscodeOutcomeFilters,
+) -> bool {
+    if let Some(file_id) = filters.file_id.as_ref() {
+        if outcome.file_id != *file_id {
+            return false;
+        }
+    }
+    true
+}
+
 #[cfg(test)]
 mod verification_storage_tests {
     use super::*;
@@ -1102,5 +1160,79 @@ mod verification_storage_tests {
             .expect("due files");
 
         assert!(due.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod transcode_outcome_storage_tests {
+    use super::*;
+    use crate::storage::{TranscodeOutcomeFilters, TranscodeOutcomeStorage};
+    use crate::transcode::TranscodeOutcome;
+
+    fn outcome(
+        id: u128,
+        file_id: &str,
+        completed_at: chrono::DateTime<chrono::Utc>,
+    ) -> TranscodeOutcome {
+        TranscodeOutcome {
+            id: Uuid::from_u128(id),
+            file_id: file_id.to_string(),
+            target_vmaf: Some(95),
+            achieved_vmaf: Some(94.8),
+            crf_used: Some(22),
+            bitrate_used: Some("3200k".to_string()),
+            iterations: 3,
+            sample_strategy: crate::plan::SampleStrategy::Uniform {
+                count: 5,
+                duration: "10s".to_string(),
+            },
+            fallback_used: false,
+            completed_at,
+        }
+    }
+
+    #[test]
+    fn list_transcode_outcomes_filters_file_newest_first_with_id_tiebreaker() {
+        let file_id = Uuid::new_v4().to_string();
+        let other_file_id = Uuid::new_v4().to_string();
+        let completed_at = chrono::Utc::now();
+        let store = InMemoryStore::new()
+            .with_transcode_outcome(outcome(1, &file_id, completed_at))
+            .with_transcode_outcome(outcome(3, &file_id, completed_at))
+            .with_transcode_outcome(outcome(
+                2,
+                &file_id,
+                completed_at - chrono::Duration::minutes(1),
+            ))
+            .with_transcode_outcome(outcome(4, &other_file_id, completed_at));
+
+        let listed = store
+            .list_transcode_outcomes(&TranscodeOutcomeFilters {
+                file_id: Some(file_id),
+                limit: None,
+            })
+            .expect("list outcomes");
+        let ids: Vec<_> = listed.iter().map(|record| record.id).collect();
+
+        assert_eq!(
+            ids,
+            vec![Uuid::from_u128(3), Uuid::from_u128(1), Uuid::from_u128(2)]
+        );
+    }
+
+    #[test]
+    fn latest_outcome_for_file_returns_newest_with_id_tiebreaker() {
+        let file_id = Uuid::new_v4().to_string();
+        let completed_at = chrono::Utc::now();
+        let store = InMemoryStore::new()
+            .with_transcode_outcome(outcome(1, &file_id, completed_at))
+            .with_transcode_outcome(outcome(2, &file_id, completed_at));
+
+        let latest = store
+            .latest_outcome_for_file(&file_id)
+            .expect("latest outcome")
+            .expect("some outcome");
+
+        assert_eq!(latest.id, Uuid::from_u128(2));
     }
 }

--- a/crates/voom-domain/src/transcode.rs
+++ b/crates/voom-domain/src/transcode.rs
@@ -1,0 +1,20 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::plan::SampleStrategy;
+
+/// Persisted outcome from a VMAF-guided transcode run.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TranscodeOutcome {
+    pub id: Uuid,
+    pub file_id: String,
+    pub target_vmaf: Option<u32>,
+    pub achieved_vmaf: Option<f32>,
+    pub crf_used: Option<u32>,
+    pub bitrate_used: Option<String>,
+    pub iterations: u32,
+    pub sample_strategy: SampleStrategy,
+    pub fallback_used: bool,
+    pub completed_at: DateTime<Utc>,
+}

--- a/plugins/sqlite-store/src/schema.rs
+++ b/plugins/sqlite-store/src/schema.rs
@@ -222,6 +222,22 @@ CREATE INDEX IF NOT EXISTS idx_verifications_file ON verifications(file_id);
 CREATE INDEX IF NOT EXISTS idx_verifications_outcome ON verifications(outcome);
 CREATE INDEX IF NOT EXISTS idx_verifications_time ON verifications(verified_at);
 CREATE INDEX IF NOT EXISTS idx_verifications_file_verified_at ON verifications(file_id, verified_at);
+
+CREATE TABLE IF NOT EXISTS transcode_outcomes (
+    id TEXT PRIMARY KEY,
+    file_id TEXT NOT NULL REFERENCES files(id),
+    target_vmaf INTEGER,
+    achieved_vmaf REAL,
+    crf_used INTEGER,
+    bitrate_used TEXT,
+    iterations INTEGER NOT NULL,
+    sample_strategy TEXT NOT NULL,
+    fallback_used INTEGER NOT NULL,
+    completed_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_transcode_outcomes_file_completed
+    ON transcode_outcomes(file_id, completed_at DESC);
 ";
 
 /// Initialize the database schema.
@@ -257,6 +273,7 @@ pub(crate) fn migrate(conn: &Connection) -> rusqlite::Result<()> {
         "library_snapshots",
         "pending_operations",
         "verifications",
+        "transcode_outcomes",
     ];
     let has_column = |table: &str, column: &str| -> rusqlite::Result<bool> {
         assert!(KNOWN_TABLES.contains(&table), "unknown table: {table}");
@@ -484,6 +501,25 @@ fn migrate_missing_tables(conn: &Connection) -> rusqlite::Result<()> {
         )?;
     }
 
+    if table_missing("transcode_outcomes")? {
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS transcode_outcomes (
+                id TEXT PRIMARY KEY,
+                file_id TEXT NOT NULL REFERENCES files(id),
+                target_vmaf INTEGER,
+                achieved_vmaf REAL,
+                crf_used INTEGER,
+                bitrate_used TEXT,
+                iterations INTEGER NOT NULL,
+                sample_strategy TEXT NOT NULL,
+                fallback_used INTEGER NOT NULL,
+                completed_at TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_transcode_outcomes_file_completed
+                ON transcode_outcomes(file_id, completed_at DESC);",
+        )?;
+    }
+
     Ok(())
 }
 
@@ -499,6 +535,15 @@ fn migrate_indexes_and_constraints(conn: &Connection) -> rusqlite::Result<()> {
 
     if table_exists(conn, "tracks")? && !has_index("idx_tracks_type")? {
         conn.execute_batch("CREATE INDEX IF NOT EXISTS idx_tracks_type ON tracks(track_type);")?;
+    }
+
+    if table_exists(conn, "transcode_outcomes")?
+        && !has_index("idx_transcode_outcomes_file_completed")?
+    {
+        conn.execute_batch(
+            "CREATE INDEX IF NOT EXISTS idx_transcode_outcomes_file_completed
+                ON transcode_outcomes(file_id, completed_at DESC);",
+        )?;
     }
 
     if !has_index("idx_files_superseded_by")? {
@@ -771,6 +816,7 @@ mod tests {
         assert!(tables.contains(&"subtitles".to_string()));
         assert!(tables.contains(&"library_snapshots".to_string()));
         assert!(tables.contains(&"pending_operations".to_string()));
+        assert!(tables.contains(&"transcode_outcomes".to_string()));
     }
 
     #[test]
@@ -1037,5 +1083,30 @@ mod tests {
             )
             .unwrap();
         assert!(exists);
+    }
+
+    #[test]
+    fn transcode_outcomes_table_and_index_are_created() {
+        let conn = Connection::open_in_memory().unwrap();
+        create_schema(&conn).unwrap();
+        let table_exists: bool = conn
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM sqlite_master \
+                 WHERE type='table' AND name='transcode_outcomes'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let index_exists: bool = conn
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM sqlite_master \
+                 WHERE type='index' AND name='idx_transcode_outcomes_file_completed'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+
+        assert!(table_exists);
+        assert!(index_exists);
     }
 }

--- a/plugins/sqlite-store/src/store/mod.rs
+++ b/plugins/sqlite-store/src/store/mod.rs
@@ -12,6 +12,7 @@ mod plugin_data_storage;
 mod row_mappers;
 mod snapshot_storage;
 mod subtitle_storage;
+mod transcode_outcome_storage;
 mod verification_storage;
 
 use std::collections::HashMap;

--- a/plugins/sqlite-store/src/store/transcode_outcome_storage.rs
+++ b/plugins/sqlite-store/src/store/transcode_outcome_storage.rs
@@ -1,0 +1,242 @@
+//! `TranscodeOutcomeStorage` implementation backed by SQLite.
+
+use rusqlite::{params, Row};
+
+use voom_domain::errors::Result;
+use voom_domain::storage::{TranscodeOutcomeFilters, TranscodeOutcomeStorage};
+use voom_domain::transcode::TranscodeOutcome;
+
+use super::{format_datetime, parse_required_datetime, row_uuid, storage_err, SqlQuery};
+use super::{other_storage_err, SqliteStore};
+
+const SELECT_TRANSCODE_OUTCOME: &str = "SELECT id, file_id, target_vmaf, achieved_vmaf, \
+    crf_used, bitrate_used, iterations, sample_strategy, fallback_used, completed_at \
+    FROM transcode_outcomes";
+
+fn optional_u32(row: &Row<'_>, column: &str) -> rusqlite::Result<Option<u32>> {
+    row.get::<_, Option<i64>>(column)?
+        .map(|value| {
+            u32::try_from(value).map_err(|e| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    0,
+                    rusqlite::types::Type::Integer,
+                    format!("invalid {column} in transcode_outcomes: {e}").into(),
+                )
+            })
+        })
+        .transpose()
+}
+
+fn row_to_transcode_outcome(row: &Row<'_>) -> rusqlite::Result<TranscodeOutcome> {
+    let id: String = row.get("id")?;
+    let sample_strategy: String = row.get("sample_strategy")?;
+    let completed_at: String = row.get("completed_at")?;
+    let iterations = u32::try_from(row.get::<_, i64>("iterations")?).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(
+            0,
+            rusqlite::types::Type::Integer,
+            format!("invalid iterations in transcode_outcomes: {e}").into(),
+        )
+    })?;
+    let sample_strategy = serde_json::from_str(&sample_strategy).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(
+            0,
+            rusqlite::types::Type::Text,
+            format!("invalid JSON in transcode_outcomes.sample_strategy: {e}").into(),
+        )
+    })?;
+
+    Ok(TranscodeOutcome {
+        id: row_uuid(&id, "transcode_outcomes")?,
+        file_id: row.get("file_id")?,
+        target_vmaf: optional_u32(row, "target_vmaf")?,
+        achieved_vmaf: row
+            .get::<_, Option<f64>>("achieved_vmaf")?
+            .map(|v| v as f32),
+        crf_used: optional_u32(row, "crf_used")?,
+        bitrate_used: row.get("bitrate_used")?,
+        iterations,
+        sample_strategy,
+        fallback_used: row.get::<_, i64>("fallback_used")? != 0,
+        completed_at: parse_required_datetime(completed_at, "transcode_outcomes.completed_at")?,
+    })
+}
+
+impl TranscodeOutcomeStorage for SqliteStore {
+    fn insert_transcode_outcome(&self, outcome: &TranscodeOutcome) -> Result<()> {
+        let conn = self.conn()?;
+        let sample_strategy = serde_json::to_string(&outcome.sample_strategy)
+            .map_err(other_storage_err("failed to serialize sample strategy"))?;
+        conn.execute(
+            "INSERT INTO transcode_outcomes \
+             (id, file_id, target_vmaf, achieved_vmaf, crf_used, bitrate_used, iterations, \
+              sample_strategy, fallback_used, completed_at) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+            params![
+                outcome.id.to_string(),
+                outcome.file_id,
+                outcome.target_vmaf.map(i64::from),
+                outcome.achieved_vmaf.map(f64::from),
+                outcome.crf_used.map(i64::from),
+                outcome.bitrate_used,
+                i64::from(outcome.iterations),
+                sample_strategy,
+                i64::from(outcome.fallback_used),
+                format_datetime(&outcome.completed_at),
+            ],
+        )
+        .map_err(storage_err("failed to insert transcode outcome"))?;
+        Ok(())
+    }
+
+    fn list_transcode_outcomes(
+        &self,
+        filters: &TranscodeOutcomeFilters,
+    ) -> Result<Vec<TranscodeOutcome>> {
+        let conn = self.conn()?;
+        let mut q = SqlQuery::new(&format!("{SELECT_TRANSCODE_OUTCOME} WHERE 1=1"));
+        if let Some(file_id) = filters.file_id.as_ref() {
+            q.condition(" AND file_id = {}", file_id.clone());
+        }
+        q.sql.push_str(" ORDER BY completed_at DESC, id DESC");
+        q.paginate(filters.limit, None);
+
+        let mut stmt = conn
+            .prepare(&q.sql)
+            .map_err(storage_err("failed to prepare transcode outcome query"))?;
+        let rows = stmt
+            .query_map(q.param_refs().as_slice(), row_to_transcode_outcome)
+            .map_err(storage_err("failed to query transcode outcomes"))?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row.map_err(storage_err("failed to read transcode outcome row"))?);
+        }
+        Ok(out)
+    }
+
+    fn latest_outcome_for_file(&self, file_id: &str) -> Result<Option<TranscodeOutcome>> {
+        let mut filters = TranscodeOutcomeFilters::default();
+        filters.file_id = Some(file_id.to_string());
+        filters.limit = Some(1);
+        let mut outcomes = self.list_transcode_outcomes(&filters)?;
+        Ok(outcomes.pop())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use std::path::PathBuf;
+    use uuid::Uuid;
+    use voom_domain::media::{Container, MediaFile};
+    use voom_domain::plan::SampleStrategy;
+    use voom_domain::storage::FileStorage;
+    use voom_domain::test_support::InMemoryStore;
+
+    fn make_file(path: &str) -> MediaFile {
+        let mut file = MediaFile::new(PathBuf::from(path));
+        file.size = 1;
+        file.content_hash = Some("hash-stub".to_string());
+        file.container = Container::Mkv;
+        file.introspected_at = Utc::now();
+        file
+    }
+
+    fn outcome(id: u128, file_id: &str, completed_at: chrono::DateTime<Utc>) -> TranscodeOutcome {
+        TranscodeOutcome {
+            id: Uuid::from_u128(id),
+            file_id: file_id.to_string(),
+            target_vmaf: Some(95),
+            achieved_vmaf: Some(94.8),
+            crf_used: Some(22),
+            bitrate_used: Some("3200k".to_string()),
+            iterations: 3,
+            sample_strategy: SampleStrategy::Scenes {
+                count: 8,
+                duration: "12s".to_string(),
+            },
+            fallback_used: false,
+            completed_at,
+        }
+    }
+
+    #[test]
+    fn insert_and_list_transcode_outcomes_round_trip() {
+        let store = SqliteStore::in_memory().expect("in-memory store");
+        let file = make_file("/media/test.mkv");
+        let file_id = file.id.to_string();
+        store.upsert_file(&file).expect("insert file");
+        let record = outcome(1, &file_id, Utc::now());
+
+        store
+            .insert_transcode_outcome(&record)
+            .expect("insert outcome");
+        let mut filters = TranscodeOutcomeFilters::default();
+        filters.file_id = Some(file_id);
+        let listed = store
+            .list_transcode_outcomes(&filters)
+            .expect("list outcomes");
+
+        assert_eq!(listed, vec![record]);
+    }
+
+    #[test]
+    fn latest_outcome_for_file_returns_newest_with_id_tiebreaker() {
+        let store = SqliteStore::in_memory().expect("in-memory store");
+        let file = make_file("/media/test.mkv");
+        let file_id = file.id.to_string();
+        let completed_at = Utc::now();
+        store.upsert_file(&file).expect("insert file");
+
+        for record in [
+            outcome(1, &file_id, completed_at),
+            outcome(2, &file_id, completed_at),
+        ] {
+            store
+                .insert_transcode_outcome(&record)
+                .expect("insert outcome");
+        }
+
+        let latest = store
+            .latest_outcome_for_file(&file_id)
+            .expect("latest")
+            .expect("some outcome");
+        assert_eq!(latest.id, Uuid::from_u128(2));
+    }
+
+    #[test]
+    fn transcode_outcome_storage_matches_in_memory_store() {
+        let sqlite = SqliteStore::in_memory().expect("in-memory sqlite");
+        let memory = InMemoryStore::new();
+        let file = make_file("/media/test.mkv");
+        let file_id = file.id.to_string();
+        let completed_at = Utc::now();
+        sqlite.upsert_file(&file).expect("sqlite insert file");
+        memory.upsert_file(&file).expect("memory insert file");
+
+        for record in [
+            outcome(1, &file_id, completed_at),
+            outcome(3, &file_id, completed_at),
+            outcome(2, &file_id, completed_at - chrono::Duration::minutes(1)),
+        ] {
+            sqlite
+                .insert_transcode_outcome(&record)
+                .expect("sqlite insert outcome");
+            memory
+                .insert_transcode_outcome(&record)
+                .expect("memory insert outcome");
+        }
+        let mut filters = TranscodeOutcomeFilters::default();
+        filters.file_id = Some(file_id);
+
+        assert_eq!(
+            sqlite
+                .list_transcode_outcomes(&filters)
+                .expect("sqlite outcomes"),
+            memory
+                .list_transcode_outcomes(&filters)
+                .expect("memory outcomes")
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Persistence layer for VMAF-guided encoding outcomes. New `transcode_outcomes` table records target/achieved VMAF, CRF/bitrate used, iterations, sample strategy, and fallback flag for every transcode invocation.

- New table + composite index via the schema-versioning path
- `TranscodeOutcomeStorage` trait with `insert_transcode_outcome`, `list_transcode_outcomes`, `latest_outcome_for_file`
- SQLite impl in `plugins/sqlite-store/src/store/transcode_outcome_storage.rs`
- InMemoryStore stub in `voom-domain::test_support`
- Storage parity tests (same fixture against both stores)

E4's executor changes will write into this table; E8's `voom report --vmaf` reads from it.

E5 of the vo-doj epic. Progress on #200.

---

Recovery context: opened by the Mayor — Codex polecat completed work and submitted MR `vo-wisp-9ja` but `gh pr create` step did not fire (tracked under hq-59z).