### PR TITLE
Add event DTO constructors

### DIFF
--- a/crates/voom-cli/src/retention.rs
+++ b/crates/voom-cli/src/retention.rs
@@ -85,19 +85,22 @@ impl RetentionRunner {
         }
 
         if let Some(kernel) = &self.kernel {
-            let event = Event::RetentionCompleted(RetentionCompletedEvent {
+            let per_table = per_table
+                .iter()
+                .map(|(t, r)| {
+                    TableRetentionResult::new(
+                        t.clone(),
+                        r.as_ref().map(|x| x.deleted).unwrap_or(0),
+                        r.as_ref().map(|x| x.kept).unwrap_or(0),
+                        r.as_ref().err().map(std::string::ToString::to_string),
+                    )
+                })
+                .collect();
+            let event = Event::RetentionCompleted(RetentionCompletedEvent::new(
                 trigger,
-                per_table: per_table
-                    .iter()
-                    .map(|(t, r)| TableRetentionResult {
-                        table: t.clone(),
-                        deleted: r.as_ref().map(|x| x.deleted).unwrap_or(0),
-                        kept: r.as_ref().map(|x| x.kept).unwrap_or(0),
-                        error: r.as_ref().err().map(std::string::ToString::to_string),
-                    })
-                    .collect(),
-                duration_ms: u64::try_from(duration.as_millis()).unwrap_or(u64::MAX),
-            });
+                per_table,
+                u64::try_from(duration.as_millis()).unwrap_or(u64::MAX),
+            ));
             let _ = kernel.dispatch(event);
         }
 

--- a/crates/voom-domain/src/events.rs
+++ b/crates/voom-domain/src/events.rs
@@ -926,6 +926,7 @@ pub enum RetentionTrigger {
 
 /// Result of pruning a single table.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct TableRetentionResult {
     pub table: String,
     pub deleted: u64,
@@ -933,12 +934,40 @@ pub struct TableRetentionResult {
     pub error: Option<String>,
 }
 
+impl TableRetentionResult {
+    #[must_use]
+    pub fn new(table: impl Into<String>, deleted: u64, kept: u64, error: Option<String>) -> Self {
+        Self {
+            table: table.into(),
+            deleted,
+            kept,
+            error,
+        }
+    }
+}
+
 /// Emitted once per retention pass.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct RetentionCompletedEvent {
     pub trigger: RetentionTrigger,
     pub per_table: Vec<TableRetentionResult>,
     pub duration_ms: u64,
+}
+
+impl RetentionCompletedEvent {
+    #[must_use]
+    pub fn new(
+        trigger: RetentionTrigger,
+        per_table: Vec<TableRetentionResult>,
+        duration_ms: u64,
+    ) -> Self {
+        Self {
+            trigger,
+            per_table,
+            duration_ms,
+        }
+    }
 }
 
 /// Emitted by the verifier plugin after each verification run.
@@ -955,12 +984,32 @@ pub struct VerifyCompletedEvent {
 }
 
 #[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
 pub struct VerifyCompletedDetails {
     pub mode: crate::verification::VerificationMode,
     pub outcome: crate::verification::VerificationOutcome,
     pub error_count: u32,
     pub warning_count: u32,
     pub verification_id: Uuid,
+}
+
+impl VerifyCompletedDetails {
+    #[must_use]
+    pub fn new(
+        mode: crate::verification::VerificationMode,
+        outcome: crate::verification::VerificationOutcome,
+        error_count: u32,
+        warning_count: u32,
+        verification_id: Uuid,
+    ) -> Self {
+        Self {
+            mode,
+            outcome,
+            error_count,
+            warning_count,
+            verification_id,
+        }
+    }
 }
 
 impl VerifyCompletedEvent {

--- a/plugins/verifier/src/lib.rs
+++ b/plugins/verifier/src/lib.rs
@@ -175,13 +175,13 @@ fn verify_result(record: &VerificationRecord, path: std::path::PathBuf) -> Event
     let event = Event::VerifyCompleted(VerifyCompletedEvent::new(
         record.file_id.clone(),
         path,
-        VerifyCompletedDetails {
-            mode: record.mode,
-            outcome: record.outcome,
-            error_count: record.error_count,
-            warning_count: record.warning_count,
-            verification_id: record.id,
-        },
+        VerifyCompletedDetails::new(
+            record.mode,
+            record.outcome,
+            record.error_count,
+            record.warning_count,
+            record.id,
+        ),
     ));
     let mut result = EventResult::new("verifier");
     result.claimed = true;


### PR DESCRIPTION
## Plan
- Slice #283 to one DTO family: retention and verifier event DTOs.
- Add constructors and `#[non_exhaustive]` where future fields should not be missed by external struct literals.
- Replace cross-crate direct literals in retention and verifier code with constructor calls.
- Run the simplification review and keep the PR focused on this DTO family.

## Verification
- `cargo fmt --check`
- `cargo test -p voom-domain events::tests`
- `cargo test -p voom-cli retention::tests`
- `cargo test -p voom-verifier`
- `cargo clippy -p voom-domain -p voom-cli -p voom-verifier --all-targets -- -D warnings`
- commit hook: `cargo fmt`, `cargo clippy`

Closes #283