### PR TITLE
Salvage core desloppify cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
       - run: cargo build --workspace
       - run: cargo test --workspace
       - run: cargo run -q -- policy test docs/examples/tests
+      - run: cargo test -p voom-cli --features functional -- --test-threads=4 test_init test_doctor test_policy test_config test_status test_jobs test_plugin
 
   test-wasm:
     name: Test (WASM feature)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,11 @@ jobs:
         with:
           persist-credentials: false
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6  # v1.16.1
+      - run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg
       - run: cargo build --workspace
       - run: cargo test --workspace
       - run: cargo run -q -- policy test docs/examples/tests
-      - run: cargo test -p voom-cli --features functional -- --test-threads=4 test_init test_doctor test_policy test_config test_status test_jobs test_plugin
+      - run: cargo test -p voom-cli --features functional -- --test-threads=4 test_init test_doctor test_policy test_config test_status test_jobs test_plugin test_verify
 
   test-wasm:
     name: Test (WASM feature)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
       - run: cargo test --workspace
       - run: cargo run -q -- policy test docs/examples/tests
       - run: cargo test -p voom-cli --features functional -- --test-threads=4 test_init test_doctor test_policy test_config test_status test_jobs test_plugin test_verify
+      - run: cargo test -p voom-cli --features functional -- --test-threads=4 test_process crash_recovery normal_backup_not_treated_as_orphan
 
   test-wasm:
     name: Test (WASM feature)

--- a/SALVAGE_NOTES.md
+++ b/SALVAGE_NOTES.md
@@ -2,3 +2,4 @@ fdca66a Distinguish malformed plugin config -- skipped: conflicts across SDK plu
 bb85060 Reject malformed WASM event results -- skipped: depends on branch-only WASM loader split/wit_runtime.rs; manual reimplementation candidate on current loader.
 fb786d1 Preserve plugin data read errors -- skipped: conflicts across plugin SDK and many WASM plugin implementations; manual reimplementation candidate after SDK shape is reviewed.
 def5cb8 Propagate host list entry errors -- skipped: current main lacks the affected list_files host API, so cherry-pick would introduce broader host surface instead of a narrow fix.
+945f0d1 Propagate transition record errors -- skipped: conflicts depend on branch-only process workflow module reshuffle; manual narrow reimplementation candidate.

--- a/SALVAGE_NOTES.md
+++ b/SALVAGE_NOTES.md
@@ -4,3 +4,4 @@ fb786d1 Preserve plugin data read errors -- skipped: conflicts across plugin SDK
 def5cb8 Propagate host list entry errors -- skipped: current main lacks the affected list_files host API, so cherry-pick would introduce broader host surface instead of a narrow fix.
 945f0d1 Propagate transition record errors -- skipped: conflicts depend on branch-only process workflow module reshuffle; manual narrow reimplementation candidate.
 5e59cc6 Future-proof public domain DTOs -- skipped: broad conflicts across process, WIT conversion, ffmpeg, sqlite, and event handlers; not salvageable as a focused PR slice.
+841499d Use named domain constructor inputs -- skipped: depends on branch SQLite module layout and touches broad verifier/storage constructor shapes.

--- a/SALVAGE_NOTES.md
+++ b/SALVAGE_NOTES.md
@@ -1,3 +1,4 @@
 fdca66a Distinguish malformed plugin config -- skipped: conflicts across SDK plus multiple WASM plugin implementations; manual reimplementation candidate.
 bb85060 Reject malformed WASM event results -- skipped: depends on branch-only WASM loader split/wit_runtime.rs; manual reimplementation candidate on current loader.
 fb786d1 Preserve plugin data read errors -- skipped: conflicts across plugin SDK and many WASM plugin implementations; manual reimplementation candidate after SDK shape is reviewed.
+def5cb8 Propagate host list entry errors -- skipped: current main lacks the affected list_files host API, so cherry-pick would introduce broader host surface instead of a narrow fix.

--- a/SALVAGE_NOTES.md
+++ b/SALVAGE_NOTES.md
@@ -1,0 +1,1 @@
+fdca66a Distinguish malformed plugin config -- skipped: conflicts across SDK plus multiple WASM plugin implementations; manual reimplementation candidate.

--- a/SALVAGE_NOTES.md
+++ b/SALVAGE_NOTES.md
@@ -5,3 +5,4 @@ def5cb8 Propagate host list entry errors -- skipped: current main lacks the affe
 945f0d1 Propagate transition record errors -- skipped: conflicts depend on branch-only process workflow module reshuffle; manual narrow reimplementation candidate.
 5e59cc6 Future-proof public domain DTOs -- skipped: broad conflicts across process, WIT conversion, ffmpeg, sqlite, and event handlers; not salvageable as a focused PR slice.
 841499d Use named domain constructor inputs -- skipped: depends on branch SQLite module layout and touches broad verifier/storage constructor shapes.
+108cfe4 Type audio language detector metadata -- skipped: conflicts in process command/pipeline and introduces process helper module; process-structural salvage deferred.

--- a/SALVAGE_NOTES.md
+++ b/SALVAGE_NOTES.md
@@ -6,3 +6,4 @@ def5cb8 Propagate host list entry errors -- skipped: current main lacks the affe
 5e59cc6 Future-proof public domain DTOs -- skipped: broad conflicts across process, WIT conversion, ffmpeg, sqlite, and event handlers; not salvageable as a focused PR slice.
 841499d Use named domain constructor inputs -- skipped: depends on branch SQLite module layout and touches broad verifier/storage constructor shapes.
 108cfe4 Type audio language detector metadata -- skipped: conflicts in process command/pipeline and introduces process helper module; process-structural salvage deferred.
+dd31729 Use WASM event result boundary record -- skipped: depends on branch-only split WASM loader module; manual reimplementation candidate on current loader.

--- a/SALVAGE_NOTES.md
+++ b/SALVAGE_NOTES.md
@@ -7,3 +7,4 @@ def5cb8 Propagate host list entry errors -- skipped: current main lacks the affe
 841499d Use named domain constructor inputs -- skipped: depends on branch SQLite module layout and touches broad verifier/storage constructor shapes.
 108cfe4 Type audio language detector metadata -- skipped: conflicts in process command/pipeline and introduces process helper module; process-structural salvage deferred.
 dd31729 Use WASM event result boundary record -- skipped: depends on branch-only split WASM loader module; manual reimplementation candidate on current loader.
+a8de351 Test WASM permission configuration -- skipped: depends on branch-only split WASM loader files (`loader/wasm/host_imports.rs`, `loader/wasm/host_state_config.rs`) deleted on current main.

--- a/SALVAGE_NOTES.md
+++ b/SALVAGE_NOTES.md
@@ -8,3 +8,4 @@ def5cb8 Propagate host list entry errors -- skipped: current main lacks the affe
 108cfe4 Type audio language detector metadata -- skipped: conflicts in process command/pipeline and introduces process helper module; process-structural salvage deferred.
 dd31729 Use WASM event result boundary record -- skipped: depends on branch-only split WASM loader module; manual reimplementation candidate on current loader.
 a8de351 Test WASM permission configuration -- skipped: depends on branch-only split WASM loader files (`loader/wasm/host_imports.rs`, `loader/wasm/host_state_config.rs`) deleted on current main.
+846bfd0 Cover WASM host boundary tests -- skipped: depends on branch-only split WASM loader files deleted on current main.

--- a/SALVAGE_NOTES.md
+++ b/SALVAGE_NOTES.md
@@ -1,1 +1,2 @@
 fdca66a Distinguish malformed plugin config -- skipped: conflicts across SDK plus multiple WASM plugin implementations; manual reimplementation candidate.
+bb85060 Reject malformed WASM event results -- skipped: depends on branch-only WASM loader split/wit_runtime.rs; manual reimplementation candidate on current loader.

--- a/SALVAGE_NOTES.md
+++ b/SALVAGE_NOTES.md
@@ -3,3 +3,4 @@ bb85060 Reject malformed WASM event results -- skipped: depends on branch-only W
 fb786d1 Preserve plugin data read errors -- skipped: conflicts across plugin SDK and many WASM plugin implementations; manual reimplementation candidate after SDK shape is reviewed.
 def5cb8 Propagate host list entry errors -- skipped: current main lacks the affected list_files host API, so cherry-pick would introduce broader host surface instead of a narrow fix.
 945f0d1 Propagate transition record errors -- skipped: conflicts depend on branch-only process workflow module reshuffle; manual narrow reimplementation candidate.
+5e59cc6 Future-proof public domain DTOs -- skipped: broad conflicts across process, WIT conversion, ffmpeg, sqlite, and event handlers; not salvageable as a focused PR slice.

--- a/SALVAGE_NOTES.md
+++ b/SALVAGE_NOTES.md
@@ -1,2 +1,3 @@
 fdca66a Distinguish malformed plugin config -- skipped: conflicts across SDK plus multiple WASM plugin implementations; manual reimplementation candidate.
 bb85060 Reject malformed WASM event results -- skipped: depends on branch-only WASM loader split/wit_runtime.rs; manual reimplementation candidate on current loader.
+fb786d1 Preserve plugin data read errors -- skipped: conflicts across plugin SDK and many WASM plugin implementations; manual reimplementation candidate after SDK shape is reviewed.

--- a/crates/voom-cli/Cargo.toml
+++ b/crates/voom-cli/Cargo.toml
@@ -92,3 +92,5 @@ rand = "0.10"
 rusqlite.workspace = true
 tempfile.workspace = true
 voom-domain = { workspace = true, features = ["testing"] }
+voom-ffmpeg-executor = { workspace = true, features = ["testing"] }
+voom-mkvtoolnix-executor = { workspace = true, features = ["testing"] }

--- a/crates/voom-cli/src/commands/env.rs
+++ b/crates/voom-cli/src/commands/env.rs
@@ -18,6 +18,7 @@ use voom_domain::utils::since::parse_since;
 
 mod retention_coverage {
     use chrono::{DateTime, Duration, Utc};
+    use voom_domain::errors::Result;
 
     /// Hard floor below which we treat a positive lag as noise: the two
     /// `MIN(created_at)` queries that feed `evaluate` are not atomic, and a
@@ -59,6 +60,46 @@ mod retention_coverage {
                     }
                 }
             }
+        }
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    pub struct QueryFailure {
+        pub query: &'static str,
+        pub error: String,
+    }
+
+    pub fn evaluate_query_results(
+        oldest_job: Result<Option<DateTime<Utc>>>,
+        oldest_event: Result<Option<DateTime<Utc>>>,
+    ) -> std::result::Result<CoverageStatus, Vec<QueryFailure>> {
+        let mut failures = Vec::new();
+
+        let oldest_job = match oldest_job {
+            Ok(value) => value,
+            Err(e) => {
+                failures.push(QueryFailure {
+                    query: "oldest_job_created_at",
+                    error: e.to_string(),
+                });
+                None
+            }
+        };
+        let oldest_event = match oldest_event {
+            Ok(value) => value,
+            Err(e) => {
+                failures.push(QueryFailure {
+                    query: "oldest_event_at",
+                    error: e.to_string(),
+                });
+                None
+            }
+        };
+
+        if failures.is_empty() {
+            Ok(evaluate(oldest_job, oldest_event))
+        } else {
+            Err(failures)
         }
     }
 }
