### PR TITLE
Propagate transition record errors

### DIFF
--- a/crates/voom-cli/src/commands/process/mod.rs
+++ b/crates/voom-cli/src/commands/process/mod.rs
@@ -1361,8 +1361,9 @@ mod tests {
         let kernel = Arc::new(voom_kernel::Kernel::new());
         let ctx = fixture.make_ctx(kernel, store.clone());
 
-        let _ =
-            pipeline::handle_plan_success(plan, &file, "mkvtoolnix-executor", 0, false, &ctx).await;
+        let _ = pipeline::handle_plan_success(plan, &file, "mkvtoolnix-executor", 0, false, &ctx)
+            .await
+            .expect("finalize successful plan");
 
         assert_eq!(
             store.count_files(&Default::default()).unwrap(),
@@ -1384,6 +1385,62 @@ mod tests {
                 .is_none(),
             "the original .mp4 path must no longer resolve to a row",
         );
+    }
+
+    #[tokio::test]
+    async fn handle_plan_success_reports_transition_record_failure_with_context() {
+        use voom_domain::media::{Container, MediaFile};
+        use voom_domain::plan::{ActionParams, OperationType, Plan, PlannedAction};
+
+        let fixture =
+            TestFixture::with_policy(r#"policy "test" { phase convert { container mkv } }"#);
+        let mp4_path = fixture.dir_path().join("movie.mp4");
+        let mkv_path = fixture.dir_path().join("movie.mkv");
+        std::fs::write(&mkv_path, vec![0u8; 1024]).unwrap();
+
+        let mut file = MediaFile::new(mp4_path.clone());
+        file.container = Container::Mp4;
+        file.size = 1024;
+        file.content_hash = Some("oldhash".to_string());
+
+        let mut plan = Plan::new(file.clone(), "containerize", "convert");
+        let plan_id = plan.id;
+        plan.actions = vec![PlannedAction::file_op(
+            OperationType::ConvertContainer,
+            ActionParams::Container {
+                container: Container::Mkv,
+            },
+            "Convert to mkv",
+        )];
+
+        let store: Arc<dyn voom_domain::storage::StorageTrait> =
+            Arc::new(voom_sqlite_store::store::SqliteStore::in_memory().unwrap());
+        store.upsert_file(&file).unwrap();
+        let mut conflicting_file = MediaFile::new(mkv_path);
+        conflicting_file.container = Container::Mkv;
+        conflicting_file.size = 512;
+        conflicting_file.content_hash = Some("conflict".to_string());
+        store.upsert_file(&conflicting_file).unwrap();
+
+        let kernel = Arc::new(voom_kernel::Kernel::new());
+        let ctx = ProcessContext {
+            ffprobe_path: Some("/nonexistent/ffprobe"),
+            ..fixture.make_ctx(kernel, store)
+        };
+
+        let error =
+            pipeline::handle_plan_success(plan, &file, "mkvtoolnix-executor", 0, false, &ctx)
+                .await
+                .expect_err(
+                    "conflicting post-execution path should make transition recording fail",
+                );
+        let message = error.to_string();
+
+        assert!(message.contains("failed to record post-execution transition"));
+        assert!(message.contains(&mp4_path.display().to_string()));
+        assert!(message.contains("phase 'convert'"));
+        assert!(message.contains(&plan_id.to_string()));
+        assert!(message.contains("storage error:"));
     }
 
     #[tokio::test]
@@ -1442,7 +1499,9 @@ mod tests {
         };
 
         let new_file =
-            pipeline::handle_plan_success(plan, &file, "mkvtoolnix-executor", 0, false, &ctx).await;
+            pipeline::handle_plan_success(plan, &file, "mkvtoolnix-executor", 0, false, &ctx)
+                .await
+                .expect("finalize successful plan");
 
         assert_eq!(
             new_file.path, mkv_path,
@@ -1526,7 +1585,9 @@ mod tests {
         };
 
         let new_file =
-            pipeline::handle_plan_success(plan, &file, "mkvtoolnix-executor", 0, false, &ctx).await;
+            pipeline::handle_plan_success(plan, &file, "mkvtoolnix-executor", 0, false, &ctx)
+                .await
+                .expect("finalize successful plan");
 
         assert_eq!(
             new_file.path, path,
@@ -1578,7 +1639,8 @@ mod tests {
             phase_name: "convert",
             plan_id: uuid::Uuid::new_v4(),
             ctx: &ctx,
-        });
+        })
+        .expect("record transition");
 
         let by_new = store.transitions_for_path(&new_file.path).unwrap();
         assert_eq!(

--- a/crates/voom-cli/src/commands/process/pipeline.rs
+++ b/crates/voom-cli/src/commands/process/pipeline.rs
@@ -341,7 +341,8 @@ async fn process_single_file_execute(
                     keep_backups,
                     ctx,
                 )
-                .await;
+                .await
+                .map_err(|error| error.to_string())?;
             }
             PlanOutcome::Failed(failed) => {
                 let executor = failed.plugin_name.clone().unwrap_or_default();
@@ -353,7 +354,8 @@ async fn process_single_file_execute(
                     executor: &executor,
                     error_message: Some(&error_msg),
                     ctx,
-                });
+                })
+                .map_err(|error| error.to_string())?;
                 phase_outcomes.insert(
                     plan.phase_name.clone(),
                     voom_policy_evaluator::EvaluationOutcome::ExecutionFailed,
@@ -407,7 +409,7 @@ pub(super) async fn handle_plan_success(
     elapsed_ms: u64,
     keep_backups: bool,
     ctx: &ProcessContext<'_>,
-) -> voom_domain::media::MediaFile {
+) -> voom_domain::Result<voom_domain::media::MediaFile> {
     if keep_backups {
         ctx.counters
             .backup_bytes
@@ -456,7 +458,7 @@ pub(super) async fn handle_plan_success(
         phase_name: &phase_name,
         plan_id,
         ctx,
-    });
+    })?;
 
     // Defense-in-depth: clear any `bad_files` row at the post-execution
     // path. The bundle in `record_post_execution` already does this for
