### PR TITLE
Preserve plugin data read errors

### DIFF
--- a/crates/voom-cli/src/commands/process/pipeline.rs
+++ b/crates/voom-cli/src/commands/process/pipeline.rs
@@ -868,7 +868,7 @@ mod tests {
         .await;
 
         drop(held);
-        tokio::time::timeout(Duration::from_secs(1), &mut processing)
+        tokio::time::timeout(Duration::from_secs(5), &mut processing)
             .await
             .expect("processing should continue after the limiter permit is released")
             .expect("processing should complete without execution errors");
@@ -921,7 +921,7 @@ mod tests {
         .await;
 
         drop(held);
-        tokio::time::timeout(Duration::from_secs(1), &mut processing)
+        tokio::time::timeout(Duration::from_secs(5), &mut processing)
             .await
             .expect("processing should continue after the limiter permit is released")
             .expect("processing should complete without execution errors");

--- a/crates/voom-plugin-sdk/src/event.rs
+++ b/crates/voom-plugin-sdk/src/event.rs
@@ -60,13 +60,13 @@ pub fn serialize_json<T: Serialize>(value: &T) -> Result<Vec<u8>> {
 ///
 /// let config: Option<MyConfig> = load_plugin_config(|key| {
 ///     assert_eq!(key, "config");
-///     Some(br#"{"enabled": true}"#.to_vec())
-/// });
+///     Ok(Some(br#"{"enabled": true}"#.to_vec()))
+/// }).unwrap();
 /// assert!(config.unwrap().enabled);
 /// ```
 pub fn load_plugin_config<T: DeserializeOwned>(
-    get_data: impl FnOnce(&str) -> Option<Vec<u8>>,
-) -> Option<T> {
+    get_data: impl FnOnce(&str) -> std::result::Result<Option<Vec<u8>>, String>,
+) -> Result<Option<T>> {
     load_plugin_config_named(None, get_data)
 }
 
@@ -88,27 +88,39 @@ pub fn load_plugin_config<T: DeserializeOwned>(
 ///     Some("my-plugin"),
 ///     |key| {
 ///         assert_eq!(key, "config");
-///         Some(br#"{"threshold": 10}"#.to_vec())
+///         Ok(Some(br#"{"threshold": 10}"#.to_vec()))
 ///     },
-/// );
+/// ).unwrap();
 /// assert_eq!(config.unwrap().threshold, 10);
 /// ```
 pub fn load_plugin_config_named<T: DeserializeOwned>(
     plugin_name: Option<&str>,
-    get_data: impl FnOnce(&str) -> Option<Vec<u8>>,
-) -> Option<T> {
-    let data = get_data("config")?;
-    match serde_json::from_slice(&data) {
-        Ok(config) => Some(config),
-        Err(e) => {
-            if let Some(name) = plugin_name {
-                tracing::warn!("Failed to deserialize plugin config for '{name}': {e}");
-            } else {
-                tracing::warn!("Failed to deserialize plugin config: {e}");
-            }
-            None
-        }
-    }
+    get_data: impl FnOnce(&str) -> std::result::Result<Option<Vec<u8>>, String>,
+) -> Result<Option<T>> {
+    let Some(data) = get_data("config").map_err(|e| plugin_config_read_error(plugin_name, e))?
+    else {
+        return Ok(None);
+    };
+
+    serde_json::from_slice(&data)
+        .map(Some)
+        .map_err(|e| plugin_config_error(plugin_name, e))
+}
+
+fn plugin_config_error(plugin_name: Option<&str>, source: serde_json::Error) -> VoomError {
+    let context = plugin_name
+        .map(|name| format!(" for '{name}'"))
+        .unwrap_or_default();
+    VoomError::Wasm(format!(
+        "failed to deserialize plugin config{context}: {source}"
+    ))
+}
+
+fn plugin_config_read_error(plugin_name: Option<&str>, source: String) -> VoomError {
+    let context = plugin_name
+        .map(|name| format!(" for '{name}'"))
+        .unwrap_or_default();
+    VoomError::Wasm(format!("failed to read plugin config{context}: {source}"))
 }
 
 #[cfg(test)]
@@ -143,5 +155,47 @@ mod tests {
     fn test_deserialize_invalid_bytes() {
         assert!(deserialize_event(&[0xFF, 0xFE]).is_err());
         assert!(deserialize_json::<serde_json::Value>(&[0xFF]).is_err());
+    }
+
+    #[test]
+    fn test_load_plugin_config_missing_returns_none() {
+        let config = load_plugin_config::<serde_json::Value>(|_| Ok(None)).unwrap();
+
+        assert!(config.is_none());
+    }
+
+    #[test]
+    fn test_load_plugin_config_valid_returns_config() {
+        let config: serde_json::Value =
+            load_plugin_config(|_| Ok(Some(br#"{"enabled": true}"#.to_vec())))
+                .unwrap()
+                .unwrap();
+
+        assert_eq!(config["enabled"], true);
+    }
+
+    #[test]
+    fn test_load_plugin_config_malformed_returns_error() {
+        let error = load_plugin_config_named::<serde_json::Value>(Some("test-plugin"), |_| {
+            Ok(Some(br#"{"enabled":"#.to_vec()))
+        })
+        .unwrap_err();
+
+        let message = error.to_string();
+        assert!(message.contains("test-plugin"));
+        assert!(message.contains("failed to deserialize plugin config"));
+    }
+
+    #[test]
+    fn test_load_plugin_config_read_error_is_not_missing() {
+        let error = load_plugin_config_named::<serde_json::Value>(Some("test-plugin"), |_| {
+            Err("storage unavailable".to_string())
+        })
+        .unwrap_err();
+
+        let message = error.to_string();
+        assert!(message.contains("test-plugin"));
+        assert!(message.contains("storage unavailable"));
+        assert!(message.contains("failed to read plugin config"));
     }
 }

--- a/crates/voom-plugin-sdk/src/host.rs
+++ b/crates/voom-plugin-sdk/src/host.rs
@@ -52,7 +52,7 @@ pub trait HostFunctions {
     }
 
     /// Retrieve plugin-specific data from the host's data store.
-    fn get_plugin_data(&self, key: &str) -> Option<Vec<u8>>;
+    fn get_plugin_data(&self, key: &str) -> Result<Option<Vec<u8>>, String>;
 
     /// Store plugin-specific data in the host's data store.
     fn set_plugin_data(&self, key: &str, value: &[u8]) -> Result<(), String>;
@@ -82,8 +82,8 @@ mod tests {
     struct TestHost;
 
     impl HostFunctions for TestHost {
-        fn get_plugin_data(&self, _key: &str) -> Option<Vec<u8>> {
-            None
+        fn get_plugin_data(&self, _key: &str) -> Result<Option<Vec<u8>>, String> {
+            Ok(None)
         }
 
         fn set_plugin_data(&self, _key: &str, _value: &[u8]) -> Result<(), String> {

--- a/wasm-plugins/audio-language-detector/src/lib.rs
+++ b/wasm-plugins/audio-language-detector/src/lib.rs
@@ -75,8 +75,13 @@ pub fn on_event(
         return None;
     }
 
-    let config: Option<DetectorConfig> =
-        load_plugin_config(|key| host.get_plugin_data(key));
+    let config: Option<DetectorConfig> = match load_plugin_config(|key| host.get_plugin_data(key)) {
+        Ok(config) => config,
+        Err(e) => {
+            host.log("error", &format!("failed to load detector config: {e}"));
+            return None;
+        }
+    };
     let cfg = config.as_ref();
     let whisper_bin = cfg
         .map(|c| c.whisper_binary.as_str())
@@ -107,20 +112,16 @@ pub fn on_event(
         let cache_key =
             format!("lang:{hash_str}:{}", track.index);
 
-        if let Some(cached) = host.get_plugin_data(&cache_key) {
-            if let Ok(det) =
-                serde_json::from_slice::<TrackDetection>(&cached)
-            {
-                host.log(
-                    "debug",
-                    &format!(
-                        "cache hit for track {}",
-                        track.index
-                    ),
-                );
-                detections.push(det);
-                continue;
+        match host.get_plugin_data(&cache_key) {
+            Ok(Some(cached)) => {
+                if let Ok(det) = serde_json::from_slice::<TrackDetection>(&cached) {
+                    host.log("debug", &format!("cache hit for track {}", track.index));
+                    detections.push(det);
+                    continue;
+                }
             }
+            Ok(None) => {}
+            Err(e) => host.log("error", &format!("failed to read language cache: {e}")),
         }
 
         let detection = detect_track_language(
@@ -542,19 +543,18 @@ mod tests {
     use std::path::PathBuf;
     use voom_plugin_sdk::*;
 
+    type ToolResultHandler = Box<dyn Fn(&[String]) -> ToolOutput + Send + Sync>;
+    type ToolResults = HashMap<String, ToolResultHandler>;
+
     struct MockHost {
-        tool_results:
-            HashMap<String, Box<dyn Fn(&[String]) -> ToolOutput + Send + Sync>>,
+        tool_results: ToolResults,
         cached: std::cell::RefCell<HashMap<String, Vec<u8>>>,
     }
 
     impl MockHost {
         fn with_whisper_response(language: &str, no_speech_prob: f64) -> Self {
             let lang = language.to_string();
-            let mut tool_results: HashMap<
-                String,
-                Box<dyn Fn(&[String]) -> ToolOutput + Send + Sync>,
-            > = HashMap::new();
+            let mut tool_results: ToolResults = HashMap::new();
 
             tool_results.insert(
                 "ffmpeg".to_string(),
@@ -588,10 +588,7 @@ mod tests {
         }
 
         fn with_failing_ffmpeg() -> Self {
-            let mut tool_results: HashMap<
-                String,
-                Box<dyn Fn(&[String]) -> ToolOutput + Send + Sync>,
-            > = HashMap::new();
+            let mut tool_results: ToolResults = HashMap::new();
             tool_results.insert(
                 "ffmpeg".to_string(),
                 Box::new(|_| {
@@ -612,10 +609,7 @@ mod tests {
         fn with_multi_language() -> Self {
             let call_count =
                 std::sync::atomic::AtomicU32::new(0);
-            let mut tool_results: HashMap<
-                String,
-                Box<dyn Fn(&[String]) -> ToolOutput + Send + Sync>,
-            > = HashMap::new();
+            let mut tool_results: ToolResults = HashMap::new();
 
             tool_results.insert(
                 "ffmpeg".to_string(),
@@ -629,8 +623,7 @@ mod tests {
                         1,
                         std::sync::atomic::Ordering::SeqCst,
                     );
-                    // Alternate between two languages
-                    let lang = if n % 2 == 0 { "en" } else { "fr" };
+                    let lang = if n.is_multiple_of(2) { "en" } else { "fr" };
                     let json = serde_json::json!({
                         "language": lang,
                         "no_speech_prob": 0.05,
@@ -668,8 +661,8 @@ mod tests {
                 .ok_or_else(|| format!("tool not found: {tool}"))
         }
 
-        fn get_plugin_data(&self, key: &str) -> Option<Vec<u8>> {
-            self.cached.borrow().get(key).cloned()
+        fn get_plugin_data(&self, key: &str) -> Result<Option<Vec<u8>>, String> {
+            Ok(self.cached.borrow().get(key).cloned())
         }
 
         fn set_plugin_data(

--- a/wasm-plugins/audio-synthesizer/src/lib.rs
+++ b/wasm-plugins/audio-synthesizer/src/lib.rs
@@ -80,7 +80,13 @@ pub fn on_event(
         return None;
     }
 
-    let config: Option<SynthConfig> = load_plugin_config(|key| host.get_plugin_data(key));
+    let config: Option<SynthConfig> = match load_plugin_config(|key| host.get_plugin_data(key)) {
+        Ok(config) => config,
+        Err(e) => {
+            host.log("error", &format!("failed to load synthesizer config: {e}"));
+            return None;
+        }
+    };
     let cfg = config.as_ref();
     let tts_engine = cfg.map(|c| c.tts_engine.as_str()).unwrap_or("piper");
     let tts_model = cfg.map(|c| c.tts_model.as_str()).unwrap_or("en_US-lessac-medium");
@@ -243,12 +249,13 @@ mod tests {
             Ok(ToolOutput::new(0, vec![], vec![]))
         }
 
-        fn get_plugin_data(&self, key: &str) -> Option<Vec<u8>> {
-            if key == "config" {
+        fn get_plugin_data(&self, key: &str) -> Result<Option<Vec<u8>>, String> {
+            let data = if key == "config" {
                 self.config.as_ref().map(|c| serde_json::to_vec(c).unwrap())
             } else {
                 None
-            }
+            };
+            Ok(data)
         }
 
         fn set_plugin_data(&self, _key: &str, _value: &[u8]) -> Result<(), String> {

--- a/wasm-plugins/example-metadata/src/lib.rs
+++ b/wasm-plugins/example-metadata/src/lib.rs
@@ -156,8 +156,8 @@ mod tests {
 
     struct NoopHost;
     impl HostFunctions for NoopHost {
-        fn get_plugin_data(&self, _key: &str) -> Option<Vec<u8>> {
-            None
+        fn get_plugin_data(&self, _key: &str) -> Result<Option<Vec<u8>>, String> {
+            Ok(None)
         }
         fn set_plugin_data(&self, _key: &str, _value: &[u8]) -> Result<(), String> {
             Ok(())

--- a/wasm-plugins/handbrake-executor/src/lib.rs
+++ b/wasm-plugins/handbrake-executor/src/lib.rs
@@ -90,7 +90,13 @@ pub fn on_event(
         return None;
     }
 
-    let config: Option<HandbrakeConfig> = load_plugin_config(|key| host.get_plugin_data(key));
+    let config: Option<HandbrakeConfig> = match load_plugin_config(|key| host.get_plugin_data(key)) {
+        Ok(config) => config,
+        Err(e) => {
+            host.log("error", &format!("failed to load HandBrake config: {e}"));
+            return None;
+        }
+    };
     let handbrake_bin = config
         .as_ref()
         .map(|c| c.handbrake_binary.as_str())
@@ -315,16 +321,6 @@ mod tests {
             }
         }
 
-        fn with_preset(preset: &str) -> Self {
-            Self {
-                config: Some(HandbrakeConfig {
-                    handbrake_binary: "HandBrakeCLI".to_string(),
-                    preset: Some(preset.to_string()),
-                    timeout_ms: 1_800_000,
-                }),
-                exit_code: 0,
-            }
-        }
     }
 
     impl HostFunctions for MockHost {
@@ -340,12 +336,13 @@ mod tests {
             ))
         }
 
-        fn get_plugin_data(&self, key: &str) -> Option<Vec<u8>> {
-            if key == "config" {
+        fn get_plugin_data(&self, key: &str) -> Result<Option<Vec<u8>>, String> {
+            let data = if key == "config" {
                 self.config.as_ref().map(|c| serde_json::to_vec(c).unwrap())
             } else {
                 None
-            }
+            };
+            Ok(data)
         }
 
         fn set_plugin_data(&self, _key: &str, _value: &[u8]) -> Result<(), String> {

--- a/wasm-plugins/radarr-metadata/src/lib.rs
+++ b/wasm-plugins/radarr-metadata/src/lib.rs
@@ -74,7 +74,17 @@ pub fn on_event(
 
     host.log("info", &format!("looking up Radarr metadata for: {}", file.path.display()));
 
-    let config: RadarrConfig = load_plugin_config(|key| host.get_plugin_data(key))?;
+    let config: RadarrConfig = match load_plugin_config(|key| host.get_plugin_data(key)) {
+        Ok(Some(config)) => config,
+        Ok(None) => {
+            host.log("error", "missing Radarr config");
+            return None;
+        }
+        Err(e) => {
+            host.log("error", &format!("failed to load Radarr config: {e}"));
+            return None;
+        }
+    };
     let movie = lookup_movie(host, &config, &file.path.to_string_lossy())?;
 
     let original_language = movie
@@ -222,12 +232,13 @@ mod tests {
             Ok(HttpResponse::new(200, body))
         }
 
-        fn get_plugin_data(&self, key: &str) -> Option<Vec<u8>> {
-            if key == "config" {
+        fn get_plugin_data(&self, key: &str) -> Result<Option<Vec<u8>>, String> {
+            let data = if key == "config" {
                 self.config.as_ref().map(|c| serde_json::to_vec(c).unwrap())
             } else {
                 None
-            }
+            };
+            Ok(data)
         }
 
         fn set_plugin_data(&self, _key: &str, _value: &[u8]) -> Result<(), String> {

--- a/wasm-plugins/sonarr-metadata/src/lib.rs
+++ b/wasm-plugins/sonarr-metadata/src/lib.rs
@@ -71,7 +71,17 @@ pub fn on_event(
 
     host.log("info", &format!("looking up Sonarr metadata for: {}", file.path.display()));
 
-    let config: SonarrConfig = load_plugin_config(|key| host.get_plugin_data(key))?;
+    let config: SonarrConfig = match load_plugin_config(|key| host.get_plugin_data(key)) {
+        Ok(Some(config)) => config,
+        Ok(None) => {
+            host.log("error", "missing Sonarr config");
+            return None;
+        }
+        Err(e) => {
+            host.log("error", &format!("failed to load Sonarr config: {e}"));
+            return None;
+        }
+    };
     let episode = lookup_episode(host, &config, &file.path.to_string_lossy())?;
 
     let mut metadata = serde_json::json!({
@@ -282,12 +292,13 @@ mod tests {
             Ok(HttpResponse::new(200, body))
         }
 
-        fn get_plugin_data(&self, key: &str) -> Option<Vec<u8>> {
-            if key == "config" {
+        fn get_plugin_data(&self, key: &str) -> Result<Option<Vec<u8>>, String> {
+            let data = if key == "config" {
                 self.config.as_ref().map(|c| serde_json::to_vec(c).unwrap())
             } else {
                 None
-            }
+            };
+            Ok(data)
         }
 
         fn set_plugin_data(&self, _key: &str, _value: &[u8]) -> Result<(), String> {

--- a/wasm-plugins/subtitle-generator/src/lib.rs
+++ b/wasm-plugins/subtitle-generator/src/lib.rs
@@ -64,7 +64,13 @@ pub fn on_event(
     }
 
     let config: Option<SubtitleGeneratorConfig> =
-        load_plugin_config(|key| host.get_plugin_data(key));
+        match load_plugin_config(|key| host.get_plugin_data(key)) {
+            Ok(config) => config,
+            Err(e) => {
+                host.log("error", &format!("failed to load subtitle config: {e}"));
+                return None;
+            }
+        };
     let default_config = SubtitleGeneratorConfig {
         primary_language: default_primary_language(),
         subtitle_language: None,
@@ -260,12 +266,13 @@ mod tests {
             Ok(())
         }
 
-        fn get_plugin_data(&self, key: &str) -> Option<Vec<u8>> {
-            if key == "config" {
+        fn get_plugin_data(&self, key: &str) -> Result<Option<Vec<u8>>, String> {
+            let data = if key == "config" {
                 self.config.as_ref().map(|c| serde_json::to_vec(c).unwrap())
             } else {
                 None
-            }
+            };
+            Ok(data)
         }
 
         fn set_plugin_data(&self, _key: &str, _value: &[u8]) -> Result<(), String> {

--- a/wasm-plugins/whisper-transcriber/src/lib.rs
+++ b/wasm-plugins/whisper-transcriber/src/lib.rs
@@ -90,12 +90,22 @@ pub fn on_event(
         .as_deref()
         .unwrap_or(&path_hash_owned);
     let cache_key = format!("transcript:{hash_str}");
-    if let Some(cached) = host.get_plugin_data(&cache_key) {
-        host.log("debug", "using cached transcript");
-        return build_result(file, &cached, host);
+    match host.get_plugin_data(&cache_key) {
+        Ok(Some(cached)) => {
+            host.log("debug", "using cached transcript");
+            return build_result(file, &cached, host);
+        }
+        Ok(None) => {}
+        Err(e) => host.log("error", &format!("failed to read transcript cache: {e}")),
     }
 
-    let config: Option<WhisperConfig> = load_plugin_config(|key| host.get_plugin_data(key));
+    let config: Option<WhisperConfig> = match load_plugin_config(|key| host.get_plugin_data(key)) {
+        Ok(config) => config,
+        Err(e) => {
+            host.log("error", &format!("failed to load Whisper config: {e}"));
+            return None;
+        }
+    };
 
     // Step 1: Extract audio to a temp WAV file via ffmpeg.
     let file_path = file.path.to_string_lossy().to_string();
@@ -336,12 +346,13 @@ mod tests {
                 .ok_or_else(|| format!("tool not found: {tool}"))
         }
 
-        fn get_plugin_data(&self, key: &str) -> Option<Vec<u8>> {
-            if key == "config" {
+        fn get_plugin_data(&self, key: &str) -> Result<Option<Vec<u8>>, String> {
+            let data = if key == "config" {
                 self.config.as_ref().map(|c| serde_json::to_vec(c).unwrap())
             } else {
                 self.cached.borrow().get(key).cloned()
-            }
+            };
+            Ok(data)
         }
 
         fn set_plugin_data(&self, key: &str, value: &[u8]) -> Result<(), String> {


### PR DESCRIPTION
## Plan
- Change the Rust plugin SDK host abstraction so plugin data reads return `Result<Option<Vec<u8>>, String>`.
- Make `load_plugin_config` preserve host read errors and malformed config as errors while keeping missing config as `Ok(None)`.
- Update Rust WASM plugins and tests to handle explicit plugin-data read errors instead of silently using defaults.
- Run the simplification review and address concrete cleanup recommendations.

## Verification
- `cargo fmt --check`
- `cargo test -p voom-plugin-sdk`
- `cargo check --manifest-path` for all affected Rust WASM plugin manifests
- `cargo clippy -p voom-plugin-sdk --all-targets -- -D warnings`
- `cargo clippy --manifest-path ... --all-targets -- -D warnings` for all affected Rust WASM plugin manifests
- commit hook: `cargo fmt`, `cargo clippy`

Closes #279