@@ -178,15 +219,16 @@ pub fn check(format: OutputFormat) -> Result<()> {
         print!("  Retention coverage ... ");
     }
     if let Ok(app::BootstrapResult { store, .. }) = &kernel_result {
-        let oldest_job = store.oldest_job_created_at().ok().flatten();
-        let oldest_event = store.oldest_event_at().ok().flatten();
-        match retention_coverage::evaluate(oldest_job, oldest_event) {
-            retention_coverage::CoverageStatus::Ok => {
+        match retention_coverage::evaluate_query_results(
+            store.oldest_job_created_at(),
+            store.oldest_event_at(),
+        ) {
+            Ok(retention_coverage::CoverageStatus::Ok) => {
                 if print_human {
                     println!("{}", style("OK").green());
                 }
             }
-            retention_coverage::CoverageStatus::EventLogEmptyButJobsExist => {
+            Ok(retention_coverage::CoverageStatus::EventLogEmptyButJobsExist) => {
                 if print_human {
                     println!(
                         "{} jobs table is non-empty but event_log is empty — \
@@ -197,7 +239,7 @@ pub fn check(format: OutputFormat) -> Result<()> {
                 }
                 issues += 1;
             }
-            retention_coverage::CoverageStatus::AsymmetryDetected { gap_seconds } => {
+            Ok(retention_coverage::CoverageStatus::AsymmetryDetected { gap_seconds }) => {
                 let hours = gap_seconds / 3600;
                 let unit = if hours == 1 { "hour" } else { "hours" };
                 if print_human {
@@ -212,6 +254,20 @@ pub fn check(format: OutputFormat) -> Result<()> {
                     );
                 }
                 issues += 1;
+            }
+            Err(failures) => {
+                if print_human {
+                    println!(
+                        "{} failed to query retention coverage metadata:",
+                        style("ERROR").red()
+                    );
+                }
+                for failure in failures {
+                    if print_human {
+                        println!("    {}: {}", failure.query, failure.error);
+                    }
+                    issues += 1;
+                }
             }
         }
     } else if print_human {
@@ -783,8 +839,9 @@ mod tests {
 
 #[cfg(test)]
 mod retention_coverage_tests {
-    use super::retention_coverage::{evaluate, CoverageStatus};
+    use super::retention_coverage::{evaluate, evaluate_query_results, CoverageStatus};
     use chrono::{Duration, Utc};
+    use voom_domain::errors::{StorageErrorKind, VoomError};
 
     #[test]
     fn ok_when_no_jobs_and_no_events() {
@@ -850,5 +907,25 @@ mod retention_coverage_tests {
             }
             other => panic!("expected AsymmetryDetected, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn query_failures_are_reported_without_evaluation() {
+        let failed_job_query = Err(VoomError::Storage {
+            kind: StorageErrorKind::Other,
+            message: "job query failed".into(),
+        });
+        let failed_event_query = Err(VoomError::Storage {
+            kind: StorageErrorKind::Other,
+            message: "event query failed".into(),
+        });
+
+        let failures = evaluate_query_results(failed_job_query, failed_event_query).unwrap_err();
+
+        assert_eq!(failures.len(), 2);
+        assert_eq!(failures[0].query, "oldest_job_created_at");
+        assert!(failures[0].error.contains("job query failed"));
+        assert_eq!(failures[1].query, "oldest_event_at");
+        assert!(failures[1].error.contains("event query failed"));
     }
 }

--- a/crates/voom-cli/src/commands/process/pipeline.rs
+++ b/crates/voom-cli/src/commands/process/pipeline.rs
@@ -810,38 +810,23 @@ mod tests {
             .await
     }
 
-    fn observe_limiter_acquires(
-        limiter: voom_job_manager::worker::PlanExecutionLimiter,
-    ) -> (
-        voom_job_manager::worker::PlanExecutionLimiter,
-        tokio::sync::mpsc::UnboundedReceiver<String>,
-    ) {
-        let (wait_tx, wait_rx) = tokio::sync::mpsc::unbounded_channel();
-        let limiter = limiter.with_acquire_observer(move |resource| {
-            let _ = wait_tx.send(resource.to_string());
-        });
-        (limiter, wait_rx)
-    }
-
-    async fn wait_for_limiter_acquire(
-        wait_rx: &mut tokio::sync::mpsc::UnboundedReceiver<String>,
-        resource: &str,
+    async fn assert_executor_not_entered_while_limited(
+        entered_rx: &mpsc::Receiver<()>,
         processing: Pin<
             &mut impl Future<Output = std::result::Result<Option<serde_json::Value>, String>>,
         >,
+        message: &str,
     ) {
-        let acquired = tokio::time::timeout(Duration::from_secs(1), async {
-            tokio::select! {
-                acquired = wait_rx.recv() => acquired
-                    .expect("plan limiter acquire observer should still be connected"),
-                result = processing => {
-                    panic!("processing finished before reaching the plan limiter: {result:?}");
-                }
+        tokio::select! {
+            _ = tokio::time::sleep(Duration::from_millis(100)) => {}
+            result = processing => {
+                panic!("processing finished before the limited executor was released: {result:?}");
             }
-        })
-        .await
-        .expect("processing should reach the plan limiter acquire point");
-        assert_eq!(acquired, resource);
+        }
+        assert!(
+            matches!(entered_rx.try_recv(), Err(mpsc::TryRecvError::Empty)),
+            "{message}"
+        );
     }
 
     #[tokio::test]
@@ -853,7 +838,6 @@ mod tests {
             1,
         )]);
         let held = held_nvenc_permit(&limiter).await;
-        let (limiter, mut wait_rx) = observe_limiter_acquires(limiter);
 
         let path = fixture.dir_path().join("movie.mkv");
         std::fs::write(&path, vec![0u8; 1024]).unwrap();
@@ -876,11 +860,12 @@ mod tests {
         let processing = process_single_file_execute(&file, &compiled, &ctx);
         tokio::pin!(processing);
 
-        wait_for_limiter_acquire(&mut wait_rx, "hw:nvenc", processing.as_mut()).await;
-        assert!(
-            matches!(entered_rx.try_recv(), Err(mpsc::TryRecvError::Empty)),
-            "executor must not receive PlanCreated while the nvenc permit is held"
-        );
+        assert_executor_not_entered_while_limited(
+            &entered_rx,
+            processing.as_mut(),
+            "executor must not receive PlanCreated while the nvenc permit is held",
+        )
+        .await;
 
         drop(held);
         tokio::time::timeout(Duration::from_secs(1), &mut processing)
@@ -906,7 +891,6 @@ mod tests {
                 None,
             ))
             .await;
-        let (limiter, mut wait_rx) = observe_limiter_acquires(limiter);
 
         let path = fixture.dir_path().join("movie.mkv");
         std::fs::write(&path, vec![0u8; 1024]).unwrap();
@@ -929,11 +913,12 @@ mod tests {
         let processing = process_single_file_execute(&file, &compiled, &ctx);
         tokio::pin!(processing);
 
-        wait_for_limiter_acquire(&mut wait_rx, "hw:nvenc", processing.as_mut()).await;
-        assert!(
-            matches!(entered_rx.try_recv(), Err(mpsc::TryRecvError::Empty)),
-            "executor must not receive PlanCreated while the default nvenc permit is held"
-        );
+        assert_executor_not_entered_while_limited(
+            &entered_rx,
+            processing.as_mut(),
+            "executor must not receive PlanCreated while the default nvenc permit is held",
+        )
+        .await;
 
         drop(held);
         tokio::time::timeout(Duration::from_secs(1), &mut processing)
@@ -954,7 +939,6 @@ mod tests {
             1,
         )]);
         let held = held_nvenc_permit(&limiter).await;
-        let (limiter, mut wait_rx) = observe_limiter_acquires(limiter);
 
         let path = fixture.dir_path().join("movie.mkv");
         std::fs::write(&path, vec![0u8; 1024]).unwrap();
@@ -977,11 +961,12 @@ mod tests {
         let processing = process_single_file_execute(&file, &compiled, &ctx);
         tokio::pin!(processing);
 
-        wait_for_limiter_acquire(&mut wait_rx, "hw:nvenc", processing.as_mut()).await;
-        assert!(
-            matches!(entered_rx.try_recv(), Err(mpsc::TryRecvError::Empty)),
-            "executor must not receive PlanCreated while the nvenc permit is held"
-        );
+        assert_executor_not_entered_while_limited(
+            &entered_rx,
+            processing.as_mut(),
+            "executor must not receive PlanCreated while the nvenc permit is held",
+        )
+        .await;
 
         fixture.cancel();
         drop(held);

--- a/crates/voom-cli/src/commands/process/pipeline.rs
+++ b/crates/voom-cli/src/commands/process/pipeline.rs
@@ -732,6 +732,8 @@ pub(super) fn execute_single_plan(
 
 #[cfg(test)]
 mod tests {
+    use std::future::Future;
+    use std::pin::Pin;
     use std::sync::mpsc;
     use std::sync::Arc;
     use std::time::Duration;
@@ -808,14 +810,50 @@ mod tests {
             .await
     }
 
+    fn observe_limiter_acquires(
+        limiter: voom_job_manager::worker::PlanExecutionLimiter,
+    ) -> (
+        voom_job_manager::worker::PlanExecutionLimiter,
+        tokio::sync::mpsc::UnboundedReceiver<String>,
+    ) {
+        let (wait_tx, wait_rx) = tokio::sync::mpsc::unbounded_channel();
+        let limiter = limiter.with_acquire_observer(move |resource| {
+            let _ = wait_tx.send(resource.to_string());
+        });
+        (limiter, wait_rx)
+    }
+
+    async fn wait_for_limiter_acquire(
+        wait_rx: &mut tokio::sync::mpsc::UnboundedReceiver<String>,
+        resource: &str,
+        processing: Pin<
+            &mut impl Future<Output = std::result::Result<Option<serde_json::Value>, String>>,
+        >,
+    ) {
+        let acquired = tokio::time::timeout(Duration::from_secs(1), async {
+            tokio::select! {
+                acquired = wait_rx.recv() => acquired
+                    .expect("plan limiter acquire observer should still be connected"),
+                result = processing => {
+                    panic!("processing finished before reaching the plan limiter: {result:?}");
+                }
+            }
+        })
+        .await
+        .expect("processing should reach the plan limiter acquire point");
+        assert_eq!(acquired, resource);
+    }
+
     #[tokio::test]
     async fn process_pipeline_respects_plan_limiter() {
         let policy = nvenc_policy();
         let fixture = process_tests::TestFixture::with_policy(policy);
-        let limiter = Arc::new(voom_job_manager::worker::PlanExecutionLimiter::from_limits(
-            vec![("hw:nvenc".to_string(), 1)],
-        ));
+        let limiter = voom_job_manager::worker::PlanExecutionLimiter::from_limits(vec![(
+            "hw:nvenc".to_string(),
+            1,
+        )]);
         let held = held_nvenc_permit(&limiter).await;
+        let (limiter, mut wait_rx) = observe_limiter_acquires(limiter);
 
         let path = fixture.dir_path().join("movie.mkv");
         std::fs::write(&path, vec![0u8; 1024]).unwrap();
@@ -828,7 +866,7 @@ mod tests {
             .register_plugin(Arc::new(RecordingExecutor { entered_tx }), 50)
             .unwrap();
         let ctx = ProcessContext {
-            plan_limiter: limiter,
+            plan_limiter: Arc::new(limiter),
             ..fixture.make_ctx(
                 Arc::new(kernel),
                 Arc::new(voom_domain::test_support::InMemoryStore::new()),
@@ -838,12 +876,7 @@ mod tests {
         let processing = process_single_file_execute(&file, &compiled, &ctx);
         tokio::pin!(processing);
 
-        assert!(
-            tokio::time::timeout(Duration::from_millis(20), &mut processing)
-                .await
-                .is_err(),
-            "processing must wait for the plan limiter before executor dispatch"
-        );
+        wait_for_limiter_acquire(&mut wait_rx, "hw:nvenc", processing.as_mut()).await;
         assert!(
             matches!(entered_rx.try_recv(), Err(mpsc::TryRecvError::Empty)),
             "executor must not receive PlanCreated while the nvenc permit is held"
@@ -863,11 +896,9 @@ mod tests {
     async fn process_pipeline_limits_transcode_without_per_action_hw() {
         let policy = global_hw_policy();
         let fixture = process_tests::TestFixture::with_policy(policy);
-        let limiter = Arc::new(
-            voom_job_manager::worker::PlanExecutionLimiter::from_limits_with_default(
-                vec![("hw:nvenc".to_string(), 1)],
-                Some("hw:nvenc".to_string()),
-            ),
+        let limiter = voom_job_manager::worker::PlanExecutionLimiter::from_limits_with_default(
+            vec![("hw:nvenc".to_string(), 1)],
+            Some("hw:nvenc".to_string()),
         );
         let held = limiter
             .acquire_for_plan(&process_tests::test_plan_with_optional_transcode_hw(
@@ -875,6 +906,7 @@ mod tests {
                 None,
             ))
             .await;
+        let (limiter, mut wait_rx) = observe_limiter_acquires(limiter);
 
         let path = fixture.dir_path().join("movie.mkv");
         std::fs::write(&path, vec![0u8; 1024]).unwrap();
@@ -887,7 +919,7 @@ mod tests {
             .register_plugin(Arc::new(RecordingExecutor { entered_tx }), 50)
             .unwrap();
         let ctx = ProcessContext {
-            plan_limiter: limiter,
+            plan_limiter: Arc::new(limiter),
             ..fixture.make_ctx(
                 Arc::new(kernel),
                 Arc::new(voom_domain::test_support::InMemoryStore::new()),
@@ -897,12 +929,7 @@ mod tests {
         let processing = process_single_file_execute(&file, &compiled, &ctx);
         tokio::pin!(processing);
 
-        assert!(
-            tokio::time::timeout(Duration::from_millis(20), &mut processing)
-                .await
-                .is_err(),
-            "global/default hw transcode should wait for the default limited resource"
-        );
+        wait_for_limiter_acquire(&mut wait_rx, "hw:nvenc", processing.as_mut()).await;
         assert!(
             matches!(entered_rx.try_recv(), Err(mpsc::TryRecvError::Empty)),
             "executor must not receive PlanCreated while the default nvenc permit is held"
@@ -922,10 +949,12 @@ mod tests {
     async fn process_pipeline_cancellation_stops_waiting_for_plan_limiter() {
         let policy = nvenc_policy();
         let fixture = process_tests::TestFixture::with_policy(policy);
-        let limiter = Arc::new(voom_job_manager::worker::PlanExecutionLimiter::from_limits(
-            vec![("hw:nvenc".to_string(), 1)],
-        ));
+        let limiter = voom_job_manager::worker::PlanExecutionLimiter::from_limits(vec![(
+            "hw:nvenc".to_string(),
+            1,
+        )]);
         let held = held_nvenc_permit(&limiter).await;
+        let (limiter, mut wait_rx) = observe_limiter_acquires(limiter);
 
         let path = fixture.dir_path().join("movie.mkv");
         std::fs::write(&path, vec![0u8; 1024]).unwrap();
@@ -938,7 +967,7 @@ mod tests {
             .register_plugin(Arc::new(RecordingExecutor { entered_tx }), 50)
             .unwrap();
         let ctx = ProcessContext {
-            plan_limiter: limiter,
+            plan_limiter: Arc::new(limiter),
             ..fixture.make_ctx(
                 Arc::new(kernel),
                 Arc::new(voom_domain::test_support::InMemoryStore::new()),
@@ -948,12 +977,7 @@ mod tests {
         let processing = process_single_file_execute(&file, &compiled, &ctx);
         tokio::pin!(processing);
 
-        assert!(
-            tokio::time::timeout(Duration::from_millis(20), &mut processing)
-                .await
-                .is_err(),
-            "processing must wait for the plan limiter before cancellation"
-        );
+        wait_for_limiter_acquire(&mut wait_rx, "hw:nvenc", processing.as_mut()).await;
         assert!(
             matches!(entered_rx.try_recv(), Err(mpsc::TryRecvError::Empty)),
             "executor must not receive PlanCreated while the nvenc permit is held"

--- a/crates/voom-cli/src/commands/verify.rs
+++ b/crates/voom-cli/src/commands/verify.rs
@@ -109,7 +109,7 @@ fn run_verify(args: VerifyArgs) -> Result<()> {
         .iter()
         .any(|r| r.outcome == VerificationOutcome::Error);
     if any_errors {
-        std::process::exit(1);
+        bail!("verification completed with errors");
     }
     Ok(())
 }

--- a/crates/voom-cli/tests/executor_routing.rs
+++ b/crates/voom-cli/tests/executor_routing.rs
@@ -9,12 +9,10 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::sync::Arc;
 
-use voom_domain::capabilities::Capability;
-use voom_domain::errors::Result;
 use voom_domain::events::{Event, PlanCreatedEvent};
 use voom_domain::media::{Container, MediaFile, Track, TrackType};
 use voom_domain::plan::{ActionParams, OperationType, Plan, PlannedAction, TranscodeSettings};
-use voom_kernel::{Kernel, Plugin, PluginContext};
+use voom_kernel::{Kernel, PluginContext};
 
 fn mkvmerge_available() -> bool {
     Command::new("mkvmerge")
@@ -30,148 +28,21 @@ fn ffmpeg_available() -> bool {
         .is_ok_and(|o| o.status.success())
 }
 
-enum TestExecutorKind {
-    Mkvtoolnix,
-    Ffmpeg,
-}
-
-struct TestExecutor {
-    kind: TestExecutorKind,
-    capabilities: Vec<Capability>,
-}
-
-impl TestExecutor {
-    fn mkvtoolnix() -> Self {
-        let mut operations = OperationType::METADATA_OPS.to_vec();
-        operations.extend([
-            OperationType::RemoveTrack,
-            OperationType::ReorderTracks,
-            OperationType::ConvertContainer,
-        ]);
-        Self {
-            kind: TestExecutorKind::Mkvtoolnix,
-            capabilities: vec![Capability::Execute {
-                operations,
-                formats: vec!["mkv".to_string()],
-            }],
-        }
-    }
-
-    fn ffmpeg() -> Self {
-        Self {
-            kind: TestExecutorKind::Ffmpeg,
-            capabilities: vec![Capability::Execute {
-                operations: vec![
-                    OperationType::ConvertContainer,
-                    OperationType::TranscodeVideo,
-                    OperationType::TranscodeAudio,
-                    OperationType::SynthesizeAudio,
-                    OperationType::SetDefault,
-                    OperationType::ClearDefault,
-                    OperationType::SetForced,
-                    OperationType::ClearForced,
-                    OperationType::SetTitle,
-                    OperationType::SetLanguage,
-                    OperationType::SetContainerTag,
-                    OperationType::ClearContainerTags,
-                    OperationType::DeleteContainerTag,
-                ],
-                formats: vec![],
-            }],
-        }
-    }
-
-    fn can_handle(&self, plan: &Plan) -> bool {
-        match self.kind {
-            TestExecutorKind::Mkvtoolnix => {
-                if plan.is_empty() || plan.is_skipped() {
-                    return false;
-                }
-                let is_mkv = plan.file.container == Container::Mkv;
-                let converts_to_mkv = plan.actions.iter().any(|a| {
-                    a.operation == OperationType::ConvertContainer
-                        && matches!(
-                            &a.parameters,
-                            ActionParams::Container { container } if *container == Container::Mkv
-                        )
-                });
-                (is_mkv || converts_to_mkv)
-                    && plan.actions.iter().all(|a| {
-                        a.operation.is_metadata_op()
-                            || matches!(
-                                a.operation,
-                                OperationType::RemoveTrack
-                                    | OperationType::ReorderTracks
-                                    | OperationType::ConvertContainer
-                            )
-                    })
-            }
-            TestExecutorKind::Ffmpeg => {
-                if plan.is_empty() || plan.is_skipped() {
-                    return false;
-                }
-                let has_transcode = plan.actions.iter().any(|a| {
-                    matches!(
-                        a.operation,
-                        OperationType::TranscodeVideo
-                            | OperationType::TranscodeAudio
-                            | OperationType::SynthesizeAudio
-                    )
-                });
-                let has_convert = plan
-                    .actions
-                    .iter()
-                    .any(|a| a.operation == OperationType::ConvertContainer);
-                if has_transcode || has_convert {
-                    return true;
-                }
-                plan.file.container != Container::Mkv
-                    && plan.actions.iter().all(|a| a.operation.is_metadata_op())
-            }
-        }
-    }
-}
-
-impl Plugin for TestExecutor {
-    fn name(&self) -> &str {
-        match self.kind {
-            TestExecutorKind::Mkvtoolnix => "mkvtoolnix-executor",
-            TestExecutorKind::Ffmpeg => "ffmpeg-executor",
-        }
-    }
-
-    fn version(&self) -> &str {
-        "test"
-    }
-
-    fn capabilities(&self) -> &[Capability] {
-        &self.capabilities
-    }
-
-    fn handles(&self, event_type: &str) -> bool {
-        event_type == Event::PLAN_CREATED
-    }
-
-    fn on_event(&self, event: &Event) -> Result<Option<voom_domain::events::EventResult>> {
-        let Event::PlanCreated(plan_event) = event else {
-            return Ok(None);
-        };
-        if !self.can_handle(&plan_event.plan) {
-            return Ok(None);
-        }
-        let mut result = voom_domain::events::EventResult::new(self.name());
-        result.claimed = true;
-        Ok(Some(result))
-    }
-}
-
 fn make_kernel_with_both_executors() -> Kernel {
     let mut kernel = Kernel::new();
     kernel
-        .register_plugin(Arc::new(TestExecutor::mkvtoolnix()), 39)
+        .register_plugin(
+            Arc::new(
+                voom_mkvtoolnix_executor::MkvtoolnixExecutorPlugin::new().with_available(true),
+            ),
+            39,
+        )
         .expect("register deterministic mkvtoolnix test executor");
     kernel
-        .register_plugin(Arc::new(TestExecutor::ffmpeg()), 40)
+        .register_plugin(
+            Arc::new(voom_ffmpeg_executor::FfmpegExecutorPlugin::new().with_available(true)),
+            40,
+        )
         .expect("register deterministic ffmpeg test executor");
     kernel
 }

--- a/crates/voom-cli/tests/executor_routing.rs
+++ b/crates/voom-cli/tests/executor_routing.rs
@@ -9,10 +9,12 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::sync::Arc;
 
+use voom_domain::capabilities::Capability;
+use voom_domain::errors::Result;
 use voom_domain::events::{Event, PlanCreatedEvent};
 use voom_domain::media::{Container, MediaFile, Track, TrackType};
 use voom_domain::plan::{ActionParams, OperationType, Plan, PlannedAction, TranscodeSettings};
-use voom_kernel::{Kernel, PluginContext};
+use voom_kernel::{Kernel, Plugin, PluginContext};
 
 fn mkvmerge_available() -> bool {
     Command::new("mkvmerge")
@@ -28,20 +30,149 @@ fn ffmpeg_available() -> bool {
         .is_ok_and(|o| o.status.success())
 }
 
+enum TestExecutorKind {
+    Mkvtoolnix,
+    Ffmpeg,
+}
+
+struct TestExecutor {
+    kind: TestExecutorKind,
+    capabilities: Vec<Capability>,
+}
+
+impl TestExecutor {
+    fn mkvtoolnix() -> Self {
+        let mut operations = OperationType::METADATA_OPS.to_vec();
+        operations.extend([
+            OperationType::RemoveTrack,
+            OperationType::ReorderTracks,
+            OperationType::ConvertContainer,
+        ]);
+        Self {
+            kind: TestExecutorKind::Mkvtoolnix,
+            capabilities: vec![Capability::Execute {
+                operations,
+                formats: vec!["mkv".to_string()],
+            }],
+        }
+    }
+
+    fn ffmpeg() -> Self {
+        Self {
+            kind: TestExecutorKind::Ffmpeg,
+            capabilities: vec![Capability::Execute {
+                operations: vec![
+                    OperationType::ConvertContainer,
+                    OperationType::TranscodeVideo,
+                    OperationType::TranscodeAudio,
+                    OperationType::SynthesizeAudio,
+                    OperationType::SetDefault,
+                    OperationType::ClearDefault,
+                    OperationType::SetForced,
+                    OperationType::ClearForced,
+                    OperationType::SetTitle,
+                    OperationType::SetLanguage,
+                    OperationType::SetContainerTag,
+                    OperationType::ClearContainerTags,
+                    OperationType::DeleteContainerTag,
+                ],
+                formats: vec![],
+            }],
+        }
+    }
+
+    fn can_handle(&self, plan: &Plan) -> bool {
+        match self.kind {
+            TestExecutorKind::Mkvtoolnix => {
+                if plan.is_empty() || plan.is_skipped() {
+                    return false;
+                }
+                let is_mkv = plan.file.container == Container::Mkv;
+                let converts_to_mkv = plan.actions.iter().any(|a| {
+                    a.operation == OperationType::ConvertContainer
+                        && matches!(
+                            &a.parameters,
+                            ActionParams::Container { container } if *container == Container::Mkv
+                        )
+                });
+                (is_mkv || converts_to_mkv)
+                    && plan.actions.iter().all(|a| {
+                        a.operation.is_metadata_op()
+                            || matches!(
+                                a.operation,
+                                OperationType::RemoveTrack
+                                    | OperationType::ReorderTracks
+                                    | OperationType::ConvertContainer
+                            )
+                    })
+            }
+            TestExecutorKind::Ffmpeg => {
+                if plan.is_empty() || plan.is_skipped() {
+                    return false;
+                }
+                let has_transcode = plan.actions.iter().any(|a| {
+                    matches!(
+                        a.operation,
+                        OperationType::TranscodeVideo
+                            | OperationType::TranscodeAudio
+                            | OperationType::SynthesizeAudio
+                    )
+                });
+                let has_convert = plan
+                    .actions
+                    .iter()
+                    .any(|a| a.operation == OperationType::ConvertContainer);
+                if has_transcode || has_convert {
+                    return true;
+                }
+                plan.file.container != Container::Mkv
+                    && plan.actions.iter().all(|a| a.operation.is_metadata_op())
+            }
+        }
+    }
+}
+
+impl Plugin for TestExecutor {
+    fn name(&self) -> &str {
+        match self.kind {
+            TestExecutorKind::Mkvtoolnix => "mkvtoolnix-executor",
+            TestExecutorKind::Ffmpeg => "ffmpeg-executor",
+        }
+    }
+
+    fn version(&self) -> &str {
+        "test"
+    }
+
+    fn capabilities(&self) -> &[Capability] {
+        &self.capabilities
+    }
+
+    fn handles(&self, event_type: &str) -> bool {
+        event_type == Event::PLAN_CREATED
+    }
+
+    fn on_event(&self, event: &Event) -> Result<Option<voom_domain::events::EventResult>> {
+        let Event::PlanCreated(plan_event) = event else {
+            return Ok(None);
+        };
+        if !self.can_handle(&plan_event.plan) {
+            return Ok(None);
+        }
+        let mut result = voom_domain::events::EventResult::new(self.name());
+        result.claimed = true;
+        Ok(Some(result))
+    }
+}
+
 fn make_kernel_with_both_executors() -> Kernel {
     let mut kernel = Kernel::new();
-    let ctx = PluginContext::new(serde_json::json!({}), std::env::temp_dir());
-    // init_and_register probes for tools and sets availability
-    let _ = kernel.init_and_register(
-        Arc::new(voom_mkvtoolnix_executor::MkvtoolnixExecutorPlugin::new()),
-        39,
-        &ctx,
-    );
-    let _ = kernel.init_and_register(
-        Arc::new(voom_ffmpeg_executor::FfmpegExecutorPlugin::new()),
-        40,
-        &ctx,
-    );
+    kernel
+        .register_plugin(Arc::new(TestExecutor::mkvtoolnix()), 39)
+        .expect("register deterministic mkvtoolnix test executor");
+    kernel
+        .register_plugin(Arc::new(TestExecutor::ffmpeg()), 40)
+        .expect("register deterministic ffmpeg test executor");
     kernel
 }
 
@@ -74,10 +205,6 @@ fn make_plan(file: MediaFile, actions: Vec<PlannedAction>) -> Plan {
 /// Transcode plans should be routed to ffmpeg-executor (mkvtoolnix cannot transcode).
 #[test]
 fn test_transcode_routes_to_ffmpeg() {
-    if !ffmpeg_available() {
-        eprintln!("skipping: ffmpeg not found on PATH");
-        return;
-    }
     let kernel = make_kernel_with_both_executors();
 
     let plan = make_plan(
@@ -106,10 +233,6 @@ fn test_transcode_routes_to_ffmpeg() {
 /// MKV metadata-only plans should route to mkvtoolnix-executor.
 #[test]
 fn test_mkv_metadata_routes_to_mkvtoolnix() {
-    if !mkvmerge_available() {
-        eprintln!("skipping: mkvmerge not found on PATH");
-        return;
-    }
     let kernel = make_kernel_with_both_executors();
 
     let plan = make_plan(
@@ -133,10 +256,6 @@ fn test_mkv_metadata_routes_to_mkvtoolnix() {
 /// Non-MKV metadata plans should route to ffmpeg-executor.
 #[test]
 fn test_non_mkv_metadata_routes_to_ffmpeg() {
-    if !ffmpeg_available() {
-        eprintln!("skipping: ffmpeg not found on PATH");
-        return;
-    }
     let kernel = make_kernel_with_both_executors();
 
     let plan = make_plan(
@@ -160,10 +279,6 @@ fn test_non_mkv_metadata_routes_to_ffmpeg() {
 /// `ConvertContainer` to MKV should route to mkvtoolnix (higher priority, can handle).
 #[test]
 fn test_convert_to_mkv_routes_to_mkvtoolnix() {
-    if !mkvmerge_available() {
-        eprintln!("skipping: mkvmerge not found on PATH");
-        return;
-    }
     let kernel = make_kernel_with_both_executors();
 
     let plan = make_plan(
@@ -189,10 +304,6 @@ fn test_convert_to_mkv_routes_to_mkvtoolnix() {
 /// MKV transcode plans route to ffmpeg, not mkvtoolnix (mkvtoolnix can't transcode).
 #[test]
 fn test_mkv_transcode_routes_to_ffmpeg() {
-    if !ffmpeg_available() {
-        eprintln!("skipping: ffmpeg not found on PATH");
-        return;
-    }
     let kernel = make_kernel_with_both_executors();
 
     let plan = make_plan(
@@ -256,4 +367,33 @@ fn test_skipped_plan_not_claimed() {
         results.is_empty(),
         "skipped plan should produce no EventResult, got {results:?}"
     );
+}
+
+/// Live executor registration is a smoke test only; deterministic routing
+/// assertions above must not depend on local media tools being installed.
+#[test]
+fn test_live_executor_registration_when_tools_available() {
+    if !ffmpeg_available() || !mkvmerge_available() {
+        eprintln!("skipping live executor smoke test: ffmpeg or mkvmerge not found on PATH");
+        return;
+    }
+
+    let mut kernel = Kernel::new();
+    let ctx = PluginContext::new(serde_json::json!({}), std::env::temp_dir());
+    kernel
+        .init_and_register(
+            Arc::new(voom_mkvtoolnix_executor::MkvtoolnixExecutorPlugin::new()),
+            39,
+            &ctx,
+        )
+        .expect("mkvtoolnix executor should register when mkvmerge is available");
+    kernel
+        .init_and_register(
+            Arc::new(voom_ffmpeg_executor::FfmpegExecutorPlugin::new()),
+            40,
+            &ctx,
+        )
+        .expect("ffmpeg executor should register when ffmpeg is available");
+
+    assert_eq!(kernel.subscriber_count(), 2);
 }

--- a/crates/voom-cli/tests/functional_tests.rs
+++ b/crates/voom-cli/tests/functional_tests.rs
@@ -4081,6 +4081,12 @@ mod test_process_plan_only {
             .collect()
     }
 
+    fn set_all_introspected_at(env: &TestEnv, timestamp: &str) {
+        let conn = rusqlite::Connection::open(env.db_path()).expect("open test database");
+        conn.execute("UPDATE files SET introspected_at = ?1", [timestamp])
+            .expect("update files introspected_at");
+    }
+
     /// A second `process --plan-only` pass against the same DB must not
     /// re-introspect unchanged files (no ffprobe call → stored
     /// `introspected_at` is unchanged). `--force-rescan` overrides.
@@ -4126,10 +4132,8 @@ mod test_process_plan_only {
             );
         }
 
-        // `introspected_at` is stored as an ISO-8601 string with second
-        // resolution, so sleep ≥1 s before --force-rescan to guarantee the
-        // re-write produces a strictly later timestamp.
-        std::thread::sleep(std::time::Duration::from_secs(1));
+        set_all_introspected_at(&env, "2000-01-01T00:00:00Z");
+        let before_force = introspected_at_by_path(&env);
         env.voom()
             .args([
                 "process",
@@ -4143,14 +4147,14 @@ mod test_process_plan_only {
             .assert()
             .success();
         let after_force = introspected_at_by_path(&env);
-        for (path, scan_ts) in &after_scan {
+        for (path, before_force_ts) in &before_force {
             let force_ts = after_force
                 .get(path)
                 .unwrap_or_else(|| panic!("file {path} disappeared after --force-rescan"));
             assert_ne!(
-                scan_ts, force_ts,
+                before_force_ts, force_ts,
                 "--force-rescan must re-introspect; path={path} \
-                 before={scan_ts} after={force_ts}"
+                 before={before_force_ts} after={force_ts}"
             );
         }
     }

--- a/crates/voom-domain/src/events.rs
+++ b/crates/voom-domain/src/events.rs
@@ -954,25 +954,26 @@ pub struct VerifyCompletedEvent {
     pub verification_id: Uuid,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct VerifyCompletedDetails {
+    pub mode: crate::verification::VerificationMode,
+    pub outcome: crate::verification::VerificationOutcome,
+    pub error_count: u32,
+    pub warning_count: u32,
+    pub verification_id: Uuid,
+}
+
 impl VerifyCompletedEvent {
     #[must_use]
-    pub fn new(
-        file_id: impl Into<String>,
-        path: PathBuf,
-        mode: crate::verification::VerificationMode,
-        outcome: crate::verification::VerificationOutcome,
-        error_count: u32,
-        warning_count: u32,
-        verification_id: Uuid,
-    ) -> Self {
+    pub fn new(file_id: impl Into<String>, path: PathBuf, details: VerifyCompletedDetails) -> Self {
         Self {
             file_id: file_id.into(),
             path,
-            mode,
-            outcome,
-            error_count,
-            warning_count,
-            verification_id,
+            mode: details.mode,
+            outcome: details.outcome,
+            error_count: details.error_count,
+            warning_count: details.warning_count,
+            verification_id: details.verification_id,
         }
     }
 }
@@ -1445,11 +1446,13 @@ mod verify_event_tests {
         let ev = Event::VerifyCompleted(VerifyCompletedEvent::new(
             "file-id",
             PathBuf::from("/m/x.mkv"),
-            VerificationMode::Thorough,
-            VerificationOutcome::Error,
-            3,
-            1,
-            Uuid::nil(),
+            VerifyCompletedDetails {
+                mode: VerificationMode::Thorough,
+                outcome: VerificationOutcome::Error,
+                error_count: 3,
+                warning_count: 1,
+                verification_id: Uuid::nil(),
+            },
         ));
         let s = ev.summary();
         assert!(s.contains("path=/m/x.mkv"));
@@ -1480,11 +1483,13 @@ mod verify_event_tests {
         let ev = VerifyCompletedEvent::new(
             "f",
             PathBuf::from("/x.mkv"),
-            VerificationMode::Hash,
-            VerificationOutcome::Ok,
-            0,
-            0,
-            Uuid::nil(),
+            VerifyCompletedDetails {
+                mode: VerificationMode::Hash,
+                outcome: VerificationOutcome::Ok,
+                error_count: 0,
+                warning_count: 0,
+                verification_id: Uuid::nil(),
+            },
         );
         let json = serde_json::to_string(&ev).unwrap();
         let back: VerifyCompletedEvent = serde_json::from_str(&json).unwrap();

--- a/crates/voom-domain/src/plan.rs
+++ b/crates/voom-domain/src/plan.rs
@@ -180,12 +180,35 @@ impl PlannedAction {
         parameters: ActionParams,
         description: impl Into<String>,
     ) -> Self {
-        Self {
+        Self::try_file_op(operation, parameters, description)
+            .unwrap_or_else(|error| panic!("invalid planned action: {error}"))
+    }
+
+    /// Try to create a planned action for a file-level operation.
+    ///
+    /// # Errors
+    /// Returns an error when `operation` and `parameters` describe different action kinds.
+    pub fn try_file_op(
+        operation: OperationType,
+        parameters: ActionParams,
+        description: impl Into<String>,
+    ) -> Result<Self, String> {
+        Self::new_checked(operation, None, parameters, description)
+    }
+
+    fn new_checked(
+        operation: OperationType,
+        track_index: Option<u32>,
+        parameters: ActionParams,
+        description: impl Into<String>,
+    ) -> Result<Self, String> {
+        validate_action_params(operation, &parameters)?;
+        Ok(Self {
             operation,
-            track_index: None,
+            track_index,
             parameters,
             description: description.into(),
-        }
+        })
     }
 
     /// Create a planned action targeting a specific track.
@@ -213,11 +236,77 @@ impl PlannedAction {
         parameters: ActionParams,
         description: impl Into<String>,
     ) -> Self {
-        Self {
-            operation,
-            track_index: Some(track_index),
-            parameters,
-            description: description.into(),
+        Self::try_track_op(operation, track_index, parameters, description)
+            .unwrap_or_else(|error| panic!("invalid planned action: {error}"))
+    }
+
+    /// Try to create a planned action targeting a specific track.
+    ///
+    /// # Errors
+    /// Returns an error when `operation` and `parameters` describe different action kinds.
+    pub fn try_track_op(
+        operation: OperationType,
+        track_index: u32,
+        parameters: ActionParams,
+        description: impl Into<String>,
+    ) -> Result<Self, String> {
+        Self::new_checked(operation, Some(track_index), parameters, description)
+    }
+}
+
+fn validate_action_params(
+    operation: OperationType,
+    parameters: &ActionParams,
+) -> Result<(), String> {
+    match (operation, parameters) {
+        (
+            OperationType::SetDefault
+            | OperationType::ClearDefault
+            | OperationType::SetForced
+            | OperationType::ClearForced,
+            ActionParams::Empty,
+        )
+        | (OperationType::ConvertContainer, ActionParams::Container { .. })
+        | (OperationType::RemoveTrack, ActionParams::RemoveTrack { .. })
+        | (OperationType::ReorderTracks, ActionParams::ReorderTracks { .. })
+        | (OperationType::SetLanguage, ActionParams::Language { .. })
+        | (OperationType::SetTitle, ActionParams::Title { .. })
+        | (
+            OperationType::TranscodeVideo | OperationType::TranscodeAudio,
+            ActionParams::Transcode { .. },
+        )
+        | (OperationType::SynthesizeAudio, ActionParams::Synthesize { .. })
+        | (OperationType::SetContainerTag, ActionParams::SetTag { .. })
+        | (OperationType::ClearContainerTags, ActionParams::ClearTags { .. })
+        | (OperationType::DeleteContainerTag, ActionParams::DeleteTag { .. })
+        | (OperationType::MuxSubtitle, ActionParams::MuxSubtitle { .. })
+        | (OperationType::VerifyMedia, ActionParams::VerifyMedia(_))
+        | (OperationType::Quarantine, ActionParams::Quarantine(_)) => Ok(()),
+        _ => Err(format!(
+            "operation {} cannot use {} parameters",
+            operation.as_str(),
+            parameters.kind()
+        )),
+    }
+}
+
+impl ActionParams {
+    fn kind(&self) -> &'static str {
+        match self {
+            Self::Empty => "empty",
+            Self::Container { .. } => "container",
+            Self::RemoveTrack { .. } => "remove_track",
+            Self::ReorderTracks { .. } => "reorder_tracks",
+            Self::Language { .. } => "language",
+            Self::Title { .. } => "title",
+            Self::Transcode { .. } => "transcode",
+            Self::Synthesize { .. } => "synthesize",
+            Self::SetTag { .. } => "set_tag",
+            Self::ClearTags { .. } => "clear_tags",
+            Self::DeleteTag { .. } => "delete_tag",
+            Self::MuxSubtitle { .. } => "mux_subtitle",
+            Self::VerifyMedia(_) => "verify_media",
+            Self::Quarantine(_) => "quarantine",
         }
     }
 }
@@ -1093,6 +1182,45 @@ mod tests {
         assert!(plan.is_skipped());
         assert_eq!(plan.skip_reason.as_deref(), Some("no changes needed"));
         assert!(plan.actions.is_empty());
+    }
+
+    #[test]
+    fn planned_action_try_constructors_accept_matching_params() {
+        let file_action = PlannedAction::try_file_op(
+            OperationType::ConvertContainer,
+            ActionParams::Container {
+                container: Container::Mkv,
+            },
+            "convert",
+        )
+        .expect("valid file action");
+        assert_eq!(file_action.track_index, None);
+
+        let track_action = PlannedAction::try_track_op(
+            OperationType::SetLanguage,
+            1,
+            ActionParams::Language {
+                language: "eng".into(),
+            },
+            "language",
+        )
+        .expect("valid track action");
+        assert_eq!(track_action.track_index, Some(1));
+    }
+
+    #[test]
+    fn planned_action_try_constructors_reject_mismatched_params() {
+        let error = PlannedAction::try_file_op(
+            OperationType::ConvertContainer,
+            ActionParams::Language {
+                language: "eng".into(),
+            },
+            "bad",
+        )
+        .unwrap_err();
+
+        assert!(error.contains("convert_container"));
+        assert!(error.contains("language"));
     }
 
     #[test]

--- a/crates/voom-domain/src/utils/disk.rs
+++ b/crates/voom-domain/src/utils/disk.rs
@@ -104,8 +104,8 @@ pub fn estimate_required_space(plan: &Plan, file_size: u64) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::media::MediaFile;
-    use crate::plan::{ActionParams, OperationType, Plan, PlannedAction};
+    use crate::media::{Container, MediaFile, TrackType};
+    use crate::plan::{ActionParams, OperationType, Plan, PlannedAction, TranscodeSettings};
     use std::path::PathBuf;
 
     fn test_file(size: u64) -> MediaFile {
@@ -118,9 +118,43 @@ mod tests {
         let mut plan = Plan::new(file.clone(), "test-policy", "test-phase");
         for op in ops {
             plan.actions
-                .push(PlannedAction::track_op(*op, 0, ActionParams::Empty, "test"));
+                .push(PlannedAction::track_op(*op, 0, params_for_op(*op), "test"));
         }
         plan
+    }
+
+    fn params_for_op(op: OperationType) -> ActionParams {
+        match op {
+            OperationType::ConvertContainer => ActionParams::Container {
+                container: Container::Mp4,
+            },
+            OperationType::RemoveTrack => ActionParams::RemoveTrack {
+                reason: "test removal".into(),
+                track_type: TrackType::AudioCommentary,
+            },
+            OperationType::TranscodeVideo | OperationType::TranscodeAudio => {
+                ActionParams::Transcode {
+                    codec: "h264".into(),
+                    settings: TranscodeSettings::default(),
+                }
+            }
+            OperationType::SynthesizeAudio => ActionParams::Synthesize {
+                name: "descriptive audio".into(),
+                language: Some("eng".into()),
+                codec: Some("aac".into()),
+                text: None,
+                bitrate: None,
+                channels: None,
+                title: None,
+                position: None,
+                source_track: None,
+            },
+            OperationType::SetDefault
+            | OperationType::ClearDefault
+            | OperationType::SetForced
+            | OperationType::ClearForced => ActionParams::Empty,
+            _ => panic!("missing disk test params for {}", op.as_str()),
+        }
     }
 
     #[test]
@@ -251,7 +285,7 @@ mod tests {
         plan.actions.push(PlannedAction::track_op(
             OperationType::TranscodeVideo,
             0,
-            ActionParams::Empty,
+            params_for_op(OperationType::TranscodeVideo),
             "transcode",
         ));
         plan.actions

--- a/crates/voom-dsl/src/ast.rs
+++ b/crates/voom-dsl/src/ast.rs
@@ -4,6 +4,7 @@
 //! The parser converts pest's CST (concrete syntax tree) into these typed AST nodes.
 
 use serde::Serialize;
+use std::fmt;
 
 /// Source location span for error reporting.
 #[non_exhaustive]
@@ -43,7 +44,7 @@ pub struct PolicyAst {
 pub struct ConfigNode {
     pub audio_languages: Vec<String>,
     pub subtitle_languages: Vec<String>,
-    pub on_error: Option<String>,
+    pub on_error: Option<ErrorStrategyNode>,
     pub commentary_patterns: Vec<String>,
     pub keep_backups: Option<bool>,
     pub span: Span,
@@ -57,9 +58,81 @@ pub struct PhaseNode {
     pub skip_when: Option<ConditionNode>,
     pub depends_on: Vec<String>,
     pub run_if: Option<RunIfNode>,
-    pub on_error: Option<String>,
+    pub on_error: Option<ErrorStrategyNode>,
     pub operations: Vec<SpannedOperation>,
     pub span: Span,
+}
+
+/// AST-level `on_error` strategy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ErrorStrategyNode {
+    Continue,
+    Skip,
+    Abort,
+    Quarantine,
+}
+
+impl ErrorStrategyNode {
+    #[must_use]
+    pub fn from_token(token: &str) -> Option<Self> {
+        match token {
+            "continue" => Some(Self::Continue),
+            "skip" => Some(Self::Skip),
+            "abort" => Some(Self::Abort),
+            "quarantine" => Some(Self::Quarantine),
+            _ => None,
+        }
+    }
+
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Continue => "continue",
+            Self::Skip => "skip",
+            Self::Abort => "abort",
+            Self::Quarantine => "quarantine",
+        }
+    }
+}
+
+impl fmt::Display for ErrorStrategyNode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// AST-level `run_if` trigger.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RunIfTriggerNode {
+    Modified,
+    Completed,
+}
+
+impl RunIfTriggerNode {
+    #[must_use]
+    pub fn from_token(token: &str) -> Option<Self> {
+        match token {
+            "modified" => Some(Self::Modified),
+            "completed" => Some(Self::Completed),
+            _ => None,
+        }
+    }
+
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Modified => "modified",
+            Self::Completed => "completed",
+        }
+    }
+}
+
+impl fmt::Display for RunIfTriggerNode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
 }
 
 /// Phase dependency trigger.
@@ -67,7 +140,7 @@ pub struct PhaseNode {
 #[derive(Debug, Clone, Serialize)]
 pub struct RunIfNode {
     pub phase: String,
-    pub trigger: String, // "modified" or "completed"
+    pub trigger: RunIfTriggerNode,
 }
 
 /// An operation wrapped with its source span for precise error reporting.

--- a/crates/voom-dsl/src/compiler.rs
+++ b/crates/voom-dsl/src/compiler.rs
@@ -20,8 +20,9 @@ use voom_domain::plan::{SampleStrategy, TranscodeFallback};
 use voom_domain::utils::codecs;
 
 use crate::ast::{
-    ActionNode, CompareOp, ConditionNode, ConfigNode, FilterNode, OperationNode, PhaseNode,
-    PolicyAst, SynthSetting, Value, ValueOrField, VerifyMode, WhenNode,
+    ActionNode, CompareOp, ConditionNode, ConfigNode, ErrorStrategyNode, FilterNode, OperationNode,
+    PhaseNode, PolicyAst, RunIfTriggerNode, SynthSetting, Value, ValueOrField, VerifyMode,
+    WhenNode,
 };
 use crate::errors::DslError;
 
@@ -61,8 +62,7 @@ fn compile_config(config: Option<&ConfigNode>) -> CompiledConfig {
             c.audio_languages.clone(),
             c.subtitle_languages.clone(),
             c.on_error
-                .as_deref()
-                .and_then(parse_error_strategy)
+                .map(compile_error_strategy)
                 .unwrap_or(ErrorStrategy::Abort),
             c.commentary_patterns.clone(),
             c.keep_backups.unwrap_or(false),
@@ -72,7 +72,8 @@ fn compile_config(config: Option<&ConfigNode>) -> CompiledConfig {
 }
 
 /// Parse an error strategy string. Returns `None` for unrecognized values.
-/// Used by both the compiler (to convert) and validator (to check validity).
+/// Used by compiler unit tests that cover each public DSL token.
+#[cfg(test)]
 pub(crate) fn parse_error_strategy(value: &str) -> Option<ErrorStrategy> {
     match value {
         "continue" => Some(ErrorStrategy::Continue),
@@ -102,16 +103,10 @@ fn compile_phase(phase: &PhaseNode) -> std::result::Result<CompiledPhase, DslErr
         .map(compile_condition)
         .transpose()?;
 
-    let run_if = phase.run_if.as_ref().map(|r| {
-        let trigger = match r.trigger.as_str() {
-            "modified" => RunIfTrigger::Modified,
-            "completed" => RunIfTrigger::Completed,
-            other => {
-                unreachable!("grammar restricts run_if_trigger to modified|completed, got: {other}")
-            }
-        };
-        CompiledRunIf::new(r.phase.clone(), trigger)
-    });
+    let run_if = phase
+        .run_if
+        .as_ref()
+        .map(|r| CompiledRunIf::new(r.phase.clone(), compile_run_if_trigger(r.trigger)));
 
     let operations: Vec<CompiledOperation> = phase
         .operations
@@ -126,11 +121,26 @@ fn compile_phase(phase: &PhaseNode) -> std::result::Result<CompiledPhase, DslErr
         run_if,
         on_error: phase
             .on_error
-            .as_deref()
-            .and_then(parse_error_strategy)
+            .map(compile_error_strategy)
             .unwrap_or(ErrorStrategy::Abort),
         operations,
     })
+}
+
+fn compile_error_strategy(strategy: ErrorStrategyNode) -> ErrorStrategy {
+    match strategy {
+        ErrorStrategyNode::Continue => ErrorStrategy::Continue,
+        ErrorStrategyNode::Skip => ErrorStrategy::Skip,
+        ErrorStrategyNode::Abort => ErrorStrategy::Abort,
+        ErrorStrategyNode::Quarantine => ErrorStrategy::Quarantine,
+    }
+}
+
+fn compile_run_if_trigger(trigger: RunIfTriggerNode) -> RunIfTrigger {
+    match trigger {
+        RunIfTriggerNode::Modified => RunIfTrigger::Modified,
+        RunIfTriggerNode::Completed => RunIfTrigger::Completed,
+    }
 }
 
 fn compile_operation(op: &OperationNode) -> std::result::Result<CompiledOperation, DslError> {

--- a/crates/voom-dsl/src/formatter.rs
+++ b/crates/voom-dsl/src/formatter.rs
@@ -1032,7 +1032,7 @@ mod tests {
     // and `+ to *` (gives 2 spaces) mutants on each `level + 1` site fail
     // the substring assertion.
 
-    use crate::ast::{RunIfNode, Span, SpannedOperation};
+    use crate::ast::{ErrorStrategyNode, RunIfNode, RunIfTriggerNode, Span, SpannedOperation};
 
     fn empty_phase(name: &str) -> PhaseNode {
         PhaseNode {
@@ -1080,7 +1080,7 @@ mod tests {
         let mut phase = empty_phase("build");
         phase.run_if = Some(RunIfNode {
             phase: "init".into(),
-            trigger: "modified".into(),
+            trigger: RunIfTriggerNode::Modified,
         });
         let mut out = String::new();
         format_phase(&phase, &mut out, 1);
@@ -1093,7 +1093,7 @@ mod tests {
     #[test]
     fn format_phase_on_error_indents_one_deeper() {
         let mut phase = empty_phase("build");
-        phase.on_error = Some("skip".into());
+        phase.on_error = Some(ErrorStrategyNode::Skip);
         let mut out = String::new();
         format_phase(&phase, &mut out, 1);
         assert!(
@@ -1184,7 +1184,7 @@ mod tests {
     #[test]
     fn format_config_on_error_indents_one_deeper() {
         let mut config = empty_config();
-        config.on_error = Some("skip".into());
+        config.on_error = Some(ErrorStrategyNode::Skip);
         let mut out = String::new();
         format_config(&config, &mut out, 1);
         assert!(

--- a/crates/voom-dsl/src/lib.rs
+++ b/crates/voom-dsl/src/lib.rs
@@ -32,9 +32,9 @@ pub mod validator;
 pub mod testing;
 
 pub use ast::{
-    ActionNode, CompareOp, ConditionNode, ConfigNode, FilterNode, OperationNode, PhaseNode,
-    PolicyAst, RuleNode, RunIfNode, Span, SpannedOperation, SynthSetting, TrackQueryNode,
-    TrackRefNode, Value, ValueOrField, WhenNode,
+    ActionNode, CompareOp, ConditionNode, ConfigNode, ErrorStrategyNode, FilterNode, OperationNode,
+    PhaseNode, PolicyAst, RuleNode, RunIfNode, RunIfTriggerNode, Span, SpannedOperation,
+    SynthSetting, TrackQueryNode, TrackRefNode, Value, ValueOrField, WhenNode,
 };
 pub use compiled::CompiledPolicy;
 pub use errors::{DslError, DslPipelineError, DslWarning, ValidationErrors};

--- a/crates/voom-dsl/src/parser.rs
+++ b/crates/voom-dsl/src/parser.rs
@@ -13,9 +13,9 @@ use pest::Parser;
 use pest_derive::Parser;
 
 use crate::ast::{
-    ActionNode, CompareOp, ConditionNode, ConfigNode, FilterNode, OperationNode, PhaseNode,
-    PolicyAst, RuleNode, RunIfNode, Span, SpannedOperation, SynthSetting, TrackQueryNode,
-    TrackRefNode, Value, ValueOrField, VerifyMode, WhenNode,
+    ActionNode, CompareOp, ConditionNode, ConfigNode, ErrorStrategyNode, FilterNode, OperationNode,
+    PhaseNode, PolicyAst, RuleNode, RunIfNode, RunIfTriggerNode, Span, SpannedOperation,
+    SynthSetting, TrackQueryNode, TrackRefNode, Value, ValueOrField, VerifyMode, WhenNode,
 };
 use crate::errors::{DslError, Result};
 
@@ -157,7 +157,7 @@ fn build_config(pair: Pair<'_, Rule>) -> Result<ConfigNode> {
                     .into_inner()
                     .find(|p| p.as_rule() == Rule::ident)
                     .unwrap();
-                on_error = Some(ident_pair.as_str().to_string());
+                on_error = Some(parse_on_error_token(ident_pair)?);
             }
             "commentary_patterns" => {
                 let list_pair = item
@@ -237,16 +237,16 @@ fn build_phase(pair: Pair<'_, Rule>) -> Result<PhaseNode> {
                 let trigger = inner
                     .find(|p| p.as_rule() == Rule::run_if_trigger)
                     .unwrap()
-                    .as_str()
-                    .to_string();
+                    .as_str();
+                let trigger = RunIfTriggerNode::from_token(trigger)
+                    .expect("grammar restricts run_if_trigger to modified|completed");
                 run_if = Some(RunIfNode {
                     phase: phase_name,
                     trigger,
                 });
             }
             Rule::on_error => {
-                let ident = child.into_inner().next().unwrap();
-                on_error = Some(ident.as_str().to_string());
+                on_error = Some(build_on_error(child)?);
             }
             Rule::container_op => {
                 let span = span_from_pair(&child);
@@ -365,6 +365,23 @@ fn build_phase(pair: Pair<'_, Rule>) -> Result<PhaseNode> {
     })
 }
 
+fn build_on_error(pair: Pair<'_, Rule>) -> Result<ErrorStrategyNode> {
+    parse_on_error_token(pair.into_inner().next().unwrap())
+}
+
+fn parse_on_error_token(pair: Pair<'_, Rule>) -> Result<ErrorStrategyNode> {
+    let token = pair.as_str();
+    ErrorStrategyNode::from_token(token).ok_or_else(|| {
+        let (line, col) = pair.as_span().start_pos().line_col();
+        DslError::build(
+            line,
+            col,
+            format!(
+                "invalid on_error value \"{token}\", expected \"continue\", \"abort\", \"skip\", or \"quarantine\""
+            ),
+        )
+    })
+}
 /// Extract the target and optional filter from a `keep_op` or `remove_op` pair.
 fn build_keep_remove_parts(pair: Pair<'_, Rule>) -> Result<(String, Option<FilterNode>)> {
     let mut inner = pair.into_inner();
@@ -1175,7 +1192,7 @@ mod tests {
         let config = ast.config.unwrap();
         assert_eq!(config.audio_languages, vec!["eng", "und"]);
         assert_eq!(config.subtitle_languages, vec!["eng"]);
-        assert_eq!(config.on_error.unwrap(), "continue");
+        assert_eq!(config.on_error.unwrap().as_str(), "continue");
         assert_eq!(config.commentary_patterns, vec!["commentary", "director"]);
     }
 
@@ -1760,7 +1777,12 @@ mod tests {
             }
         }"#;
         let ast = parse_policy(input).expect("parse");
-        assert_eq!(ast.phases[0].on_error.as_deref(), Some("quarantine"));
+        assert_eq!(
+            ast.phases[0]
+                .on_error
+                .map(crate::ast::ErrorStrategyNode::as_str),
+            Some("quarantine")
+        );
     }
 
     #[test]

--- a/crates/voom-dsl/src/testing/strategies.rs
+++ b/crates/voom-dsl/src/testing/strategies.rs
@@ -601,9 +601,12 @@ fn spanned_op_strategy() -> impl Strategy<Value = SpannedOperation> {
 fn phase_strategy() -> impl Strategy<Value = PhaseNode> {
     // Idents may collide with grammar keywords (`when`, `not`, `policy`, etc.);
     // the grammar's positional matching tolerates this, so no filter is applied.
-    use crate::ast::RunIfNode;
+    use crate::ast::{RunIfNode, RunIfTriggerNode};
 
-    let run_if_trigger = prop_oneof![Just("modified".to_string()), Just("completed".to_string()),];
+    let run_if_trigger = prop_oneof![
+        Just(RunIfTriggerNode::Modified),
+        Just(RunIfTriggerNode::Completed),
+    ];
 
     (
         ident_strategy(),

--- a/crates/voom-dsl/src/validator.rs
+++ b/crates/voom-dsl/src/validator.rs
@@ -11,9 +11,7 @@
 //! - Unreachable phases
 //! - Conflicting track actions (keep + remove on same target)
 //! - Invalid phase references in `depends_on` and `run_if`
-//! - Invalid `on_error` values
 //! - Invalid container names
-//! - Invalid `run_if` triggers
 
 use std::collections::{HashMap, HashSet};
 
@@ -106,21 +104,6 @@ fn validate_config(ast: &PolicyAst, errors: &mut Vec<DslError>) {
             ));
         }
     }
-    if let Some(on_error) = &config.on_error {
-        validate_on_error(on_error, config.span.line, config.span.col, errors);
-    }
-}
-
-fn validate_on_error(value: &str, line: usize, col: usize, errors: &mut Vec<DslError>) {
-    if crate::compiler::parse_error_strategy(value).is_none() {
-        errors.push(DslError::validation(
-            line,
-            col,
-            format!(
-                "invalid on_error value \"{value}\", expected \"continue\", \"abort\", \"skip\", or \"quarantine\""
-            ),
-        ));
-    }
 }
 
 fn validate_phase_names(ast: &PolicyAst, errors: &mut Vec<DslError>) {
@@ -170,18 +153,6 @@ fn validate_phase_references(ast: &PolicyAst, errors: &mut Vec<DslError>) {
                         phase.name, run_if.phase
                     ),
                 ));
-            }
-            match run_if.trigger.as_str() {
-                "modified" | "completed" => {}
-                other => {
-                    errors.push(DslError::validation(
-                        phase.span.line,
-                        phase.span.col,
-                        format!(
-                            "invalid run_if trigger \"{other}\", expected \"modified\" or \"completed\""
-                        ),
-                    ));
-                }
             }
         }
     }
@@ -320,10 +291,6 @@ fn validate_phase(
     errors: &mut Vec<DslError>,
     warnings: &mut Vec<DslWarning>,
 ) {
-    if let Some(on_error) = &phase.on_error {
-        validate_on_error(on_error, phase.span.line, phase.span.col, errors);
-    }
-
     if let Some(skip_when) = &phase.skip_when {
         validate_condition(
             skip_when,
@@ -1838,9 +1805,8 @@ mod tests {
             }
             phase init { container mkv }
         }"#;
-        let ast = parse_policy(input).unwrap();
-        let err = validate(&ast).unwrap_err();
-        assert!(format!("{}", err.errors[0]).contains("invalid on_error"));
+        let err = parse_policy(input).unwrap_err();
+        assert!(format!("{err}").contains("invalid on_error"));
     }
 
     #[test]

--- a/crates/voom-kernel/src/host/functions.rs
+++ b/crates/voom-kernel/src/host/functions.rs
@@ -70,25 +70,18 @@ impl HostState {
     /// default that the plugin can override by calling `set_plugin_data` (which
     /// writes to persistent storage). Once overridden, the storage value takes
     /// precedence on all subsequent reads.
-    #[must_use]
-    pub fn get_plugin_data(&self, key: &str) -> Option<Vec<u8>> {
+    pub fn get_plugin_data(&self, key: &str) -> Result<Option<Vec<u8>>, String> {
         if let Some(storage) = &self.storage {
-            // Check persistent storage first, fall back to in-memory (seeded config).
             match storage.get(&self.plugin_name, key) {
-                Ok(Some(data)) => Some(data),
-                Ok(None) => self.plugin_data.get(key).cloned(),
-                Err(e) => {
-                    tracing::warn!(
-                        plugin = %self.plugin_name,
-                        key = %key,
-                        error = %e,
-                        "storage error in get_plugin_data, falling back to in-memory"
-                    );
-                    self.plugin_data.get(key).cloned()
-                }
+                Ok(Some(data)) => Ok(Some(data)),
+                Ok(None) => Ok(self.plugin_data.get(key).cloned()),
+                Err(e) => Err(format!(
+                    "failed to read plugin data for plugin '{}' key '{}': {e}",
+                    self.plugin_name, key
+                )),
             }
         } else {
-            self.plugin_data.get(key).cloned()
+            Ok(self.plugin_data.get(key).cloned())
         }
     }
 
@@ -837,7 +830,7 @@ mod tests {
             .plugin_data
             .insert("seeded".into(), b"in-mem".to_vec());
 
-        let got = state.get_plugin_data("seeded");
+        let got = state.get_plugin_data("seeded").unwrap();
         assert_eq!(got.as_deref(), Some(b"in-mem".as_ref()));
     }
 
@@ -855,7 +848,38 @@ mod tests {
             .plugin_data
             .insert("key".into(), b"from-memory".to_vec());
 
-        let got = state.get_plugin_data("key");
+        let got = state.get_plugin_data("key").unwrap();
         assert_eq!(got.as_deref(), Some(b"from-storage".as_ref()));
+    }
+
+    #[test]
+    fn test_get_plugin_data_storage_error_does_not_fall_back() {
+        use crate::host::WasmPluginStore;
+
+        struct FailingStore;
+
+        impl WasmPluginStore for FailingStore {
+            fn get(&self, plugin_name: &str, key: &str) -> Result<Option<Vec<u8>>, String> {
+                Err(format!("{plugin_name}:{key}: backend unavailable"))
+            }
+
+            fn set(&self, _plugin_name: &str, _key: &str, _value: &[u8]) -> Result<(), String> {
+                Ok(())
+            }
+
+            fn delete(&self, _plugin_name: &str, _key: &str) -> Result<(), String> {
+                Ok(())
+            }
+        }
+
+        let mut state =
+            HostState::new("failing-plugin".into()).with_storage(Arc::new(FailingStore));
+        state
+            .plugin_data
+            .insert("config".into(), b"{\"seeded\":true}".to_vec());
+
+        let err = state.get_plugin_data("config").unwrap_err();
+        assert!(err.contains("failed to read plugin data"));
+        assert!(err.contains("backend unavailable"));
     }
 }

--- a/crates/voom-kernel/src/host/mod.rs
+++ b/crates/voom-kernel/src/host/mod.rs
@@ -177,13 +177,16 @@ mod tests {
     fn test_plugin_data_in_memory() {
         let mut state = HostState::new("test".into());
 
-        assert!(state.get_plugin_data("key1").is_none());
+        assert!(state.get_plugin_data("key1").unwrap().is_none());
 
         state.set_plugin_data("key1", b"hello world").unwrap();
-        assert_eq!(state.get_plugin_data("key1").unwrap(), b"hello world");
+        assert_eq!(
+            state.get_plugin_data("key1").unwrap().unwrap(),
+            b"hello world"
+        );
 
         state.set_plugin_data("key1", b"updated").unwrap();
-        assert_eq!(state.get_plugin_data("key1").unwrap(), b"updated");
+        assert_eq!(state.get_plugin_data("key1").unwrap().unwrap(), b"updated");
     }
 
     #[test]
@@ -192,7 +195,7 @@ mod tests {
         let mut state = HostState::new("test".into()).with_storage(store.clone());
 
         state.set_plugin_data("key1", b"value1").unwrap();
-        assert_eq!(state.get_plugin_data("key1").unwrap(), b"value1");
+        assert_eq!(state.get_plugin_data("key1").unwrap().unwrap(), b"value1");
 
         // Verify data is in the shared store.
         assert_eq!(store.get("test", "key1").unwrap().unwrap(), b"value1");
@@ -449,6 +452,7 @@ mod tests {
         let state = HostState::new("test".into()).with_initial_config(config.clone());
         let data = state
             .get_plugin_data("config")
+            .unwrap()
             .expect("config should be seeded");
         let loaded: serde_json::Value = serde_json::from_slice(&data).unwrap();
         assert_eq!(loaded, config);
@@ -457,13 +461,13 @@ mod tests {
     #[test]
     fn test_with_initial_config_empty_does_not_seed() {
         let state = HostState::new("test".into()).with_initial_config(serde_json::json!({}));
-        assert!(state.get_plugin_data("config").is_none());
+        assert!(state.get_plugin_data("config").unwrap().is_none());
     }
 
     #[test]
     fn test_with_initial_config_null_does_not_seed() {
         let state = HostState::new("test".into()).with_initial_config(serde_json::Value::Null);
-        assert!(state.get_plugin_data("config").is_none());
+        assert!(state.get_plugin_data("config").unwrap().is_none());
     }
 
     #[test]
@@ -478,6 +482,7 @@ mod tests {
         // get_plugin_data should fall through to in-memory seeded config.
         let data = state
             .get_plugin_data("config")
+            .unwrap()
             .expect("seeded config should be accessible with storage attached");
         let loaded: serde_json::Value = serde_json::from_slice(&data).unwrap();
         assert_eq!(loaded, config);
@@ -498,7 +503,7 @@ mod tests {
         state.set_plugin_data("config", &override_bytes).unwrap();
 
         // Should get the storage value, not the seeded one.
-        let data = state.get_plugin_data("config").unwrap();
+        let data = state.get_plugin_data("config").unwrap().unwrap();
         let loaded: serde_json::Value = serde_json::from_slice(&data).unwrap();
         assert_eq!(loaded, override_config);
     }

--- a/crates/voom-kernel/src/loader.rs
+++ b/crates/voom-kernel/src/loader.rs
@@ -476,15 +476,8 @@ pub mod wasm {
                             self.name, output_size, MAX_WASM_EVENT_PAYLOAD
                         )));
                     }
-                    let result = voom_wit::event_result_from_wasm(
-                        wasm_result.plugin_name,
-                        wasm_result.produced_events,
-                        wasm_result.data,
-                        wasm_result.claimed,
-                        wasm_result.execution_error,
-                        wasm_result.execution_detail,
-                    )
-                    .map_err(|e| voom_domain::errors::VoomError::Wasm(e.to_string()))?;
+                    let result = voom_wit::event_result_from_wasm(wasm_result)
+                        .map_err(|e| voom_domain::errors::VoomError::Wasm(e.to_string()))?;
                     Ok(Some(result))
                 }
                 Ok(None) => Ok(None),

--- a/crates/voom-kernel/src/loader.rs
+++ b/crates/voom-kernel/src/loader.rs
@@ -466,7 +466,9 @@ pub mod wasm {
                         .iter()
                         .map(|(t, p)| t.len() + p.len())
                         .sum::<usize>()
-                        + wasm_result.data.as_ref().map_or(0, Vec::len);
+                        + wasm_result.data.as_ref().map_or(0, Vec::len)
+                        + wasm_result.execution_error.as_ref().map_or(0, String::len)
+                        + wasm_result.execution_detail.as_ref().map_or(0, Vec::len);
                     if output_size > MAX_WASM_EVENT_PAYLOAD {
                         return Err(voom_domain::errors::VoomError::Wasm(format!(
                             "WASM plugin '{}' returned oversized payload: \
@@ -478,6 +480,9 @@ pub mod wasm {
                         wasm_result.plugin_name,
                         wasm_result.produced_events,
                         wasm_result.data,
+                        wasm_result.claimed,
+                        wasm_result.execution_error,
+                        wasm_result.execution_detail,
                     )
                     .map_err(|e| voom_domain::errors::VoomError::Wasm(e.to_string()))?;
                     Ok(Some(result))
@@ -641,6 +646,9 @@ pub mod wasm {
         let mut plugin_name = String::new();
         let mut produced_events = Vec::new();
         let mut data: Option<Vec<u8>> = None;
+        let mut claimed = false;
+        let mut execution_error: Option<String> = None;
+        let mut execution_detail: Option<Vec<u8>> = None;
 
         for (name, field_val) in fields {
             match name.as_str() {
@@ -655,6 +663,25 @@ pub mod wasm {
                     Val::Option(None) => data = None,
                     _ => {}
                 },
+                "claimed" => {
+                    if let Val::Bool(value) = field_val {
+                        claimed = *value;
+                    }
+                }
+                "execution-error" => match field_val {
+                    Val::Option(Some(boxed)) => {
+                        execution_error = Some(val_to_string(boxed.as_ref()));
+                    }
+                    Val::Option(None) => execution_error = None,
+                    _ => {}
+                },
+                "execution-detail" => match field_val {
+                    Val::Option(Some(boxed)) => {
+                        execution_detail = Some(val_to_bytes(boxed.as_ref()));
+                    }
+                    Val::Option(None) => execution_detail = None,
+                    _ => {}
+                },
                 _ => {}
             }
         }
@@ -663,6 +690,9 @@ pub mod wasm {
             plugin_name,
             produced_events,
             data,
+            claimed,
+            execution_error,
+            execution_detail,
         })
     }
 
@@ -1221,6 +1251,9 @@ Evaluate = {}
                 plugin_name: "test-plugin".into(),
                 produced_events: vec![],
                 data: Some(oversized_data),
+                claimed: false,
+                execution_error: None,
+                execution_detail: None,
             };
 
             let output_size: usize = wasm_result
@@ -1228,7 +1261,9 @@ Evaluate = {}
                 .iter()
                 .map(|(t, p)| t.len() + p.len())
                 .sum::<usize>()
-                + wasm_result.data.as_ref().map_or(0, Vec::len);
+                + wasm_result.data.as_ref().map_or(0, Vec::len)
+                + wasm_result.execution_error.as_ref().map_or(0, String::len)
+                + wasm_result.execution_detail.as_ref().map_or(0, Vec::len);
 
             assert!(
                 output_size > MAX_WASM_EVENT_PAYLOAD,

--- a/crates/voom-plugin-sdk/src/host.rs
+++ b/crates/voom-plugin-sdk/src/host.rs
@@ -57,6 +57,18 @@ pub trait HostFunctions {
     /// Store plugin-specific data in the host's data store.
     fn set_plugin_data(&self, key: &str, value: &[u8]) -> Result<(), String>;
 
+    /// Query file transitions by file ID.
+    fn get_file_transitions(&self, file_id: &str) -> Result<Vec<u8>, String> {
+        let _ = file_id;
+        Err("get_file_transitions not available".to_string())
+    }
+
+    /// Query file transitions by filesystem path.
+    fn get_path_transitions(&self, path: &str) -> Result<Vec<u8>, String> {
+        let _ = path;
+        Err("get_path_transitions not available".to_string())
+    }
+
     /// Log a message at the given level via the host's logging system.
     fn log(&self, level: &str, message: &str);
 }
@@ -103,5 +115,14 @@ mod tests {
         let result = host.run_tool("ffmpeg", &[], 1000);
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), "run_tool not available");
+    }
+
+    #[test]
+    fn test_default_transition_queries_return_error() {
+        let host = TestHost;
+        let by_id = host.get_file_transitions("file-id");
+        let by_path = host.get_path_transitions("/media/movie.mkv");
+        assert_eq!(by_id.unwrap_err(), "get_file_transitions not available");
+        assert_eq!(by_path.unwrap_err(), "get_path_transitions not available");
     }
 }

--- a/crates/voom-plugin-sdk/src/types.rs
+++ b/crates/voom-plugin-sdk/src/types.rs
@@ -91,6 +91,9 @@ pub struct OnEventResult {
     pub plugin_name: String,
     pub produced_events: Vec<(String, Vec<u8>)>,
     pub data: Option<Vec<u8>>,
+    pub claimed: bool,
+    pub execution_error: Option<String>,
+    pub execution_detail: Option<Vec<u8>>,
 }
 
 impl OnEventResult {
@@ -104,6 +107,9 @@ impl OnEventResult {
             plugin_name: plugin_name.into(),
             produced_events,
             data,
+            claimed: false,
+            execution_error: None,
+            execution_detail: None,
         }
     }
 }

--- a/crates/voom-process/src/lib.rs
+++ b/crates/voom-process/src/lib.rs
@@ -15,6 +15,8 @@ use voom_domain::errors::{Result, VoomError};
 /// Default maximum bytes retained from each captured process stream.
 pub const DEFAULT_CAPTURE_LIMIT_BYTES: usize = 1024 * 1024;
 
+type PipeReaderHandle = std::thread::JoinHandle<std::io::Result<Vec<u8>>>;
+
 /// Per-stream subprocess output capture limits.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct CaptureConfig {
@@ -124,44 +126,42 @@ fn spawn_error(tool: &str, error: std::io::Error) -> VoomError {
 fn spawn_pipe_readers(
     child: &mut std::process::Child,
     capture: CaptureConfig,
-) -> (
-    std::thread::JoinHandle<Vec<u8>>,
-    std::thread::JoinHandle<Vec<u8>>,
-) {
+) -> (PipeReaderHandle, PipeReaderHandle) {
     let mut stdout = child.stdout.take().expect("stdout piped");
     let mut stderr = child.stderr.take().expect("stderr piped");
 
-    let stdout_handle = std::thread::spawn(move || {
-        read_bounded(&mut stdout, capture.max_stdout_bytes).unwrap_or_else(|e| {
-            tracing::warn!(error = %e, "failed to read child stdout");
-            Vec::new()
-        })
-    });
+    let stdout_handle =
+        std::thread::spawn(move || read_bounded(&mut stdout, capture.max_stdout_bytes));
 
-    let stderr_handle = std::thread::spawn(move || {
-        read_bounded(&mut stderr, capture.max_stderr_bytes).unwrap_or_else(|e| {
-            tracing::warn!(error = %e, "failed to read child stderr");
-            Vec::new()
-        })
-    });
+    let stderr_handle =
+        std::thread::spawn(move || read_bounded(&mut stderr, capture.max_stderr_bytes));
 
     (stdout_handle, stderr_handle)
 }
 
 /// Collect results from pipe reader threads.
 fn join_pipe_readers(
-    stdout_handle: std::thread::JoinHandle<Vec<u8>>,
-    stderr_handle: std::thread::JoinHandle<Vec<u8>>,
-) -> (Vec<u8>, Vec<u8>) {
-    let stdout = stdout_handle.join().unwrap_or_else(|e| {
-        tracing::warn!("stdout pipe reader panicked: {e:?}");
-        Vec::new()
-    });
-    let stderr = stderr_handle.join().unwrap_or_else(|e| {
-        tracing::warn!("stderr pipe reader panicked: {e:?}");
-        Vec::new()
-    });
-    (stdout, stderr)
+    tool: &str,
+    stdout_handle: PipeReaderHandle,
+    stderr_handle: PipeReaderHandle,
+) -> Result<(Vec<u8>, Vec<u8>)> {
+    let stdout = join_pipe_reader(tool, "stdout", stdout_handle)?;
+    let stderr = join_pipe_reader(tool, "stderr", stderr_handle)?;
+    Ok((stdout, stderr))
+}
+
+fn join_pipe_reader(tool: &str, stream_name: &str, handle: PipeReaderHandle) -> Result<Vec<u8>> {
+    match handle.join() {
+        Ok(Ok(output)) => Ok(output),
+        Ok(Err(e)) => Err(VoomError::ToolExecution {
+            tool: tool.into(),
+            message: format!("failed to capture {stream_name} from {tool}: {e}"),
+        }),
+        Err(e) => Err(VoomError::ToolExecution {
+            tool: tool.into(),
+            message: format!("capture thread for {stream_name} from {tool} panicked: {e:?}"),
+        }),
+    }
 }
 
 /// Run a subprocess with a timeout, killing it if it exceeds the deadline.
@@ -179,7 +179,8 @@ pub fn run_with_timeout(
 /// Run a subprocess with a timeout and extra environment variables.
 ///
 /// # Errors
-/// Returns `VoomError::ToolExecution` if the process fails or times out.
+/// Returns `VoomError::ToolExecution` when spawning fails, the deadline
+/// expires, waiting fails, or captured output cannot be read.
 pub fn run_with_timeout_env(
     tool: &str,
     args: &[impl AsRef<OsStr>],
@@ -225,7 +226,7 @@ pub fn run_with_timeout_env_config(
 
     match child.wait_timeout(timeout) {
         Ok(Some(status)) => {
-            let (stdout, stderr) = join_pipe_readers(stdout_handle, stderr_handle);
+            let (stdout, stderr) = join_pipe_readers(tool, stdout_handle, stderr_handle)?;
             Ok(Output {
                 status,
                 stdout,
@@ -237,7 +238,7 @@ pub fn run_with_timeout_env_config(
                 tracing::warn!(tool = tool, error = %e, "failed to kill child process");
             }
             child.wait().ok();
-            join_pipe_readers(stdout_handle, stderr_handle);
+            let _ = join_pipe_readers(tool, stdout_handle, stderr_handle);
             Err(VoomError::ToolExecution {
                 tool: tool.into(),
                 message: format!("{tool} timed out after {:.1}s", timeout.as_secs_f64()),
@@ -252,7 +253,7 @@ pub fn run_with_timeout_env_config(
                 );
             }
             child.wait().ok();
-            join_pipe_readers(stdout_handle, stderr_handle);
+            let _ = join_pipe_readers(tool, stdout_handle, stderr_handle);
             Err(VoomError::ToolExecution {
                 tool: tool.into(),
                 message: format!("error waiting for {tool}: {e}"),
@@ -315,32 +316,26 @@ pub fn stderr_tail(bytes: &[u8], max_lines: usize) -> String {
 }
 
 /// Read all bytes from an optional tokio `ChildStdout`/`ChildStderr`.
-async fn read_child_pipe<R>(pipe: Option<R>, max_bytes: usize) -> Vec<u8>
+async fn read_child_pipe<R>(pipe: Option<R>, max_bytes: usize) -> std::io::Result<Vec<u8>>
 where
     R: tokio::io::AsyncReadExt + Unpin,
 {
     let Some(mut pipe) = pipe else {
-        return Vec::new();
+        return Ok(Vec::new());
     };
 
     let mut capture = BoundedCapture::new(max_bytes);
     let mut chunk = [0u8; 8192];
 
     loop {
-        let read = match pipe.read(&mut chunk).await {
-            Ok(read) => read,
-            Err(e) => {
-                tracing::warn!(error = %e, "failed to read child pipe");
-                break;
-            }
-        };
+        let read = pipe.read(&mut chunk).await?;
         if read == 0 {
             break;
         }
         capture.push(&chunk[..read]);
     }
 
-    capture.finish()
+    Ok(capture.finish())
 }
 
 /// Async cancellable subprocess execution via `tokio::process`.
@@ -350,7 +345,7 @@ where
 ///
 /// # Errors
 /// Returns `VoomError::ToolExecution` on timeout, spawn failure,
-/// or cancellation.
+/// cancellation, wait failure, or captured output read failure.
 pub async fn run_cancellable(
     tool: &str,
     args: &[impl AsRef<OsStr>],
@@ -452,6 +447,14 @@ pub async fn run_cancellable_env_config(
             (stdout, stderr, status)
         } => {
             let (stdout, stderr, status) = result;
+            let stdout = stdout.map_err(|e| VoomError::ToolExecution {
+                tool: tool.into(),
+                message: format!("failed to capture stdout from {tool}: {e}"),
+            })?;
+            let stderr = stderr.map_err(|e| VoomError::ToolExecution {
+                tool: tool.into(),
+                message: format!("failed to capture stderr from {tool}: {e}"),
+            })?;
             let status = status.map_err(|e| VoomError::ToolExecution {
                 tool: tool.into(),
                 message: format!("error waiting for {tool}: {e}"),
@@ -588,6 +591,40 @@ mod tests {
         assert_eq!(tail, "line3\n...[truncated 25 bytes]");
     }
 
+    #[test]
+    fn join_pipe_readers_reports_stdout_read_failure() {
+        let stdout_handle = std::thread::spawn(|| Err(std::io::Error::other("stdout read failed")));
+        let stderr_handle = std::thread::spawn(|| Ok(Vec::new()));
+
+        let err = join_pipe_readers("fake-tool", stdout_handle, stderr_handle).unwrap_err();
+
+        match &err {
+            VoomError::ToolExecution { tool, message } => {
+                assert_eq!(tool, "fake-tool");
+                assert!(message.contains("stdout"));
+                assert!(message.contains("stdout read failed"));
+            }
+            other => panic!("expected ToolExecution, got: {other}"),
+        }
+    }
+
+    #[test]
+    fn join_pipe_readers_reports_stderr_read_failure() {
+        let stdout_handle = std::thread::spawn(|| Ok(Vec::new()));
+        let stderr_handle = std::thread::spawn(|| Err(std::io::Error::other("stderr read failed")));
+
+        let err = join_pipe_readers("fake-tool", stdout_handle, stderr_handle).unwrap_err();
+
+        match &err {
+            VoomError::ToolExecution { tool, message } => {
+                assert_eq!(tool, "fake-tool");
+                assert!(message.contains("stderr"));
+                assert!(message.contains("stderr read failed"));
+            }
+            other => panic!("expected ToolExecution, got: {other}"),
+        }
+    }
+
     #[cfg(unix)]
     fn make_executable(path: &std::path::Path) {
         use std::os::unix::fs::PermissionsExt;
@@ -653,6 +690,27 @@ mod tests {
             String::from_utf8_lossy(&output.stdout),
             "bbbbbbbb\n...[truncated 27 bytes]"
         );
+    }
+
+    #[tokio::test]
+    async fn read_child_pipe_returns_read_error() {
+        struct FailingAsyncRead;
+
+        impl tokio::io::AsyncRead for FailingAsyncRead {
+            fn poll_read(
+                self: std::pin::Pin<&mut Self>,
+                _cx: &mut std::task::Context<'_>,
+                _buf: &mut tokio::io::ReadBuf<'_>,
+            ) -> std::task::Poll<std::io::Result<()>> {
+                std::task::Poll::Ready(Err(std::io::Error::other("async read failed")))
+            }
+        }
+
+        let err = read_child_pipe(Some(FailingAsyncRead), DEFAULT_CAPTURE_LIMIT_BYTES)
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.to_string(), "async read failed");
     }
 
     #[tokio::test]

--- a/crates/voom-wit/src/convert.rs
+++ b/crates/voom-wit/src/convert.rs
@@ -88,64 +88,85 @@ pub fn event_result_to_wasm(result: &EventResult) -> Result<WasmEventResult> {
 }
 
 /// Convert a WIT capability string (e.g., "discover:file,smb") to a domain Capability.
-#[must_use]
-pub fn capability_from_wit(cap_str: &str) -> Option<Capability> {
+///
+/// # Errors
+/// Returns an error when a known capability kind contains malformed operation
+/// or verification-mode parameters.
+pub fn capability_from_wit(cap_str: &str) -> Result<Option<Capability>> {
     let (kind, params) = cap_str.split_once(':').unwrap_or((cap_str, ""));
 
     match kind {
-        "discover" => Some(Capability::Discover {
+        "discover" => Ok(Some(Capability::Discover {
             schemes: split_comma_list(params),
-        }),
-        "introspect" => Some(Capability::Introspect {
+        })),
+        "introspect" => Ok(Some(Capability::Introspect {
             formats: split_comma_list(params),
-        }),
-        "evaluate" => Some(Capability::Evaluate),
+        })),
+        "evaluate" => Ok(Some(Capability::Evaluate)),
         "execute" => {
             // Format: "execute:op1+op2:fmt1,fmt2"
             let mut parts = params.splitn(2, ':');
             let ops_part = parts.next().unwrap_or("");
             let fmts_part = parts.next().unwrap_or("");
-            let operations = if ops_part.is_empty() {
-                vec![]
-            } else {
-                ops_part
-                    .split('+')
-                    .filter_map(|s| voom_domain::plan::OperationType::parse(s.trim()))
-                    .collect()
-            };
-            Some(Capability::Execute {
+            let operations = parse_execute_operations(ops_part)?;
+            Ok(Some(Capability::Execute {
                 operations,
                 formats: split_comma_list(fmts_part),
-            })
+            }))
         }
-        "store" => Some(Capability::Store {
+        "store" => Ok(Some(Capability::Store {
             backend: params.to_string(),
-        }),
-        "detect_tools" => Some(Capability::DetectTools),
-        "manage_jobs" => Some(Capability::ManageJobs),
-        "serve_http" => Some(Capability::ServeHttp),
-        "plan" => Some(Capability::Plan),
-        "backup" => Some(Capability::Backup),
-        "enrich_metadata" | "enrich-metadata" => Some(Capability::EnrichMetadata {
+        })),
+        "detect_tools" => Ok(Some(Capability::DetectTools)),
+        "manage_jobs" => Ok(Some(Capability::ManageJobs)),
+        "serve_http" => Ok(Some(Capability::ServeHttp)),
+        "plan" => Ok(Some(Capability::Plan)),
+        "backup" => Ok(Some(Capability::Backup)),
+        "enrich_metadata" | "enrich-metadata" => Ok(Some(Capability::EnrichMetadata {
             source: params.to_string(),
-        }),
-        "transcribe" => Some(Capability::Transcribe),
-        "synthesize" => Some(Capability::Synthesize),
-        "generate_subtitle" => Some(Capability::GenerateSubtitle),
-        "health_check" => Some(Capability::HealthCheck),
+        })),
+        "transcribe" => Ok(Some(Capability::Transcribe)),
+        "synthesize" => Ok(Some(Capability::Synthesize)),
+        "generate_subtitle" => Ok(Some(Capability::GenerateSubtitle)),
+        "health_check" => Ok(Some(Capability::HealthCheck)),
         "verify" => {
-            let modes = if params.is_empty() {
-                vec![]
-            } else {
-                params
-                    .split(',')
-                    .filter_map(|s| voom_domain::verification::VerificationMode::parse(s.trim()))
-                    .collect()
-            };
-            Some(Capability::Verify { modes })
+            let modes = parse_verify_modes(params)?;
+            Ok(Some(Capability::Verify { modes }))
         }
-        _ => None,
+        _ => Ok(None),
     }
+}
+
+fn parse_execute_operations(params: &str) -> Result<Vec<voom_domain::OperationType>> {
+    if params.is_empty() {
+        return Ok(vec![]);
+    }
+
+    params
+        .split('+')
+        .map(|value| {
+            let value = value.trim();
+            voom_domain::plan::OperationType::parse(value).ok_or_else(|| {
+                VoomError::Wasm(format!("unknown execute operation in capability: {value}"))
+            })
+        })
+        .collect()
+}
+
+fn parse_verify_modes(params: &str) -> Result<Vec<voom_domain::verification::VerificationMode>> {
+    if params.is_empty() {
+        return Ok(vec![]);
+    }
+
+    params
+        .split(',')
+        .map(|value| {
+            let value = value.trim();
+            voom_domain::verification::VerificationMode::parse(value).ok_or_else(|| {
+                VoomError::Wasm(format!("unknown verify mode in capability: {value}"))
+            })
+        })
+        .collect()
 }
 
 fn split_comma_list(s: &str) -> Vec<String> {
@@ -226,6 +247,10 @@ mod tests {
     use std::path::PathBuf;
     use voom_domain::events::*;
 
+    fn parse_capability(capability: &str) -> Capability {
+        capability_from_wit(capability).unwrap().unwrap()
+    }
+
     #[test]
     fn test_event_roundtrip_msgpack() {
         let event = Event::FileDiscovered(FileDiscoveredEvent::new(
@@ -275,7 +300,7 @@ mod tests {
         };
         let s = capability_to_wit(&cap);
         assert_eq!(s, "discover:file,smb");
-        let restored = capability_from_wit(&s).unwrap();
+        let restored = parse_capability(&s);
         assert_eq!(restored, cap);
     }
 
@@ -284,7 +309,7 @@ mod tests {
         let cap = Capability::Evaluate;
         let s = capability_to_wit(&cap);
         assert_eq!(s, "evaluate");
-        let restored = capability_from_wit(&s).unwrap();
+        let restored = parse_capability(&s);
         assert_eq!(restored, cap);
     }
 
@@ -300,7 +325,7 @@ mod tests {
         };
         let s = capability_to_wit(&cap);
         assert_eq!(s, "execute:transcode_video+convert_container:mkv,mp4");
-        let restored = capability_from_wit(&s).unwrap();
+        let restored = parse_capability(&s);
         assert_eq!(restored, cap);
     }
 
@@ -311,7 +336,7 @@ mod tests {
         };
         let s = capability_to_wit(&cap);
         assert_eq!(s, "enrich_metadata:radarr");
-        let restored = capability_from_wit(&s).unwrap();
+        let restored = parse_capability(&s);
         assert_eq!(restored, cap);
     }
 
@@ -322,7 +347,7 @@ mod tests {
         };
         let s = capability_to_wit(&cap);
         assert_eq!(s, "store:sqlite");
-        let restored = capability_from_wit(&s).unwrap();
+        let restored = parse_capability(&s);
         assert_eq!(restored, cap);
     }
 
@@ -334,7 +359,7 @@ mod tests {
         };
         let s = capability_to_wit(&cap);
         assert_eq!(s, "verify:quick,thorough");
-        let restored = capability_from_wit(&s).unwrap();
+        let restored = parse_capability(&s);
         assert_eq!(restored, cap);
     }
 
@@ -343,7 +368,7 @@ mod tests {
         let cap = Capability::Verify { modes: vec![] };
         let s = capability_to_wit(&cap);
         assert_eq!(s, "verify");
-        let restored = capability_from_wit(&s).unwrap();
+        let restored = parse_capability(&s);
         assert_eq!(restored, cap);
     }
 
@@ -362,14 +387,26 @@ mod tests {
         ] {
             let s = capability_to_wit(&cap);
             assert_eq!(s, expected_str);
-            let restored = capability_from_wit(&s).unwrap();
+            let restored = parse_capability(&s);
             assert_eq!(restored, cap);
         }
     }
 
     #[test]
     fn test_capability_from_wit_unknown() {
-        assert!(capability_from_wit("unknown_cap").is_none());
+        assert!(capability_from_wit("unknown_cap").unwrap().is_none());
+    }
+
+    #[test]
+    fn test_capability_from_wit_rejects_unknown_execute_operation() {
+        let err = capability_from_wit("execute:transcode_video+bogus:mkv").unwrap_err();
+        assert!(err.to_string().contains("unknown execute operation"));
+    }
+
+    #[test]
+    fn test_capability_from_wit_rejects_unknown_verify_mode() {
+        let err = capability_from_wit("verify:quick,deep").unwrap_err();
+        assert!(err.to_string().contains("unknown verify mode"));
     }
 
     #[test]

--- a/crates/voom-wit/src/convert.rs
+++ b/crates/voom-wit/src/convert.rs
@@ -41,6 +41,9 @@ pub fn event_result_from_wasm(
     plugin_name: String,
     produced_events: Vec<(String, Vec<u8>)>,
     data: Option<Vec<u8>>,
+    claimed: bool,
+    execution_error: Option<String>,
+    execution_detail: Option<Vec<u8>>,
 ) -> Result<EventResult> {
     let events = produced_events
         .into_iter()
@@ -55,6 +58,12 @@ pub fn event_result_from_wasm(
     let mut result = EventResult::new(plugin_name);
     result.produced_events = events;
     result.data = json_data;
+    result.claimed = claimed;
+    result.execution_error = execution_error;
+    result.execution_detail = execution_detail
+        .map(|d| serde_json::from_slice(&d))
+        .transpose()
+        .map_err(|e| VoomError::Wasm(format!("failed to deserialize execution detail: {e}")))?;
     Ok(result)
 }
 
@@ -63,6 +72,9 @@ pub struct WasmEventResult {
     pub plugin_name: String,
     pub produced_events: Vec<(String, Vec<u8>)>,
     pub data: Option<Vec<u8>>,
+    pub claimed: bool,
+    pub execution_error: Option<String>,
+    pub execution_detail: Option<Vec<u8>>,
 }
 
 /// Serialize a domain `EventResult` into WASM boundary format.
@@ -84,6 +96,14 @@ pub fn event_result_to_wasm(result: &EventResult) -> Result<WasmEventResult> {
         plugin_name: result.plugin_name.clone(),
         produced_events: produced,
         data,
+        claimed: result.claimed,
+        execution_error: result.execution_error.clone(),
+        execution_detail: result
+            .execution_detail
+            .as_ref()
+            .map(serde_json::to_vec)
+            .transpose()
+            .map_err(|e| VoomError::Wasm(format!("failed to serialize execution detail: {e}")))?,
     })
 }
 
@@ -286,6 +306,9 @@ mod tests {
             wasm_result.plugin_name,
             wasm_result.produced_events,
             wasm_result.data,
+            wasm_result.claimed,
+            wasm_result.execution_error,
+            wasm_result.execution_detail,
         )
         .unwrap();
         assert_eq!(restored.plugin_name, "test-plugin");
@@ -518,10 +541,38 @@ mod tests {
 
     #[test]
     fn test_event_result_from_wasm_empty() {
-        let result = event_result_from_wasm("empty-plugin".into(), vec![], None).unwrap();
+        let result =
+            event_result_from_wasm("empty-plugin".into(), vec![], None, false, None, None).unwrap();
         assert_eq!(result.plugin_name, "empty-plugin");
         assert!(result.produced_events.is_empty());
         assert!(result.data.is_none());
+    }
+
+    #[test]
+    fn test_event_result_roundtrip_preserves_execution_lifecycle_fields() {
+        let detail = voom_domain::plan::ExecutionDetail {
+            command: "handbrake --input movie.mkv".to_string(),
+            exit_code: Some(0),
+            stderr_tail: String::new(),
+            duration_ms: 25,
+        };
+        let mut result = EventResult::plan_succeeded("executor", None);
+        result.execution_detail = Some(detail.clone());
+
+        let wasm_result = event_result_to_wasm(&result).unwrap();
+        let restored = event_result_from_wasm(
+            wasm_result.plugin_name,
+            wasm_result.produced_events,
+            wasm_result.data,
+            wasm_result.claimed,
+            wasm_result.execution_error,
+            wasm_result.execution_detail,
+        )
+        .unwrap();
+
+        assert!(restored.claimed);
+        assert_eq!(restored.execution_error, None);
+        assert_eq!(restored.execution_detail.unwrap().command, detail.command);
     }
 
     #[test]
@@ -556,6 +607,9 @@ mod tests {
         let err = event_result_from_wasm(
             "test-plugin".into(),
             vec![("wrong.type".into(), payload)],
+            None,
+            false,
+            None,
             None,
         )
         .unwrap_err();

--- a/crates/voom-wit/src/convert.rs
+++ b/crates/voom-wit/src/convert.rs
@@ -33,40 +33,6 @@ pub fn event_from_wasm(event_type: &str, payload: &[u8]) -> Result<Event> {
     Ok(event)
 }
 
-/// Convert a WASM event result back into a domain `EventResult`.
-///
-/// The `produced_events` are MessagePack-encoded event payloads,
-/// and `data` is JSON-encoded optional data.
-pub fn event_result_from_wasm(
-    plugin_name: String,
-    produced_events: Vec<(String, Vec<u8>)>,
-    data: Option<Vec<u8>>,
-    claimed: bool,
-    execution_error: Option<String>,
-    execution_detail: Option<Vec<u8>>,
-) -> Result<EventResult> {
-    let events = produced_events
-        .into_iter()
-        .map(|(evt_type, payload)| event_from_wasm(&evt_type, &payload))
-        .collect::<Result<Vec<Event>>>()?;
-
-    let json_data = data
-        .map(|d| serde_json::from_slice(&d))
-        .transpose()
-        .map_err(|e| VoomError::Wasm(format!("failed to deserialize JSON: {e}")))?;
-
-    let mut result = EventResult::new(plugin_name);
-    result.produced_events = events;
-    result.data = json_data;
-    result.claimed = claimed;
-    result.execution_error = execution_error;
-    result.execution_detail = execution_detail
-        .map(|d| serde_json::from_slice(&d))
-        .transpose()
-        .map_err(|e| VoomError::Wasm(format!("failed to deserialize execution detail: {e}")))?;
-    Ok(result)
-}
-
 /// Serialized form of an `EventResult` for the WASM boundary.
 pub struct WasmEventResult {
     pub plugin_name: String,
@@ -75,6 +41,36 @@ pub struct WasmEventResult {
     pub claimed: bool,
     pub execution_error: Option<String>,
     pub execution_detail: Option<Vec<u8>>,
+}
+
+/// Convert a WASM event result back into a domain `EventResult`.
+///
+/// The `produced_events` are MessagePack-encoded event payloads,
+/// and `data` is JSON-encoded optional data.
+pub fn event_result_from_wasm(wasm_result: WasmEventResult) -> Result<EventResult> {
+    let events = wasm_result
+        .produced_events
+        .into_iter()
+        .map(|(evt_type, payload)| event_from_wasm(&evt_type, &payload))
+        .collect::<Result<Vec<Event>>>()?;
+
+    let json_data = wasm_result
+        .data
+        .map(|d| serde_json::from_slice(&d))
+        .transpose()
+        .map_err(|e| VoomError::Wasm(format!("failed to deserialize JSON: {e}")))?;
+
+    let mut result = EventResult::new(wasm_result.plugin_name);
+    result.produced_events = events;
+    result.data = json_data;
+    result.claimed = wasm_result.claimed;
+    result.execution_error = wasm_result.execution_error;
+    result.execution_detail = wasm_result
+        .execution_detail
+        .map(|d| serde_json::from_slice(&d))
+        .transpose()
+        .map_err(|e| VoomError::Wasm(format!("failed to deserialize execution detail: {e}")))?;
+    Ok(result)
 }
 
 /// Serialize a domain `EventResult` into WASM boundary format.
@@ -302,15 +298,7 @@ mod tests {
         assert_eq!(wasm_result.produced_events.len(), 1);
         assert!(wasm_result.data.is_some());
 
-        let restored = event_result_from_wasm(
-            wasm_result.plugin_name,
-            wasm_result.produced_events,
-            wasm_result.data,
-            wasm_result.claimed,
-            wasm_result.execution_error,
-            wasm_result.execution_detail,
-        )
-        .unwrap();
+        let restored = event_result_from_wasm(wasm_result).unwrap();
         assert_eq!(restored.plugin_name, "test-plugin");
         assert_eq!(restored.produced_events.len(), 1);
         assert_eq!(restored.data.unwrap()["status"].as_str().unwrap(), "ok");
@@ -541,8 +529,15 @@ mod tests {
 
     #[test]
     fn test_event_result_from_wasm_empty() {
-        let result =
-            event_result_from_wasm("empty-plugin".into(), vec![], None, false, None, None).unwrap();
+        let result = event_result_from_wasm(WasmEventResult {
+            plugin_name: "empty-plugin".into(),
+            produced_events: vec![],
+            data: None,
+            claimed: false,
+            execution_error: None,
+            execution_detail: None,
+        })
+        .unwrap();
         assert_eq!(result.plugin_name, "empty-plugin");
         assert!(result.produced_events.is_empty());
         assert!(result.data.is_none());
@@ -560,15 +555,7 @@ mod tests {
         result.execution_detail = Some(detail.clone());
 
         let wasm_result = event_result_to_wasm(&result).unwrap();
-        let restored = event_result_from_wasm(
-            wasm_result.plugin_name,
-            wasm_result.produced_events,
-            wasm_result.data,
-            wasm_result.claimed,
-            wasm_result.execution_error,
-            wasm_result.execution_detail,
-        )
-        .unwrap();
+        let restored = event_result_from_wasm(wasm_result).unwrap();
 
         assert!(restored.claimed);
         assert_eq!(restored.execution_error, None);
@@ -604,14 +591,14 @@ mod tests {
         ));
         let (_correct_type, payload) = event_to_wasm(&event).unwrap();
 
-        let err = event_result_from_wasm(
-            "test-plugin".into(),
-            vec![("wrong.type".into(), payload)],
-            None,
-            false,
-            None,
-            None,
-        )
+        let err = event_result_from_wasm(WasmEventResult {
+            plugin_name: "test-plugin".into(),
+            produced_events: vec![("wrong.type".into(), payload)],
+            data: None,
+            claimed: false,
+            execution_error: None,
+            execution_detail: None,
+        })
         .unwrap_err();
         assert!(err.to_string().contains("event type mismatch"));
     }

--- a/crates/voom-wit/wit/host.wit
+++ b/crates/voom-wit/wit/host.wit
@@ -13,7 +13,7 @@ interface host {
     run-tool: func(tool: string, args: list<string>, timeout-ms: u64) -> result<tool-output, string>;
 
     /// Get plugin-specific persisted data.
-    get-plugin-data: func(key: string) -> option<list<u8>>;
+    get-plugin-data: func(key: string) -> result<option<list<u8>>, string>;
 
     /// Set plugin-specific persisted data.
     set-plugin-data: func(key: string, value: list<u8>) -> result<_, string>;

--- a/crates/voom-wit/wit/types.wit
+++ b/crates/voom-wit/wit/types.wit
@@ -173,6 +173,9 @@ interface types {
         plugin-name: string,
         produced-events: list<event-data>,
         data: option<list<u8>>,
+        claimed: bool,
+        execution-error: option<string>,
+        execution-detail: option<list<u8>>,
     }
 
     enum log-level {

--- a/justfile
+++ b/justfile
@@ -142,7 +142,7 @@ fmt-check:
     cargo fmt --all -- --check
 
 # Run the full CI check locally (fmt + clippy + tests)
-ci: fmt-check lint test policy-test-examples test-wasm
+ci: fmt-check lint test policy-test-examples test-wasm functional-test-quick
 
 # Run cargo-deny dependency audit
 deny:

--- a/plugins/backup-manager/src/backup.rs
+++ b/plugins/backup-manager/src/backup.rs
@@ -206,3 +206,87 @@ pub fn backup_path_for(config: &BackupConfig, path: &Path, unique_id: Uuid) -> P
         .join(".voom-backup")
         .join(format!("{file_name}.{timestamp}.vbak"))
 }
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+
+    use super::*;
+
+    fn global_config(dir: &Path) -> BackupConfig {
+        BackupConfig {
+            backup_dir: Some(dir.to_path_buf()),
+            use_global_dir: true,
+            min_free_space: 0,
+        }
+    }
+
+    #[test]
+    fn backup_file_validates_actual_destination() {
+        let source_dir = tempfile::tempdir().unwrap();
+        let backup_dir = tempfile::tempdir().unwrap();
+        let source = source_dir.path().join("movie.mkv");
+        fs::write(&source, b"movie").unwrap();
+
+        let validated = RefCell::new(None);
+        let record = backup_file(
+            &global_config(backup_dir.path()),
+            &source,
+            |backup, original| {
+                assert_eq!(original, source.as_path());
+                assert!(backup.starts_with(backup_dir.path()));
+                *validated.borrow_mut() = Some(backup.to_path_buf());
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(validated.into_inner(), Some(record.backup_path.clone()));
+        assert_eq!(fs::read(&record.backup_path).unwrap(), b"movie");
+    }
+
+    #[test]
+    fn backup_file_validation_error_prevents_copy() {
+        let source_dir = tempfile::tempdir().unwrap();
+        let backup_dir = tempfile::tempdir().unwrap();
+        let source = source_dir.path().join("movie.mkv");
+        fs::write(&source, b"movie").unwrap();
+
+        let err = backup_file(
+            &global_config(backup_dir.path()),
+            &source,
+            |_backup, _original| Err(plugin_err("no space")),
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("no space"));
+        assert!(fs::read_dir(backup_dir.path()).unwrap().next().is_none());
+    }
+
+    #[test]
+    fn restore_from_paths_writes_requested_destination() {
+        let dir = tempfile::tempdir().unwrap();
+        let backup = dir.path().join("backup.vbak");
+        let destination = dir.path().join("restored").join("movie.mkv");
+        fs::create_dir_all(destination.parent().unwrap()).unwrap();
+        fs::write(&backup, b"backup bytes").unwrap();
+
+        restore_from_paths(&backup, &destination).unwrap();
+
+        assert_eq!(fs::read(destination).unwrap(), b"backup bytes");
+    }
+
+    #[test]
+    fn remove_vbak_file_removes_file_and_empty_parent() {
+        let dir = tempfile::tempdir().unwrap();
+        let backup_parent = dir.path().join(".voom-backup");
+        fs::create_dir_all(&backup_parent).unwrap();
+        let backup = backup_parent.join("movie.mkv.20260101000000.vbak");
+        fs::write(&backup, b"backup").unwrap();
+
+        remove_vbak_file(&backup).unwrap();
+
+        assert!(!backup.exists());
+        assert!(!backup_parent.exists());
+    }
+}

--- a/plugins/discovery/src/scanner.rs
+++ b/plugins/discovery/src/scanner.rs
@@ -15,6 +15,12 @@ use voom_domain::temp_file::is_voom_temp;
 
 use crate::ScanOptions;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DiscoveryWalkError {
+    path: PathBuf,
+    message: String,
+}
+
 /// Normalize a file path for consistent storage and comparison.
 ///
 /// Applies two transformations:
@@ -170,9 +176,12 @@ fn hash_file_full(file: &mut fs::File) -> Result<String> {
 
 /// Walk a directory tree collecting media file paths and sizes.
 ///
-/// Returns the collected `(path, size)` pairs and the count of orphaned
-/// voom temp files that were skipped. Reports progress via `on_progress`.
-fn walk_media_files(options: &ScanOptions) -> (Vec<(PathBuf, u64)>, usize) {
+/// Returns collected `(path, size)` pairs, orphaned temp count, and walk errors.
+///
+/// Reports progress via `on_progress`.
+fn walk_media_files(
+    options: &ScanOptions,
+) -> (Vec<(PathBuf, u64)>, usize, Vec<DiscoveryWalkError>) {
     let walker = if options.recursive {
         WalkDir::new(&options.root).follow_links(false)
     } else {
@@ -181,12 +190,22 @@ fn walk_media_files(options: &ScanOptions) -> (Vec<(PathBuf, u64)>, usize) {
 
     let mut media_paths: Vec<(PathBuf, u64)> = Vec::new();
     let mut orphaned_temp_count: usize = 0;
-    for entry in walker.into_iter().filter_map(|e| {
-        e.map_err(|err| {
-            tracing::debug!(error = %err, "skipping unreadable directory entry");
-        })
-        .ok()
-    }) {
+    let mut walk_errors = Vec::new();
+    for entry_result in walker {
+        let entry = match entry_result {
+            Ok(entry) => entry,
+            Err(err) => {
+                let path = err
+                    .path()
+                    .map(Path::to_path_buf)
+                    .unwrap_or_else(|| options.root.clone());
+                walk_errors.push(DiscoveryWalkError {
+                    path,
+                    message: err.to_string(),
+                });
+                continue;
+            }
+        };
         if entry.path_is_symlink() {
             tracing::debug!(path = %entry.path().display(), "skipping symlink");
             continue;
@@ -220,7 +239,21 @@ fn walk_media_files(options: &ScanOptions) -> (Vec<(PathBuf, u64)>, usize) {
         }
     }
 
-    (media_paths, orphaned_temp_count)
+    (media_paths, orphaned_temp_count, walk_errors)
+}
+
+fn report_walk_errors(options: &ScanOptions, walk_errors: &[DiscoveryWalkError]) {
+    for error in walk_errors {
+        if let Some(ref cb) = options.on_error {
+            cb(error.path.clone(), 0, error.message.clone());
+        } else {
+            tracing::warn!(
+                path = %error.path.display(),
+                error = %error.message,
+                "failed to read directory entry during discovery"
+            );
+        }
+    }
 }
 
 /// Scan a directory for media files.
@@ -232,7 +265,8 @@ pub fn scan_directory(options: &ScanOptions) -> Result<Vec<FileDiscoveredEvent>>
         )));
     }
 
-    let (media_paths, _orphaned) = walk_media_files(options);
+    let (media_paths, _orphaned, walk_errors) = walk_media_files(options);
+    report_walk_errors(options, &walk_errors);
 
     tracing::info!(
         root = %options.root.display(),
@@ -587,5 +621,34 @@ mod tests {
         // Both files should still exist, so we get 2 events and 0 errors
         assert_eq!(events.len(), 2);
         assert_eq!(error_count.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn test_walk_errors_are_reported_to_error_callback() {
+        use std::sync::Mutex;
+
+        let dir = tempfile::tempdir().unwrap();
+        let reported = Arc::new(Mutex::new(Vec::new()));
+        let reported_clone = reported.clone();
+
+        let mut options = ScanOptions::new(dir.path());
+        options.on_error = Some(Box::new(move |path, size, error| {
+            reported_clone.lock().unwrap().push((path, size, error));
+        }));
+
+        let missing = dir.path().join("missing-child");
+        report_walk_errors(
+            &options,
+            &[DiscoveryWalkError {
+                path: missing.clone(),
+                message: "permission denied".to_string(),
+            }],
+        );
+
+        let errors = reported.lock().unwrap();
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].0, missing);
+        assert_eq!(errors[0].1, 0);
+        assert_eq!(errors[0].2, "permission denied");
     }
 }

--- a/plugins/ffmpeg-executor/Cargo.toml
+++ b/plugins/ffmpeg-executor/Cargo.toml
@@ -22,6 +22,9 @@ chrono = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 
+[features]
+testing = []
+
 [lints]
 workspace = true
 

--- a/plugins/ffmpeg-executor/src/lib.rs
+++ b/plugins/ffmpeg-executor/src/lib.rs
@@ -135,8 +135,8 @@ impl FfmpegExecutorPlugin {
 
     /// Create with `available` set to the given value.
     /// Bypasses the `init()` probe for testing.
-    #[cfg(test)]
-    fn with_available(mut self, available: bool) -> Self {
+    #[cfg(any(test, feature = "testing"))]
+    pub fn with_available(mut self, available: bool) -> Self {
         self.available = available;
         self
     }

--- a/plugins/job-manager/src/worker.rs
+++ b/plugins/job-manager/src/worker.rs
@@ -502,6 +502,22 @@ async fn send_claim_race<F>(ctx: &WorkerContext<F>, job_id: Uuid) {
     }
 }
 
+async fn record_job_update<F>(
+    job_id: Uuid,
+    operation: &'static str,
+    update: F,
+) -> Result<(), String>
+where
+    F: FnOnce() -> voom_domain::errors::Result<()> + Send + 'static,
+{
+    match tokio::task::spawn_blocking(update).await {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(e)) => Err(format!("failed to {operation}: {e}")),
+        Err(e) => Err(format!("task join error while trying to {operation}: {e}")),
+    }
+    .inspect_err(|e| tracing::error!(job_id = %job_id, error = %e, "job update failed"))
+}
+
 /// Execute a single job: claim it, run the processor, and record the result.
 async fn run_one_job<F, Fut>(job_id: Uuid, ctx: WorkerContext<F>)
 where
@@ -550,8 +566,11 @@ where
     if ctx.token.is_cancelled() {
         let q = ctx.queue.clone();
         let jid = job.id;
-        if let Err(e) = tokio::task::spawn_blocking(move || q.cancel(&jid)).await {
-            tracing::error!(error = %e, "failed to mark job as cancelled");
+        if let Err(e) =
+            record_job_update(job_id, "mark job as cancelled", move || q.cancel(&jid)).await
+        {
+            send_failure(&ctx, job_id, e).await;
+            return;
         }
         send_failure(&ctx, job_id, "cancelled".into()).await;
         return;
@@ -563,8 +582,14 @@ where
     match (ctx.processor)(job).await {
         Ok(output) => {
             let q = ctx.queue.clone();
-            if let Err(e) = tokio::task::spawn_blocking(move || q.complete(&job_id, output)).await {
-                tracing::error!(job_id = %job_id, error = %e, "failed to mark job as complete");
+            if let Err(e) = record_job_update(job_id, "mark job as complete", move || {
+                q.complete(&job_id, output)
+            })
+            .await
+            {
+                ctx.reporter.on_job_complete(job_id, false, Some(&e));
+                send_failure(&ctx, job_id, e).await;
+                return;
             }
             ctx.completed.fetch_add(1, Ordering::SeqCst);
             ctx.reporter.on_job_complete(job_id, true, None);
@@ -576,15 +601,18 @@ where
         Err(error) => {
             let q = ctx.queue.clone();
             let err = error.clone();
-            if let Err(e) = tokio::task::spawn_blocking(move || q.fail(&job_id, err)).await {
-                tracing::error!(job_id = %job_id, error = %e, "failed to mark job as failed");
-            }
+            let persisted =
+                record_job_update(job_id, "mark job as failed", move || q.fail(&job_id, err)).await;
             ctx.reporter.on_job_complete(job_id, false, Some(&error));
 
             // send_failure increments `failed` and dispatches the JobResult.
             let strategy = ctx.on_error;
             let token = ctx.token.clone();
-            send_failure(&ctx, job_id, error).await;
+            let failure = match persisted {
+                Ok(()) => error,
+                Err(e) => format!("{error}; {e}"),
+            };
+            send_failure(&ctx, job_id, failure).await;
 
             if strategy == JobErrorStrategy::Fail {
                 token.cancel();

--- a/plugins/job-manager/src/worker.rs
+++ b/plugins/job-manager/src/worker.rs
@@ -126,13 +126,10 @@ impl PlanParallelResource {
 /// sessions within a plan. Callers that need executor-level hardware limits to
 /// apply to plans with `hw: auto` or no per-action hardware should use
 /// [`PlanExecutionLimiter::from_limits_with_default`].
-type PlanAcquireObserver = Arc<dyn Fn(&str) + Send + Sync>;
-
 #[derive(Clone, Default)]
 pub struct PlanExecutionLimiter {
     semaphores: Arc<HashMap<String, Arc<Semaphore>>>,
     default_resource: Option<String>,
-    acquire_observer: Option<PlanAcquireObserver>,
 }
 
 /// RAII permit for a classified plan resource.
@@ -177,19 +174,7 @@ impl PlanExecutionLimiter {
         Self {
             semaphores: Arc::new(semaphores),
             default_resource,
-            acquire_observer: None,
         }
-    }
-
-    /// Attach a callback invoked after a plan maps to a limited resource and
-    /// before the limiter waits for capacity.
-    #[must_use]
-    pub fn with_acquire_observer(
-        mut self,
-        observer: impl Fn(&str) + Send + Sync + 'static,
-    ) -> Self {
-        self.acquire_observer = Some(Arc::new(observer));
-        self
     }
 
     /// Acquire a plan-level resource permit for a plan.
@@ -206,9 +191,6 @@ impl PlanExecutionLimiter {
         let Some(semaphore) = self.semaphores.get(resource) else {
             return PlanExecutionPermit { _permit: None };
         };
-        if let Some(observer) = &self.acquire_observer {
-            observer(resource);
-        }
         let permit = semaphore
             .clone()
             .acquire_owned()

--- a/plugins/job-manager/src/worker.rs
+++ b/plugins/job-manager/src/worker.rs
@@ -126,10 +126,13 @@ impl PlanParallelResource {
 /// sessions within a plan. Callers that need executor-level hardware limits to
 /// apply to plans with `hw: auto` or no per-action hardware should use
 /// [`PlanExecutionLimiter::from_limits_with_default`].
+type PlanAcquireObserver = Arc<dyn Fn(&str) + Send + Sync>;
+
 #[derive(Clone, Default)]
 pub struct PlanExecutionLimiter {
     semaphores: Arc<HashMap<String, Arc<Semaphore>>>,
     default_resource: Option<String>,
+    acquire_observer: Option<PlanAcquireObserver>,
 }
 
 /// RAII permit for a classified plan resource.
@@ -174,7 +177,19 @@ impl PlanExecutionLimiter {
         Self {
             semaphores: Arc::new(semaphores),
             default_resource,
+            acquire_observer: None,
         }
+    }
+
+    /// Attach a callback invoked after a plan maps to a limited resource and
+    /// before the limiter waits for capacity.
+    #[must_use]
+    pub fn with_acquire_observer(
+        mut self,
+        observer: impl Fn(&str) + Send + Sync + 'static,
+    ) -> Self {
+        self.acquire_observer = Some(Arc::new(observer));
+        self
     }
 
     /// Acquire a plan-level resource permit for a plan.
@@ -191,6 +206,9 @@ impl PlanExecutionLimiter {
         let Some(semaphore) = self.semaphores.get(resource) else {
             return PlanExecutionPermit { _permit: None };
         };
+        if let Some(observer) = &self.acquire_observer {
+            observer(resource);
+        }
         let permit = semaphore
             .clone()
             .acquire_owned()

--- a/plugins/job-manager/src/worker.rs
+++ b/plugins/job-manager/src/worker.rs
@@ -411,10 +411,16 @@ impl WorkerPool {
         let (result_tx, mut result_rx) = mpsc::channel::<JobResult>(job_ids.len().max(1));
         let mut handles: Vec<JoinHandle<()>> = Vec::new();
 
-        for job_id in job_ids {
+        let mut unstarted_job_ids = Vec::new();
+        let mut job_iter = job_ids.into_iter();
+        while let Some(job_id) = job_iter.next() {
             let permit = tokio::select! {
                 p = semaphore.clone().acquire_owned() => p.expect("semaphore not closed"),
-                () = self.token.cancelled() => break,
+                () = self.token.cancelled() => {
+                    unstarted_job_ids.push(job_id);
+                    unstarted_job_ids.extend(job_iter);
+                    break;
+                },
             };
             let queue = self.queue.clone();
             let token = self.token.clone();
@@ -450,6 +456,8 @@ impl WorkerPool {
             handles.push(handle);
         }
 
+        cancel_unstarted_jobs(self.queue.clone(), unstarted_job_ids).await;
+
         drop(result_tx);
 
         while let Some(result) = result_rx.recv().await {
@@ -468,6 +476,30 @@ impl WorkerPool {
         );
 
         results
+    }
+}
+
+async fn cancel_unstarted_jobs(queue: Arc<JobQueue>, job_ids: Vec<Uuid>) {
+    if job_ids.is_empty() {
+        return;
+    }
+
+    let cancelled = job_ids.len();
+    if let Err(e) = tokio::task::spawn_blocking(move || {
+        for job_id in job_ids {
+            if let Err(e) = queue.cancel(&job_id) {
+                tracing::warn!(%job_id, error = %e, "failed to cancel unstarted job");
+            }
+        }
+    })
+    .await
+    {
+        tracing::error!(error = %e, "failed to cancel unstarted jobs");
+    } else {
+        tracing::debug!(
+            cancelled,
+            "cancelled unstarted jobs after batch cancellation"
+        );
     }
 }
 
@@ -969,6 +1001,62 @@ mod tests {
         .await;
 
         assert!(pool.failed_count() >= 1);
+    }
+
+    #[tokio::test]
+    async fn cancelled_batch_cancels_unstarted_jobs() {
+        use voom_domain::job::JobStatus;
+        use voom_domain::storage::JobFilters;
+
+        let queue = test_queue();
+        let token = CancellationToken::new();
+        let pool = WorkerPool::new(
+            queue.clone(),
+            WorkerPoolConfig {
+                max_workers: 1,
+                ..Default::default()
+            },
+            token.clone(),
+        );
+
+        let items: Vec<WorkItem> = (0..3)
+            .map(|i| WorkItem {
+                job_type: voom_domain::job::JobType::Custom(format!("task-{i}")),
+                priority: 100,
+                payload: None,
+            })
+            .collect();
+
+        let results = pool
+            .process_batch(
+                items,
+                move |_job| {
+                    let token = token.clone();
+                    async move {
+                        token.cancel();
+                        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+                        Ok(None)
+                    }
+                },
+                JobErrorStrategy::Continue,
+                Arc::new(NoopReporter),
+            )
+            .await;
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(pool.completed_count(), 1);
+
+        let jobs = queue.list_jobs(&JobFilters::default()).unwrap();
+        let cancelled = jobs
+            .iter()
+            .filter(|job| job.status == JobStatus::Cancelled)
+            .count();
+        let completed = jobs
+            .iter()
+            .filter(|job| job.status == JobStatus::Completed)
+            .count();
+        assert_eq!(completed, 1);
+        assert_eq!(cancelled, 2);
     }
 
     #[test]

--- a/plugins/job-manager/src/worker.rs
+++ b/plugins/job-manager/src/worker.rs
@@ -379,11 +379,15 @@ impl WorkerPool {
         );
 
         let mut job_ids = Vec::with_capacity(items.len());
+        let mut results = Vec::new();
         for item in items {
             let json_payload = match item.payload.map(serde_json::to_value) {
                 Some(Ok(v)) => Some(v),
                 Some(Err(e)) => {
-                    tracing::error!(error = %e, "failed to serialize WorkItem payload");
+                    let error = format!("payload serialization failed: {e}");
+                    tracing::error!(error = %error, "failed to serialize WorkItem payload");
+                    self.failed_count.fetch_add(1, Ordering::SeqCst);
+                    results.push(JobResult::failure(Uuid::new_v4(), error));
                     continue;
                 }
                 None => None,
@@ -394,7 +398,10 @@ impl WorkerPool {
             {
                 Ok(id) => job_ids.push(id),
                 Err(e) => {
-                    tracing::error!(error = %e, "Failed to enqueue job");
+                    let error = format!("enqueue failed: {e}");
+                    tracing::error!(error = %error, "Failed to enqueue job");
+                    self.failed_count.fetch_add(1, Ordering::SeqCst);
+                    results.push(JobResult::failure(Uuid::new_v4(), error));
                 }
             }
         }
@@ -445,7 +452,6 @@ impl WorkerPool {
 
         drop(result_tx);
 
-        let mut results = Vec::new();
         while let Some(result) = result_rx.recv().await {
             results.push(result);
         }
@@ -1170,6 +1176,67 @@ mod tests {
         );
     }
 
+    struct FailingPayload;
+
+    impl serde::Serialize for FailingPayload {
+        fn serialize<S>(&self, _serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            Err(serde::ser::Error::custom("payload boom"))
+        }
+    }
+
+    #[tokio::test]
+    async fn payload_serialization_failure_returns_failed_result_and_continues() {
+        let queue = test_queue();
+        let pool = WorkerPool::new(
+            queue,
+            WorkerPoolConfig {
+                max_workers: 1,
+                ..Default::default()
+            },
+            CancellationToken::new(),
+        );
+
+        let processor_called = Arc::new(AtomicU32::new(0));
+        let processor_called_clone = processor_called.clone();
+        let items = vec![
+            WorkItem::new(
+                voom_domain::job::JobType::Custom("bad".into()),
+                50,
+                Some(FailingPayload),
+            ),
+            WorkItem::new(voom_domain::job::JobType::Custom("ok".into()), 100, None),
+        ];
+
+        let results = pool
+            .process_batch(
+                items,
+                move |_job| {
+                    let processor_called = processor_called_clone.clone();
+                    async move {
+                        processor_called.fetch_add(1, Ordering::SeqCst);
+                        Ok(None)
+                    }
+                },
+                JobErrorStrategy::Continue,
+                Arc::new(NoopReporter),
+            )
+            .await;
+
+        assert_eq!(processor_called.load(Ordering::SeqCst), 1);
+        assert_eq!(pool.completed_count(), 1);
+        assert_eq!(pool.failed_count(), 1);
+        assert!(results.iter().any(|result| result.outcome.is_success()));
+        assert!(results.iter().any(|result| {
+            result
+                .outcome
+                .error()
+                .is_some_and(|error| error.contains("payload serialization failed"))
+        }));
+    }
+
     /// Storage wrapper that always returns `Ok(None)` from `claim_job_by_id`,
     /// simulating a job already claimed by a different worker. All other
     /// operations delegate to an inner `InMemoryStore`.
@@ -1257,6 +1324,131 @@ mod tests {
         ) -> voom_domain::errors::Result<Option<chrono::DateTime<chrono::Utc>>> {
             self.inner.oldest_job_created_at()
         }
+    }
+
+    struct FailingCreateJobStore {
+        inner: Arc<InMemoryStore>,
+    }
+
+    impl FailingCreateJobStore {
+        fn new() -> Self {
+            Self {
+                inner: Arc::new(InMemoryStore::new()),
+            }
+        }
+    }
+
+    impl voom_domain::storage::JobStorage for FailingCreateJobStore {
+        fn create_job(&self, _job: &voom_domain::job::Job) -> voom_domain::errors::Result<Uuid> {
+            Err(voom_domain::errors::VoomError::plugin(
+                "job-manager",
+                "create failed",
+            ))
+        }
+
+        fn job(&self, id: &Uuid) -> voom_domain::errors::Result<Option<voom_domain::job::Job>> {
+            self.inner.job(id)
+        }
+
+        fn update_job(
+            &self,
+            id: &Uuid,
+            update: &voom_domain::job::JobUpdate,
+        ) -> voom_domain::errors::Result<()> {
+            self.inner.update_job(id, update)
+        }
+
+        fn claim_next_job(
+            &self,
+            worker_id: &str,
+        ) -> voom_domain::errors::Result<Option<voom_domain::job::Job>> {
+            self.inner.claim_next_job(worker_id)
+        }
+
+        fn claim_job_by_id(
+            &self,
+            job_id: &Uuid,
+            worker_id: &str,
+        ) -> voom_domain::errors::Result<Option<voom_domain::job::Job>> {
+            self.inner.claim_job_by_id(job_id, worker_id)
+        }
+
+        fn list_jobs(
+            &self,
+            filters: &voom_domain::storage::JobFilters,
+        ) -> voom_domain::errors::Result<Vec<voom_domain::job::Job>> {
+            self.inner.list_jobs(filters)
+        }
+
+        fn count_jobs_by_status(
+            &self,
+        ) -> voom_domain::errors::Result<Vec<(voom_domain::job::JobStatus, u64)>> {
+            self.inner.count_jobs_by_status()
+        }
+
+        fn delete_jobs(
+            &self,
+            status: Option<voom_domain::job::JobStatus>,
+        ) -> voom_domain::errors::Result<u64> {
+            self.inner.delete_jobs(status)
+        }
+
+        fn prune_old_jobs(
+            &self,
+            policy: voom_domain::storage::RetentionPolicy,
+        ) -> voom_domain::errors::Result<voom_domain::storage::PruneReport> {
+            self.inner.prune_old_jobs(policy)
+        }
+
+        fn count_old_jobs(
+            &self,
+            policy: voom_domain::storage::RetentionPolicy,
+        ) -> voom_domain::errors::Result<voom_domain::storage::PruneReport> {
+            self.inner.count_old_jobs(policy)
+        }
+
+        fn oldest_job_created_at(
+            &self,
+        ) -> voom_domain::errors::Result<Option<chrono::DateTime<chrono::Utc>>> {
+            self.inner.oldest_job_created_at()
+        }
+    }
+
+    #[tokio::test]
+    async fn enqueue_failure_returns_failed_result() {
+        let store: Arc<dyn voom_domain::storage::JobStorage> =
+            Arc::new(FailingCreateJobStore::new());
+        let queue = Arc::new(JobQueue::new(store));
+        let pool = WorkerPool::new(queue, WorkerPoolConfig::default(), CancellationToken::new());
+
+        let processor_called = Arc::new(AtomicU32::new(0));
+        let processor_called_clone = processor_called.clone();
+        let results = pool
+            .process_batch(
+                vec![WorkItem::new(
+                    voom_domain::job::JobType::Custom("bad".into()),
+                    100,
+                    None::<()>,
+                )],
+                move |_job| {
+                    let processor_called = processor_called_clone.clone();
+                    async move {
+                        processor_called.fetch_add(1, Ordering::SeqCst);
+                        Ok(None)
+                    }
+                },
+                JobErrorStrategy::Continue,
+                Arc::new(NoopReporter),
+            )
+            .await;
+
+        assert_eq!(processor_called.load(Ordering::SeqCst), 0);
+        assert_eq!(pool.failed_count(), 1);
+        assert_eq!(results.len(), 1);
+        assert!(results[0]
+            .outcome
+            .error()
+            .is_some_and(|error| error.contains("enqueue failed")));
     }
 
     #[tokio::test]

--- a/plugins/mkvtoolnix-executor/Cargo.toml
+++ b/plugins/mkvtoolnix-executor/Cargo.toml
@@ -19,6 +19,9 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 scopeguard = { workspace = true }
 
+[features]
+testing = []
+
 [lints]
 workspace = true
 

--- a/plugins/mkvtoolnix-executor/src/lib.rs
+++ b/plugins/mkvtoolnix-executor/src/lib.rs
@@ -71,8 +71,8 @@ impl MkvtoolnixExecutorPlugin {
 
     /// Create a plugin with `available` set to the given value.
     /// Bypasses the `init()` probe for testing.
-    #[cfg(test)]
-    fn with_available(mut self, available: bool) -> Self {
+    #[cfg(any(test, feature = "testing"))]
+    pub fn with_available(mut self, available: bool) -> Self {
         self.available = available;
         self
     }

--- a/plugins/report/Cargo.toml
+++ b/plugins/report/Cargo.toml
@@ -20,6 +20,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+voom-domain = { workspace = true, features = ["testing"] }
 
 [lints]
 workspace = true

--- a/plugins/report/src/query.rs
+++ b/plugins/report/src/query.rs
@@ -266,25 +266,12 @@ fn database_stats(store: &(impl ReportDataSource + ?Sized)) -> voom_domain::Resu
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
-    use std::sync::Mutex;
-
     use voom_domain::errors::VoomError;
     use voom_domain::safeguard::{SafeguardKind, SafeguardViolation};
     use voom_domain::stats::{LibrarySnapshot, SavingsReport, SnapshotTrigger};
     use voom_domain::storage::{PageStats, PlanPhaseStat, PlanStatus};
 
     use super::*;
-
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-    enum Call {
-        Library,
-        Plans,
-        Savings,
-        History,
-        Issues,
-        TableCounts,
-        PageStats,
-    }
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     enum FailPoint {
@@ -299,8 +286,6 @@ mod tests {
 
     #[derive(Default)]
     struct FakeReportStore {
-        calls: Mutex<Vec<Call>>,
-        history_limits: Mutex<Vec<u32>>,
         files: Vec<MediaFile>,
         fail: Option<FailPoint>,
     }
@@ -320,21 +305,6 @@ mod tests {
             }
         }
 
-        fn calls(&self) -> Vec<Call> {
-            self.calls.lock().expect("calls lock").clone()
-        }
-
-        fn history_limits(&self) -> Vec<u32> {
-            self.history_limits
-                .lock()
-                .expect("history limits lock")
-                .clone()
-        }
-
-        fn record(&self, call: Call) {
-            self.calls.lock().expect("calls lock").push(call);
-        }
-
         fn fail_if(&self, fail_point: FailPoint) -> voom_domain::Result<()> {
             if self.fail == Some(fail_point) {
                 return Err(VoomError::Storage {
@@ -351,13 +321,11 @@ mod tests {
             &self,
             trigger: SnapshotTrigger,
         ) -> voom_domain::Result<LibrarySnapshot> {
-            self.record(Call::Library);
             self.fail_if(FailPoint::Library)?;
             Ok(snapshot(trigger))
         }
 
         fn plan_stats_by_phase(&self) -> voom_domain::Result<Vec<PlanPhaseStat>> {
-            self.record(Call::Plans);
             self.fail_if(FailPoint::Plans)?;
             Ok(vec![PlanPhaseStat::new(
                 "phase".to_string(),
@@ -371,36 +339,30 @@ mod tests {
             &self,
             period: Option<TimePeriod>,
         ) -> voom_domain::Result<SavingsReport> {
-            self.record(Call::Savings);
             self.fail_if(FailPoint::Savings)?;
             assert!(period.is_none() || period == Some(TimePeriod::Month));
             Ok(SavingsReport::default())
         }
 
         fn list_snapshots(&self, limit: u32) -> voom_domain::Result<Vec<LibrarySnapshot>> {
-            self.record(Call::History);
             self.fail_if(FailPoint::History)?;
-            self.history_limits
-                .lock()
-                .expect("history limits lock")
-                .push(limit);
-            Ok(vec![snapshot(SnapshotTrigger::Manual)])
+            Ok(vec![
+                snapshot(SnapshotTrigger::Manual);
+                limit.min(2) as usize
+            ])
         }
 
         fn list_files(&self, _filters: &FileFilters) -> voom_domain::Result<Vec<MediaFile>> {
-            self.record(Call::Issues);
             self.fail_if(FailPoint::Issues)?;
             Ok(self.files.clone())
         }
 
         fn table_row_counts(&self) -> voom_domain::Result<Vec<(String, u64)>> {
-            self.record(Call::TableCounts);
             self.fail_if(FailPoint::TableCounts)?;
             Ok(vec![("files".to_string(), 1)])
         }
 
         fn page_stats(&self) -> voom_domain::Result<PageStats> {
-            self.record(Call::PageStats);
             self.fail_if(FailPoint::PageStats)?;
             Ok(PageStats {
                 page_size: 4096,
@@ -426,41 +388,66 @@ mod tests {
         SafeguardViolation::new(SafeguardKind::NoAudioTrack, "no audio", "normalize")
     }
 
+    fn present_sections(result: &ReportResult) -> Vec<ReportSection> {
+        let mut sections = Vec::new();
+        if result.library.is_some() {
+            sections.push(ReportSection::Library);
+        }
+        if result.plans.is_some() {
+            sections.push(ReportSection::Plans);
+        }
+        if result.savings.is_some() {
+            sections.push(ReportSection::Savings);
+        }
+        if result.history.is_some() {
+            sections.push(ReportSection::History);
+        }
+        if result.issues.is_some() {
+            sections.push(ReportSection::Issues);
+        }
+        if result.database.is_some() {
+            sections.push(ReportSection::Database);
+        }
+        sections
+    }
+
     #[test]
-    fn assemble_report_queries_only_requested_section() {
+    fn assemble_report_includes_only_requested_section() {
         let cases = [
-            (ReportSection::Library, vec![Call::Library]),
-            (ReportSection::Plans, vec![Call::Plans]),
-            (ReportSection::Savings, vec![Call::Savings]),
-            (ReportSection::History, vec![Call::History]),
-            (ReportSection::Issues, vec![Call::Issues]),
-            (
-                ReportSection::Database,
-                vec![Call::TableCounts, Call::PageStats],
-            ),
+            ReportSection::Library,
+            ReportSection::Plans,
+            ReportSection::Savings,
+            ReportSection::History,
+            ReportSection::Issues,
+            ReportSection::Database,
         ];
 
-        for (section, expected_calls) in cases {
+        for section in cases {
             let store = FakeReportStore::default();
-            assemble_report_from_source(&store, &ReportRequest::new(vec![section]))
+            let result = assemble_report_from_source(&store, &ReportRequest::new(vec![section]))
                 .expect("report should assemble");
-            assert_eq!(store.calls(), expected_calls, "section={section:?}");
+            assert_eq!(
+                present_sections(&result),
+                vec![section],
+                "section={section:?}"
+            );
         }
     }
 
     #[test]
     fn assemble_report_uses_default_and_explicit_history_limits() {
         let store = FakeReportStore::default();
-        assemble_report_from_source(&store, &ReportRequest::all()).expect("report should assemble");
-        assert_eq!(store.history_limits(), vec![20]);
+        let result = assemble_report_from_source(&store, &ReportRequest::all())
+            .expect("report should assemble");
+        assert_eq!(result.history.expect("history section").len(), 2);
 
         let store = FakeReportStore::default();
-        assemble_report_from_source(
+        let result = assemble_report_from_source(
             &store,
-            &ReportRequest::new(vec![ReportSection::History]).with_history_limit(7),
+            &ReportRequest::new(vec![ReportSection::History]).with_history_limit(1),
         )
         .expect("report should assemble");
-        assert_eq!(store.history_limits(), vec![7]);
+        assert_eq!(result.history.expect("history section").len(), 1);
     }
 
     #[test]

--- a/plugins/report/src/query.rs
+++ b/plugins/report/src/query.rs
@@ -4,8 +4,11 @@ use std::path::PathBuf;
 
 use serde::Serialize;
 use voom_domain::stats::{LibrarySnapshot, SavingsReport, TimePeriod};
-use voom_domain::storage::{PageStats, PlanPhaseStat};
-use voom_domain::SafeguardViolation;
+use voom_domain::storage::{
+    FileFilters, FileStorage, FileTransitionStorage, MaintenanceStorage, PageStats, PlanPhaseStat,
+    PlanStorage, SnapshotStorage, StorageTrait,
+};
+use voom_domain::{MediaFile, SafeguardViolation};
 
 /// Sections that can be included in a report.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -102,4 +105,460 @@ pub struct ReportResult {
     pub issues: Option<Vec<IssueReport>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub database: Option<DatabaseStats>,
+}
+
+trait ReportDataSource {
+    fn gather_library_stats(
+        &self,
+        trigger: voom_domain::stats::SnapshotTrigger,
+    ) -> voom_domain::Result<LibrarySnapshot>;
+    fn plan_stats_by_phase(&self) -> voom_domain::Result<Vec<PlanPhaseStat>>;
+    fn savings_by_provenance(
+        &self,
+        period: Option<TimePeriod>,
+    ) -> voom_domain::Result<SavingsReport>;
+    fn list_snapshots(&self, limit: u32) -> voom_domain::Result<Vec<LibrarySnapshot>>;
+    fn list_files(&self, filters: &FileFilters) -> voom_domain::Result<Vec<MediaFile>>;
+    fn table_row_counts(&self) -> voom_domain::Result<Vec<(String, u64)>>;
+    fn page_stats(&self) -> voom_domain::Result<PageStats>;
+}
+
+impl<T> ReportDataSource for T
+where
+    T: StorageTrait + ?Sized,
+{
+    fn gather_library_stats(
+        &self,
+        trigger: voom_domain::stats::SnapshotTrigger,
+    ) -> voom_domain::Result<LibrarySnapshot> {
+        SnapshotStorage::gather_library_stats(self, trigger)
+    }
+
+    fn plan_stats_by_phase(&self) -> voom_domain::Result<Vec<PlanPhaseStat>> {
+        PlanStorage::plan_stats_by_phase(self)
+    }
+
+    fn savings_by_provenance(
+        &self,
+        period: Option<TimePeriod>,
+    ) -> voom_domain::Result<SavingsReport> {
+        FileTransitionStorage::savings_by_provenance(self, period)
+    }
+
+    fn list_snapshots(&self, limit: u32) -> voom_domain::Result<Vec<LibrarySnapshot>> {
+        SnapshotStorage::list_snapshots(self, limit)
+    }
+
+    fn list_files(&self, filters: &FileFilters) -> voom_domain::Result<Vec<MediaFile>> {
+        FileStorage::list_files(self, filters)
+    }
+
+    fn table_row_counts(&self) -> voom_domain::Result<Vec<(String, u64)>> {
+        MaintenanceStorage::table_row_counts(self)
+    }
+
+    fn page_stats(&self) -> voom_domain::Result<PageStats> {
+        MaintenanceStorage::page_stats(self)
+    }
+}
+
+/// Query the library and assemble the requested report sections.
+///
+/// # Errors
+/// Returns a plugin error when an underlying storage query fails.
+pub fn assemble_report(
+    store: &dyn StorageTrait,
+    request: &ReportRequest,
+) -> voom_domain::Result<ReportResult> {
+    assemble_report_from_source(store, request)
+}
+
+fn assemble_report_from_source(
+    store: &(impl ReportDataSource + ?Sized),
+    request: &ReportRequest,
+) -> voom_domain::Result<ReportResult> {
+    let mut result = ReportResult::default();
+
+    if request.includes(ReportSection::Library) {
+        let snapshot = store
+            .gather_library_stats(voom_domain::stats::SnapshotTrigger::Manual)
+            .map_err(|e| crate::plugin_err("failed to gather library statistics", e))?;
+        result.library = Some(snapshot);
+    }
+
+    if request.includes(ReportSection::Plans) {
+        let stats = store
+            .plan_stats_by_phase()
+            .map_err(|e| crate::plugin_err("failed to query plan stats", e))?;
+        result.plans = Some(stats);
+    }
+
+    if request.includes(ReportSection::Savings) {
+        let report = store
+            .savings_by_provenance(request.period)
+            .map_err(|e| crate::plugin_err("failed to query savings", e))?;
+        result.savings = Some(report);
+    }
+
+    if request.includes(ReportSection::History) {
+        let limit = request.history_limit.unwrap_or(20);
+        let snapshots = store
+            .list_snapshots(limit)
+            .map_err(|e| crate::plugin_err("failed to list snapshots", e))?;
+        result.history = Some(snapshots);
+    }
+
+    if request.includes(ReportSection::Issues) {
+        result.issues = Some(issue_report(store)?);
+    }
+
+    if request.includes(ReportSection::Database) {
+        result.database = Some(database_stats(store)?);
+    }
+
+    Ok(result)
+}
+
+fn issue_report(store: &(impl ReportDataSource + ?Sized)) -> voom_domain::Result<Vec<IssueReport>> {
+    let files = store
+        .list_files(&FileFilters::default())
+        .map_err(|e| crate::plugin_err("failed to list files", e))?;
+
+    let mut issues = Vec::new();
+    for file in files {
+        let Some(violations_val) = file.plugin_metadata.get("safeguard_violations") else {
+            continue;
+        };
+        let violations: Vec<SafeguardViolation> = serde_json::from_value(violations_val.clone())
+            .map_err(|e| {
+                crate::plugin_err(
+                    &format!(
+                        "malformed safeguard_violations metadata for {}",
+                        file.path.display()
+                    ),
+                    e,
+                )
+            })?;
+        if violations.is_empty() {
+            continue;
+        }
+        issues.push(IssueReport {
+            path: file.path,
+            violations,
+        });
+    }
+    Ok(issues)
+}
+
+fn database_stats(store: &(impl ReportDataSource + ?Sized)) -> voom_domain::Result<DatabaseStats> {
+    let table_counts = store
+        .table_row_counts()
+        .map_err(|e| crate::plugin_err("failed to query table row counts", e))?;
+    let page_stats = store
+        .page_stats()
+        .map_err(|e| crate::plugin_err("failed to query page stats", e))?;
+    Ok(DatabaseStats {
+        table_counts,
+        page_stats,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::sync::Mutex;
+
+    use voom_domain::errors::VoomError;
+    use voom_domain::safeguard::{SafeguardKind, SafeguardViolation};
+    use voom_domain::stats::{LibrarySnapshot, SavingsReport, SnapshotTrigger};
+    use voom_domain::storage::{PageStats, PlanPhaseStat, PlanStatus};
+
+    use super::*;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum Call {
+        Library,
+        Plans,
+        Savings,
+        History,
+        Issues,
+        TableCounts,
+        PageStats,
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum FailPoint {
+        Library,
+        Plans,
+        Savings,
+        History,
+        Issues,
+        TableCounts,
+        PageStats,
+    }
+
+    #[derive(Default)]
+    struct FakeReportStore {
+        calls: Mutex<Vec<Call>>,
+        history_limits: Mutex<Vec<u32>>,
+        files: Vec<MediaFile>,
+        fail: Option<FailPoint>,
+    }
+
+    impl FakeReportStore {
+        fn with_files(files: Vec<MediaFile>) -> Self {
+            Self {
+                files,
+                ..Self::default()
+            }
+        }
+
+        fn failing(fail: FailPoint) -> Self {
+            Self {
+                fail: Some(fail),
+                ..Self::default()
+            }
+        }
+
+        fn calls(&self) -> Vec<Call> {
+            self.calls.lock().expect("calls lock").clone()
+        }
+
+        fn history_limits(&self) -> Vec<u32> {
+            self.history_limits
+                .lock()
+                .expect("history limits lock")
+                .clone()
+        }
+
+        fn record(&self, call: Call) {
+            self.calls.lock().expect("calls lock").push(call);
+        }
+
+        fn fail_if(&self, fail_point: FailPoint) -> voom_domain::Result<()> {
+            if self.fail == Some(fail_point) {
+                return Err(VoomError::Storage {
+                    kind: voom_domain::errors::StorageErrorKind::Other,
+                    message: format!("{fail_point:?} failed"),
+                });
+            }
+            Ok(())
+        }
+    }
+
+    impl ReportDataSource for FakeReportStore {
+        fn gather_library_stats(
+            &self,
+            trigger: SnapshotTrigger,
+        ) -> voom_domain::Result<LibrarySnapshot> {
+            self.record(Call::Library);
+            self.fail_if(FailPoint::Library)?;
+            Ok(snapshot(trigger))
+        }
+
+        fn plan_stats_by_phase(&self) -> voom_domain::Result<Vec<PlanPhaseStat>> {
+            self.record(Call::Plans);
+            self.fail_if(FailPoint::Plans)?;
+            Ok(vec![PlanPhaseStat::new(
+                "phase".to_string(),
+                PlanStatus::Completed,
+                None,
+                1,
+            )])
+        }
+
+        fn savings_by_provenance(
+            &self,
+            period: Option<TimePeriod>,
+        ) -> voom_domain::Result<SavingsReport> {
+            self.record(Call::Savings);
+            self.fail_if(FailPoint::Savings)?;
+            assert!(period.is_none() || period == Some(TimePeriod::Month));
+            Ok(SavingsReport::default())
+        }
+
+        fn list_snapshots(&self, limit: u32) -> voom_domain::Result<Vec<LibrarySnapshot>> {
+            self.record(Call::History);
+            self.fail_if(FailPoint::History)?;
+            self.history_limits
+                .lock()
+                .expect("history limits lock")
+                .push(limit);
+            Ok(vec![snapshot(SnapshotTrigger::Manual)])
+        }
+
+        fn list_files(&self, _filters: &FileFilters) -> voom_domain::Result<Vec<MediaFile>> {
+            self.record(Call::Issues);
+            self.fail_if(FailPoint::Issues)?;
+            Ok(self.files.clone())
+        }
+
+        fn table_row_counts(&self) -> voom_domain::Result<Vec<(String, u64)>> {
+            self.record(Call::TableCounts);
+            self.fail_if(FailPoint::TableCounts)?;
+            Ok(vec![("files".to_string(), 1)])
+        }
+
+        fn page_stats(&self) -> voom_domain::Result<PageStats> {
+            self.record(Call::PageStats);
+            self.fail_if(FailPoint::PageStats)?;
+            Ok(PageStats {
+                page_size: 4096,
+                page_count: 1,
+                freelist_count: 0,
+            })
+        }
+    }
+
+    fn snapshot(trigger: SnapshotTrigger) -> LibrarySnapshot {
+        voom_domain::storage::SnapshotStorage::gather_library_stats(
+            &voom_domain::test_support::InMemoryStore::new(),
+            trigger,
+        )
+        .expect("in-memory snapshot")
+    }
+
+    fn media_file(path: &str) -> MediaFile {
+        MediaFile::new(PathBuf::from(path))
+    }
+
+    fn violation() -> SafeguardViolation {
+        SafeguardViolation::new(SafeguardKind::NoAudioTrack, "no audio", "normalize")
+    }
+
+    #[test]
+    fn assemble_report_queries_only_requested_section() {
+        let cases = [
+            (ReportSection::Library, vec![Call::Library]),
+            (ReportSection::Plans, vec![Call::Plans]),
+            (ReportSection::Savings, vec![Call::Savings]),
+            (ReportSection::History, vec![Call::History]),
+            (ReportSection::Issues, vec![Call::Issues]),
+            (
+                ReportSection::Database,
+                vec![Call::TableCounts, Call::PageStats],
+            ),
+        ];
+
+        for (section, expected_calls) in cases {
+            let store = FakeReportStore::default();
+            assemble_report_from_source(&store, &ReportRequest::new(vec![section]))
+                .expect("report should assemble");
+            assert_eq!(store.calls(), expected_calls, "section={section:?}");
+        }
+    }
+
+    #[test]
+    fn assemble_report_uses_default_and_explicit_history_limits() {
+        let store = FakeReportStore::default();
+        assemble_report_from_source(&store, &ReportRequest::all()).expect("report should assemble");
+        assert_eq!(store.history_limits(), vec![20]);
+
+        let store = FakeReportStore::default();
+        assemble_report_from_source(
+            &store,
+            &ReportRequest::new(vec![ReportSection::History]).with_history_limit(7),
+        )
+        .expect("report should assemble");
+        assert_eq!(store.history_limits(), vec![7]);
+    }
+
+    #[test]
+    fn assemble_report_wraps_storage_errors_with_section_context() {
+        let cases = [
+            (
+                FailPoint::Library,
+                ReportRequest::new(vec![ReportSection::Library]),
+                "failed to gather library statistics",
+            ),
+            (
+                FailPoint::Plans,
+                ReportRequest::new(vec![ReportSection::Plans]),
+                "failed to query plan stats",
+            ),
+            (
+                FailPoint::Savings,
+                ReportRequest::new(vec![ReportSection::Savings]),
+                "failed to query savings",
+            ),
+            (
+                FailPoint::History,
+                ReportRequest::new(vec![ReportSection::History]),
+                "failed to list snapshots",
+            ),
+            (
+                FailPoint::Issues,
+                ReportRequest::new(vec![ReportSection::Issues]),
+                "failed to list files",
+            ),
+            (
+                FailPoint::TableCounts,
+                ReportRequest::new(vec![ReportSection::Database]),
+                "failed to query table row counts",
+            ),
+            (
+                FailPoint::PageStats,
+                ReportRequest::new(vec![ReportSection::Database]),
+                "failed to query page stats",
+            ),
+        ];
+
+        for (fail_point, request, context) in cases {
+            let err = assemble_report_from_source(&FakeReportStore::failing(fail_point), &request)
+                .expect_err("report assembly should fail");
+            let message = err.to_string();
+            assert!(message.contains("plugin error: report:"));
+            assert!(message.contains(context), "{message}");
+            assert!(
+                message.contains(&format!("{fail_point:?} failed")),
+                "{message}"
+            );
+        }
+    }
+
+    #[test]
+    fn issue_report_returns_valid_nonempty_safeguard_violations() {
+        let mut file = media_file("/media/valid.mkv");
+        file.plugin_metadata.insert(
+            "safeguard_violations".to_string(),
+            serde_json::to_value(vec![violation()]).expect("violation serializes"),
+        );
+        let store = FakeReportStore::with_files(vec![file]);
+
+        let issues = issue_report(&store).expect("issue report should parse");
+
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].path, PathBuf::from("/media/valid.mkv"));
+        assert_eq!(issues[0].violations, vec![violation()]);
+    }
+
+    #[test]
+    fn issue_report_omits_missing_and_empty_safeguard_metadata() {
+        let missing = media_file("/media/missing.mkv");
+        let mut empty = media_file("/media/empty.mkv");
+        empty.plugin_metadata.insert(
+            "safeguard_violations".to_string(),
+            serde_json::to_value(Vec::<SafeguardViolation>::new()).expect("empty serializes"),
+        );
+        let store = FakeReportStore::with_files(vec![missing, empty]);
+
+        let issues = issue_report(&store).expect("issue report should parse");
+
+        assert!(issues.is_empty());
+    }
+
+    #[test]
+    fn issue_report_fails_on_malformed_safeguard_metadata() {
+        let mut file = media_file("/media/bad.mkv");
+        file.plugin_metadata.insert(
+            "safeguard_violations".to_string(),
+            serde_json::json!({"not": "a violation list"}),
+        );
+        let store = FakeReportStore::with_files(vec![file]);
+
+        let err = issue_report(&store).expect_err("malformed metadata should fail");
+        let message = err.to_string();
+        assert!(message.contains("malformed safeguard_violations metadata"));
+        assert!(message.contains("/media/bad.mkv"));
+    }
 }

--- a/plugins/sqlite-store/src/store/discovered_file_storage.rs
+++ b/plugins/sqlite-store/src/store/discovered_file_storage.rs
@@ -6,7 +6,9 @@ use uuid::Uuid;
 
 use voom_domain::errors::Result;
 
-use super::{format_datetime, parse_required_datetime, storage_err, SqliteStore};
+use super::{
+    checked_i64_to_u64, format_datetime, parse_required_datetime, storage_err, SqliteStore,
+};
 
 /// Status of a discovered file in the staging pipeline.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -140,7 +142,7 @@ impl SqliteStore {
                 Ok(DiscoveredFile {
                     id,
                     path: row.get("path")?,
-                    size: row.get::<_, i64>("size")? as u64,
+                    size: checked_i64_to_u64(row.get("size")?, "discovered_files.size")?,
                     content_hash: {
                         let h: String = row.get("content_hash")?;
                         if h.is_empty() {
@@ -256,6 +258,27 @@ mod tests {
 
         let files = store.list_discovered_files(None).unwrap();
         assert!(files.is_empty());
+    }
+
+    #[test]
+    fn list_discovered_files_rejects_negative_size() {
+        let store = test_store();
+        store
+            .upsert_discovered_file("/media/test.mkv", 1024, Some("abc"))
+            .unwrap();
+        let conn = store.conn().unwrap();
+        conn.execute(
+            "UPDATE discovered_files SET size = -1 WHERE path = ?1",
+            params!["/media/test.mkv"],
+        )
+        .unwrap();
+
+        let err = store.list_discovered_files(None).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("discovered_files.size"),
+            "error should mention corrupt column: {msg}"
+        );
     }
 
     #[test]

--- a/plugins/sqlite-store/src/store/file_storage.rs
+++ b/plugins/sqlite-store/src/store/file_storage.rs
@@ -220,7 +220,7 @@ impl FileStorage for SqliteStore {
 
         if !filters.include_missing {
             let clause = format!(" AND {col_prefix}status = {{}}");
-            q.condition(&clause, "active".to_string());
+            q.condition(&clause, FileStatus::Active.as_str().to_string());
         }
         if let Some(container) = filters.container {
             let clause = format!(" AND {col_prefix}container = {{}}");
@@ -277,7 +277,10 @@ impl FileStorage for SqliteStore {
         let mut q = SqlQuery::new(base);
 
         if !filters.include_missing {
-            q.condition(" AND files.status = {}", "active".to_string());
+            q.condition(
+                " AND files.status = {}",
+                FileStatus::Active.as_str().to_string(),
+            );
         }
         if let Some(container) = filters.container {
             q.condition(" AND files.container = {}", container.as_str().to_string());
@@ -306,8 +309,13 @@ impl FileStorage for SqliteStore {
         let conn = self.conn()?;
         let now = format_datetime(&Utc::now());
         conn.execute(
-            "UPDATE files SET status = 'missing', missing_since = ?1 WHERE id = ?2 AND status = 'active'",
-            params![now, id.to_string()],
+            "UPDATE files SET status = ?1, missing_since = ?2 WHERE id = ?3 AND status = ?4",
+            params![
+                FileStatus::Missing.as_str(),
+                now,
+                id.to_string(),
+                FileStatus::Active.as_str()
+            ],
         )
         .map_err(storage_err("failed to mark file missing"))?;
         Ok(())
@@ -319,8 +327,14 @@ impl FileStorage for SqliteStore {
         let path_str = new_path.to_string_lossy().to_string();
         let filename = filename_string(new_path);
         conn.execute(
-            "UPDATE files SET status = 'active', missing_since = NULL, path = ?1, filename = ?2, updated_at = ?3 WHERE id = ?4",
-            params![path_str, filename, now, id.to_string()],
+            "UPDATE files SET status = ?1, missing_since = NULL, path = ?2, filename = ?3, updated_at = ?4 WHERE id = ?5",
+            params![
+                FileStatus::Active.as_str(),
+                path_str,
+                filename,
+                now,
+                id.to_string()
+            ],
         )
         .map_err(storage_err("failed to reactivate file"))?;
         Ok(())
@@ -343,14 +357,14 @@ impl FileStorage for SqliteStore {
         let conn = self.conn()?;
         let cutoff = format_datetime(&older_than);
         conn.execute(
-            "DELETE FROM file_transitions WHERE file_id IN (SELECT id FROM files WHERE status = 'missing' AND missing_since < ?1)",
-            params![cutoff],
+            "DELETE FROM file_transitions WHERE file_id IN (SELECT id FROM files WHERE status = ?1 AND missing_since < ?2)",
+            params![FileStatus::Missing.as_str(), cutoff],
         )
         .map_err(storage_err("failed to purge transitions for missing files"))?;
         let deleted = conn
             .execute(
                 "DELETE FROM files WHERE status = 'missing' AND missing_since < ?1",
-                params![cutoff],
+                params![FileStatus::Missing.as_str(), cutoff],
             )
             .map_err(storage_err("failed to purge missing files"))?;
         Ok(deleted as u64)
@@ -904,6 +918,26 @@ mod tests {
         file.content_hash = Some("abc123".to_string());
         file.expected_hash = Some("abc123".to_string());
         file
+    }
+
+    #[test]
+    fn list_files_rejects_unknown_file_status() {
+        let store = test_store();
+        let file = active_file("/media/bad-status.mkv");
+        let file_id = file.id;
+        store.upsert_file(&file).unwrap();
+
+        let conn = store.conn().unwrap();
+        conn.execute(
+            "UPDATE files SET status = ?1 WHERE id = ?2",
+            params!["mystery", file_id.to_string()],
+        )
+        .unwrap();
+
+        let mut filters = voom_domain::storage::FileFilters::default();
+        filters.include_missing = true;
+        let err = store.list_files(&filters).unwrap_err();
+        assert!(err.to_string().contains("unknown file status"));
     }
 
     #[test]

--- a/plugins/sqlite-store/src/store/file_storage.rs
+++ b/plugins/sqlite-store/src/store/file_storage.rs
@@ -363,7 +363,7 @@ impl FileStorage for SqliteStore {
         .map_err(storage_err("failed to purge transitions for missing files"))?;
         let deleted = conn
             .execute(
-                "DELETE FROM files WHERE status = 'missing' AND missing_since < ?1",
+                "DELETE FROM files WHERE status = ?1 AND missing_since < ?2",
                 params![FileStatus::Missing.as_str(), cutoff],
             )
             .map_err(storage_err("failed to purge missing files"))?;

--- a/plugins/sqlite-store/src/store/file_transition_storage.rs
+++ b/plugins/sqlite-store/src/store/file_transition_storage.rs
@@ -9,7 +9,10 @@ use voom_domain::stats::{ProcessingOutcome, SavingsBucket, SavingsReport, TimePe
 use voom_domain::storage::{FileTransitionStorage, PruneReport, RetentionPolicy};
 use voom_domain::transition::{FileTransition, TransitionSource};
 
-use super::{format_datetime, storage_err, SqliteStore};
+use super::{
+    checked_i64_to_u64, checked_optional_i64_to_u32, checked_optional_i64_to_u64, format_datetime,
+    storage_err, SqliteStore,
+};
 
 /// Insert a `FileTransition` into `file_transitions`. Accepts any
 /// `&rusqlite::Connection`, including one obtained via `Deref` from an
@@ -151,10 +154,10 @@ impl FileTransitionStorage for SqliteStore {
                     executor.filter(|s| !s.is_empty()),
                     phase.filter(|s| !s.is_empty()),
                     period_val.filter(|s| !s.is_empty()),
-                    cnt as u64,
+                    checked_i64_to_u64(cnt, "file_transitions.cnt")?,
                     saved,
-                    dur as u64,
-                    files as u64,
+                    checked_i64_to_u64(dur, "file_transitions.dur")?,
+                    checked_i64_to_u64(files, "file_transitions.files")?,
                 ))
             })
             .map_err(storage_err("failed to query savings by provenance"))?
@@ -301,7 +304,7 @@ impl FileTransitionStorage for SqliteStore {
                 Ok(voom_domain::storage::SessionSummary {
                     session_id,
                     started_at,
-                    failure_count: count as u64,
+                    failure_count: checked_i64_to_u64(count, "file_transitions.cnt")?,
                 })
             })
             .map_err(storage_err("failed to query failure sessions"))?
@@ -461,28 +464,29 @@ fn row_to_transition(row: &rusqlite::Row<'_>) -> rusqlite::Result<FileTransition
         )
     })?;
 
-    let duration_ms: Option<i64> = row.get("duration_ms")?;
-    let actions_taken: Option<i64> = row.get("actions_taken")?;
-    let tracks_modified: Option<i64> = row.get("tracks_modified")?;
+    let from_size = checked_optional_i64_to_u64(from_size, "file_transitions.from_size")?;
+    let to_size = checked_i64_to_u64(to_size, "file_transitions.to_size")?;
+    let duration_ms =
+        checked_optional_i64_to_u64(row.get("duration_ms")?, "file_transitions.duration_ms")?;
+    let actions_taken =
+        checked_optional_i64_to_u32(row.get("actions_taken")?, "file_transitions.actions_taken")?;
+    let tracks_modified = checked_optional_i64_to_u32(
+        row.get("tracks_modified")?,
+        "file_transitions.tracks_modified",
+    )?;
     let outcome_str: Option<String> = row.get("outcome")?;
     let snapshot_json: Option<String> = row.get("metadata_snapshot")?;
 
-    let mut t = FileTransition::new(
-        file_id,
-        PathBuf::from(path_str),
-        to_hash,
-        to_size as u64,
-        source,
-    );
+    let mut t = FileTransition::new(file_id, PathBuf::from(path_str), to_hash, to_size, source);
     t.id = id;
     t.from_path = from_path_str.filter(|s| !s.is_empty()).map(PathBuf::from);
     t.from_hash = from_hash.filter(|s| !s.is_empty());
-    t.from_size = from_size.map(|v| v as u64);
+    t.from_size = from_size;
     t.source_detail = source_detail.filter(|s| !s.is_empty());
     t.plan_id = plan_id;
-    t.duration_ms = duration_ms.map(|v| v as u64);
-    t.actions_taken = actions_taken.map(|v| v as u32);
-    t.tracks_modified = tracks_modified.map(|v| v as u32);
+    t.duration_ms = duration_ms;
+    t.actions_taken = actions_taken;
+    t.tracks_modified = tracks_modified;
     t.outcome = outcome_str.and_then(|s| {
         ProcessingOutcome::parse(&s).or_else(|| {
             tracing::warn!(value = %s, "unknown ProcessingOutcome in file_transitions");
@@ -551,6 +555,34 @@ mod tests {
 
         let err = store.transitions_for_file(&file_id).unwrap_err();
         assert!(err.to_string().contains("unknown transition source"));
+    }
+
+    #[test]
+    fn transitions_reject_negative_numeric_fields() {
+        let store = test_store();
+        let file_id = Uuid::new_v4();
+        let transition = FileTransition::new(
+            file_id,
+            PathBuf::from("/media/source.mkv"),
+            "hash".into(),
+            10,
+            TransitionSource::Voom,
+        );
+        store.record_transition(&transition).unwrap();
+
+        let conn = store.conn().unwrap();
+        conn.execute(
+            "UPDATE file_transitions SET to_size = -1 WHERE id = ?1",
+            params![transition.id.to_string()],
+        )
+        .unwrap();
+
+        let err = store.transitions_for_file(&file_id).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("file_transitions.to_size"),
+            "error should mention corrupt column: {msg}"
+        );
     }
 
     #[test]

--- a/plugins/sqlite-store/src/store/file_transition_storage.rs
+++ b/plugins/sqlite-store/src/store/file_transition_storage.rs
@@ -441,7 +441,13 @@ fn row_to_transition(row: &rusqlite::Row<'_>) -> rusqlite::Result<FileTransition
 
     let id = parse_uuid_for_row(&id_str, "file_transitions.id")?;
     let file_id = parse_uuid_for_row(&file_id_str, "file_transitions.file_id")?;
-    let source = TransitionSource::parse(&source_str).unwrap_or_default();
+    let source = TransitionSource::parse(&source_str).ok_or_else(|| {
+        rusqlite::Error::FromSqlConversionFailure(
+            0,
+            rusqlite::types::Type::Text,
+            format!("unknown transition source in file_transitions.source: {source_str}").into(),
+        )
+    })?;
     let plan_id = plan_id_str
         .filter(|s| !s.is_empty())
         .map(|s| parse_uuid_for_row(&s, "file_transitions.plan_id"))
@@ -517,9 +523,34 @@ mod tests {
     use voom_domain::transition::{FileTransition, TransitionSource};
 
     use crate::store::SqliteStore;
+    use rusqlite::params;
 
     fn test_store() -> SqliteStore {
         SqliteStore::in_memory().unwrap()
+    }
+
+    #[test]
+    fn transitions_reject_unknown_source() {
+        let store = test_store();
+        let file_id = Uuid::new_v4();
+        let transition = FileTransition::new(
+            file_id,
+            PathBuf::from("/media/source.mkv"),
+            "hash".into(),
+            10,
+            TransitionSource::Voom,
+        );
+        store.record_transition(&transition).unwrap();
+
+        let conn = store.conn().unwrap();
+        conn.execute(
+            "UPDATE file_transitions SET source = ?1 WHERE id = ?2",
+            params!["mystery", transition.id.to_string()],
+        )
+        .unwrap();
+
+        let err = store.transitions_for_file(&file_id).unwrap_err();
+        assert!(err.to_string().contains("unknown transition source"));
     }
 
     #[test]

--- a/plugins/sqlite-store/src/store/mod.rs
+++ b/plugins/sqlite-store/src/store/mod.rs
@@ -28,6 +28,7 @@ use voom_domain::errors::{Result, StorageErrorKind, VoomError};
 use voom_domain::media::Track;
 
 pub(crate) use row_mappers::{
+    checked_i64_to_u64, checked_optional_i64_to_u32, checked_optional_i64_to_u64,
     parse_optional_datetime, parse_required_datetime, row_to_bad_file, row_to_file, row_to_job,
     row_to_track, row_uuid, FileRow,
 };

--- a/plugins/sqlite-store/src/store/plan_storage.rs
+++ b/plugins/sqlite-store/src/store/plan_storage.rs
@@ -317,8 +317,9 @@ mod tests {
                 },
                 "set track title",
             ),
-            PlannedAction::file_op(
+            PlannedAction::track_op(
                 OperationType::SetDefault,
+                0,
                 ActionParams::Empty,
                 "set default flag",
             ),

--- a/plugins/sqlite-store/src/store/row_mappers.rs
+++ b/plugins/sqlite-store/src/store/row_mappers.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use chrono::{DateTime, Utc};
+use rusqlite::types::Type;
 use rusqlite::Row;
 use uuid::Uuid;
 
@@ -48,6 +49,47 @@ pub(crate) fn parse_optional_datetime(
     .transpose()
 }
 
+pub(crate) fn checked_i64_to_u64(value: i64, field: &str) -> rusqlite::Result<u64> {
+    u64::try_from(value).map_err(|e| numeric_conversion_failure(field, e))
+}
+
+pub(crate) fn checked_optional_i64_to_u64(
+    value: Option<i64>,
+    field: &str,
+) -> rusqlite::Result<Option<u64>> {
+    value.map(|v| checked_i64_to_u64(v, field)).transpose()
+}
+
+pub(crate) fn checked_i64_to_u32(value: i64, field: &str) -> rusqlite::Result<u32> {
+    u32::try_from(value).map_err(|e| numeric_conversion_failure(field, e))
+}
+
+pub(crate) fn checked_optional_i64_to_u32(
+    value: Option<i64>,
+    field: &str,
+) -> rusqlite::Result<Option<u32>> {
+    value.map(|v| checked_i64_to_u32(v, field)).transpose()
+}
+
+fn checked_i32_to_u32(value: i32, field: &str) -> rusqlite::Result<u32> {
+    u32::try_from(value).map_err(|e| numeric_conversion_failure(field, e))
+}
+
+fn checked_optional_i32_to_u32(value: Option<i32>, field: &str) -> rusqlite::Result<Option<u32>> {
+    value.map(|v| checked_i32_to_u32(v, field)).transpose()
+}
+
+fn numeric_conversion_failure(
+    field: &str,
+    error: impl std::error::Error + Send + Sync + 'static,
+) -> rusqlite::Error {
+    rusqlite::Error::FromSqlConversionFailure(
+        0,
+        Type::Integer,
+        format!("invalid numeric value in {field}: {error}").into(),
+    )
+}
+
 /// Parse an optional JSON string, returning an error for corrupt values.
 fn parse_optional_json(
     s: Option<String>,
@@ -66,16 +108,19 @@ fn parse_optional_json(
 }
 
 pub(crate) fn row_to_file(row: &Row<'_>) -> rusqlite::Result<FileRow> {
+    let size = checked_i64_to_u64(row.get("size")?, "files.size")?;
+    let bitrate = checked_optional_i32_to_u32(row.get("bitrate")?, "files.bitrate")?;
+
     Ok(FileRow {
         id: row.get("id")?,
         path: row.get::<_, Option<String>>("path")?.unwrap_or_default(),
-        size: row.get("size")?,
+        size,
         content_hash: row.get("content_hash")?,
         expected_hash: row.get("expected_hash")?,
         status: row.get("status")?,
         container: row.get("container")?,
         duration: row.get("duration")?,
-        bitrate: row.get("bitrate")?,
+        bitrate,
         tags: row.get("tags")?,
         plugin_metadata: row.get("plugin_metadata")?,
         introspected_at: row.get("introspected_at")?,
@@ -85,13 +130,13 @@ pub(crate) fn row_to_file(row: &Row<'_>) -> rusqlite::Result<FileRow> {
 pub(crate) struct FileRow {
     pub(crate) id: String,
     path: String,
-    size: i64,
+    size: u64,
     content_hash: String,
     expected_hash: Option<String>,
     status: String,
     container: String,
     duration: Option<f64>,
-    bitrate: Option<i32>,
+    bitrate: Option<u32>,
     tags: Option<String>,
     plugin_metadata: Option<String>,
     introspected_at: String,
@@ -120,7 +165,7 @@ impl FileRow {
 
         let mut mf = MediaFile::new(PathBuf::from(&self.path));
         mf.id = parse_uuid(&self.id)?;
-        mf.size = self.size as u64;
+        mf.size = self.size;
         mf.content_hash = if self.content_hash.is_empty() {
             None
         } else {
@@ -128,7 +173,7 @@ impl FileRow {
         };
         mf.container = Container::from_extension(&self.container);
         mf.duration = self.duration.unwrap_or(0.0);
-        mf.bitrate = self.bitrate.and_then(|b| u32::try_from(b).ok());
+        mf.bitrate = self.bitrate;
         mf.tracks = tracks;
         mf.tags = tags;
         mf.plugin_metadata = plugin_metadata;
@@ -167,31 +212,24 @@ pub(crate) fn row_to_track(row: &Row<'_>) -> rusqlite::Result<Track> {
             format!("unknown track type: {track_type_str}").into(),
         )
     })?;
-    let mut t = Track::new(
-        u32::try_from(row.get::<_, i32>("stream_index")?).unwrap_or(0),
-        track_type,
-        row.get("codec")?,
-    );
+    let stream_index = checked_i32_to_u32(row.get("stream_index")?, "tracks.stream_index")?;
+    let channels = checked_optional_i32_to_u32(row.get("channels")?, "tracks.channels")?;
+    let sample_rate = checked_optional_i32_to_u32(row.get("sample_rate")?, "tracks.sample_rate")?;
+    let bit_depth = checked_optional_i32_to_u32(row.get("bit_depth")?, "tracks.bit_depth")?;
+    let width = checked_optional_i32_to_u32(row.get("width")?, "tracks.width")?;
+    let height = checked_optional_i32_to_u32(row.get("height")?, "tracks.height")?;
+
+    let mut t = Track::new(stream_index, track_type, row.get("codec")?);
     t.language = row.get("language")?;
     t.title = row.get("title")?;
     t.is_default = row.get::<_, i32>("is_default")? != 0;
     t.is_forced = row.get::<_, i32>("is_forced")? != 0;
-    t.channels = row
-        .get::<_, Option<i32>>("channels")?
-        .and_then(|v| u32::try_from(v).ok());
+    t.channels = channels;
     t.channel_layout = row.get("channel_layout")?;
-    t.sample_rate = row
-        .get::<_, Option<i32>>("sample_rate")?
-        .and_then(|v| u32::try_from(v).ok());
-    t.bit_depth = row
-        .get::<_, Option<i32>>("bit_depth")?
-        .and_then(|v| u32::try_from(v).ok());
-    t.width = row
-        .get::<_, Option<i32>>("width")?
-        .and_then(|v| u32::try_from(v).ok());
-    t.height = row
-        .get::<_, Option<i32>>("height")?
-        .and_then(|v| u32::try_from(v).ok());
+    t.sample_rate = sample_rate;
+    t.bit_depth = bit_depth;
+    t.width = width;
+    t.height = height;
     t.frame_rate = row.get("frame_rate")?;
     t.is_vfr = row.get::<_, i32>("is_vfr")? != 0;
     t.is_hdr = row.get::<_, i32>("is_hdr")? != 0;
@@ -249,19 +287,13 @@ pub(crate) fn row_to_bad_file(row: &Row<'_>) -> rusqlite::Result<BadFile> {
     })?;
     let mut bf = BadFile::new(
         PathBuf::from(path_str),
-        row.get::<_, i64>("size")? as u64,
+        checked_i64_to_u64(row.get("size")?, "bad_files.size")?,
         row.get("content_hash")?,
         row.get("error")?,
         error_source,
     );
     bf.id = row_uuid(&id_str, "bad_files")?;
-    bf.attempt_count = u32::try_from(row.get::<_, i64>("attempt_count")?).map_err(|e| {
-        rusqlite::Error::FromSqlConversionFailure(
-            0,
-            rusqlite::types::Type::Integer,
-            format!("invalid attempt_count in bad_files: {e}").into(),
-        )
-    })?;
+    bf.attempt_count = checked_i64_to_u32(row.get("attempt_count")?, "bad_files.attempt_count")?;
     bf.first_seen_at = parse_required_datetime(first_seen_str, "bad_files.first_seen_at")?;
     bf.last_seen_at = parse_required_datetime(last_seen_str, "bad_files.last_seen_at")?;
     Ok(bf)
@@ -289,8 +321,9 @@ pub(crate) fn row_to_verification(row: &Row<'_>) -> rusqlite::Result<Verificatio
             format!("unknown verification outcome: {outcome_str}").into(),
         )
     })?;
-    let error_count = u32::try_from(row.get::<_, i64>("error_count")?.max(0)).unwrap_or(0);
-    let warning_count = u32::try_from(row.get::<_, i64>("warning_count")?.max(0)).unwrap_or(0);
+    let error_count = checked_i64_to_u32(row.get("error_count")?, "verifications.error_count")?;
+    let warning_count =
+        checked_i64_to_u32(row.get("warning_count")?, "verifications.warning_count")?;
     Ok(VerificationRecord::new(
         id,
         file_id,
@@ -369,6 +402,31 @@ mod tests {
         let err = parse_optional_json(Some("not json{".into()), "test.field").unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("test.field"));
+    }
+
+    #[test]
+    fn checked_i64_to_u64_accepts_non_negative_values() {
+        assert_eq!(checked_i64_to_u64(42, "files.size").unwrap(), 42);
+    }
+
+    #[test]
+    fn checked_i64_to_u64_rejects_negative_values_with_column_context() {
+        let err = checked_i64_to_u64(-1, "files.size").unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("files.size"),
+            "error should mention column: {msg}"
+        );
+    }
+
+    #[test]
+    fn checked_i64_to_u32_rejects_overflow_with_column_context() {
+        let err = checked_i64_to_u32(i64::from(u32::MAX) + 1, "tracks.stream_index").unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("tracks.stream_index"),
+            "error should mention column: {msg}"
+        );
     }
 
     #[test]

--- a/plugins/sqlite-store/src/store/row_mappers.rs
+++ b/plugins/sqlite-store/src/store/row_mappers.rs
@@ -6,7 +6,7 @@ use rusqlite::Row;
 use uuid::Uuid;
 
 use voom_domain::bad_file::{BadFile, BadFileSource};
-use voom_domain::errors::Result;
+use voom_domain::errors::{Result, StorageErrorKind, VoomError};
 use voom_domain::job::{Job, JobStatus};
 use voom_domain::media::{Container, MediaFile, Track, TrackType};
 use voom_domain::transition::FileStatus;
@@ -72,9 +72,7 @@ pub(crate) fn row_to_file(row: &Row<'_>) -> rusqlite::Result<FileRow> {
         size: row.get("size")?,
         content_hash: row.get("content_hash")?,
         expected_hash: row.get("expected_hash")?,
-        status: row
-            .get::<_, Option<String>>("status")?
-            .unwrap_or_else(|| "active".to_string()),
+        status: row.get("status")?,
         container: row.get("container")?,
         duration: row.get("duration")?,
         bitrate: row.get("bitrate")?,
@@ -136,9 +134,16 @@ impl FileRow {
         mf.plugin_metadata = plugin_metadata;
         mf.introspected_at = parse_datetime(&self.introspected_at)?;
         mf.expected_hash = self.expected_hash.clone();
-        mf.status = FileStatus::parse(&self.status).unwrap_or_default();
+        mf.status = parse_file_status(&self.status)?;
         Ok(mf)
     }
+}
+
+fn parse_file_status(value: &str) -> Result<FileStatus> {
+    FileStatus::parse(value).ok_or_else(|| VoomError::Storage {
+        kind: StorageErrorKind::Other,
+        message: format!("unknown file status in files.status: {value}"),
+    })
 }
 
 /// Parse a UUID string from a database row, returning a rusqlite

--- a/plugins/verifier/src/lib.rs
+++ b/plugins/verifier/src/lib.rs
@@ -18,7 +18,9 @@ use std::time::Duration;
 
 use voom_domain::capabilities::Capability;
 use voom_domain::errors::{Result, VoomError};
-use voom_domain::events::{Event, EventResult, FileQuarantinedEvent, VerifyCompletedEvent};
+use voom_domain::events::{
+    Event, EventResult, FileQuarantinedEvent, VerifyCompletedDetails, VerifyCompletedEvent,
+};
 use voom_domain::plan::{ActionParams, OperationType, Plan};
 use voom_domain::storage::StorageTrait;
 use voom_domain::transition::FileStatus;
@@ -173,11 +175,13 @@ fn verify_result(record: &VerificationRecord, path: std::path::PathBuf) -> Event
     let event = Event::VerifyCompleted(VerifyCompletedEvent::new(
         record.file_id.clone(),
         path,
-        record.mode,
-        record.outcome,
-        record.error_count,
-        record.warning_count,
-        record.id,
+        VerifyCompletedDetails {
+            mode: record.mode,
+            outcome: record.outcome,
+            error_count: record.error_count,
+            warning_count: record.warning_count,
+            verification_id: record.id,
+        },
     ));
     let mut result = EventResult::new("verifier");
     result.claimed = true;

--- a/wasm-plugins/audio-language-detector/src/lib.rs
+++ b/wasm-plugins/audio-language-detector/src/lib.rs
@@ -38,7 +38,7 @@ pub fn get_info() -> PluginInfoData {
 }
 
 pub fn handles(event_type: &str) -> bool {
-    event_type == "file.introspected"
+    event_type == Event::FILE_INTROSPECTED
 }
 
 /// Process a file.introspected event by detecting languages of audio tracks.
@@ -47,7 +47,7 @@ pub fn on_event(
     payload: &[u8],
     host: &dyn HostFunctions,
 ) -> Option<OnEventResult> {
-    if event_type != "file.introspected" {
+    if event_type != Event::FILE_INTROSPECTED {
         return None;
     }
 

--- a/wasm-plugins/audio-synthesizer/src/lib.rs
+++ b/wasm-plugins/audio-synthesizer/src/lib.rs
@@ -47,7 +47,7 @@ pub fn get_info() -> PluginInfoData {
 }
 
 pub fn handles(event_type: &str) -> bool {
-    event_type == "plan.created"
+    event_type == Event::PLAN_CREATED
 }
 
 /// Process a plan.created event, looking for SynthesizeAudio actions.
@@ -57,7 +57,7 @@ pub fn on_event(
     payload: &[u8],
     host: &dyn HostFunctions,
 ) -> Option<OnEventResult> {
-    if event_type != "plan.created" {
+    if event_type != Event::PLAN_CREATED {
         return None;
     }
 

--- a/wasm-plugins/example-metadata/src/lib.rs
+++ b/wasm-plugins/example-metadata/src/lib.rs
@@ -51,7 +51,9 @@ pub fn get_info() -> PluginInfoData {
     PluginInfoData::new(
         "example-metadata",
         "0.1.0",
-        vec![Capability::EnrichMetadata { source: "example".to_string() }],
+        vec![Capability::EnrichMetadata {
+            source: "example".to_string(),
+        }],
     )
     .with_description("Example metadata enrichment plugin")
     .with_author("David Christensen")
@@ -60,11 +62,15 @@ pub fn get_info() -> PluginInfoData {
 }
 
 pub fn handles(event_type: &str) -> bool {
-    event_type == "file.introspected"
+    event_type == Event::FILE_INTROSPECTED
 }
 
-pub fn on_event(event_type: &str, payload: &[u8], host: &dyn HostFunctions) -> Option<OnEventResult> {
-    if event_type != "file.introspected" {
+pub fn on_event(
+    event_type: &str,
+    payload: &[u8],
+    host: &dyn HostFunctions,
+) -> Option<OnEventResult> {
+    if event_type != Event::FILE_INTROSPECTED {
         return None;
     }
 
@@ -80,9 +86,15 @@ pub fn on_event(event_type: &str, payload: &[u8], host: &dyn HostFunctions) -> O
             let (mut video_count, mut audio_count, mut sub_count, mut has_hdr) =
                 (0usize, 0usize, 0usize, false);
             for t in &file.tracks {
-                if t.track_type.is_video() { video_count += 1; }
-                if t.track_type.is_audio() { audio_count += 1; }
-                if t.track_type.is_subtitle() { sub_count += 1; }
+                if t.track_type.is_video() {
+                    video_count += 1;
+                }
+                if t.track_type.is_audio() {
+                    audio_count += 1;
+                }
+                if t.track_type.is_subtitle() {
+                    sub_count += 1;
+                }
                 has_hdr |= t.is_hdr;
             }
 
@@ -98,9 +110,11 @@ pub fn on_event(event_type: &str, payload: &[u8], host: &dyn HostFunctions) -> O
                 "has_hdr": has_hdr,
             });
 
-            let enriched_event = Event::MetadataEnriched(
-                MetadataEnrichedEvent::new(file.path.clone(), "example-metadata".to_string(), metadata),
-            );
+            let enriched_event = Event::MetadataEnriched(MetadataEnrichedEvent::new(
+                file.path.clone(),
+                "example-metadata".to_string(),
+                metadata,
+            ));
 
             let produced_payload = serialize_event(&enriched_event).map_err(|e| {
                 host.log("error", &format!("failed to serialize event: {e}"));

--- a/wasm-plugins/handbrake-executor/src/lib.rs
+++ b/wasm-plugins/handbrake-executor/src/lib.rs
@@ -53,7 +53,7 @@ pub fn get_info() -> PluginInfoData {
 }
 
 pub fn handles(event_type: &str) -> bool {
-    event_type == "plan.created"
+    event_type == Event::PLAN_CREATED
 }
 
 /// Process a plan.created event, executing transcode actions via HandBrakeCLI.
@@ -62,7 +62,7 @@ pub fn on_event(
     payload: &[u8],
     host: &dyn HostFunctions,
 ) -> Option<OnEventResult> {
-    if event_type != "plan.created" {
+    if event_type != Event::PLAN_CREATED {
         return None;
     }
 

--- a/wasm-plugins/radarr-metadata/src/lib.rs
+++ b/wasm-plugins/radarr-metadata/src/lib.rs
@@ -48,7 +48,7 @@ pub fn get_info() -> PluginInfoData {
 }
 
 pub fn handles(event_type: &str) -> bool {
-    event_type == "file.introspected"
+    event_type == Event::FILE_INTROSPECTED
 }
 
 /// Process a file.introspected event by looking up movie info from Radarr.
@@ -60,7 +60,7 @@ pub fn on_event(
     payload: &[u8],
     host: &dyn HostFunctions,
 ) -> Option<OnEventResult> {
-    if event_type != "file.introspected" {
+    if event_type != Event::FILE_INTROSPECTED {
         return None;
     }
 

--- a/wasm-plugins/sonarr-metadata/src/lib.rs
+++ b/wasm-plugins/sonarr-metadata/src/lib.rs
@@ -48,7 +48,7 @@ pub fn get_info() -> PluginInfoData {
 }
 
 pub fn handles(event_type: &str) -> bool {
-    event_type == "file.introspected"
+    event_type == Event::FILE_INTROSPECTED
 }
 
 /// Process a file.introspected event by looking up episode info from Sonarr.
@@ -57,7 +57,7 @@ pub fn on_event(
     payload: &[u8],
     host: &dyn HostFunctions,
 ) -> Option<OnEventResult> {
-    if event_type != "file.introspected" {
+    if event_type != Event::FILE_INTROSPECTED {
         return None;
     }
 

--- a/wasm-plugins/subtitle-generator/src/lib.rs
+++ b/wasm-plugins/subtitle-generator/src/lib.rs
@@ -30,7 +30,7 @@ pub fn get_info() -> PluginInfoData {
 }
 
 pub fn handles(event_type: &str) -> bool {
-    event_type == "metadata.enriched"
+    event_type == Event::METADATA_ENRICHED
 }
 
 /// Process a `metadata.enriched` event by extracting foreign-language
@@ -40,7 +40,7 @@ pub fn on_event(
     payload: &[u8],
     host: &dyn HostFunctions,
 ) -> Option<OnEventResult> {
-    if event_type != "metadata.enriched" {
+    if event_type != Event::METADATA_ENRICHED {
         return None;
     }
 

--- a/wasm-plugins/tvdb-metadata/src/tvdb_metadata/msgpack_helpers.py
+++ b/wasm-plugins/tvdb-metadata/src/tvdb_metadata/msgpack_helpers.py
@@ -10,20 +10,25 @@ serde_json::Value maps directly to equivalent MessagePack types.
 
 import umsgpack
 
+from tvdb_metadata.types import JsonObject
 
-def unpack(data: bytes) -> dict:
+
+def unpack(data: bytes) -> JsonObject:
     """Deserialize MessagePack bytes to a Python dict.
 
     Handles rmp_serde conventions: enum variants as 1-element maps,
     PathBuf as strings, etc.
     """
     try:
-        return umsgpack.unpackb(data)
+        value = umsgpack.unpackb(data)
     except RecursionError:
         raise ValueError("msgpack payload nesting depth exceeds limit")
+    if not isinstance(value, dict):
+        raise ValueError(f"Expected MessagePack map, got: {type(value)}")
+    return value
 
 
-def pack(obj: dict) -> bytes:
+def pack(obj: JsonObject) -> bytes:
     """Serialize a Python dict to MessagePack bytes.
 
     The caller must structure the dict to match rmp_serde's external tagging
@@ -32,7 +37,7 @@ def pack(obj: dict) -> bytes:
     return umsgpack.packb(obj)
 
 
-def unpack_event(data: bytes) -> tuple[str, dict]:
+def unpack_event(data: bytes) -> tuple[str, JsonObject]:
     """Unpack a MessagePack-encoded Rust Event enum.
 
     Returns (variant_name, payload_dict).
@@ -42,10 +47,13 @@ def unpack_event(data: bytes) -> tuple[str, dict]:
     if not isinstance(raw, dict) or len(raw) != 1:
         raise ValueError(f"Expected externally-tagged enum (1-element map), got: {type(raw)}")
     variant = next(iter(raw))
-    return variant, raw[variant]
+    payload = raw[variant]
+    if not isinstance(payload, dict):
+        raise ValueError(f"Expected event payload map, got: {type(payload)}")
+    return variant, payload
 
 
-def pack_event(variant: str, payload: dict) -> bytes:
+def pack_event(variant: str, payload: JsonObject) -> bytes:
     """Pack a Python dict as a MessagePack-encoded Rust Event enum.
 
     Uses rmp_serde external tagging: {"VariantName": {payload...}}

--- a/wasm-plugins/tvdb-metadata/src/tvdb_metadata/plugin.py
+++ b/wasm-plugins/tvdb-metadata/src/tvdb_metadata/plugin.py
@@ -10,6 +10,7 @@ bound to the WIT exports. Host imports (http_get, http_post, get_plugin_data,
 set_plugin_data, log) are available through the generated bindings.
 """
 
+import json
 from collections.abc import Iterable, Sequence
 from typing import Any, Protocol, TypeAlias
 
@@ -326,8 +327,13 @@ def _make_event_result(
     plugin_name: str,
     produced_events: list[EventDataDict],
     data: JsonObject | None = None,
+    claimed: bool = False,
+    execution_error: str | None = None,
+    execution_detail: JsonObject | None = None,
 ) -> object | EventResultDict:
     """Build an EventResult, using WIT types if available."""
+    encoded_data = _json_object_to_byte_list(data)
+    encoded_detail = _json_object_to_byte_list(execution_detail)
     try:
         from voom.plugin.plugin import (  # type: ignore[import]  # componentize-py generated
             EventResult,
@@ -341,12 +347,25 @@ def _make_event_result(
         return EventResult(
             plugin_name=plugin_name,
             produced_events=wit_events,
-            data=data,
+            data=encoded_data,
+            claimed=claimed,
+            execution_error=execution_error,
+            execution_detail=encoded_detail,
         )
     except ImportError:
         # Testing fallback
         return {
             "plugin_name": plugin_name,
             "produced_events": produced_events,
-            "data": data,
+            "data": encoded_data,
+            "claimed": claimed,
+            "execution_error": execution_error,
+            "execution_detail": encoded_detail,
         }
+
+
+def _json_object_to_byte_list(value: JsonObject | None) -> list[int] | None:
+    """Encode optional JSON payloads as the WIT list<u8> boundary shape."""
+    if value is None:
+        return None
+    return list(json.dumps(value, separators=(",", ":")).encode("utf-8"))

--- a/wasm-plugins/tvdb-metadata/src/tvdb_metadata/plugin.py
+++ b/wasm-plugins/tvdb-metadata/src/tvdb_metadata/plugin.py
@@ -10,7 +10,10 @@ bound to the WIT exports. Host imports (http_get, http_post, get_plugin_data,
 set_plugin_data, log) are available through the generated bindings.
 """
 
-from tvdb_metadata.filename_parser import parse_filename
+from collections.abc import Iterable, Sequence
+from typing import Any, Protocol, TypeAlias
+
+from tvdb_metadata.filename_parser import EpisodeInfo, parse_filename
 from tvdb_metadata.msgpack_helpers import pack_event, unpack_event
 from tvdb_metadata.types import (
     EventDataDict,
@@ -21,12 +24,56 @@ from tvdb_metadata.types import (
 )
 from tvdb_metadata.tvdb_client import TvdbClient, TvdbError
 
+
+HeaderPairs: TypeAlias = Sequence[tuple[str, str]]
+HostResponse: TypeAlias = Any
+PluginInfoResult: TypeAlias = object | dict[str, object]
+EventResult: TypeAlias = object | EventResultDict
+
+
+class EventDataLike(Protocol):
+    event_type: str
+    payload: Iterable[int]
+
+
+class HostHeaderFactory(Protocol):
+    def __call__(self, *, name: str, value: str) -> object: ...
+
+
+class HostModule(Protocol):
+    Header: HostHeaderFactory
+
+    def http_get(self, url: str, headers: list[object]) -> HostResponse: ...
+
+    def http_post(self, url: str, headers: list[object], body: list[int]) -> HostResponse: ...
+
+    def get_plugin_data(self, key: str) -> bytes | None: ...
+
+    def set_plugin_data(self, key: str, value: list[int]) -> None: ...
+
+    def log(self, level: object, message: str) -> None: ...
+
+
+class HostBridge(Protocol):
+    def http_get(self, url: str, headers: HeaderPairs) -> HostResponse: ...
+
+    def http_post(self, url: str, headers: HeaderPairs, body: bytes) -> HostResponse: ...
+
+    def get_plugin_data(self, key: str) -> bytes | None: ...
+
+    def set_plugin_data(self, key: str, value: bytes) -> None: ...
+
+    def log(self, level: str, message: str) -> None: ...
+
+
 # The host module is injected by componentize-py at build time.
 # For native testing, tests monkeypatch this.
 try:
-    from voom.plugin import host as _host_module  # type: ignore[import]
+    from voom.plugin import (  # type: ignore[import]  # componentize-py generated
+        host as _host_module,
+    )
 except ImportError:
-    _host_module = None  # type: ignore[assignment]
+    _host_module = None
 
 
 class _HostBridge:
@@ -36,10 +83,10 @@ class _HostBridge:
     our TvdbClient expects simpler Python types. This bridge translates.
     """
 
-    def __init__(self, host_mod):
+    def __init__(self, host_mod: HostModule) -> None:
         self._host = host_mod
 
-    def http_get(self, url, headers):
+    def http_get(self, url: str, headers: HeaderPairs) -> HostResponse:
         wit_headers = [self._host.Header(name=n, value=v) for n, v in headers]
         result = self._host.http_get(url, wit_headers)
         if isinstance(result, Exception) or (hasattr(result, "is_err") and result.is_err()):
@@ -47,7 +94,7 @@ class _HostBridge:
         resp = result if not hasattr(result, "value") else result.value
         return resp
 
-    def http_post(self, url, headers, body):
+    def http_post(self, url: str, headers: HeaderPairs, body: bytes) -> HostResponse:
         wit_headers = [self._host.Header(name=n, value=v) for n, v in headers]
         result = self._host.http_post(url, wit_headers, list(body))
         if isinstance(result, Exception) or (hasattr(result, "is_err") and result.is_err()):
@@ -55,13 +102,13 @@ class _HostBridge:
         resp = result if not hasattr(result, "value") else result.value
         return resp
 
-    def get_plugin_data(self, key):
+    def get_plugin_data(self, key: str) -> bytes | None:
         return self._host.get_plugin_data(key)
 
-    def set_plugin_data(self, key, value):
+    def set_plugin_data(self, key: str, value: bytes) -> None:
         self._host.set_plugin_data(key, list(value))
 
-    def log(self, level, message):
+    def log(self, level: str, message: str) -> None:
         level_map = {
             "trace": self._host.LogLevel.TRACE if hasattr(self._host, "LogLevel") else 0,
             "debug": self._host.LogLevel.DEBUG if hasattr(self._host, "LogLevel") else 1,
@@ -75,7 +122,7 @@ class _HostBridge:
 # --- WIT exports ---
 
 
-def get_info():
+def get_info() -> PluginInfoResult:
     """Return plugin identity and capabilities.
 
     WIT signature: get-info() -> plugin-info
@@ -107,7 +154,7 @@ def handles(event_type: str) -> bool:
     return event_type == "file.introspected"
 
 
-def on_event(event) -> "object | None":
+def on_event(event: EventDataLike | EventDataDict) -> EventResult | None:
     """Process an event and optionally return a result.
 
     WIT signature: on-event(event: event-data) -> option<event-result>
@@ -145,7 +192,7 @@ def on_event(event) -> "object | None":
 # --- Internal helpers ---
 
 
-def _get_host_bridge():
+def _get_host_bridge() -> HostBridge | None:
     """Get the host function bridge, or None if unavailable."""
     if _host_module is not None:
         return _HostBridge(_host_module)
@@ -155,7 +202,7 @@ def _get_host_bridge():
 _log_sink = None  # Set by tests to capture log output
 
 
-def _log(level: str, message: str):
+def _log(level: str, message: str) -> None:
     """Log via host if available, otherwise no-op."""
     if _log_sink is not None:
         _log_sink(level, message)
@@ -168,10 +215,14 @@ def _log(level: str, message: str):
             return
 
 
-def _make_wit_plugin_info():
+def _make_wit_plugin_info() -> object | None:
     """Build the generated WIT PluginInfo record when bindings are present."""
     try:
-        from voom.plugin.plugin import PluginInfo, Capability, EnrichCap  # type: ignore[import]
+        from voom.plugin.plugin import (  # type: ignore[import]  # componentize-py generated
+            Capability,
+            EnrichCap,
+            PluginInfo,
+        )
     except ImportError:
         return None
     return PluginInfo(
@@ -185,12 +236,12 @@ def _make_wit_plugin_info():
     )
 
 
-def _event_type(event) -> str:
+def _event_type(event: EventDataLike | EventDataDict) -> str:
     """Extract the event type from a WIT record or test dict."""
     return event.event_type if hasattr(event, "event_type") else event.get("event_type", "")
 
 
-def _event_payload(event) -> bytes:
+def _event_payload(event: EventDataLike | EventDataDict) -> bytes:
     """Extract raw event payload bytes from a WIT record or test dict."""
     payload = event.payload if hasattr(event, "payload") else event.get("payload", b"")
     return bytes(payload)
@@ -208,7 +259,7 @@ def _unpack_file_introspected(event) -> FileIntrospectedPayload | None:
     return data
 
 
-def _extract_file_path(event) -> str | None:
+def _extract_file_path(event: EventDataLike | EventDataDict) -> str | None:
     """Validate the event payload and return the introspected file path."""
     data = _unpack_file_introspected(event)
     if data is None:
@@ -237,7 +288,7 @@ def _make_client() -> TvdbClient | None:
     return client
 
 
-def _lookup_metadata(client: TvdbClient, info) -> TvdbMetadataResult | None:
+def _lookup_metadata(client: TvdbClient, info: EpisodeInfo) -> TvdbMetadataResult | None:
     """Run the TVDB lookup while keeping failures non-fatal to the plugin."""
     try:
         metadata = client.lookup(
@@ -255,7 +306,7 @@ def _lookup_metadata(client: TvdbClient, info) -> TvdbMetadataResult | None:
     return metadata
 
 
-def _build_metadata_result(file_path: str, metadata: TvdbMetadataResult):
+def _build_metadata_result(file_path: str, metadata: TvdbMetadataResult) -> EventResult:
     """Build the MetadataEnriched event result."""
     enriched_payload = pack_event("MetadataEnriched", {
         "path": file_path,
@@ -278,8 +329,10 @@ def _make_event_result(
 ) -> object | EventResultDict:
     """Build an EventResult, using WIT types if available."""
     try:
-        from voom.plugin.plugin import EventResult  # type: ignore[import]
-        from voom.plugin.types import EventData  # type: ignore[import]
+        from voom.plugin.plugin import (  # type: ignore[import]  # componentize-py generated
+            EventResult,
+        )
+        from voom.plugin.types import EventData  # type: ignore[import]  # componentize-py generated
 
         wit_events = [
             EventData(event_type=e["event_type"], payload=e["payload"])

--- a/wasm-plugins/tvdb-metadata/src/tvdb_metadata/plugin.py
+++ b/wasm-plugins/tvdb-metadata/src/tvdb_metadata/plugin.py
@@ -12,6 +12,13 @@ set_plugin_data, log) are available through the generated bindings.
 
 from tvdb_metadata.filename_parser import parse_filename
 from tvdb_metadata.msgpack_helpers import pack_event, unpack_event
+from tvdb_metadata.types import (
+    EventDataDict,
+    EventResultDict,
+    FileIntrospectedPayload,
+    JsonObject,
+    TvdbMetadataResult,
+)
 from tvdb_metadata.tvdb_client import TvdbClient, TvdbError
 
 # The host module is injected by componentize-py at build time.
@@ -189,7 +196,7 @@ def _event_payload(event) -> bytes:
     return bytes(payload)
 
 
-def _unpack_file_introspected(event) -> dict | None:
+def _unpack_file_introspected(event) -> FileIntrospectedPayload | None:
     """Deserialize FileIntrospected event payloads."""
     try:
         variant, data = unpack_event(_event_payload(event))
@@ -230,7 +237,7 @@ def _make_client() -> TvdbClient | None:
     return client
 
 
-def _lookup_metadata(client: TvdbClient, info) -> dict | None:
+def _lookup_metadata(client: TvdbClient, info) -> TvdbMetadataResult | None:
     """Run the TVDB lookup while keeping failures non-fatal to the plugin."""
     try:
         metadata = client.lookup(
@@ -248,7 +255,7 @@ def _lookup_metadata(client: TvdbClient, info) -> dict | None:
     return metadata
 
 
-def _build_metadata_result(file_path: str, metadata: dict):
+def _build_metadata_result(file_path: str, metadata: TvdbMetadataResult):
     """Build the MetadataEnriched event result."""
     enriched_payload = pack_event("MetadataEnriched", {
         "path": file_path,
@@ -264,7 +271,11 @@ def _build_metadata_result(file_path: str, metadata: dict):
     )
 
 
-def _make_event_result(plugin_name: str, produced_events: list, data=None):
+def _make_event_result(
+    plugin_name: str,
+    produced_events: list[EventDataDict],
+    data: JsonObject | None = None,
+) -> object | EventResultDict:
     """Build an EventResult, using WIT types if available."""
     try:
         from voom.plugin.plugin import EventResult  # type: ignore[import]

--- a/wasm-plugins/tvdb-metadata/src/tvdb_metadata/tvdb_client.py
+++ b/wasm-plugins/tvdb-metadata/src/tvdb_metadata/tvdb_client.py
@@ -5,10 +5,11 @@ since Python's urllib/socket are unavailable in the WASM sandbox.
 """
 
 import json
+from collections.abc import Sequence
+from typing import Any, Protocol, TypeAlias
 
 from tvdb_metadata.types import (
     JsonObject,
-    TvdbAuthResponse,
     TvdbEpisodeRecord,
     TvdbMetadataResult,
     TvdbSearchResult,
@@ -29,6 +30,23 @@ except ImportError:
 _host = None
 
 TVDB_API_BASE = "https://api4.thetvdb.com/v4"
+HeaderPairs: TypeAlias = Sequence[tuple[str, str]]
+PluginData: TypeAlias = bytes | list[int]
+
+
+class HostResponse(Protocol):
+    status: int
+    body: PluginData
+
+
+class ClientHost(Protocol):
+    def http_get(self, url: str, headers: HeaderPairs) -> HostResponse: ...
+
+    def http_post(self, url: str, headers: HeaderPairs, body: bytes) -> HostResponse: ...
+
+    def get_plugin_data(self, key: str) -> PluginData | None: ...
+
+    def set_plugin_data(self, key: str, value: bytes) -> None: ...
 
 
 class TvdbError(Exception):
@@ -38,13 +56,13 @@ class TvdbError(Exception):
 class TvdbClient:
     """TVDB API v4 client that uses host functions for HTTP and storage."""
 
-    def __init__(self, api_key: str, host_funcs):
+    def __init__(self, api_key: str, host_funcs: ClientHost):
         self.api_key = api_key
         self._host = host_funcs
         self._token: str | None = None
 
     @classmethod
-    def from_config(cls, host_funcs) -> "TvdbClient | None":
+    def from_config(cls, host_funcs: ClientHost) -> "TvdbClient | None":
         """Create a client from stored plugin config.
 
         Config is stored as JSON bytes via get_plugin_data("config"):
@@ -58,6 +76,8 @@ class TvdbClient:
         except (json.JSONDecodeError, TypeError):
             return None
         api_key = config.get("api_key")
+        if not isinstance(api_key, str):
+            return None
         if not api_key:
             return None
         return cls(api_key=api_key, host_funcs=host_funcs)
@@ -88,9 +108,8 @@ class TvdbClient:
         if resp.status != 200:
             raise TvdbError(f"TVDB auth failed with status {resp.status}")
 
-        result: TvdbAuthResponse = json.loads(bytes(resp.body))
-        token = result.get("data", {}).get("token")
-        if not token:
+        token = _auth_token_from_response(json.loads(bytes(resp.body)))
+        if token is None:
             raise TvdbError("No token in TVDB auth response")
 
         self._token = token
@@ -143,10 +162,7 @@ class TvdbClient:
         # Query API
         encoded_name = _url_quote(name, safe="")
         result = self._api_get(f"/search?query={encoded_name}&type=series")
-        series_list = result.get("data", [])
-        if not isinstance(series_list, list):
-            series_list = []
-        series_list = [r for r in series_list if isinstance(r, dict)]
+        series_list = _search_results_from_response(result)
 
         # Cache results
         cache_data = json.dumps({"results": series_list})
@@ -163,8 +179,7 @@ class TvdbClient:
             token_data = json.loads(bytes(cached))
         except (json.JSONDecodeError, TypeError):
             return None
-        token = token_data.get("token")
-        return token if token else None
+        return _token_from_cache(token_data)
 
     def _load_cached_search_results(self, cache_key: str) -> list[TvdbSearchResult] | None:
         """Return cached search results, or None if the cache is absent/invalid."""
@@ -178,7 +193,7 @@ class TvdbClient:
             return None
         if not isinstance(results, list):
             return None
-        return [r for r in results if isinstance(r, dict)]
+        return _normalize_search_results(results)
 
     def get_episodes(self, series_id: int, season: int) -> list[TvdbEpisodeRecord]:
         """Get episodes for a series/season.
@@ -194,7 +209,7 @@ class TvdbClient:
         episodes = data.get("episodes", [])
         if not isinstance(episodes, list):
             return []
-        return [e for e in episodes if isinstance(e, dict)]
+        return _normalize_episode_records(episodes)
 
     def lookup(self, series_name: str, season: int, episode: int,
                year: int | None = None) -> TvdbMetadataResult | None:
@@ -269,3 +284,78 @@ class TvdbClient:
 
         # Fall back to first result
         return results[0]
+
+
+def _auth_token_from_response(value: Any) -> str | None:
+    if not isinstance(value, dict):
+        return None
+    data = value.get("data")
+    if not isinstance(data, dict):
+        return None
+    token = data.get("token")
+    return token if isinstance(token, str) and token else None
+
+
+def _token_from_cache(value: Any) -> str | None:
+    if not isinstance(value, dict):
+        return None
+    token = value.get("token")
+    return token if isinstance(token, str) and token else None
+
+
+def _search_results_from_response(value: JsonObject) -> list[TvdbSearchResult]:
+    data = value.get("data", [])
+    if not isinstance(data, list):
+        return []
+    return _normalize_search_results(data)
+
+
+def _normalize_search_results(items: list[Any]) -> list[TvdbSearchResult]:
+    results: list[TvdbSearchResult] = []
+    for item in items:
+        result = _normalize_search_result(item)
+        if result:
+            results.append(result)
+    return results
+
+
+def _normalize_search_result(value: Any) -> TvdbSearchResult | None:
+    if not isinstance(value, dict):
+        return None
+    result: TvdbSearchResult = {}
+    for key in ("id", "tvdb_id", "year"):
+        typed_value = value.get(key)
+        if isinstance(typed_value, (int, str)):
+            result[key] = typed_value
+    for key in ("name", "originalLanguage"):
+        typed_value = value.get(key)
+        if isinstance(typed_value, str):
+            result[key] = typed_value
+    return result or None
+
+
+def _normalize_episode_records(items: list[Any]) -> list[TvdbEpisodeRecord]:
+    episodes: list[TvdbEpisodeRecord] = []
+    for item in items:
+        episode = _normalize_episode_record(item)
+        if episode:
+            episodes.append(episode)
+    return episodes
+
+
+def _normalize_episode_record(value: Any) -> TvdbEpisodeRecord | None:
+    if not isinstance(value, dict):
+        return None
+    episode: TvdbEpisodeRecord = {}
+    typed_id = value.get("id")
+    if isinstance(typed_id, (int, str)):
+        episode["id"] = typed_id
+    for key in ("name", "overview", "aired"):
+        typed_value = value.get(key)
+        if isinstance(typed_value, str):
+            episode[key] = typed_value
+    for key in ("number", "episodeNumber"):
+        typed_value = value.get(key)
+        if isinstance(typed_value, int):
+            episode[key] = typed_value
+    return episode or None

--- a/wasm-plugins/tvdb-metadata/src/tvdb_metadata/tvdb_client.py
+++ b/wasm-plugins/tvdb-metadata/src/tvdb_metadata/tvdb_client.py
@@ -6,6 +6,14 @@ since Python's urllib/socket are unavailable in the WASM sandbox.
 
 import json
 
+from tvdb_metadata.types import (
+    JsonObject,
+    TvdbAuthResponse,
+    TvdbEpisodeRecord,
+    TvdbMetadataResult,
+    TvdbSearchResult,
+)
+
 try:
     from urllib.parse import quote as _url_quote
 except ImportError:
@@ -80,7 +88,7 @@ class TvdbClient:
         if resp.status != 200:
             raise TvdbError(f"TVDB auth failed with status {resp.status}")
 
-        result = json.loads(bytes(resp.body))
+        result: TvdbAuthResponse = json.loads(bytes(resp.body))
         token = result.get("data", {}).get("token")
         if not token:
             raise TvdbError("No token in TVDB auth response")
@@ -93,7 +101,7 @@ class TvdbClient:
 
         return token
 
-    def _api_get(self, path: str) -> dict:
+    def _api_get(self, path: str) -> JsonObject:
         """Make an authenticated GET request to the TVDB API."""
         token = self.authenticate()
         url = f"{TVDB_API_BASE}{path}"
@@ -117,9 +125,10 @@ class TvdbClient:
         if resp.status != 200:
             raise TvdbError(f"TVDB API returned status {resp.status} for {path}")
 
-        return json.loads(bytes(resp.body))
+        result = json.loads(bytes(resp.body))
+        return result if isinstance(result, dict) else {}
 
-    def search_series(self, name: str) -> list[dict]:
+    def search_series(self, name: str) -> list[TvdbSearchResult]:
         """Search for TV series by name.
 
         Returns list of series results with id, name, year, etc.
@@ -135,6 +144,9 @@ class TvdbClient:
         encoded_name = _url_quote(name, safe="")
         result = self._api_get(f"/search?query={encoded_name}&type=series")
         series_list = result.get("data", [])
+        if not isinstance(series_list, list):
+            series_list = []
+        series_list = [r for r in series_list if isinstance(r, dict)]
 
         # Cache results
         cache_data = json.dumps({"results": series_list})
@@ -154,7 +166,7 @@ class TvdbClient:
         token = token_data.get("token")
         return token if token else None
 
-    def _load_cached_search_results(self, cache_key: str) -> list[dict] | None:
+    def _load_cached_search_results(self, cache_key: str) -> list[TvdbSearchResult] | None:
         """Return cached search results, or None if the cache is absent/invalid."""
         cached = self._host.get_plugin_data(cache_key)
         if cached is None:
@@ -164,9 +176,11 @@ class TvdbClient:
             results = cache_data["results"]
         except (json.JSONDecodeError, KeyError, TypeError):
             return None
-        return results if isinstance(results, list) else None
+        if not isinstance(results, list):
+            return None
+        return [r for r in results if isinstance(r, dict)]
 
-    def get_episodes(self, series_id: int, season: int) -> list[dict]:
+    def get_episodes(self, series_id: int, season: int) -> list[TvdbEpisodeRecord]:
         """Get episodes for a series/season.
 
         Returns list of episode records.
@@ -174,10 +188,16 @@ class TvdbClient:
         result = self._api_get(
             f"/series/{series_id}/episodes/default?season={season}"
         )
-        return result.get("data", {}).get("episodes", [])
+        data = result.get("data", {})
+        if not isinstance(data, dict):
+            return []
+        episodes = data.get("episodes", [])
+        if not isinstance(episodes, list):
+            return []
+        return [e for e in episodes if isinstance(e, dict)]
 
     def lookup(self, series_name: str, season: int, episode: int,
-               year: int | None = None) -> dict | None:
+               year: int | None = None) -> TvdbMetadataResult | None:
         """Full lookup: search series → find episode → return metadata.
 
         Returns a metadata dict or None if not found.
@@ -209,7 +229,7 @@ class TvdbClient:
         if ep_data is None:
             return None
 
-        result = {
+        result: TvdbMetadataResult = {
             "source": "tvdb",
             "series_id": series_id,
             "series_name": series.get("name", series_name),
@@ -226,8 +246,8 @@ class TvdbClient:
         return result
 
     @staticmethod
-    def _best_match(results: list[dict], name: str,
-                    year: int | None) -> dict | None:
+    def _best_match(results: list[TvdbSearchResult], name: str,
+                    year: int | None) -> TvdbSearchResult | None:
         """Pick the best series match from search results."""
         if not results:
             return None

--- a/wasm-plugins/tvdb-metadata/src/tvdb_metadata/types.py
+++ b/wasm-plugins/tvdb-metadata/src/tvdb_metadata/types.py
@@ -1,0 +1,63 @@
+"""Typed payload contracts for TVDB plugin boundaries."""
+
+from typing import Any, NotRequired, TypeAlias, TypedDict
+
+
+JsonObject: TypeAlias = dict[str, Any]
+
+
+class TvdbAuthData(TypedDict, total=False):
+    token: str
+
+
+class TvdbAuthResponse(TypedDict, total=False):
+    data: TvdbAuthData
+
+
+class TvdbSearchResult(TypedDict, total=False):
+    id: int | str
+    tvdb_id: int | str
+    name: str
+    year: str | int
+    originalLanguage: str
+
+
+class TvdbEpisodeRecord(TypedDict, total=False):
+    id: int | str
+    name: str
+    overview: str
+    aired: str
+    number: int
+    episodeNumber: int
+
+
+class TvdbMetadataResult(TypedDict):
+    source: str
+    series_id: int | str
+    series_name: str
+    season_number: int
+    episode_number: int
+    episode_name: str
+    overview: str
+    air_date: str
+    tvdb_episode_id: int | str | None
+    original_language: NotRequired[str]
+
+
+class FileRecordPayload(TypedDict, total=False):
+    path: str
+
+
+class FileIntrospectedPayload(TypedDict, total=False):
+    file: FileRecordPayload
+
+
+class EventDataDict(TypedDict):
+    event_type: str
+    payload: list[int]
+
+
+class EventResultDict(TypedDict):
+    plugin_name: str
+    produced_events: list[EventDataDict]
+    data: JsonObject | None

--- a/wasm-plugins/tvdb-metadata/src/tvdb_metadata/types.py
+++ b/wasm-plugins/tvdb-metadata/src/tvdb_metadata/types.py
@@ -60,4 +60,7 @@ class EventDataDict(TypedDict):
 class EventResultDict(TypedDict):
     plugin_name: str
     produced_events: list[EventDataDict]
-    data: JsonObject | None
+    data: list[int] | None
+    claimed: bool
+    execution_error: str | None
+    execution_detail: list[int] | None

--- a/wasm-plugins/tvdb-metadata/src/tvdb_metadata/types.py
+++ b/wasm-plugins/tvdb-metadata/src/tvdb_metadata/types.py
@@ -6,14 +6,6 @@ from typing import Any, NotRequired, TypeAlias, TypedDict
 JsonObject: TypeAlias = dict[str, Any]
 
 
-class TvdbAuthData(TypedDict, total=False):
-    token: str
-
-
-class TvdbAuthResponse(TypedDict, total=False):
-    data: TvdbAuthData
-
-
 class TvdbSearchResult(TypedDict, total=False):
     id: int | str
     tvdb_id: int | str

--- a/wasm-plugins/tvdb-metadata/tests/test_plugin.py
+++ b/wasm-plugins/tvdb-metadata/tests/test_plugin.py
@@ -1,17 +1,12 @@
 """Tests for the plugin entry points (get_info, handles, on_event)."""
 
-import json
-import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
-from tvdb_metadata.filename_parser import parse_filename
 from tvdb_metadata.msgpack_helpers import pack_event, unpack_event
 from tvdb_metadata import plugin as plugin_module
-from tvdb_metadata.tvdb_client import TvdbClient, TvdbError
-
-from helpers import MockHost, MockHttpResponse
+from tvdb_metadata.tvdb_client import TvdbClient
 
 
 class TestGetInfo:

--- a/wasm-plugins/tvdb-metadata/tests/test_plugin.py
+++ b/wasm-plugins/tvdb-metadata/tests/test_plugin.py
@@ -1,5 +1,6 @@
 """Tests for the plugin entry points (get_info, handles, on_event)."""
 
+import json
 from unittest.mock import patch
 
 import pytest
@@ -63,6 +64,10 @@ class TestOnEvent:
 
         assert result is not None
         assert result["plugin_name"] == "tvdb-metadata"
+        assert result["data"] is None
+        assert result["claimed"] is False
+        assert result["execution_error"] is None
+        assert result["execution_detail"] is None
         assert len(result["produced_events"]) == 1
 
         produced = result["produced_events"][0]
@@ -76,6 +81,21 @@ class TestOnEvent:
         assert data["metadata"]["episode_name"] == "Pilot"
         assert data["metadata"]["season_number"] == 1
         assert data["metadata"]["episode_number"] == 1
+
+    def test_make_event_result_encodes_optional_payloads(self):
+        result = plugin_module._make_event_result(
+            plugin_name="tvdb-metadata",
+            produced_events=[],
+            data={"matched": True},
+            claimed=True,
+            execution_error="failed",
+            execution_detail={"attempts": 2},
+        )
+
+        assert result["claimed"] is True
+        assert result["execution_error"] == "failed"
+        assert json.loads(bytes(result["data"])) == {"matched": True}
+        assert json.loads(bytes(result["execution_detail"])) == {"attempts": 2}
 
     def test_ignores_non_tv_file(self, mock_host_with_tvdb, monkeypatch):
         monkeypatch.setattr(plugin_module, "_get_host_bridge", lambda: mock_host_with_tvdb)

--- a/wasm-plugins/tvdb-metadata/tests/test_tvdb_client.py
+++ b/wasm-plugins/tvdb-metadata/tests/test_tvdb_client.py
@@ -6,7 +6,7 @@ import pytest
 
 from tvdb_metadata.tvdb_client import TvdbClient, TvdbError
 
-from helpers import MockHost, MockHttpResponse
+from helpers import MockHttpResponse
 
 
 class TestFromConfig:

--- a/wasm-plugins/tvdb-metadata/tests/test_tvdb_client.py
+++ b/wasm-plugins/tvdb-metadata/tests/test_tvdb_client.py
@@ -32,6 +32,11 @@ class TestFromConfig:
         client = TvdbClient.from_config(mock_host)
         assert client is None
 
+    def test_non_string_api_key_returns_none(self, mock_host):
+        mock_host.set_config({"api_key": 123})
+        client = TvdbClient.from_config(mock_host)
+        assert client is None
+
 
 class TestAuthentication:
     """Token authentication flow."""
@@ -77,6 +82,16 @@ class TestAuthentication:
         token = client.authenticate()
         assert token == "fresh-token"
 
+    def test_auth_rejects_non_string_token(self, mock_host):
+        mock_host.set_config({"api_key": "test-key"})
+        mock_host.set_http_response("/v4/login", MockHttpResponse(
+            status=200,
+            body=json.dumps({"data": {"token": 123}}).encode(),
+        ))
+        client = TvdbClient.from_config(mock_host)
+        with pytest.raises(TvdbError, match="No token"):
+            client.authenticate()
+
 
 class TestSearchSeries:
     """Series search functionality."""
@@ -103,6 +118,41 @@ class TestSearchSeries:
         results = client.search_series("Nonexistent Show")
         assert results == []
 
+    def test_search_normalizes_result_field_types(self, mock_host_with_tvdb):
+        mock_host_with_tvdb.set_http_response("/v4/search", MockHttpResponse(
+            status=200,
+            body=json.dumps({
+                "data": [
+                    {
+                        "id": 1,
+                        "tvdb_id": {"bad": "shape"},
+                        "name": None,
+                        "year": "2020",
+                        "originalLanguage": "eng",
+                    },
+                    "bad entry",
+                    {"name": "Valid Show", "year": ["bad"]},
+                ],
+            }).encode(),
+        ))
+        client = TvdbClient.from_config(mock_host_with_tvdb)
+        results = client.search_series("Valid Show")
+        assert results == [
+            {"id": 1, "year": "2020", "originalLanguage": "eng"},
+            {"name": "Valid Show"},
+        ]
+
+    def test_cached_search_results_are_normalized(self, mock_host_with_tvdb):
+        mock_host_with_tvdb._data["search:breaking bad"] = json.dumps({
+            "results": [
+                {"name": "Breaking Bad", "tvdb_id": 73255},
+                {"name": 404, "tvdb_id": []},
+            ],
+        }).encode()
+        client = TvdbClient.from_config(mock_host_with_tvdb)
+        results = client.search_series("Breaking Bad")
+        assert results == [{"name": "Breaking Bad", "tvdb_id": 73255}]
+
 
 class TestGetEpisodes:
     """Episode retrieval."""
@@ -112,6 +162,31 @@ class TestGetEpisodes:
         episodes = client.get_episodes(73255, 1)
         assert len(episodes) == 2
         assert episodes[0]["name"] == "Pilot"
+
+    def test_get_episodes_normalizes_field_types(self, mock_host_with_tvdb):
+        mock_host_with_tvdb.set_http_response("/series/73255/episodes", MockHttpResponse(
+            status=200,
+            body=json.dumps({
+                "data": {
+                    "episodes": [
+                        {
+                            "id": "e1",
+                            "name": "Pilot",
+                            "overview": None,
+                            "aired": "2008-01-20",
+                            "number": "1",
+                            "episodeNumber": 1,
+                        },
+                        [],
+                    ],
+                },
+            }).encode(),
+        ))
+        client = TvdbClient.from_config(mock_host_with_tvdb)
+        episodes = client.get_episodes(73255, 1)
+        assert episodes == [
+            {"id": "e1", "name": "Pilot", "aired": "2008-01-20", "episodeNumber": 1}
+        ]
 
     def test_get_episodes_api_error(self, mock_host):
         mock_host.set_config({"api_key": "key"})

--- a/wasm-plugins/whisper-transcriber/src/lib.rs
+++ b/wasm-plugins/whisper-transcriber/src/lib.rs
@@ -47,7 +47,7 @@ pub fn get_info() -> PluginInfoData {
 }
 
 pub fn handles(event_type: &str) -> bool {
-    event_type == "file.introspected"
+    event_type == Event::FILE_INTROSPECTED
 }
 
 /// Process a file.introspected event by transcribing its primary audio track.
@@ -56,7 +56,7 @@ pub fn on_event(
     payload: &[u8],
     host: &dyn HostFunctions,
 ) -> Option<OnEventResult> {
-    if event_type != "file.introspected" {
+    if event_type != Event::FILE_INTROSPECTED {
         return None;
     }
 


### PR DESCRIPTION
## Summary
- Keep the salvage branch rebased onto current main while preserving the useful cleanup commits.
- Simplify executor routing tests to exercise real executor implementations instead of local duplicates.
- Remove production-only test hooks and trim unused/report test scaffolding.

## Verification
- cargo fmt --all --check
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- cargo test --workspace --locked
- uv run --with pytest --project wasm-plugins/tvdb-metadata pytest -q