### PR TITLE
Use named domain constructor inputs

### DIFF
--- a/crates/voom-cli/src/commands/verify.rs
+++ b/crates/voom-cli/src/commands/verify.rs
@@ -400,6 +400,7 @@ mod tests {
     use super::*;
     use voom_domain::media::MediaFile;
     use voom_domain::test_support::InMemoryStore;
+    use voom_domain::verification::VerificationRecordInput;
 
     fn verify_args() -> VerifyArgs {
         VerifyArgs {
@@ -428,28 +429,28 @@ mod tests {
                 .with_file(never_file)
                 .with_file(stale_file)
                 .with_file(fresh_file)
-                .with_verification(VerificationRecord::new(
-                    uuid::Uuid::new_v4(),
-                    stale_id.clone(),
-                    cutoff - chrono::Duration::days(1),
-                    VerificationMode::Quick,
-                    VerificationOutcome::Ok,
-                    0,
-                    0,
-                    None,
-                    None,
-                ))
-                .with_verification(VerificationRecord::new(
-                    uuid::Uuid::new_v4(),
-                    fresh_id,
-                    cutoff + chrono::Duration::days(1),
-                    VerificationMode::Quick,
-                    VerificationOutcome::Ok,
-                    0,
-                    0,
-                    None,
-                    None,
-                )),
+                .with_verification(VerificationRecord::new(VerificationRecordInput {
+                    id: uuid::Uuid::new_v4(),
+                    file_id: stale_id.clone(),
+                    verified_at: cutoff - chrono::Duration::days(1),
+                    mode: VerificationMode::Quick,
+                    outcome: VerificationOutcome::Ok,
+                    error_count: 0,
+                    warning_count: 0,
+                    content_hash: None,
+                    details: None,
+                }))
+                .with_verification(VerificationRecord::new(VerificationRecordInput {
+                    id: uuid::Uuid::new_v4(),
+                    file_id: fresh_id,
+                    verified_at: cutoff + chrono::Duration::days(1),
+                    mode: VerificationMode::Quick,
+                    outcome: VerificationOutcome::Ok,
+                    error_count: 0,
+                    warning_count: 0,
+                    content_hash: None,
+                    details: None,
+                })),
         );
 
         let targets = resolve_due_targets(&store, &verify_args()).expect("resolve targets");

--- a/crates/voom-domain/src/stats.rs
+++ b/crates/voom-domain/src/stats.rs
@@ -82,6 +82,18 @@ pub struct LibrarySnapshot {
     pub jobs: JobAggregateStats,
 }
 
+/// Named input for constructing a [`LibrarySnapshot`].
+#[derive(Debug, Clone)]
+pub struct LibrarySnapshotInput {
+    pub trigger: SnapshotTrigger,
+    pub files: FileStats,
+    pub video: VideoStats,
+    pub audio: AudioStats,
+    pub subtitles: SubtitleStats,
+    pub processing: ProcessingAggregateStats,
+    pub jobs: JobAggregateStats,
+}
+
 /// Aggregate file-level statistics.
 #[non_exhaustive]
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -168,26 +180,30 @@ pub struct SavingsBucket {
     pub file_count: u64,
 }
 
+/// Named input for constructing a [`SavingsBucket`].
+#[derive(Debug, Clone, Default)]
+pub struct SavingsBucketInput {
+    pub executor: Option<String>,
+    pub phase: Option<String>,
+    pub period: Option<String>,
+    pub transition_count: u64,
+    pub bytes_saved: i64,
+    pub duration_ms: u64,
+    pub file_count: u64,
+}
+
 impl SavingsBucket {
     /// Create a new bucket with all fields set explicitly.
     #[must_use]
-    pub fn new(
-        executor: Option<String>,
-        phase: Option<String>,
-        period: Option<String>,
-        transition_count: u64,
-        bytes_saved: i64,
-        duration_ms: u64,
-        file_count: u64,
-    ) -> Self {
+    pub fn new(input: SavingsBucketInput) -> Self {
         Self {
-            executor,
-            phase,
-            period,
-            transition_count,
-            bytes_saved,
-            duration_ms,
-            file_count,
+            executor: input.executor,
+            phase: input.phase,
+            period: input.period,
+            transition_count: input.transition_count,
+            bytes_saved: input.bytes_saved,
+            duration_ms: input.duration_ms,
+            file_count: input.file_count,
         }
     }
 }
@@ -267,25 +283,17 @@ pub struct JobAggregateStats {
 
 impl LibrarySnapshot {
     #[must_use]
-    pub fn new(
-        trigger: SnapshotTrigger,
-        files: FileStats,
-        video: VideoStats,
-        audio: AudioStats,
-        subtitles: SubtitleStats,
-        processing: ProcessingAggregateStats,
-        jobs: JobAggregateStats,
-    ) -> Self {
+    pub fn new(input: LibrarySnapshotInput) -> Self {
         Self {
             id: Uuid::new_v4(),
             captured_at: Utc::now(),
-            trigger,
-            files,
-            video,
-            audio,
-            subtitles,
-            processing,
-            jobs,
+            trigger: input.trigger,
+            files: input.files,
+            video: input.video,
+            audio: input.audio,
+            subtitles: input.subtitles,
+            processing: input.processing,
+            jobs: input.jobs,
         }
     }
 }

--- a/crates/voom-domain/src/test_support.rs
+++ b/crates/voom-domain/src/test_support.rs
@@ -33,8 +33,8 @@ use crate::transition::{
     DiscoveredFile, FileStatus, FileTransition, ReconcileResult, TransitionSource,
 };
 use crate::verification::{
-    IntegritySummary, VerificationFilters, VerificationMode, VerificationOutcome,
-    VerificationRecord,
+    IntegritySummary, IntegritySummaryInput, VerificationFilters, VerificationMode,
+    VerificationOutcome, VerificationRecord,
 };
 
 /// Create a standard test `MediaFile` with video, two audio, and one subtitle track.
@@ -916,14 +916,14 @@ impl crate::storage::VerificationStorage for InMemoryStore {
             }
         }
 
-        Ok(IntegritySummary::new(
+        Ok(IntegritySummary::new(IntegritySummaryInput {
             total_files,
             never_verified,
             stale,
             with_errors,
             with_warnings,
             hash_mismatches,
-        ))
+        }))
     }
 }
 
@@ -1088,6 +1088,7 @@ fn matches_transcode_outcome_filter(
 mod verification_storage_tests {
     use super::*;
     use crate::storage::{FileStorage, VerificationStorage};
+    use crate::verification::VerificationRecordInput;
 
     fn media_file(path: &str) -> MediaFile {
         MediaFile::new(PathBuf::from(path))
@@ -1117,28 +1118,28 @@ mod verification_storage_tests {
         let store = InMemoryStore::new()
             .with_file(stale_file)
             .with_file(fresh_file)
-            .with_verification(VerificationRecord::new(
-                Uuid::new_v4(),
-                stale_id.to_string(),
-                cutoff - chrono::Duration::seconds(1),
-                VerificationMode::Quick,
-                VerificationOutcome::Ok,
-                0,
-                0,
-                None,
-                None,
-            ))
-            .with_verification(VerificationRecord::new(
-                Uuid::new_v4(),
-                fresh_id.to_string(),
-                cutoff + chrono::Duration::seconds(1),
-                VerificationMode::Quick,
-                VerificationOutcome::Ok,
-                0,
-                0,
-                None,
-                None,
-            ));
+            .with_verification(VerificationRecord::new(VerificationRecordInput {
+                id: Uuid::new_v4(),
+                file_id: stale_id.to_string(),
+                verified_at: cutoff - chrono::Duration::seconds(1),
+                mode: VerificationMode::Quick,
+                outcome: VerificationOutcome::Ok,
+                error_count: 0,
+                warning_count: 0,
+                content_hash: None,
+                details: None,
+            }))
+            .with_verification(VerificationRecord::new(VerificationRecordInput {
+                id: Uuid::new_v4(),
+                file_id: fresh_id.to_string(),
+                verified_at: cutoff + chrono::Duration::seconds(1),
+                mode: VerificationMode::Quick,
+                outcome: VerificationOutcome::Ok,
+                error_count: 0,
+                warning_count: 0,
+                content_hash: None,
+                details: None,
+            }));
 
         let due = store
             .list_files_due_for_verification(cutoff)

--- a/crates/voom-domain/src/verification.rs
+++ b/crates/voom-domain/src/verification.rs
@@ -83,31 +83,34 @@ pub struct VerificationRecord {
     pub details: Option<String>,
 }
 
+/// Named input for constructing a [`VerificationRecord`].
+#[derive(Debug, Clone)]
+pub struct VerificationRecordInput {
+    pub id: Uuid,
+    pub file_id: String,
+    pub verified_at: DateTime<Utc>,
+    pub mode: VerificationMode,
+    pub outcome: VerificationOutcome,
+    pub error_count: u32,
+    pub warning_count: u32,
+    pub content_hash: Option<String>,
+    pub details: Option<String>,
+}
+
 impl VerificationRecord {
-    /// Construct a new verification record. `id` should be a freshly-generated UUID.
+    /// Construct a new verification record. `input.id` should be freshly generated.
     #[must_use]
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        id: Uuid,
-        file_id: impl Into<String>,
-        verified_at: DateTime<Utc>,
-        mode: VerificationMode,
-        outcome: VerificationOutcome,
-        error_count: u32,
-        warning_count: u32,
-        content_hash: Option<String>,
-        details: Option<String>,
-    ) -> Self {
+    pub fn new(input: VerificationRecordInput) -> Self {
         Self {
-            id,
-            file_id: file_id.into(),
-            verified_at,
-            mode,
-            outcome,
-            error_count,
-            warning_count,
-            content_hash,
-            details,
+            id: input.id,
+            file_id: input.file_id,
+            verified_at: input.verified_at,
+            mode: input.mode,
+            outcome: input.outcome,
+            error_count: input.error_count,
+            warning_count: input.warning_count,
+            content_hash: input.content_hash,
+            details: input.details,
         }
     }
 }
@@ -135,24 +138,28 @@ pub struct IntegritySummary {
     pub hash_mismatches: u64,
 }
 
+/// Named input for constructing an [`IntegritySummary`].
+#[derive(Debug, Clone, Default)]
+pub struct IntegritySummaryInput {
+    pub total_files: u64,
+    pub never_verified: u64,
+    pub stale: u64,
+    pub with_errors: u64,
+    pub with_warnings: u64,
+    pub hash_mismatches: u64,
+}
+
 impl IntegritySummary {
     /// Construct a summary from precomputed counts.
     #[must_use]
-    pub fn new(
-        total_files: u64,
-        never_verified: u64,
-        stale: u64,
-        with_errors: u64,
-        with_warnings: u64,
-        hash_mismatches: u64,
-    ) -> Self {
+    pub fn new(input: IntegritySummaryInput) -> Self {
         Self {
-            total_files,
-            never_verified,
-            stale,
-            with_errors,
-            with_warnings,
-            hash_mismatches,
+            total_files: input.total_files,
+            never_verified: input.never_verified,
+            stale: input.stale,
+            with_errors: input.with_errors,
+            with_warnings: input.with_warnings,
+            hash_mismatches: input.hash_mismatches,
         }
     }
 }

--- a/plugins/sqlite-store/benches/verification_due.rs
+++ b/plugins/sqlite-store/benches/verification_due.rs
@@ -8,6 +8,7 @@ use voom_domain::media::MediaFile;
 use voom_domain::storage::{FileFilters, FileStorage, VerificationStorage};
 use voom_domain::verification::{
     VerificationFilters, VerificationMode, VerificationOutcome, VerificationRecord,
+    VerificationRecordInput,
 };
 use voom_sqlite_store::store::SqliteStore;
 
@@ -23,17 +24,17 @@ fn seed_store(file_count: usize) -> (TempDir, SqliteStore) {
         store.upsert_file(&file).expect("insert file");
 
         if index % 2 == 0 {
-            let record = VerificationRecord::new(
-                Uuid::new_v4(),
-                file.id.to_string(),
-                now,
-                VerificationMode::Quick,
-                VerificationOutcome::Ok,
-                0,
-                0,
-                None,
-                None,
-            );
+            let record = VerificationRecord::new(VerificationRecordInput {
+                id: Uuid::new_v4(),
+                file_id: file.id.to_string(),
+                verified_at: now,
+                mode: VerificationMode::Quick,
+                outcome: VerificationOutcome::Ok,
+                error_count: 0,
+                warning_count: 0,
+                content_hash: None,
+                details: None,
+            });
             store
                 .insert_verification(&record)
                 .expect("insert verification");

--- a/plugins/sqlite-store/src/store/file_transition_storage.rs
+++ b/plugins/sqlite-store/src/store/file_transition_storage.rs
@@ -5,7 +5,9 @@ use rusqlite::OptionalExtension;
 use uuid::Uuid;
 
 use voom_domain::errors::Result;
-use voom_domain::stats::{ProcessingOutcome, SavingsBucket, SavingsReport, TimePeriod};
+use voom_domain::stats::{
+    ProcessingOutcome, SavingsBucket, SavingsBucketInput, SavingsReport, TimePeriod,
+};
 use voom_domain::storage::{FileTransitionStorage, PruneReport, RetentionPolicy};
 use voom_domain::transition::{FileTransition, TransitionSource};
 
@@ -150,15 +152,15 @@ impl FileTransitionStorage for SqliteStore {
                 let saved: i64 = row.get("saved")?;
                 let dur: i64 = row.get("dur")?;
                 let files: i64 = row.get("files")?;
-                Ok(SavingsBucket::new(
-                    executor.filter(|s| !s.is_empty()),
-                    phase.filter(|s| !s.is_empty()),
-                    period_val.filter(|s| !s.is_empty()),
-                    checked_i64_to_u64(cnt, "file_transitions.cnt")?,
-                    saved,
-                    checked_i64_to_u64(dur, "file_transitions.dur")?,
-                    checked_i64_to_u64(files, "file_transitions.files")?,
-                ))
+                Ok(SavingsBucket::new(SavingsBucketInput {
+                    executor: executor.filter(|s| !s.is_empty()),
+                    phase: phase.filter(|s| !s.is_empty()),
+                    period: period_val.filter(|s| !s.is_empty()),
+                    transition_count: checked_i64_to_u64(cnt, "file_transitions.cnt")?,
+                    bytes_saved: saved,
+                    duration_ms: checked_i64_to_u64(dur, "file_transitions.dur")?,
+                    file_count: checked_i64_to_u64(files, "file_transitions.files")?,
+                }))
             })
             .map_err(storage_err("failed to query savings by provenance"))?
             .collect::<rusqlite::Result<Vec<_>>>()

--- a/plugins/sqlite-store/src/store/row_mappers.rs
+++ b/plugins/sqlite-store/src/store/row_mappers.rs
@@ -11,7 +11,9 @@ use voom_domain::errors::{Result, StorageErrorKind, VoomError};
 use voom_domain::job::{Job, JobStatus};
 use voom_domain::media::{Container, MediaFile, Track, TrackType};
 use voom_domain::transition::FileStatus;
-use voom_domain::verification::{VerificationMode, VerificationOutcome, VerificationRecord};
+use voom_domain::verification::{
+    VerificationMode, VerificationOutcome, VerificationRecord, VerificationRecordInput,
+};
 
 use super::{other_storage_err, parse_datetime, parse_uuid};
 
@@ -324,7 +326,7 @@ pub(crate) fn row_to_verification(row: &Row<'_>) -> rusqlite::Result<Verificatio
     let error_count = checked_i64_to_u32(row.get("error_count")?, "verifications.error_count")?;
     let warning_count =
         checked_i64_to_u32(row.get("warning_count")?, "verifications.warning_count")?;
-    Ok(VerificationRecord::new(
+    Ok(VerificationRecord::new(VerificationRecordInput {
         id,
         file_id,
         verified_at,
@@ -332,9 +334,9 @@ pub(crate) fn row_to_verification(row: &Row<'_>) -> rusqlite::Result<Verificatio
         outcome,
         error_count,
         warning_count,
-        row.get("content_hash")?,
-        row.get("details")?,
-    ))
+        content_hash: row.get("content_hash")?,
+        details: row.get("details")?,
+    }))
 }
 
 #[cfg(test)]

--- a/plugins/sqlite-store/src/store/snapshot_storage.rs
+++ b/plugins/sqlite-store/src/store/snapshot_storage.rs
@@ -2,8 +2,8 @@ use rusqlite::params;
 
 use voom_domain::errors::Result;
 use voom_domain::stats::{
-    AudioStats, FileStats, JobAggregateStats, LibrarySnapshot, ProcessingAggregateStats,
-    SnapshotTrigger, SubtitleStats, VideoStats,
+    AudioStats, FileStats, JobAggregateStats, LibrarySnapshot, LibrarySnapshotInput,
+    ProcessingAggregateStats, SnapshotTrigger, SubtitleStats, VideoStats,
 };
 use voom_domain::storage::SnapshotStorage;
 
@@ -20,9 +20,15 @@ impl SnapshotStorage for SqliteStore {
         let processing = gather_processing_stats(&conn)?;
         let jobs = gather_job_stats(&conn)?;
 
-        Ok(LibrarySnapshot::new(
-            trigger, files, video, audio, subtitles, processing, jobs,
-        ))
+        Ok(LibrarySnapshot::new(LibrarySnapshotInput {
+            trigger,
+            files,
+            video,
+            audio,
+            subtitles,
+            processing,
+            jobs,
+        }))
     }
 
     fn save_snapshot(&self, snapshot: &LibrarySnapshot) -> Result<()> {

--- a/plugins/sqlite-store/src/store/verification_storage.rs
+++ b/plugins/sqlite-store/src/store/verification_storage.rs
@@ -8,7 +8,8 @@ use voom_domain::media::{Container, MediaFile};
 use voom_domain::storage::VerificationStorage;
 use voom_domain::transition::FileStatus;
 use voom_domain::verification::{
-    IntegritySummary, VerificationFilters, VerificationMode, VerificationRecord,
+    IntegritySummary, IntegritySummaryInput, VerificationFilters, VerificationMode,
+    VerificationRecord,
 };
 
 use super::row_mappers::row_to_verification;
@@ -224,14 +225,14 @@ impl VerificationStorage for SqliteStore {
             .query_row(INTEGRITY_HASH_MISMATCHES_SQL, [], |r| r.get(0))
             .map_err(storage_err("failed to count hash mismatches"))?;
 
-        Ok(IntegritySummary::new(
-            u64::try_from(total_files.max(0)).unwrap_or(0),
-            u64::try_from(never_verified.max(0)).unwrap_or(0),
-            u64::try_from(stale.max(0)).unwrap_or(0),
-            u64::try_from(with_errors.max(0)).unwrap_or(0),
-            u64::try_from(with_warnings.max(0)).unwrap_or(0),
-            u64::try_from(hash_mismatches.max(0)).unwrap_or(0),
-        ))
+        Ok(IntegritySummary::new(IntegritySummaryInput {
+            total_files: u64::try_from(total_files.max(0)).unwrap_or(0),
+            never_verified: u64::try_from(never_verified.max(0)).unwrap_or(0),
+            stale: u64::try_from(stale.max(0)).unwrap_or(0),
+            with_errors: u64::try_from(with_errors.max(0)).unwrap_or(0),
+            with_warnings: u64::try_from(with_warnings.max(0)).unwrap_or(0),
+            hash_mismatches: u64::try_from(hash_mismatches.max(0)).unwrap_or(0),
+        }))
     }
 }
 
@@ -246,6 +247,7 @@ mod tests {
     use voom_domain::test_support::InMemoryStore;
     use voom_domain::transition::FileStatus;
     use voom_domain::verification::VerificationOutcome;
+    use voom_domain::verification::VerificationRecordInput;
 
     fn store_with_file() -> (SqliteStore, String) {
         let store = SqliteStore::in_memory().expect("in-memory store");
@@ -278,33 +280,33 @@ mod tests {
         mode: VerificationMode,
         outcome: VerificationOutcome,
     ) -> VerificationRecord {
-        VerificationRecord::new(
-            Uuid::new_v4(),
-            file_id.to_string(),
+        VerificationRecord::new(VerificationRecordInput {
+            id: Uuid::new_v4(),
+            file_id: file_id.to_string(),
             verified_at,
             mode,
             outcome,
-            u32::from(outcome == VerificationOutcome::Error),
-            u32::from(outcome == VerificationOutcome::Warning),
-            None,
-            None,
-        )
+            error_count: u32::from(outcome == VerificationOutcome::Error),
+            warning_count: u32::from(outcome == VerificationOutcome::Warning),
+            content_hash: None,
+            details: None,
+        })
     }
 
     #[test]
     fn insert_and_list_verification() {
         let (store, file_id) = store_with_file();
-        let record = VerificationRecord::new(
-            Uuid::new_v4(),
-            file_id.clone(),
-            Utc::now(),
-            VerificationMode::Quick,
-            VerificationOutcome::Ok,
-            0,
-            0,
-            None,
-            None,
-        );
+        let record = VerificationRecord::new(VerificationRecordInput {
+            id: Uuid::new_v4(),
+            file_id: file_id.clone(),
+            verified_at: Utc::now(),
+            mode: VerificationMode::Quick,
+            outcome: VerificationOutcome::Ok,
+            error_count: 0,
+            warning_count: 0,
+            content_hash: None,
+            details: None,
+        });
         store.insert_verification(&record).expect("insert");
 
         let mut filters = VerificationFilters::default();
@@ -319,28 +321,28 @@ mod tests {
     #[test]
     fn latest_verification_returns_newest() {
         let (store, file_id) = store_with_file();
-        let earlier = VerificationRecord::new(
-            Uuid::new_v4(),
-            file_id.clone(),
-            Utc::now() - chrono::Duration::hours(1),
-            VerificationMode::Hash,
-            VerificationOutcome::Ok,
-            0,
-            0,
-            Some("hash-a".into()),
-            None,
-        );
-        let later = VerificationRecord::new(
-            Uuid::new_v4(),
-            file_id.clone(),
-            Utc::now(),
-            VerificationMode::Hash,
-            VerificationOutcome::Ok,
-            0,
-            0,
-            Some("hash-b".into()),
-            None,
-        );
+        let earlier = VerificationRecord::new(VerificationRecordInput {
+            id: Uuid::new_v4(),
+            file_id: file_id.clone(),
+            verified_at: Utc::now() - chrono::Duration::hours(1),
+            mode: VerificationMode::Hash,
+            outcome: VerificationOutcome::Ok,
+            error_count: 0,
+            warning_count: 0,
+            content_hash: Some("hash-a".into()),
+            details: None,
+        });
+        let later = VerificationRecord::new(VerificationRecordInput {
+            id: Uuid::new_v4(),
+            file_id: file_id.clone(),
+            verified_at: Utc::now(),
+            mode: VerificationMode::Hash,
+            outcome: VerificationOutcome::Ok,
+            error_count: 0,
+            warning_count: 0,
+            content_hash: Some("hash-b".into()),
+            details: None,
+        });
         store.insert_verification(&earlier).expect("insert earlier");
         store.insert_verification(&later).expect("insert later");
 
@@ -372,7 +374,10 @@ mod tests {
         let summary = store
             .integrity_summary(Utc::now() - chrono::Duration::days(30))
             .expect("summary");
-        assert_eq!(summary, IntegritySummary::new(0, 0, 0, 0, 0, 0));
+        assert_eq!(
+            summary,
+            IntegritySummary::new(IntegritySummaryInput::default())
+        );
     }
 
     #[test]
@@ -420,7 +425,17 @@ mod tests {
         }
 
         let summary = store.integrity_summary(cutoff).expect("summary");
-        assert_eq!(summary, IntegritySummary::new(4, 1, 1, 1, 1, 0));
+        assert_eq!(
+            summary,
+            IntegritySummary::new(IntegritySummaryInput {
+                total_files: 4,
+                never_verified: 1,
+                stale: 1,
+                with_errors: 1,
+                with_warnings: 1,
+                hash_mismatches: 0,
+            })
+        );
     }
 
     #[test]
@@ -430,28 +445,28 @@ mod tests {
         let low_id = Uuid::from_u128(1);
         let high_id = Uuid::from_u128(2);
 
-        let older_by_id = VerificationRecord::new(
-            low_id,
-            file_id.clone(),
+        let older_by_id = VerificationRecord::new(VerificationRecordInput {
+            id: low_id,
+            file_id: file_id.clone(),
             verified_at,
-            VerificationMode::Quick,
-            VerificationOutcome::Error,
-            1,
-            0,
-            None,
-            None,
-        );
-        let latest_by_id = VerificationRecord::new(
-            high_id,
+            mode: VerificationMode::Quick,
+            outcome: VerificationOutcome::Error,
+            error_count: 1,
+            warning_count: 0,
+            content_hash: None,
+            details: None,
+        });
+        let latest_by_id = VerificationRecord::new(VerificationRecordInput {
+            id: high_id,
             file_id,
             verified_at,
-            VerificationMode::Quick,
-            VerificationOutcome::Warning,
-            0,
-            1,
-            None,
-            None,
-        );
+            mode: VerificationMode::Quick,
+            outcome: VerificationOutcome::Warning,
+            error_count: 0,
+            warning_count: 1,
+            content_hash: None,
+            details: None,
+        });
         store
             .insert_verification(&older_by_id)
             .expect("insert older");
@@ -590,30 +605,30 @@ mod tests {
         stale_file.content_hash = Some("stale".into());
         fresh_file.content_hash = Some("fresh".into());
         store
-            .insert_verification(&VerificationRecord::new(
-                Uuid::new_v4(),
-                stale_file.id.to_string(),
-                cutoff - chrono::Duration::seconds(1),
-                VerificationMode::Quick,
-                VerificationOutcome::Ok,
-                0,
-                0,
-                None,
-                None,
-            ))
+            .insert_verification(&VerificationRecord::new(VerificationRecordInput {
+                id: Uuid::new_v4(),
+                file_id: stale_file.id.to_string(),
+                verified_at: cutoff - chrono::Duration::seconds(1),
+                mode: VerificationMode::Quick,
+                outcome: VerificationOutcome::Ok,
+                error_count: 0,
+                warning_count: 0,
+                content_hash: None,
+                details: None,
+            }))
             .expect("insert stale verification");
         store
-            .insert_verification(&VerificationRecord::new(
-                Uuid::new_v4(),
-                fresh_file.id.to_string(),
-                cutoff + chrono::Duration::seconds(1),
-                VerificationMode::Quick,
-                VerificationOutcome::Ok,
-                0,
-                0,
-                None,
-                None,
-            ))
+            .insert_verification(&VerificationRecord::new(VerificationRecordInput {
+                id: Uuid::new_v4(),
+                file_id: fresh_file.id.to_string(),
+                verified_at: cutoff + chrono::Duration::seconds(1),
+                mode: VerificationMode::Quick,
+                outcome: VerificationOutcome::Ok,
+                error_count: 0,
+                warning_count: 0,
+                content_hash: None,
+                details: None,
+            }))
             .expect("insert fresh verification");
 
         let due = store
@@ -641,29 +656,29 @@ mod tests {
     fn hash_mismatch_detected() {
         let (store, fid) = store_with_file();
         // First hash run — baseline
-        let first = VerificationRecord::new(
-            Uuid::new_v4(),
-            fid.clone(),
-            Utc::now() - chrono::Duration::hours(2),
-            VerificationMode::Hash,
-            voom_domain::verification::VerificationOutcome::Ok,
-            0,
-            0,
-            Some("hash-a".into()),
-            None,
-        );
+        let first = VerificationRecord::new(VerificationRecordInput {
+            id: Uuid::new_v4(),
+            file_id: fid.clone(),
+            verified_at: Utc::now() - chrono::Duration::hours(2),
+            mode: VerificationMode::Hash,
+            outcome: voom_domain::verification::VerificationOutcome::Ok,
+            error_count: 0,
+            warning_count: 0,
+            content_hash: Some("hash-a".into()),
+            details: None,
+        });
         // Second hash run — different content
-        let second = VerificationRecord::new(
-            Uuid::new_v4(),
-            fid,
-            Utc::now(),
-            VerificationMode::Hash,
-            voom_domain::verification::VerificationOutcome::Error,
-            1,
-            0,
-            Some("hash-b".into()),
-            Some(r#"{"prior_hash":"hash-a"}"#.into()),
-        );
+        let second = VerificationRecord::new(VerificationRecordInput {
+            id: Uuid::new_v4(),
+            file_id: fid,
+            verified_at: Utc::now(),
+            mode: VerificationMode::Hash,
+            outcome: voom_domain::verification::VerificationOutcome::Error,
+            error_count: 1,
+            warning_count: 0,
+            content_hash: Some("hash-b".into()),
+            details: Some(r#"{"prior_hash":"hash-a"}"#.into()),
+        });
         store.insert_verification(&first).unwrap();
         store.insert_verification(&second).unwrap();
         let summary = store
@@ -675,28 +690,28 @@ mod tests {
     #[test]
     fn no_hash_mismatch_when_identical() {
         let (store, fid) = store_with_file();
-        let first = VerificationRecord::new(
-            Uuid::new_v4(),
-            fid.clone(),
-            Utc::now() - chrono::Duration::hours(2),
-            VerificationMode::Hash,
-            voom_domain::verification::VerificationOutcome::Ok,
-            0,
-            0,
-            Some("same-hash".into()),
-            None,
-        );
-        let second = VerificationRecord::new(
-            Uuid::new_v4(),
-            fid,
-            Utc::now(),
-            VerificationMode::Hash,
-            voom_domain::verification::VerificationOutcome::Ok,
-            0,
-            0,
-            Some("same-hash".into()),
-            None,
-        );
+        let first = VerificationRecord::new(VerificationRecordInput {
+            id: Uuid::new_v4(),
+            file_id: fid.clone(),
+            verified_at: Utc::now() - chrono::Duration::hours(2),
+            mode: VerificationMode::Hash,
+            outcome: voom_domain::verification::VerificationOutcome::Ok,
+            error_count: 0,
+            warning_count: 0,
+            content_hash: Some("same-hash".into()),
+            details: None,
+        });
+        let second = VerificationRecord::new(VerificationRecordInput {
+            id: Uuid::new_v4(),
+            file_id: fid,
+            verified_at: Utc::now(),
+            mode: VerificationMode::Hash,
+            outcome: voom_domain::verification::VerificationOutcome::Ok,
+            error_count: 0,
+            warning_count: 0,
+            content_hash: Some("same-hash".into()),
+            details: None,
+        });
         store.insert_verification(&first).unwrap();
         store.insert_verification(&second).unwrap();
         let summary = store
@@ -709,29 +724,29 @@ mod tests {
     fn with_errors_uses_latest_only() {
         let (store, fid) = store_with_file();
         // Older error
-        let earlier = VerificationRecord::new(
-            Uuid::new_v4(),
-            fid.clone(),
-            Utc::now() - chrono::Duration::hours(2),
-            VerificationMode::Quick,
-            voom_domain::verification::VerificationOutcome::Error,
-            1,
-            0,
-            None,
-            None,
-        );
+        let earlier = VerificationRecord::new(VerificationRecordInput {
+            id: Uuid::new_v4(),
+            file_id: fid.clone(),
+            verified_at: Utc::now() - chrono::Duration::hours(2),
+            mode: VerificationMode::Quick,
+            outcome: voom_domain::verification::VerificationOutcome::Error,
+            error_count: 1,
+            warning_count: 0,
+            content_hash: None,
+            details: None,
+        });
         // Newer ok — should make this file NOT count as with_errors
-        let later = VerificationRecord::new(
-            Uuid::new_v4(),
-            fid,
-            Utc::now(),
-            VerificationMode::Quick,
-            voom_domain::verification::VerificationOutcome::Ok,
-            0,
-            0,
-            None,
-            None,
-        );
+        let later = VerificationRecord::new(VerificationRecordInput {
+            id: Uuid::new_v4(),
+            file_id: fid,
+            verified_at: Utc::now(),
+            mode: VerificationMode::Quick,
+            outcome: voom_domain::verification::VerificationOutcome::Ok,
+            error_count: 0,
+            warning_count: 0,
+            content_hash: None,
+            details: None,
+        });
         store.insert_verification(&earlier).unwrap();
         store.insert_verification(&later).unwrap();
         let summary = store

--- a/plugins/verifier/src/hash.rs
+++ b/plugins/verifier/src/hash.rs
@@ -12,7 +12,9 @@ use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 use voom_domain::errors::{Result, VoomError};
-use voom_domain::verification::{VerificationMode, VerificationOutcome, VerificationRecord};
+use voom_domain::verification::{
+    VerificationMode, VerificationOutcome, VerificationRecord, VerificationRecordInput,
+};
 
 /// Run hash verification on `path`. `prior` is the previous hash record
 /// for the same file (used to detect bit-rot). `None` means this is the
@@ -44,17 +46,17 @@ pub fn run_hash(
         None
     };
     let error_count = u32::from(outcome == VerificationOutcome::Error);
-    Ok(VerificationRecord::new(
-        Uuid::new_v4(),
-        file_id,
-        started,
-        VerificationMode::Hash,
+    Ok(VerificationRecord::new(VerificationRecordInput {
+        id: Uuid::new_v4(),
+        file_id: file_id.to_string(),
+        verified_at: started,
+        mode: VerificationMode::Hash,
         outcome,
         error_count,
-        0,
-        Some(hash),
+        warning_count: 0,
+        content_hash: Some(hash),
         details,
-    ))
+    }))
 }
 
 fn compute_sha256(path: &Path) -> Result<String> {
@@ -107,17 +109,17 @@ mod tests {
 
     #[test]
     fn mismatched_hash_is_error() {
-        let prior = VerificationRecord::new(
-            Uuid::new_v4(),
-            "file-id",
-            Utc::now(),
-            VerificationMode::Hash,
-            VerificationOutcome::Ok,
-            0,
-            0,
-            Some("deadbeef".into()),
-            None,
-        );
+        let prior = VerificationRecord::new(VerificationRecordInput {
+            id: Uuid::new_v4(),
+            file_id: "file-id".into(),
+            verified_at: Utc::now(),
+            mode: VerificationMode::Hash,
+            outcome: VerificationOutcome::Ok,
+            error_count: 0,
+            warning_count: 0,
+            content_hash: Some("deadbeef".into()),
+            details: None,
+        });
         let mut tmp = tempfile::NamedTempFile::new().unwrap();
         tmp.write_all(b"different content").unwrap();
         let rec = run_hash("file-id", tmp.path(), Some(&prior)).unwrap();

--- a/plugins/verifier/src/quick.rs
+++ b/plugins/verifier/src/quick.rs
@@ -10,7 +10,9 @@ use chrono::Utc;
 use uuid::Uuid;
 
 use voom_domain::errors::{Result, VoomError};
-use voom_domain::verification::{VerificationMode, VerificationOutcome, VerificationRecord};
+use voom_domain::verification::{
+    VerificationMode, VerificationOutcome, VerificationRecord, VerificationRecordInput,
+};
 
 use crate::util::truncate;
 
@@ -69,17 +71,17 @@ pub fn run_quick(
         Some(truncated)
     };
 
-    Ok(VerificationRecord::new(
-        Uuid::new_v4(),
-        file_id,
-        started,
-        VerificationMode::Quick,
+    Ok(VerificationRecord::new(VerificationRecordInput {
+        id: Uuid::new_v4(),
+        file_id: file_id.to_string(),
+        verified_at: started,
+        mode: VerificationMode::Quick,
         outcome,
         error_count,
         warning_count,
-        None,
+        content_hash: None,
         details,
-    ))
+    }))
 }
 
 #[cfg(test)]

--- a/plugins/verifier/src/thorough.rs
+++ b/plugins/verifier/src/thorough.rs
@@ -16,7 +16,9 @@ use chrono::Utc;
 use uuid::Uuid;
 
 use voom_domain::errors::{Result, VoomError};
-use voom_domain::verification::{VerificationMode, VerificationOutcome, VerificationRecord};
+use voom_domain::verification::{
+    VerificationMode, VerificationOutcome, VerificationRecord, VerificationRecordInput,
+};
 
 use crate::hwaccel::{self, HwAccelMode};
 use crate::util::truncate;
@@ -79,17 +81,17 @@ pub fn run_thorough(
         Some(truncate(&stderr, 16 * 1024))
     };
 
-    Ok(VerificationRecord::new(
-        Uuid::new_v4(),
-        file_id,
-        started,
-        VerificationMode::Thorough,
+    Ok(VerificationRecord::new(VerificationRecordInput {
+        id: Uuid::new_v4(),
+        file_id: file_id.to_string(),
+        verified_at: started,
+        mode: VerificationMode::Thorough,
         outcome,
         error_count,
         warning_count,
-        None,
+        content_hash: None,
         details,
-    ))
+    }))
 }
 
 /// Classify `ffmpeg -v error` stderr.  At loglevel `error` ffmpeg emits one

--- a/plugins/web-server/tests/api_tests.rs
+++ b/plugins/web-server/tests/api_tests.rs
@@ -9,7 +9,9 @@ use uuid::Uuid;
 use voom_domain::job::{Job, JobType};
 use voom_domain::media::{Container, MediaFile};
 use voom_domain::test_support::InMemoryStore;
-use voom_domain::verification::{VerificationMode, VerificationOutcome, VerificationRecord};
+use voom_domain::verification::{
+    VerificationMode, VerificationOutcome, VerificationRecord, VerificationRecordInput,
+};
 
 fn make_test_file(name: &str) -> MediaFile {
     let mut file = MediaFile::new(format!("/media/{name}").into());
@@ -21,17 +23,17 @@ fn make_test_file(name: &str) -> MediaFile {
 }
 
 fn make_verification(file_id: Uuid, outcome: VerificationOutcome) -> VerificationRecord {
-    VerificationRecord::new(
-        Uuid::new_v4(),
-        file_id.to_string(),
-        chrono::Utc::now(),
-        VerificationMode::Hash,
+    VerificationRecord::new(VerificationRecordInput {
+        id: Uuid::new_v4(),
+        file_id: file_id.to_string(),
+        verified_at: chrono::Utc::now(),
+        mode: VerificationMode::Hash,
         outcome,
-        u32::from(outcome == VerificationOutcome::Error),
-        0,
-        Some("abc123".into()),
-        Some("verification details".into()),
-    )
+        error_count: u32::from(outcome == VerificationOutcome::Error),
+        warning_count: 0,
+        content_hash: Some("abc123".into()),
+        details: Some("verification details".into()),
+    })
 }
 
 fn make_verification_at(
@@ -39,17 +41,17 @@ fn make_verification_at(
     outcome: VerificationOutcome,
     verified_at: chrono::DateTime<chrono::Utc>,
 ) -> VerificationRecord {
-    VerificationRecord::new(
-        Uuid::new_v4(),
-        file_id.to_string(),
+    VerificationRecord::new(VerificationRecordInput {
+        id: Uuid::new_v4(),
+        file_id: file_id.to_string(),
         verified_at,
-        VerificationMode::Hash,
+        mode: VerificationMode::Hash,
         outcome,
-        u32::from(outcome == VerificationOutcome::Error),
-        0,
-        Some("abc123".into()),
-        Some("verification details".into()),
-    )
+        error_count: u32::from(outcome == VerificationOutcome::Error),
+        warning_count: 0,
+        content_hash: Some("abc123".into()),
+        details: Some("verification details".into()),
+    })
 }
 
 fn make_server(store: InMemoryStore) -> TestServer {


### PR DESCRIPTION
## Summary
- add named input structs for verification records, integrity summaries, library snapshots, and savings buckets
- update verifier, SQLite row mapping/storage, CLI tests, web tests, and benchmarks to use named constructor inputs
- preserve existing verification and stats behavior while removing ambiguous positional constructor calls

Closes #284

## Tests
- cargo fmt --check
- cargo test -p voom-domain
- cargo test -p voom-sqlite-store
- cargo test -p voom-verifier
- cargo test -p voom-cli verify
- cargo test -p voom-web-server
- cargo clippy -p voom-domain -p voom-sqlite-store -p voom-verifier -p voom-cli -p voom-web-server --all-targets -- -D warnings

## Simplification Review
- Reviewed the diff locally with the simplification-review workflow. One low-risk cleanup was applied by using IntegritySummaryInput::default() for the all-zero summary assertion; no remaining actionable simplification findings.