### PR TITLE
Type audio language detector metadata

### DIFF
--- a/crates/voom-cli/src/commands/process/audio_language.rs
+++ b/crates/voom-cli/src/commands/process/audio_language.rs
@@ -1,0 +1,249 @@
+use serde::Deserialize;
+
+pub(super) const AUDIO_LANGUAGE_DETECTOR_PLUGIN: &str = "audio-language-detector";
+
+#[derive(Debug, Deserialize)]
+struct AudioLanguageMetadata {
+    #[serde(default)]
+    detections: Vec<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AudioLanguageDetection {
+    track_index: u32,
+    detected_language: String,
+}
+
+/// Apply audio language detection results to track language fields.
+///
+/// This translates the `audio-language-detector` metadata contract into track
+/// mutations before policy evaluation, keeping plugin-specific JSON validation
+/// out of the process pipeline.
+pub(super) fn apply_detected_languages(file: &mut voom_domain::media::MediaFile) {
+    let Some(metadata) = file.plugin_metadata.get(AUDIO_LANGUAGE_DETECTOR_PLUGIN) else {
+        return;
+    };
+
+    let metadata = match serde_json::from_value::<AudioLanguageMetadata>(metadata.clone()) {
+        Ok(metadata) => metadata,
+        Err(error) => {
+            tracing::warn!(
+                path = %file.path.display(),
+                error = %error,
+                "audio language detector metadata has an unexpected shape"
+            );
+            return;
+        }
+    };
+
+    for detection in metadata.detections {
+        let detection = match serde_json::from_value::<AudioLanguageDetection>(detection) {
+            Ok(detection) => detection,
+            Err(error) => {
+                tracing::warn!(
+                    path = %file.path.display(),
+                    error = %error,
+                    "audio language detector detection has an unexpected shape"
+                );
+                continue;
+            }
+        };
+        apply_detection(file, detection);
+    }
+}
+
+fn apply_detection(file: &mut voom_domain::media::MediaFile, detection: AudioLanguageDetection) {
+    let Some(track) = file
+        .tracks
+        .iter_mut()
+        .find(|track| track.index == detection.track_index)
+    else {
+        return;
+    };
+
+    let Some(normalized) =
+        voom_domain::utils::language::normalize_language(&detection.detected_language)
+    else {
+        tracing::warn!(
+            path = %file.path.display(),
+            track = detection.track_index,
+            detected = %detection.detected_language,
+            "unrecognized language code from detector, skipping"
+        );
+        return;
+    };
+
+    if track.language == normalized {
+        return;
+    }
+
+    if track.language != "und" {
+        tracing::warn!(
+            path = %file.path.display(),
+            track = detection.track_index,
+            existing = %track.language,
+            detected = %normalized,
+            "overwriting track language with detected value"
+        );
+    }
+
+    track.language = normalized.to_string();
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use voom_domain::media::{MediaFile, Track, TrackType};
+
+    use super::{apply_detected_languages, AUDIO_LANGUAGE_DETECTOR_PLUGIN};
+
+    fn make_file_with_audio_tracks() -> MediaFile {
+        let mut file = MediaFile::new(PathBuf::from("/tmp/test.mkv"));
+        let mut main = Track::new(0, TrackType::AudioMain, "aac".into());
+        main.language = "und".to_string();
+        let mut alternate = Track::new(1, TrackType::AudioAlternate, "ac3".into());
+        alternate.language = "fre".to_string();
+        file.tracks = vec![main, alternate];
+        file
+    }
+
+    fn set_detector_metadata(file: &mut MediaFile, metadata: serde_json::Value) {
+        file.plugin_metadata
+            .insert(AUDIO_LANGUAGE_DETECTOR_PLUGIN.to_string(), metadata);
+    }
+
+    #[test]
+    fn applies_detected_language_to_unknown_track_language() {
+        let mut file = make_file_with_audio_tracks();
+        set_detector_metadata(
+            &mut file,
+            serde_json::json!({
+                "detections": [{
+                    "track_index": 0,
+                    "detected_language": "eng",
+                    "confidence": 0.95
+                }]
+            }),
+        );
+
+        apply_detected_languages(&mut file);
+
+        assert_eq!(file.tracks[0].language, "eng");
+        assert_eq!(file.tracks[1].language, "fre");
+    }
+
+    #[test]
+    fn overwrites_existing_mismatched_language() {
+        let mut file = make_file_with_audio_tracks();
+        set_detector_metadata(
+            &mut file,
+            serde_json::json!({
+                "detections": [{
+                    "track_index": 1,
+                    "detected_language": "eng",
+                    "confidence": 0.92
+                }]
+            }),
+        );
+
+        apply_detected_languages(&mut file);
+
+        assert_eq!(file.tracks[1].language, "eng");
+    }
+
+    #[test]
+    fn applies_special_language_codes() {
+        for language in ["zxx", "mul"] {
+            let mut file = make_file_with_audio_tracks();
+            set_detector_metadata(
+                &mut file,
+                serde_json::json!({
+                    "detections": [{
+                        "track_index": 0,
+                        "detected_language": language,
+                        "confidence": 0.98
+                    }]
+                }),
+            );
+
+            apply_detected_languages(&mut file);
+
+            assert_eq!(file.tracks[0].language, language);
+        }
+    }
+
+    #[test]
+    fn missing_metadata_leaves_tracks_unchanged() {
+        let mut file = make_file_with_audio_tracks();
+
+        apply_detected_languages(&mut file);
+
+        assert_eq!(file.tracks[0].language, "und");
+        assert_eq!(file.tracks[1].language, "fre");
+    }
+
+    #[test]
+    fn malformed_metadata_leaves_tracks_unchanged() {
+        let mut file = make_file_with_audio_tracks();
+        set_detector_metadata(
+            &mut file,
+            serde_json::json!({
+                "detections": [{
+                    "track_index": "not-an-index",
+                    "detected_language": "eng"
+                }]
+            }),
+        );
+
+        apply_detected_languages(&mut file);
+
+        assert_eq!(file.tracks[0].language, "und");
+        assert_eq!(file.tracks[1].language, "fre");
+    }
+
+    #[test]
+    fn malformed_detection_does_not_block_valid_detection() {
+        let mut file = make_file_with_audio_tracks();
+        set_detector_metadata(
+            &mut file,
+            serde_json::json!({
+                "detections": [
+                    {
+                        "track_index": "not-an-index",
+                        "detected_language": "eng"
+                    },
+                    {
+                        "track_index": 0,
+                        "detected_language": "eng"
+                    }
+                ]
+            }),
+        );
+
+        apply_detected_languages(&mut file);
+
+        assert_eq!(file.tracks[0].language, "eng");
+        assert_eq!(file.tracks[1].language, "fre");
+    }
+
+    #[test]
+    fn unknown_track_detection_leaves_tracks_unchanged() {
+        let mut file = make_file_with_audio_tracks();
+        set_detector_metadata(
+            &mut file,
+            serde_json::json!({
+                "detections": [{
+                    "track_index": 99,
+                    "detected_language": "eng",
+                    "confidence": 0.95
+                }]
+            }),
+        );
+
+        apply_detected_languages(&mut file);
+
+        assert_eq!(file.tracks[0].language, "und");
+        assert_eq!(file.tracks[1].language, "fre");
+    }
+}

--- a/crates/voom-cli/src/commands/process/mod.rs
+++ b/crates/voom-cli/src/commands/process/mod.rs
@@ -1,3 +1,4 @@
+mod audio_language;
 mod dispatch;
 mod pipeline;
 mod plan_outcome;
@@ -879,9 +880,7 @@ mod tests {
     use voom_domain::media::MediaFile;
     use voom_domain::plan::{ActionParams, OperationType, Plan, PlannedAction, TranscodeSettings};
 
-    use super::pipeline::{
-        apply_detected_languages, execute_single_plan, AUDIO_LANGUAGE_DETECTOR_PLUGIN,
-    };
+    use super::pipeline::execute_single_plan;
     use super::plan_outcome::PlanOutcome;
     use super::safeguards::{check_disk_space, check_duration_shrink, check_size_increase};
 
@@ -1273,118 +1272,6 @@ mod tests {
         // These should not panic
         reporter.on_batch_start(10);
         reporter.on_batch_complete(5, 0);
-    }
-
-    // --- apply_detected_languages tests ---
-
-    fn make_file_with_audio_tracks() -> MediaFile {
-        use voom_domain::media::{Track, TrackType};
-        let mut file = MediaFile::new(PathBuf::from("/tmp/test.mkv"));
-        let mut t0 = Track::new(0, TrackType::AudioMain, "aac".into());
-        t0.language = "und".to_string();
-        let mut t1 = Track::new(1, TrackType::AudioAlternate, "ac3".into());
-        t1.language = "fre".to_string();
-        file.tracks = vec![t0, t1];
-        file
-    }
-
-    #[test]
-    fn test_apply_detected_und_to_eng() {
-        let mut file = make_file_with_audio_tracks();
-        file.plugin_metadata.insert(
-            AUDIO_LANGUAGE_DETECTOR_PLUGIN.to_string(),
-            serde_json::json!({
-                "detections": [{
-                    "track_index": 0,
-                    "detected_language": "eng",
-                    "confidence": 0.95,
-                }]
-            }),
-        );
-        apply_detected_languages(&mut file);
-        assert_eq!(file.tracks[0].language, "eng");
-        // Track 1 unchanged (no detection for it).
-        assert_eq!(file.tracks[1].language, "fre");
-    }
-
-    #[test]
-    fn test_apply_detected_overwrite_mismatch() {
-        let mut file = make_file_with_audio_tracks();
-        file.plugin_metadata.insert(
-            AUDIO_LANGUAGE_DETECTOR_PLUGIN.to_string(),
-            serde_json::json!({
-                "detections": [{
-                    "track_index": 1,
-                    "detected_language": "eng",
-                    "confidence": 0.92,
-                }]
-            }),
-        );
-        apply_detected_languages(&mut file);
-        // Track 1 was "fre" but detection says "eng" — overwritten.
-        assert_eq!(file.tracks[1].language, "eng");
-    }
-
-    #[test]
-    fn test_apply_detected_zxx() {
-        let mut file = make_file_with_audio_tracks();
-        file.plugin_metadata.insert(
-            AUDIO_LANGUAGE_DETECTOR_PLUGIN.to_string(),
-            serde_json::json!({
-                "detections": [{
-                    "track_index": 0,
-                    "detected_language": "zxx",
-                    "confidence": 0.98,
-                }]
-            }),
-        );
-        apply_detected_languages(&mut file);
-        assert_eq!(file.tracks[0].language, "zxx");
-    }
-
-    #[test]
-    fn test_apply_detected_mul() {
-        let mut file = make_file_with_audio_tracks();
-        file.plugin_metadata.insert(
-            AUDIO_LANGUAGE_DETECTOR_PLUGIN.to_string(),
-            serde_json::json!({
-                "detections": [{
-                    "track_index": 0,
-                    "detected_language": "mul",
-                    "confidence": 0.6,
-                }]
-            }),
-        );
-        apply_detected_languages(&mut file);
-        assert_eq!(file.tracks[0].language, "mul");
-    }
-
-    #[test]
-    fn test_apply_detected_no_metadata() {
-        let mut file = make_file_with_audio_tracks();
-        apply_detected_languages(&mut file);
-        // No crash, tracks unchanged.
-        assert_eq!(file.tracks[0].language, "und");
-        assert_eq!(file.tracks[1].language, "fre");
-    }
-
-    #[test]
-    fn test_apply_detected_nonexistent_track() {
-        let mut file = make_file_with_audio_tracks();
-        file.plugin_metadata.insert(
-            AUDIO_LANGUAGE_DETECTOR_PLUGIN.to_string(),
-            serde_json::json!({
-                "detections": [{
-                    "track_index": 99,
-                    "detected_language": "eng",
-                    "confidence": 0.95,
-                }]
-            }),
-        );
-        // No panic.
-        apply_detected_languages(&mut file);
-        assert_eq!(file.tracks[0].language, "und");
-        assert_eq!(file.tracks[1].language, "fre");
     }
 
     #[test]

--- a/crates/voom-cli/src/commands/process/pipeline.rs
+++ b/crates/voom-cli/src/commands/process/pipeline.rs
@@ -19,6 +19,7 @@ use anyhow::Context;
 use voom_domain::events::PlanFailedEvent;
 use voom_domain::plan::OperationType;
 
+use super::audio_language::apply_detected_languages;
 use super::dispatch::PlanDispatcher;
 use super::plan_outcome::PlanOutcome;
 use super::safeguards::{
@@ -32,8 +33,6 @@ use super::transitions::{
 use super::{record_phase_stat, PhaseOutcomeKind, ProcessContext};
 
 use crate::introspect::DiscoveredFilePayload;
-
-pub(super) const AUDIO_LANGUAGE_DETECTOR_PLUGIN: &str = "audio-language-detector";
 
 /// Extract and deserialize the job payload from a process job.
 fn parse_job_payload(job: &voom_domain::job::Job) -> anyhow::Result<DiscoveredFilePayload> {
@@ -601,63 +600,6 @@ async fn reintrospect_file(
             }
             fallback
         }
-    }
-}
-
-/// Apply audio language detection results to track language fields.
-///
-/// If the `audio-language-detector` plugin has produced metadata, update
-/// each track's language to match the detected value. This runs before
-/// policy evaluation so that policies can filter on detected languages
-/// (e.g. `remove audio where lang == zxx` for silent tracks).
-pub(super) fn apply_detected_languages(file: &mut voom_domain::media::MediaFile) {
-    let Some(metadata) = file.plugin_metadata.get(AUDIO_LANGUAGE_DETECTOR_PLUGIN) else {
-        return;
-    };
-
-    let Some(detections) = metadata.get("detections").and_then(|d| d.as_array()) else {
-        return;
-    };
-
-    for det in detections {
-        let Some(track_index_u64) = det.get("track_index").and_then(serde_json::Value::as_u64)
-        else {
-            continue;
-        };
-        let track_index = u32::try_from(track_index_u64).unwrap_or(u32::MAX);
-        let Some(detected) = det.get("detected_language").and_then(|v| v.as_str()) else {
-            continue;
-        };
-
-        let Some(track) = file.tracks.iter_mut().find(|t| t.index == track_index) else {
-            continue;
-        };
-
-        let Some(normalized) = voom_domain::utils::language::normalize_language(detected) else {
-            tracing::warn!(
-                path = %file.path.display(),
-                track = track_index,
-                detected = %detected,
-                "unrecognized language code from detector, skipping"
-            );
-            continue;
-        };
-
-        if track.language == normalized {
-            continue;
-        }
-
-        if track.language != "und" {
-            tracing::warn!(
-                path = %file.path.display(),
-                track = track_index,
-                existing = %track.language,
-                detected = %normalized,
-                "overwriting track language with detected value"
-            );
-        }
-
-        track.language = normalized.to_string();
     }
 }
 


### PR DESCRIPTION
## Summary
- move audio-language-detector metadata parsing out of the process pipeline into a focused helper module
- deserialize detector metadata through typed structs and include parse error context in warnings
- keep malformed detections isolated so valid detections still apply
- move and expand tests for valid metadata, missing metadata, malformed metadata, unknown tracks, and overwrite behavior

Closes #285

## Tests
- cargo fmt --check
- cargo test -p voom-cli audio_language
- cargo test -p voom-cli commands::process
- cargo clippy -p voom-cli --all-targets -- -D warnings

## Simplification Review
- Reviewed the diff locally with the simplification-review workflow. The actionable finding was preserving per-detection skip behavior for malformed entries instead of rejecting an entire metadata list; that cleanup is included.