@@ -474,7 +476,7 @@ pub(super) async fn handle_plan_success(
         );
     }
 
-    new_file
+    Ok(new_file)
 }
 
 /// Check file hash for TOCTOU guard. Returns Some(json) if file should be skipped.

--- a/crates/voom-cli/src/commands/process/safeguards.rs
+++ b/crates/voom-cli/src/commands/process/safeguards.rs
@@ -40,13 +40,21 @@ fn record_safeguard_failure(
         &plan.phase_name,
         PhaseOutcomeKind::Failed,
     );
-    record_failure_transition(&FailureTransitionContext {
+    if let Err(error) = record_failure_transition(&FailureTransitionContext {
         file,
         plan,
         executor: "",
         error_message: Some(message),
         ctx,
-    });
+    }) {
+        tracing::warn!(
+            path = %file.path.display(),
+            phase = %plan.phase_name,
+            plan_id = %plan.id,
+            error = %error,
+            "failed to record safeguard failure transition"
+        );
+    }
 }
 
 /// Check if the output file grew larger than the original.

--- a/crates/voom-cli/src/commands/process/transitions.rs
+++ b/crates/voom-cli/src/commands/process/transitions.rs
@@ -6,6 +6,8 @@
 //! module.
 
 use super::ProcessContext;
+use voom_domain::errors::StorageErrorKind;
+use voom_domain::VoomError;
 
 /// Grouped arguments for `record_file_transition`.
 pub(super) struct FileTransitionContext<'a> {
@@ -22,11 +24,11 @@ pub(super) struct FileTransitionContext<'a> {
 }
 
 /// Record a file transition in the store if the content hash or path changed.
