### PR TITLE
Document malformed plugin config errors

### DIFF
--- a/crates/voom-plugin-sdk/src/event.rs
+++ b/crates/voom-plugin-sdk/src/event.rs
@@ -70,8 +70,8 @@ pub fn load_plugin_config<T: DeserializeOwned>(
     load_plugin_config_named(None, get_data)
 }
 
-/// Like [`load_plugin_config`], but includes the plugin name in the warning
-/// log when deserialization fails.
+/// Like [`load_plugin_config`], but includes the plugin name in the error
+/// when reading or deserializing config fails.
 ///
 /// # Examples
 ///

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -612,8 +612,8 @@ pub fn serialize_json<T: Serialize>(value: &T) -> Result<Vec<u8>>;
 /// Load plugin config from the host's plugin data store.
 /// Pass a closure that calls `host::get_plugin_data`.
 pub fn load_plugin_config<T: DeserializeOwned>(
-    get_data: impl FnOnce(&str) -> Option<Vec<u8>>,
-) -> Option<T>;
+    get_data: impl FnOnce(&str) -> Result<Option<Vec<u8>>, String>,
+) -> Result<Option<T>>;
 ```
 
 Usage in a WASM plugin:
@@ -627,7 +627,13 @@ struct MyConfig {
     poll_interval_secs: u64,
 }
 
-let config: Option<MyConfig> = load_plugin_config(|key| host::get_plugin_data(key));
+let config: Option<MyConfig> = match load_plugin_config(|key| host::get_plugin_data(key)) {
+    Ok(config) => config,
+    Err(e) => {
+        host::log("error", &format!("failed to load plugin config: {e}"));
+        return None;
+    }
+};
 ```
 
 ### PluginInfo Types


### PR DESCRIPTION
## Plan
- Build on the SDK and Rust plugin behavior merged for #279.
- Update SDK comments to describe read and deserialize failures as returned errors.
- Update plugin development docs so examples use the `Result<Option<_>>` contract and log malformed config errors instead of falling back silently.
- Run the simplification review on the branch.

## Verification
- `cargo fmt --check`
- `cargo test -p voom-plugin-sdk`
- `cargo clippy -p voom-plugin-sdk --all-targets -- -D warnings`
- commit hook: `cargo fmt`, `cargo clippy`

Closes #280