### PR TITLE
test: VMAF integration corpus + E2E hit-rate verification (closes #200)

### DIFF
--- a/plugins/ffmpeg-executor/src/vmaf.rs
+++ b/plugins/ffmpeg-executor/src/vmaf.rs
@@ -685,7 +685,17 @@ mod tests {
         )
         .unwrap_err();
 
-        assert!(matches!(err, VmafError::FfmpegFailed { .. }));
+        // Intent: for V061 (the default model), a missing-from-model_dir lookup
+        // must NOT bail with ModelNotFound — it should fall through and let
+        // libvmaf use its built-in default. The downstream failure mode varies
+        // by environment: hosts with ffmpeg report FfmpegFailed (bogus input
+        // paths); hosts without ffmpeg report LibvmafUnavailable (ToolNotFound
+        // mapped). Either is a valid outcome; the assertion is that we got
+        // past the model lookup.
+        assert!(
+            !matches!(err, VmafError::ModelNotFound(_)),
+            "V061 must not bail with ModelNotFound when model_dir is empty; got: {err:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Final bead of the #200 epic (vo-doj). Adds the synthetic test corpus and end-to-end test that verifies VMAF-guided encoding hits target within ±2 in ≤5 iterations across representative source types.

- `tests/vmaf_corpus/` — synthetic clips (clean / noisy / animated / 4K / mixed-motion / low-motion) generated via `ffmpeg -f lavfi`; regeneration script committed
- `crates/voom-cli/tests/vmaf_e2e.rs` gated behind `feature = "integration"` — runs target_vmaf 88/92/95 across the corpus, asserts achieved within ±2 and iterations ≤ 5 per AC
- CI documentation for running the integration job

Closes #200

## Test plan

- [ ] `cargo test --features integration` passes on a host with ffmpeg + libvmaf
- [ ] `cargo test` (default) skips the integration tests
- [ ] Corpus regeneration script runs cleanly and is deterministic

---

This PR closes the umbrella #200 with all 9 sub-beads (vo-doj.1 through vo-doj.9) landed. Recovery context: opened by the Mayor — Codex polecat completed work and submitted MR `vo-wisp-2r4`, racing refinery to capture an audit trail.