-pub(super) fn record_file_transition(tctx: &FileTransitionContext<'_>) {
+pub(super) fn record_file_transition(tctx: &FileTransitionContext<'_>) -> voom_domain::Result<()> {
     let hash_changed = tctx.new_file.content_hash != tctx.old_file.content_hash;
     let path_changed = tctx.old_file.path != tctx.new_file.path;
     if !hash_changed && !path_changed {
-        return;
+        return Ok(());
     }
 
     let mut transition = voom_domain::FileTransition::new(
@@ -63,17 +65,20 @@ pub(super) fn record_file_transition(tctx: &FileTransitionContext<'_>) {
         .then_some(tctx.new_file.content_hash.as_deref())
         .flatten();
 
-    if let Err(e) = tctx
-        .ctx
+    tctx.ctx
         .store
         .record_post_execution(new_path, new_expected_hash, &transition)
-    {
-        tracing::warn!(
-            path = %tctx.old_file.path.display(),
-            error = %e,
-            "failed to record post-execution bundle"
-        );
-    }
+        .map_err(|error| {
+            transition_record_error(
+                "post-execution transition",
+                &tctx.old_file.path,
+                tctx.phase_name,
+                tctx.plan_id,
+                error,
+            )
+        })?;
+
+    Ok(())
 }
 
 /// Grouped arguments for `record_failure_transition`.
@@ -96,7 +101,9 @@ pub(super) struct FailureTransitionContext<'a> {
 /// Dual-write: `file_transitions.error_message` is used for session-based
 /// queries (`voom report errors`), while `plans.result` stores the structured
 /// `ExecutionDetail` JSON for plan-based queries with full subprocess output.
-pub(super) fn record_failure_transition(fctx: &FailureTransitionContext<'_>) {
+pub(super) fn record_failure_transition(
+    fctx: &FailureTransitionContext<'_>,
+) -> voom_domain::Result<()> {
     let file = fctx.file;
     let to_hash = file.content_hash.clone().unwrap_or_default();
     let mut transition = voom_domain::FileTransition::new(
@@ -123,11 +130,39 @@ pub(super) fn record_failure_transition(fctx: &FailureTransitionContext<'_>) {
         transition = transition.with_error_message(msg);
     }
 
-    if let Err(e) = fctx.ctx.store.record_transition(&transition) {
-        tracing::warn!(
-            path = %fctx.file.path.display(),
-            error = %e,
-            "failed to record failure transition"
-        );
+    fctx.ctx
+        .store
+        .record_transition(&transition)
+        .map_err(|error| {
+            transition_record_error(
+                "failure transition",
+                &fctx.file.path,
+                &fctx.plan.phase_name,
+                fctx.plan.id,
+                error,
+            )
+        })?;
+
+    Ok(())
+}
+
+fn transition_record_error(
+    operation: &str,
+    path: &std::path::Path,
+    phase_name: &str,
+    plan_id: uuid::Uuid,
+    error: VoomError,
+) -> VoomError {
+    let message = format!(
+        "failed to record {operation} for file '{}' in phase '{phase_name}' \
+         for plan {plan_id}: {error}",
+        path.display()
+    );
+    match error {
+        VoomError::Storage { kind, .. } => VoomError::Storage { kind, message },
+        _ => VoomError::Storage {
+            kind: StorageErrorKind::Other,
+            message,
+        },
     }
 }


### PR DESCRIPTION
## Summary
- make transition recording helpers return storage errors instead of only logging them
- propagate successful-plan transition write failures through process execution with file, phase, plan, and storage context
- propagate execution-failure transition write failures through the process pipeline
- keep safeguard transition recording best-effort while logging the contextual wrapped error

Closes #286

## Tests
- cargo fmt --check
- cargo test -p voom-cli handle_plan_success_reports_transition_record_failure_with_context
- cargo test -p voom-cli commands::process
- cargo clippy -p voom-cli --all-targets -- -D warnings

## Simplification Review
- Reviewed the diff locally with the simplification-review workflow. The only actionable cleanup was a stale test expectation message after switching the failure fixture to a deterministic path conflict; that cleanup is included.