### PR TITLE
Add automatic black-bar crop detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ Set `hw: auto` in any `transcode` block and VOOM picks the best available
 backend. `hw_fallback: true` drops to software encoding if hardware fails at
 runtime. Per-device validation ensures only working encoders are selected.
 
+Video transcodes can also use `crop: auto` to detect black bars with FFmpeg,
+cache the result, and apply the crop during encoding.
+
 ### Subtitle Intelligence
 
 Full subtitle pipeline from filtering to AI-powered generation:

--- a/crates/voom-cli/src/commands/process/pipeline.rs
+++ b/crates/voom-cli/src/commands/process/pipeline.rs
@@ -13,11 +13,14 @@
 //! through [`super::transitions`].
 
 use std::collections::HashMap;
+use std::path::Path;
 use std::sync::atomic::Ordering as AtomicOrdering;
 
 use anyhow::Context;
 use voom_domain::events::PlanFailedEvent;
-use voom_domain::plan::OperationType;
+use voom_domain::media::{CropDetection, MediaFile, TrackType};
+use voom_domain::plan::{ActionParams, CropSettings, OperationType, Plan};
+use voom_ffmpeg_executor::cropdetect::CropDetectSource;
 
 use super::audio_language::apply_detected_languages;
 use super::dispatch::PlanDispatcher;
@@ -241,7 +244,7 @@ async fn process_single_file_execute(
         ) else {
             continue;
         };
-        let plan = plan.with_session_id(ctx.counters.session_id);
+        let mut plan = plan.with_session_id(ctx.counters.session_id);
 
         plans_evaluated += 1;
 
@@ -265,6 +268,8 @@ async fn process_single_file_execute(
             );
             continue;
         }
+
+        apply_auto_crop_detection(&mut plan, &mut current_file, ctx).await?;
 
         // Pre-execution safeguard: check disk space
         // Note: check_disk_space dispatches only PlanFailed (not
@@ -672,6 +677,100 @@ pub(super) fn execute_single_plan(
 ) -> PlanOutcome {
     let results = PlanDispatcher::new(kernel).begin(plan, file);
     PlanOutcome::from_event_result(&results, plan, file)
+}
+
+type CropDetector =
+    fn(&str, &Path, CropDetectSource, &CropSettings) -> voom_domain::Result<Option<CropDetection>>;
+
+struct CropDetectRequest {
+    settings: CropSettings,
+    source: CropDetectSource,
+}
+
+async fn apply_auto_crop_detection(
+    plan: &mut Plan,
+    current_file: &mut MediaFile,
+    ctx: &ProcessContext<'_>,
+) -> Result<(), String> {
+    apply_auto_crop_detection_with_detector(
+        plan,
+        current_file,
+        ctx,
+        voom_ffmpeg_executor::cropdetect::detect_crop,
+    )
+    .await
+}
+
+async fn apply_auto_crop_detection_with_detector(
+    plan: &mut Plan,
+    current_file: &mut MediaFile,
+    ctx: &ProcessContext<'_>,
+    detector: CropDetector,
+) -> Result<(), String> {
+    let Some(request) = cropdetect_request_for_plan(plan, current_file) else {
+        return Ok(());
+    };
+    let settings_fingerprint = crop_settings_fingerprint(&request.settings)?;
+    if current_file
+        .crop_detection
+        .as_ref()
+        .and_then(|detection| detection.settings_fingerprint.as_deref())
+        == Some(settings_fingerprint.as_str())
+    {
+        plan.file = current_file.clone();
+        return Ok(());
+    }
+
+    let ffmpeg_path = "ffmpeg".to_string();
+    let source_path = current_file.path.clone();
+    let settings = request.settings;
+    let source = request.source;
+    let detection = tokio::task::spawn_blocking(move || {
+        detector(&ffmpeg_path, &source_path, source, &settings)
+    })
+    .await
+    .map_err(|e| format!("crop detection join error: {e}"))?
+    .map_err(|e| format!("crop detection failed: {e}"))?
+    .map(|detection| detection.with_settings_fingerprint(settings_fingerprint));
+
+    let changed = current_file.crop_detection != detection;
+    current_file.crop_detection = detection;
+    if changed {
+        plan.file = current_file.clone();
+        ctx.store
+            .upsert_file(current_file)
+            .map_err(|e| format!("failed to persist crop detection: {e}"))?;
+    }
+    Ok(())
+}
+
+fn cropdetect_request_for_plan(plan: &Plan, file: &MediaFile) -> Option<CropDetectRequest> {
+    let action = plan.actions.iter().find(|action| {
+        action.operation == OperationType::TranscodeVideo
+            && matches!(
+                &action.parameters,
+                ActionParams::Transcode { settings, .. } if settings.crop.is_some()
+            )
+    })?;
+    let ActionParams::Transcode { settings, .. } = &action.parameters else {
+        return None;
+    };
+    let crop_settings = settings.crop.clone()?;
+    let track_index = action.track_index?;
+    let track = file
+        .tracks
+        .iter()
+        .find(|track| track.index == track_index && track.track_type == TrackType::Video)?;
+    let width = track.width?;
+    let height = track.height?;
+    Some(CropDetectRequest {
+        settings: crop_settings,
+        source: CropDetectSource::new(width, height, file.duration),
+    })
+}
+
+fn crop_settings_fingerprint(settings: &CropSettings) -> Result<String, String> {
+    serde_json::to_string(settings).map_err(|e| format!("failed to fingerprint crop settings: {e}"))
 }
 
 #[cfg(test)]

--- a/crates/voom-cli/src/commands/process/pipeline.rs
+++ b/crates/voom-cli/src/commands/process/pipeline.rs
@@ -269,7 +269,31 @@ async fn process_single_file_execute(
             continue;
         }
 
-        apply_auto_crop_detection(&mut plan, &mut current_file, ctx).await?;
+        let mut permit = None;
+        if plan_requires_auto_crop(&plan) {
+            let acquired = tokio::select! {
+                biased;
+                () = ctx.token.cancelled() => break,
+                permit = ctx.plan_limiter.acquire_for_plan(&plan) => permit,
+            };
+            if let Err(error) = apply_auto_crop_detection(&mut plan, &mut current_file, ctx).await {
+                let mut failed = PlanFailedEvent::new(
+                    plan.id,
+                    current_file.path.clone(),
+                    plan.phase_name.clone(),
+                    error,
+                );
+                failed.plugin_name = Some("ffmpeg-executor".to_string());
+                dispatch_plan_failure(failed, &plan.phase_name, ctx);
+                phase_outcomes.insert(
+                    phase_name.clone(),
+                    voom_policy_evaluator::EvaluationOutcome::ExecutionFailed,
+                );
+                drop(acquired);
+                continue;
+            }
+            permit = Some(acquired);
+        }
 
         // Pre-execution safeguard: check disk space
         // Note: check_disk_space dispatches only PlanFailed (not
@@ -285,10 +309,15 @@ async fn process_single_file_execute(
         }
 
         // Execute this plan
-        let permit = tokio::select! {
-            biased;
-            () = ctx.token.cancelled() => break,
-            permit = ctx.plan_limiter.acquire_for_plan(&plan) => permit,
+        let permit = match permit {
+            Some(permit) => permit,
+            None => {
+                tokio::select! {
+                    biased;
+                    () = ctx.token.cancelled() => break,
+                    permit = ctx.plan_limiter.acquire_for_plan(&plan) => permit,
+                }
+            }
         };
         let plan_clone = plan.clone();
         let file_clone = current_file.clone();
@@ -734,14 +763,26 @@ async fn apply_auto_crop_detection_with_detector(
     .map(|detection| detection.with_settings_fingerprint(settings_fingerprint));
 
     let changed = current_file.crop_detection != detection;
-    current_file.crop_detection = detection;
     if changed {
-        plan.file = current_file.clone();
+        let mut updated_file = current_file.clone();
+        updated_file.crop_detection = detection;
         ctx.store
-            .upsert_file(current_file)
+            .upsert_file(&updated_file)
             .map_err(|e| format!("failed to persist crop detection: {e}"))?;
+        *current_file = updated_file;
+        plan.file = current_file.clone();
     }
     Ok(())
+}
+
+fn plan_requires_auto_crop(plan: &Plan) -> bool {
+    plan.actions.iter().any(|action| {
+        action.operation == OperationType::TranscodeVideo
+            && matches!(
+                &action.parameters,
+                ActionParams::Transcode { settings, .. } if settings.crop.is_some()
+            )
+    })
 }
 
 fn cropdetect_request_for_plan(plan: &Plan, file: &MediaFile) -> Option<CropDetectRequest> {
@@ -782,8 +823,11 @@ mod tests {
     use std::time::Duration;
 
     use voom_domain::capabilities::Capability;
+    use voom_domain::errors::VoomError;
     use voom_domain::events::{Event, EventResult};
-    use voom_domain::media::{Container, MediaFile, Track, TrackType};
+    use voom_domain::media::{Container, CropDetection, CropRect, MediaFile, Track, TrackType};
+    use voom_domain::plan::{CropSettings, PlannedAction, TranscodeSettings};
+    use voom_domain::storage::FileStorage;
 
     use super::super::tests as process_tests;
     use super::*;
@@ -837,9 +881,51 @@ mod tests {
     }
 
     fn h264_file(path: std::path::PathBuf) -> MediaFile {
-        MediaFile::new(path)
+        let mut file = MediaFile::new(path)
             .with_container(Container::Mkv)
-            .with_tracks(vec![Track::new(0, TrackType::Video, "h264".into())])
+            .with_tracks(vec![Track::new(0, TrackType::Video, "h264".into())]);
+        file.duration = 120.0;
+        file.tracks[0].width = Some(1920);
+        file.tracks[0].height = Some(1080);
+        file
+    }
+
+    fn crop_plan(file: MediaFile, settings: CropSettings) -> Plan {
+        let mut plan = Plan::new(file, "test-policy", "transcode-video");
+        plan.actions = vec![PlannedAction::track_op(
+            OperationType::TranscodeVideo,
+            0,
+            ActionParams::Transcode {
+                codec: "hevc".into(),
+                settings: TranscodeSettings::default().with_crop(Some(settings)),
+            },
+            "Transcode video with crop",
+        )];
+        plan
+    }
+
+    fn crop_detector_ok(
+        _ffmpeg_path: &str,
+        _source_path: &Path,
+        _source: CropDetectSource,
+        _settings: &CropSettings,
+    ) -> voom_domain::Result<Option<CropDetection>> {
+        Ok(Some(CropDetection::new(
+            CropRect::new(0, 132, 0, 132),
+            chrono::Utc::now(),
+        )))
+    }
+
+    fn crop_detector_fails(
+        _ffmpeg_path: &str,
+        _source_path: &Path,
+        _source: CropDetectSource,
+        _settings: &CropSettings,
+    ) -> voom_domain::Result<Option<CropDetection>> {
+        Err(VoomError::ToolExecution {
+            tool: "ffmpeg".to_string(),
+            message: "synthetic cropdetect failure".to_string(),
+        })
     }
 
     async fn held_nvenc_permit(
@@ -870,6 +956,90 @@ mod tests {
             matches!(entered_rx.try_recv(), Err(mpsc::TryRecvError::Empty)),
             "{message}"
         );
+    }
+
+    #[tokio::test]
+    async fn auto_crop_detection_persists_and_updates_plan_file() {
+        let fixture = process_tests::TestFixture::with_policy(global_hw_policy());
+        let store = Arc::new(voom_domain::test_support::InMemoryStore::new());
+        let ctx = fixture.make_ctx(Arc::new(voom_kernel::Kernel::new()), store.clone());
+        let path = fixture.dir_path().join("movie.mkv");
+        let mut file = h264_file(path);
+        let mut plan = crop_plan(file.clone(), CropSettings::auto());
+
+        apply_auto_crop_detection_with_detector(&mut plan, &mut file, &ctx, crop_detector_ok)
+            .await
+            .unwrap();
+
+        let detection = file.crop_detection.as_ref().expect("crop detection");
+        assert_eq!(detection.rect, CropRect::new(0, 132, 0, 132));
+        assert!(detection.settings_fingerprint.is_some());
+        assert_eq!(
+            plan.file.crop_detection.as_ref().map(|d| d.rect),
+            Some(CropRect::new(0, 132, 0, 132))
+        );
+        let stored = store.file(&file.id).unwrap().expect("stored file");
+        assert_eq!(
+            stored.crop_detection.as_ref().map(|d| d.rect),
+            Some(CropRect::new(0, 132, 0, 132))
+        );
+    }
+
+    #[tokio::test]
+    async fn auto_crop_detection_reuses_matching_cached_fingerprint() {
+        let fixture = process_tests::TestFixture::with_policy(global_hw_policy());
+        let ctx = fixture.make_default_ctx();
+        let path = fixture.dir_path().join("movie.mkv");
+        let settings = CropSettings::auto();
+        let fingerprint = crop_settings_fingerprint(&settings).unwrap();
+        let mut file = h264_file(path);
+        file.crop_detection = Some(
+            CropDetection::new(CropRect::new(0, 120, 0, 120), chrono::Utc::now())
+                .with_settings_fingerprint(fingerprint),
+        );
+        let mut plan = crop_plan(file.clone(), settings);
+
+        apply_auto_crop_detection_with_detector(&mut plan, &mut file, &ctx, crop_detector_fails)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            file.crop_detection.as_ref().map(|d| d.rect),
+            Some(CropRect::new(0, 120, 0, 120))
+        );
+    }
+
+    #[tokio::test]
+    async fn auto_crop_detection_failure_leaves_file_unmodified() {
+        let fixture = process_tests::TestFixture::with_policy(global_hw_policy());
+        let ctx = fixture.make_default_ctx();
+        let path = fixture.dir_path().join("movie.mkv");
+        let mut file = h264_file(path);
+        let mut plan = crop_plan(file.clone(), CropSettings::auto());
+
+        let err = apply_auto_crop_detection_with_detector(
+            &mut plan,
+            &mut file,
+            &ctx,
+            crop_detector_fails,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(err.contains("crop detection failed"));
+        assert!(file.crop_detection.is_none());
+        assert!(plan.file.crop_detection.is_none());
+    }
+
+    #[test]
+    fn plan_requires_auto_crop_only_for_crop_enabled_transcode() {
+        let path = std::path::PathBuf::from("/tmp/movie.mkv");
+        let file = h264_file(path);
+        let crop = crop_plan(file.clone(), CropSettings::auto());
+        let plain = process_tests::test_plan_with_optional_transcode_hw("transcode-video", None);
+
+        assert!(plan_requires_auto_crop(&crop));
+        assert!(!plan_requires_auto_crop(&plain));
     }
 
     #[tokio::test]

--- a/crates/voom-domain/src/lib.rs
+++ b/crates/voom-domain/src/lib.rs
@@ -32,11 +32,11 @@ pub use capability_map::CapabilityMap;
 pub use errors::{Result, VoomError};
 pub use events::Event;
 pub use job::{DiscoveredFilePayload, Job, JobStatus, JobUpdate};
-pub use media::{Container, MediaFile, Track, TrackType};
+pub use media::{Container, CropDetection, CropRect, MediaFile, Track, TrackType};
 pub use plan::{
-    ActionParams, ActionResult, OperationType, PhaseOutcome, PhaseOutput, PhaseResult, Plan,
-    PlannedAction, SampleStrategy, TranscodeChannels, TranscodeFallback, TranscodeSettings,
-    PHASE_OUTPUT_FIELDS,
+    ActionParams, ActionResult, CropSettings, OperationType, PhaseOutcome, PhaseOutput,
+    PhaseResult, Plan, PlannedAction, SampleStrategy, TranscodeChannels, TranscodeFallback,
+    TranscodeSettings, PHASE_OUTPUT_FIELDS,
 };
 pub use safeguard::{SafeguardKind, SafeguardViolation};
 pub use snapshot::MetadataSnapshot;

--- a/crates/voom-domain/src/media.rs
+++ b/crates/voom-domain/src/media.rs
@@ -7,6 +7,60 @@ use uuid::Uuid;
 
 use crate::transition::FileStatus;
 
+/// Crop rectangle expressed as pixels removed from each source edge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct CropRect {
+    pub left: u32,
+    pub top: u32,
+    pub right: u32,
+    pub bottom: u32,
+}
+
+impl CropRect {
+    #[must_use]
+    pub fn new(left: u32, top: u32, right: u32, bottom: u32) -> Self {
+        Self {
+            left,
+            top,
+            right,
+            bottom,
+        }
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.left == 0 && self.top == 0 && self.right == 0 && self.bottom == 0
+    }
+}
+
+/// Cached result from automatic black-bar detection.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct CropDetection {
+    pub rect: CropRect,
+    pub detected_at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub settings_fingerprint: Option<String>,
+}
+
+impl CropDetection {
+    #[must_use]
+    pub fn new(rect: CropRect, detected_at: DateTime<Utc>) -> Self {
+        Self {
+            rect,
+            detected_at,
+            settings_fingerprint: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_settings_fingerprint(mut self, fingerprint: String) -> Self {
+        self.settings_fingerprint = Some(fingerprint);
+        self
+    }
+}
+
 /// Cached fingerprint used to decide whether a previously-hashed file needs
 /// to be re-hashed during discovery.
 ///
@@ -41,6 +95,8 @@ pub struct MediaFile {
     pub container: Container,
     pub duration: f64,
     pub bitrate: Option<u32>,
+    #[serde(default)]
+    pub crop_detection: Option<CropDetection>,
     pub tracks: Vec<Track>,
     pub tags: HashMap<String, String>,
     pub plugin_metadata: HashMap<String, serde_json::Value>,
@@ -82,6 +138,7 @@ impl MediaFile {
             container: Container::Other,
             duration: 0.0,
             bitrate: None,
+            crop_detection: None,
             tracks: Vec::new(),
             tags: HashMap::new(),
             plugin_metadata: HashMap::new(),

--- a/crates/voom-domain/src/plan.rs
+++ b/crates/voom-domain/src/plan.rs
@@ -392,6 +392,34 @@ pub struct TranscodeSettings {
     pub hdr_mode: Option<String>,
     /// Encoder tuning hint (e.g. "film", "animation").
     pub tune: Option<String>,
+    /// Automatic crop settings for black-bar removal.
+    pub crop: Option<CropSettings>,
+}
+
+/// Automatic black-bar crop detection settings.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct CropSettings {
+    pub sample_duration_secs: Option<u32>,
+    pub sample_count: Option<u32>,
+    pub threshold: Option<u8>,
+    pub minimum_crop: Option<u32>,
+    pub preserve_bottom_pixels: Option<u32>,
+    pub aspect_lock: Vec<String>,
+}
+
+impl CropSettings {
+    #[must_use]
+    pub fn auto() -> Self {
+        Self {
+            sample_duration_secs: None,
+            sample_count: None,
+            threshold: None,
+            minimum_crop: None,
+            preserve_bottom_pixels: None,
+            aspect_lock: Vec::new(),
+        }
+    }
 }
 
 /// Deserialization helper for [`ActionParams`] that lifts legacy flat
@@ -458,6 +486,8 @@ enum ActionParamsCompat {
         hdr_mode: Option<String>,
         #[serde(default)]
         tune: Option<String>,
+        #[serde(default)]
+        crop: Option<CropSettings>,
     },
     Synthesize {
         name: String,
@@ -521,6 +551,7 @@ impl From<ActionParamsCompat> for ActionParams {
                 scale_algorithm,
                 hdr_mode,
                 tune,
+                crop,
             } => {
                 // If the nested `settings` object has values, use it.
                 // Otherwise, lift the legacy flat fields.
@@ -542,6 +573,7 @@ impl From<ActionParamsCompat> for ActionParams {
                         scale_algorithm,
                         hdr_mode,
                         tune,
+                        crop,
                         ..Default::default()
                     }
                 } else {
@@ -708,6 +740,12 @@ impl TranscodeSettings {
     #[must_use]
     pub fn with_tune(mut self, tune: Option<String>) -> Self {
         self.tune = tune;
+        self
+    }
+
+    #[must_use]
+    pub fn with_crop(mut self, crop: Option<CropSettings>) -> Self {
+        self.crop = crop;
         self
     }
 }

--- a/crates/voom-dsl/src/compiled.rs
+++ b/crates/voom-dsl/src/compiled.rs
@@ -9,7 +9,7 @@ use std::fmt;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 pub use voom_domain::media::Container;
-pub use voom_domain::plan::{SampleStrategy, TranscodeChannels, TranscodeFallback};
+pub use voom_domain::plan::{CropSettings, SampleStrategy, TranscodeChannels, TranscodeFallback};
 
 /// A pre-compiled regex that supports `Clone`, `Debug`, `Serialize`, and `Deserialize`.
 ///
@@ -306,6 +306,9 @@ pub struct CompiledTranscodeSettings {
     /// Encoder tuning hint (e.g. "film", "animation", "grain").
     #[serde(default)]
     pub tune: Option<String>,
+    /// Automatic or explicit crop settings.
+    #[serde(default)]
+    pub crop: Option<Box<CropSettings>>,
 }
 
 impl CompiledTranscodeSettings {
@@ -335,6 +338,7 @@ impl CompiledTranscodeSettings {
             scale_algorithm: None,
             hdr_mode: None,
             tune: None,
+            crop: None,
         }
     }
 }

--- a/crates/voom-dsl/src/compiler.rs
+++ b/crates/voom-dsl/src/compiler.rs
@@ -16,7 +16,7 @@ use crate::compiled::{
     CompiledTranscodeSettings, CompiledValueOrField, DefaultStrategy, ErrorStrategy, RulesMode,
     RunIfTrigger, SynthLanguage, SynthPosition, TrackTarget, TranscodeChannels,
 };
-use voom_domain::plan::{SampleStrategy, TranscodeFallback};
+use voom_domain::plan::{CropSettings, SampleStrategy, TranscodeFallback};
 use voom_domain::utils::codecs;
 
 use crate::ast::{
@@ -325,11 +325,47 @@ fn compile_transcode(target: &str, codec: &str, settings: &[(String, Value)]) ->
     compiled_settings.scale_algorithm = get_str("scale_algorithm");
     compiled_settings.hdr_mode = get_str("hdr_mode");
     compiled_settings.tune = get_str("tune");
+    compiled_settings.crop = compile_crop_settings(get, &get_str).map(Box::new);
 
     CompiledOperation::Transcode {
         target: parse_track_target(target),
         codec: canonical,
         settings: compiled_settings,
+    }
+}
+
+fn compile_crop_settings<'a>(
+    get: impl Fn(&str) -> Option<&'a Value>,
+    get_str: &impl Fn(&str) -> Option<String>,
+) -> Option<CropSettings> {
+    if get_str("crop").as_deref() != Some("auto") {
+        return None;
+    }
+
+    let mut crop = CropSettings::auto();
+    crop.sample_duration_secs = get_u32(get("crop_sample_duration"));
+    crop.sample_count = get_u32(get("crop_sample_count"));
+    crop.threshold = get_u32(get("crop_threshold")).and_then(|v| u8::try_from(v).ok());
+    crop.minimum_crop = get_u32(get("crop_minimum"));
+    crop.preserve_bottom_pixels = get_u32(get("crop_preserve_bottom_pixels"));
+    crop.aspect_lock = match get("crop_aspect_lock") {
+        Some(Value::List(items)) => items.iter().filter_map(value_as_string).collect(),
+        _ => Vec::new(),
+    };
+    Some(crop)
+}
+
+fn get_u32(value: Option<&Value>) -> Option<u32> {
+    match value {
+        Some(Value::Number(n, _)) => safe_u32(*n),
+        _ => None,
+    }
+}
+
+fn value_as_string(value: &Value) -> Option<String> {
+    match value {
+        Value::Ident(s) | Value::String(s) | Value::Number(_, s) => Some(s.clone()),
+        _ => None,
     }
 }
 
@@ -1469,6 +1505,50 @@ mod tests {
     fn compile_transcode_channels_named() {
         let s = transcode_with("channels", Value::Ident("stereo".into()));
         assert_eq!(s.channels, Some(TranscodeChannels::Named("stereo".into())));
+    }
+
+    #[test]
+    fn compile_transcode_crop_auto() {
+        let settings = vec![
+            ("crop".to_string(), Value::Ident("auto".into())),
+            (
+                "crop_sample_duration".to_string(),
+                Value::Number(30.0, "30".into()),
+            ),
+            (
+                "crop_sample_count".to_string(),
+                Value::Number(4.0, "4".into()),
+            ),
+            (
+                "crop_threshold".to_string(),
+                Value::Number(18.0, "18".into()),
+            ),
+            ("crop_minimum".to_string(), Value::Number(6.0, "6".into())),
+            (
+                "crop_preserve_bottom_pixels".to_string(),
+                Value::Number(40.0, "40".into()),
+            ),
+            (
+                "crop_aspect_lock".to_string(),
+                Value::List(vec![
+                    Value::String("16/9".into()),
+                    Value::String("4/3".into()),
+                ]),
+            ),
+        ];
+        let CompiledOperation::Transcode { settings, .. } =
+            compile_transcode("video", "hevc", &settings)
+        else {
+            unreachable!("compile_transcode always returns Transcode")
+        };
+        let crop = settings.crop.expect("crop settings should compile");
+
+        assert_eq!(crop.sample_duration_secs, Some(30));
+        assert_eq!(crop.sample_count, Some(4));
+        assert_eq!(crop.threshold, Some(18));
+        assert_eq!(crop.minimum_crop, Some(6));
+        assert_eq!(crop.preserve_bottom_pixels, Some(40));
+        assert_eq!(crop.aspect_lock, vec!["16/9", "4/3"]);
     }
 
     #[test]

--- a/crates/voom-dsl/src/validator.rs
+++ b/crates/voom-dsl/src/validator.rs
@@ -870,6 +870,13 @@ const KNOWN_TRANSCODE_KEYS: &[&str] = &[
     "scale_algorithm",
     "hdr_mode",
     "tune",
+    "crop",
+    "crop_sample_duration",
+    "crop_sample_count",
+    "crop_threshold",
+    "crop_minimum",
+    "crop_preserve_bottom_pixels",
+    "crop_aspect_lock",
 ];
 
 fn validate_transcode_keys(
@@ -1089,6 +1096,13 @@ const VIDEO_ONLY_KEYS: &[&str] = &[
     "min_bitrate",
     "sample_strategy",
     "fallback",
+    "crop",
+    "crop_sample_duration",
+    "crop_sample_count",
+    "crop_threshold",
+    "crop_minimum",
+    "crop_preserve_bottom_pixels",
+    "crop_aspect_lock",
 ];
 
 fn reject_video_only_keys(
@@ -1169,9 +1183,129 @@ fn validate_video_transcode_settings(
                     }
                 }
             }
+            "crop" => validate_crop_mode(val, line, col, errors),
+            "crop_sample_duration" | "crop_sample_count" => {
+                validate_crop_positive_integer(val, key, line, col, errors);
+            }
+            "crop_threshold" => {
+                validate_crop_integer_bounds(val, key, 0, 255, line, col, errors);
+            }
+            "crop_minimum" | "crop_preserve_bottom_pixels" => {
+                validate_crop_integer_bounds(val, key, 0, u32::MAX, line, col, errors);
+            }
+            "crop_aspect_lock" => validate_crop_aspect_lock(val, line, col, errors),
             _ => {}
         }
     }
+}
+
+fn validate_crop_mode(val: &Value, line: usize, col: usize, errors: &mut Vec<DslError>) {
+    match val {
+        Value::Ident(mode) | Value::String(mode) if mode == "auto" => {}
+        _ => errors.push(DslError::validation(
+            line,
+            col,
+            "crop must be auto".to_string(),
+        )),
+    }
+}
+
+fn validate_crop_positive_integer(
+    val: &Value,
+    key: &str,
+    line: usize,
+    col: usize,
+    errors: &mut Vec<DslError>,
+) {
+    let Some(value) = numeric_u32(val) else {
+        errors.push(DslError::validation(
+            line,
+            col,
+            format!("{key} must be a positive integer"),
+        ));
+        return;
+    };
+    if value == 0 {
+        errors.push(DslError::validation(
+            line,
+            col,
+            format!("{key} must be greater than 0"),
+        ));
+    }
+}
+
+fn validate_crop_integer_bounds(
+    val: &Value,
+    key: &str,
+    min: u32,
+    max: u32,
+    line: usize,
+    col: usize,
+    errors: &mut Vec<DslError>,
+) {
+    let Some(value) = numeric_u32(val) else {
+        errors.push(DslError::validation(
+            line,
+            col,
+            format!("{key} must be an integer"),
+        ));
+        return;
+    };
+    if value < min || value > max {
+        errors.push(DslError::validation(
+            line,
+            col,
+            format!("{key} must be from {min} to {max}"),
+        ));
+    }
+}
+
+fn validate_crop_aspect_lock(val: &Value, line: usize, col: usize, errors: &mut Vec<DslError>) {
+    let Value::List(items) = val else {
+        errors.push(DslError::validation(
+            line,
+            col,
+            "crop_aspect_lock must be a list of ratios like [16/9, 4/3]".to_string(),
+        ));
+        return;
+    };
+    for item in items {
+        let Some(ratio) = value_string(item) else {
+            errors.push(DslError::validation(
+                line,
+                col,
+                "crop_aspect_lock entries must be ratios like 16/9".to_string(),
+            ));
+            continue;
+        };
+        if !is_crop_ratio(ratio) {
+            errors.push(DslError::validation(
+                line,
+                col,
+                format!("invalid crop_aspect_lock ratio \"{ratio}\", expected WIDTH/HEIGHT"),
+            ));
+        }
+    }
+}
+
+fn value_string(value: &Value) -> Option<&str> {
+    match value {
+        Value::String(s) | Value::Ident(s) | Value::Number(_, s) => Some(s.as_str()),
+        _ => None,
+    }
+}
+
+fn is_crop_ratio(value: &str) -> bool {
+    let Some((width, height)) = value.split_once('/') else {
+        return false;
+    };
+    let Ok(width) = width.parse::<u32>() else {
+        return false;
+    };
+    let Ok(height) = height.parse::<u32>() else {
+        return false;
+    };
+    width > 0 && height > 0
 }
 
 fn validate_vmaf_transcode_settings(
@@ -2061,6 +2195,66 @@ mod tests {
             }
             _ => panic!("expected validation error"),
         }
+    }
+
+    #[test]
+    fn test_transcode_crop_settings_validate() {
+        let input = r#"policy "test" {
+            phase tc {
+                transcode video to hevc {
+                    crop: auto
+                    crop_sample_duration: 30
+                    crop_sample_count: 4
+                    crop_threshold: 18
+                    crop_minimum: 6
+                    crop_preserve_bottom_pixels: 40
+                    crop_aspect_lock: ["16/9", "4/3"]
+                }
+            }
+        }"#;
+        let ast = parse_policy(input).unwrap();
+        validate(&ast).unwrap();
+    }
+
+    #[test]
+    fn test_transcode_crop_rejected_for_audio() {
+        let input = r#"policy "test" {
+            phase tc {
+                transcode audio to aac {
+                    crop: auto
+                }
+            }
+        }"#;
+        let ast = parse_policy(input).unwrap();
+        let err = validate(&ast).unwrap_err();
+        assert!(
+            err.errors
+                .iter()
+                .any(|e| format!("{e}").contains("crop is only valid for video transcodes")),
+            "expected video-only crop error, got: {:?}",
+            err.errors
+        );
+    }
+
+    #[test]
+    fn test_transcode_crop_invalid_aspect_lock() {
+        let input = r#"policy "test" {
+            phase tc {
+                transcode video to hevc {
+                    crop: auto
+                    crop_aspect_lock: ["16x9"]
+                }
+            }
+        }"#;
+        let ast = parse_policy(input).unwrap();
+        let err = validate(&ast).unwrap_err();
+        assert!(
+            err.errors
+                .iter()
+                .any(|e| format!("{e}").contains("invalid crop_aspect_lock ratio")),
+            "expected aspect lock error, got: {:?}",
+            err.errors
+        );
     }
 
     #[test]

--- a/crates/voom-dsl/src/validator.rs
+++ b/crates/voom-dsl/src/validator.rs
@@ -1132,6 +1132,9 @@ fn validate_video_transcode_settings(
     col: usize,
     errors: &mut Vec<DslError>,
 ) {
+    let crop_enabled = settings.iter().any(|(key, val)| {
+        key == "crop" && matches!(val, Value::Ident(mode) | Value::String(mode) if mode == "auto")
+    });
     for (key, val) in settings {
         match key.as_str() {
             "hdr_mode" => {
@@ -1185,17 +1188,39 @@ fn validate_video_transcode_settings(
             }
             "crop" => validate_crop_mode(val, line, col, errors),
             "crop_sample_duration" | "crop_sample_count" => {
+                validate_crop_enabled(crop_enabled, key, line, col, errors);
                 validate_crop_positive_integer(val, key, line, col, errors);
             }
             "crop_threshold" => {
+                validate_crop_enabled(crop_enabled, key, line, col, errors);
                 validate_crop_integer_bounds(val, key, 0, 255, line, col, errors);
             }
             "crop_minimum" | "crop_preserve_bottom_pixels" => {
+                validate_crop_enabled(crop_enabled, key, line, col, errors);
                 validate_crop_integer_bounds(val, key, 0, u32::MAX, line, col, errors);
             }
-            "crop_aspect_lock" => validate_crop_aspect_lock(val, line, col, errors),
+            "crop_aspect_lock" => {
+                validate_crop_enabled(crop_enabled, key, line, col, errors);
+                validate_crop_aspect_lock(val, line, col, errors);
+            }
             _ => {}
         }
+    }
+}
+
+fn validate_crop_enabled(
+    crop_enabled: bool,
+    key: &str,
+    line: usize,
+    col: usize,
+    errors: &mut Vec<DslError>,
+) {
+    if !crop_enabled {
+        errors.push(DslError::validation(
+            line,
+            col,
+            format!("{key} has no effect without crop: auto"),
+        ));
     }
 }
 
@@ -2253,6 +2278,26 @@ mod tests {
                 .iter()
                 .any(|e| format!("{e}").contains("invalid crop_aspect_lock ratio")),
             "expected aspect lock error, got: {:?}",
+            err.errors
+        );
+    }
+
+    #[test]
+    fn test_transcode_crop_tuning_requires_crop_auto() {
+        let input = r#"policy "test" {
+            phase tc {
+                transcode video to hevc {
+                    crop_threshold: 18
+                }
+            }
+        }"#;
+        let ast = parse_policy(input).unwrap();
+        let err = validate(&ast).unwrap_err();
+        assert!(
+            err.errors
+                .iter()
+                .any(|e| format!("{e}").contains("crop_threshold has no effect without crop: auto")),
+            "expected crop tuning no-op error, got: {:?}",
             err.errors
         );
     }

--- a/docs/dsl-reference.md
+++ b/docs/dsl-reference.md
@@ -275,6 +275,37 @@ transcode video to hevc {
   tune: film                 // encoder tuning: film | animation | grain | ...
   hw: auto                   // hardware acceleration: auto | nvenc | qsv | vaapi | none
   hw_fallback: true          // fall back to software if HW fails
+  crop: auto                 // detect and remove black bars before encoding
+}
+```
+
+Auto-crop runs FFmpeg's `cropdetect` filter before the transcode, caches the
+detected crop rectangle on the file record, and reuses the cached result on
+later runs. Crop values are stored as pixels removed from the left, top, right,
+and bottom edges.
+
+| Setting | Type | Description |
+|---------|------|-------------|
+| `crop` | identifier | Enable automatic crop detection. The only supported value is `auto`. |
+| `crop_sample_duration` | integer | Seconds to inspect per sample. Default: `60`. |
+| `crop_sample_count` | integer | Number of samples across the file. Default: `3`. |
+| `crop_threshold` | integer | FFmpeg cropdetect luma threshold, `0`-`255`. Default: `24`. |
+| `crop_minimum` | integer | Ignore edge crops smaller than this many pixels. Default: `4`. |
+| `crop_preserve_bottom_pixels` | integer | Reduce the detected bottom crop by this many pixels, useful for subtitles or captions near the lower edge. Default: `0`. |
+| `crop_aspect_lock` | list | Optional ratio strings such as `["16/9", "4/3"]`; VOOM expands the crop to the closest reachable ratio without cropping deeper. |
+
+Example:
+
+```
+transcode video to hevc {
+  crf: 20
+  crop: auto
+  crop_sample_duration: 60
+  crop_sample_count: 3
+  crop_threshold: 24
+  crop_minimum: 4
+  crop_preserve_bottom_pixels: 60
+  crop_aspect_lock: ["16/9", "4/3"]
 }
 ```
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -18,7 +18,7 @@ Multi-language anime library with Japanese/English handling. Forced subtitle det
 **Plugins used:** all native + sonarr-metadata (WASM)
 
 ### [transcode-hevc.voom](transcode-hevc.voom)
-HEVC transcoding pipeline with hardware acceleration. `skip when` with field access, video/audio transcode settings, `synthesize` with all options (codec, channels, source, bitrate, skip_if_exists, create_if, title, language, position), `run_if` conditional phases.
+HEVC transcoding pipeline with hardware acceleration. `skip when` with field access, video/audio transcode settings, auto-crop tuning, `synthesize` with all options (codec, channels, source, bitrate, skip_if_exists, create_if, title, language, position), `run_if` conditional phases.
 
 **Plugins used:** ffmpeg-executor, mkvtoolnix-executor, backup-manager
 
@@ -57,6 +57,7 @@ Comprehensive reference exercising **every DSL construct**. Not intended for pro
 | `defaults` | movie-library, anime, strict, full |
 | `actions` (video/audio/subtitle) | movie-library, anime, strict, full |
 | `transcode` (video/audio) | transcode, full |
+| `crop: auto` | transcode |
 | `synthesize` | transcode, full |
 | `when` / `else` | anime, metadata, full |
 | `rules first` | metadata, full |

--- a/docs/examples/tests/minimal.snapshot.json
+++ b/docs/examples/tests/minimal.snapshot.json
@@ -17,6 +17,7 @@
       "bitrate": null,
       "container": "Mp4",
       "content_hash": null,
+      "crop_detection": null,
       "duration": 120.0,
       "expected_hash": null,
       "id": null,

--- a/docs/examples/transcode-hevc.voom
+++ b/docs/examples/transcode-hevc.voom
@@ -3,7 +3,7 @@
 // Transcodes video to HEVC and audio to AAC, with synthesized
 // compatibility stereo track. Demonstrates:
 // - skip when with field access (video.codec)
-// - Transcode video with full settings (crf, preset, hw accel, resolution)
+// - Transcode video with full settings (crf, preset, hw accel, resolution, auto-crop)
 // - Transcode audio with codec preservation
 // - synthesize with all settings (codec, channels, source, bitrate,
 //   skip_if_exists, create_if, title, language, position)
@@ -37,6 +37,13 @@ policy "transcode-hevc" {
       hw_fallback: true
       hdr_mode: preserve
       tune: film
+      crop: auto
+      crop_sample_duration: 60
+      crop_sample_count: 3
+      crop_threshold: 24
+      crop_minimum: 4
+      crop_preserve_bottom_pixels: 60
+      crop_aspect_lock: ["16/9", "4/3"]
     }
   }
 

--- a/plugins/ffmpeg-executor/src/command.rs
+++ b/plugins/ffmpeg-executor/src/command.rs
@@ -302,10 +302,17 @@ fn resolve_effective_hw<'a>(
 
 /// Build the list of video filters from transcode settings.
 ///
-/// Combines scale (from `max_resolution`) and tonemap (from `hdr_mode`)
+/// Combines crop, scale (from `max_resolution`), and tonemap (from `hdr_mode`)
 /// filters into a single list suitable for joining with commas.
-fn collect_video_filters(settings: &voom_domain::plan::TranscodeSettings) -> Vec<String> {
+fn collect_video_filters(file: &MediaFile, action: &PlannedAction) -> Vec<String> {
+    let ActionParams::Transcode { settings, .. } = &action.parameters else {
+        return Vec::new();
+    };
     let mut filters: Vec<String> = Vec::new();
+
+    if let Some(filter) = crop_filter(file, action, settings) {
+        filters.push(filter);
+    }
 
     if let Some(ref max_res) = settings.max_resolution {
         if let Some(max_h) = parse_max_height(max_res) {
@@ -326,17 +333,48 @@ fn collect_video_filters(settings: &voom_domain::plan::TranscodeSettings) -> Vec
     filters
 }
 
+fn crop_filter(
+    file: &MediaFile,
+    action: &PlannedAction,
+    settings: &voom_domain::plan::TranscodeSettings,
+) -> Option<String> {
+    settings.crop.as_ref()?;
+    let detection = file.crop_detection.as_ref()?;
+    if detection.rect.is_empty() {
+        return None;
+    }
+    let track = source_video_track(file, action)?;
+    let source_width = track.width?;
+    let source_height = track.height?;
+    let width = source_width
+        .checked_sub(detection.rect.left)?
+        .checked_sub(detection.rect.right)?;
+    let height = source_height
+        .checked_sub(detection.rect.top)?
+        .checked_sub(detection.rect.bottom)?;
+    let width = width - (width % 2);
+    let height = height - (height % 2);
+    if width == 0 || height == 0 {
+        return None;
+    }
+    Some(format!(
+        "crop={width}:{height}:{}:{}",
+        detection.rect.left, detection.rect.top
+    ))
+}
+
 fn requires_software_video_filters(settings: &voom_domain::plan::TranscodeSettings) -> bool {
     let scales_video = settings
         .max_resolution
         .as_deref()
         .and_then(parse_max_height)
         .is_some();
-    scales_video || settings.hdr_mode.as_deref() == Some("tonemap")
+    scales_video || settings.hdr_mode.as_deref() == Some("tonemap") || settings.crop.is_some()
 }
 
 fn apply_transcode_video(
     mut cmd: FfmpegCommand,
+    file: &MediaFile,
     action: &PlannedAction,
     hw_accel: Option<&HwAccelConfig>,
 ) -> Result<FfmpegCommand> {
@@ -399,7 +437,7 @@ fn apply_transcode_video(
         cmd = cmd.arg("-b:v").arg(brate);
     }
 
-    let filters = collect_video_filters(settings);
+    let filters = collect_video_filters(file, action);
     if !filters.is_empty() {
         cmd = cmd.video_filter(&filters.join(","));
     }
@@ -547,7 +585,7 @@ pub fn build_ffmpeg_command(
                 // Container conversion is handled by output extension; codecs stay as copy
             }
             OperationType::TranscodeVideo => {
-                cmd = apply_transcode_video(cmd, action, hw_accel)?;
+                cmd = apply_transcode_video(cmd, file, action, hw_accel)?;
             }
             OperationType::TranscodeAudio => {
                 cmd = apply_transcode_audio(cmd, action);
@@ -652,9 +690,10 @@ pub fn output_extension(file: &MediaFile, actions: &[&PlannedAction]) -> String 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::Utc;
     use std::path::PathBuf;
-    use voom_domain::media::{Container, MediaFile, Track, TrackType};
-    use voom_domain::plan::TranscodeSettings;
+    use voom_domain::media::{Container, CropDetection, CropRect, MediaFile, Track, TrackType};
+    use voom_domain::plan::{CropSettings, TranscodeSettings};
 
     fn sample_mp4_file() -> MediaFile {
         let mut file = MediaFile::new(PathBuf::from("/media/video.mp4"));
@@ -736,6 +775,37 @@ mod tests {
         assert!(args.contains(&"23".to_string()));
         assert!(args.contains(&"-preset".to_string()));
         assert!(args.contains(&"medium".to_string()));
+    }
+
+    #[test]
+    fn test_build_command_transcode_video_auto_crop_filter() {
+        let mut file = sample_mp4_file();
+        file.crop_detection = Some(CropDetection::new(
+            CropRect::new(0, 132, 0, 132),
+            Utc::now(),
+        ));
+        file.tracks[0].width = Some(1920);
+        file.tracks[0].height = Some(1080);
+        let action = PlannedAction::track_op(
+            OperationType::TranscodeVideo,
+            0,
+            ActionParams::Transcode {
+                codec: "hevc".into(),
+                settings: TranscodeSettings::default().with_crop(Some(CropSettings::auto())),
+            },
+            "Transcode video to HEVC with auto crop",
+        );
+        let actions: Vec<&PlannedAction> = vec![&action];
+        let output = Path::new("/tmp/output.mp4");
+
+        let args = build_ffmpeg_command(&file, &actions, output, None).unwrap();
+
+        let filter_arg = args
+            .iter()
+            .position(|arg| arg == "-vf")
+            .and_then(|idx| args.get(idx + 1))
+            .expect("video filter should be emitted");
+        assert_eq!(filter_arg, "crop=1920:816:0:132");
     }
 
     #[test]

--- a/plugins/ffmpeg-executor/src/cropdetect.rs
+++ b/plugins/ffmpeg-executor/src/cropdetect.rs
@@ -1,0 +1,498 @@
+//! Automatic black-bar detection using FFmpeg's `cropdetect` filter.
+
+use std::path::Path;
+use std::time::Duration;
+
+use chrono::Utc;
+use voom_domain::errors::{Result, VoomError};
+use voom_domain::media::{CropDetection, CropRect};
+use voom_domain::plan::CropSettings;
+
+const DEFAULT_SAMPLE_DURATION_SECS: u32 = 60;
+const DEFAULT_SAMPLE_COUNT: u32 = 3;
+const DEFAULT_THRESHOLD: u8 = 24;
+const DEFAULT_MINIMUM_CROP: u32 = 4;
+const DEFAULT_TIMEOUT_SECS: u64 = 300;
+
+/// Source dimensions and duration needed to convert `cropdetect` output into edge crops.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CropDetectSource {
+    pub width: u32,
+    pub height: u32,
+    pub duration_secs: f64,
+}
+
+impl CropDetectSource {
+    #[must_use]
+    pub fn new(width: u32, height: u32, duration_secs: f64) -> Self {
+        Self {
+            width,
+            height,
+            duration_secs,
+        }
+    }
+}
+
+/// Run FFmpeg crop detection and return a cached crop value when useful.
+///
+/// # Errors
+/// Returns `VoomError::ToolExecution` if `ffmpeg` fails or emits invalid crop values.
+pub fn detect_crop(
+    ffmpeg_path: &str,
+    source_path: &Path,
+    source: CropDetectSource,
+    settings: &CropSettings,
+) -> Result<Option<CropDetection>> {
+    let config = CropDetectConfig::from(settings);
+    let rects = detect_sample_rects(ffmpeg_path, source_path, source, &config)?;
+    let Some(rect) = conservative_crop(&rects, source, &config)? else {
+        return Ok(None);
+    };
+    if rect.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(CropDetection::new(rect, Utc::now())))
+}
+
+fn detect_sample_rects(
+    ffmpeg_path: &str,
+    source_path: &Path,
+    source: CropDetectSource,
+    config: &CropDetectConfig,
+) -> Result<Vec<CropRect>> {
+    let mut rects = Vec::new();
+    for start in sample_starts(
+        source.duration_secs,
+        config.sample_count,
+        config.sample_duration_secs,
+    ) {
+        let stderr = run_cropdetect_sample(ffmpeg_path, source_path, start, config)?;
+        rects.extend(parse_cropdetect_rects(&stderr, source)?);
+    }
+    Ok(rects)
+}
+
+fn run_cropdetect_sample(
+    ffmpeg_path: &str,
+    source_path: &Path,
+    start_secs: f64,
+    config: &CropDetectConfig,
+) -> Result<String> {
+    let duration = config.sample_duration_secs.to_string();
+    let start = format!("{start_secs:.3}");
+    let filter = format!("cropdetect=limit={}:round=2", config.threshold);
+    let args = [
+        "-hide_banner",
+        "-ss",
+        &start,
+        "-t",
+        &duration,
+        "-i",
+        &source_path.to_string_lossy(),
+        "-vf",
+        &filter,
+        "-f",
+        "null",
+        "-",
+    ];
+    let output = voom_process::run_with_timeout(
+        ffmpeg_path,
+        &args,
+        Duration::from_secs(DEFAULT_TIMEOUT_SECS),
+    )?;
+    if !output.status.success() {
+        return Err(VoomError::ToolExecution {
+            tool: ffmpeg_path.to_string(),
+            message: format!(
+                "cropdetect failed with {}:\n{}",
+                output.status,
+                voom_process::stderr_tail(&output.stderr, 20)
+            ),
+        });
+    }
+    Ok(String::from_utf8_lossy(&output.stderr).to_string())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CropDetectConfig {
+    sample_duration_secs: u32,
+    sample_count: u32,
+    threshold: u8,
+    minimum_crop: u32,
+    preserve_bottom_pixels: u32,
+    aspect_locks: Vec<AspectRatio>,
+}
+
+impl From<&CropSettings> for CropDetectConfig {
+    fn from(settings: &CropSettings) -> Self {
+        Self {
+            sample_duration_secs: settings
+                .sample_duration_secs
+                .unwrap_or(DEFAULT_SAMPLE_DURATION_SECS)
+                .max(1),
+            sample_count: settings.sample_count.unwrap_or(DEFAULT_SAMPLE_COUNT).max(1),
+            threshold: settings.threshold.unwrap_or(DEFAULT_THRESHOLD),
+            minimum_crop: settings.minimum_crop.unwrap_or(DEFAULT_MINIMUM_CROP),
+            preserve_bottom_pixels: settings.preserve_bottom_pixels.unwrap_or(0),
+            aspect_locks: settings
+                .aspect_lock
+                .iter()
+                .filter_map(|value| AspectRatio::parse(value))
+                .collect(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct AspectRatio {
+    width: u32,
+    height: u32,
+}
+
+impl AspectRatio {
+    fn parse(value: &str) -> Option<Self> {
+        let (width, height) = value.split_once('/')?;
+        let width = width.parse().ok()?;
+        let height = height.parse().ok()?;
+        if width == 0 || height == 0 {
+            return None;
+        }
+        Some(Self { width, height })
+    }
+}
+
+fn sample_starts(duration_secs: f64, count: u32, sample_duration_secs: u32) -> Vec<f64> {
+    if duration_secs <= 0.0 || count == 1 {
+        return vec![0.0];
+    }
+    let latest_start = (duration_secs - f64::from(sample_duration_secs)).max(0.0);
+    if latest_start == 0.0 {
+        return vec![0.0];
+    }
+    (0..count)
+        .map(|idx| latest_start * f64::from(idx) / f64::from(count - 1))
+        .collect()
+}
+
+fn parse_cropdetect_rects(stderr: &str, source: CropDetectSource) -> Result<Vec<CropRect>> {
+    stderr
+        .lines()
+        .filter_map(parse_crop_line)
+        .map(|crop| crop.to_rect(source))
+        .collect()
+}
+
+fn parse_crop_line(line: &str) -> Option<DetectedCrop> {
+    let crop = line.split("crop=").last()?;
+    let mut parts = crop.split(|c: char| c == ':' || c.is_whitespace());
+    Some(DetectedCrop {
+        width: parts.next()?.parse().ok()?,
+        height: parts.next()?.parse().ok()?,
+        x: parts.next()?.parse().ok()?,
+        y: parts.next()?.parse().ok()?,
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct DetectedCrop {
+    width: u32,
+    height: u32,
+    x: u32,
+    y: u32,
+}
+
+impl DetectedCrop {
+    fn to_rect(self, source: CropDetectSource) -> Result<CropRect> {
+        let right = source
+            .width
+            .checked_sub(self.x)
+            .and_then(|v| v.checked_sub(self.width))
+            .ok_or_else(|| invalid_crop("crop width exceeds source width"))?;
+        let bottom = source
+            .height
+            .checked_sub(self.y)
+            .and_then(|v| v.checked_sub(self.height))
+            .ok_or_else(|| invalid_crop("crop height exceeds source height"))?;
+        Ok(CropRect::new(self.x, self.y, right, bottom))
+    }
+}
+
+fn conservative_crop(
+    rects: &[CropRect],
+    source: CropDetectSource,
+    config: &CropDetectConfig,
+) -> Result<Option<CropRect>> {
+    let Some(first) = rects.first().copied() else {
+        return Ok(None);
+    };
+    let mut rect = rects.iter().skip(1).fold(first, |acc, item| {
+        CropRect::new(
+            acc.left.min(item.left),
+            acc.top.min(item.top),
+            acc.right.min(item.right),
+            acc.bottom.min(item.bottom),
+        )
+    });
+    rect = apply_minimum_crop(rect, config.minimum_crop);
+    rect.bottom = rect.bottom.saturating_sub(config.preserve_bottom_pixels);
+    rect = snap_to_aspect_lock(rect, source, &config.aspect_locks)?;
+    rect = snap_output_to_even(rect, source)?;
+    Ok(Some(rect))
+}
+
+fn apply_minimum_crop(rect: CropRect, minimum: u32) -> CropRect {
+    let side = |value| if value < minimum { 0 } else { value };
+    CropRect::new(
+        side(rect.left),
+        side(rect.top),
+        side(rect.right),
+        side(rect.bottom),
+    )
+}
+
+fn snap_to_aspect_lock(
+    rect: CropRect,
+    source: CropDetectSource,
+    aspect_locks: &[AspectRatio],
+) -> Result<CropRect> {
+    if aspect_locks.is_empty() {
+        return Ok(rect);
+    }
+    let original_dims = output_dimensions(rect, source)?;
+    let mut best: Option<(CropRect, u64)> = None;
+    for ratio in aspect_locks {
+        let Some((candidate, candidate_dims)) = snap_to_aspect(rect, source, original_dims, *ratio)
+        else {
+            continue;
+        };
+        let expanded_pixels = candidate_dims.area().saturating_sub(original_dims.area());
+        if best
+            .as_ref()
+            .is_none_or(|(_, best_pixels)| expanded_pixels < *best_pixels)
+        {
+            best = Some((candidate, expanded_pixels));
+        }
+    }
+    Ok(best.map_or(rect, |(candidate, _)| candidate))
+}
+
+fn snap_to_aspect(
+    rect: CropRect,
+    source: CropDetectSource,
+    dims: OutputDimensions,
+    ratio: AspectRatio,
+) -> Option<(CropRect, OutputDimensions)> {
+    let current = u64::from(dims.width) * u64::from(ratio.height);
+    let target = u64::from(dims.height) * u64::from(ratio.width);
+    if current == target {
+        return Some((rect, dims));
+    }
+    if current > target {
+        let height = even_u64_to_u32(
+            (u64::from(dims.width) * u64::from(ratio.height)).div_ceil(u64::from(ratio.width)),
+        )?;
+        if height > source.height {
+            return None;
+        }
+        let (top, bottom) = expand_axis(rect.top, rect.bottom, height - dims.height)?;
+        return Some((
+            CropRect::new(rect.left, top, rect.right, bottom),
+            OutputDimensions {
+                width: dims.width,
+                height,
+            },
+        ));
+    }
+
+    let width = even_u64_to_u32(
+        (u64::from(dims.height) * u64::from(ratio.width)).div_ceil(u64::from(ratio.height)),
+    )?;
+    if width > source.width {
+        return None;
+    }
+    let (left, right) = expand_axis(rect.left, rect.right, width - dims.width)?;
+    Some((
+        CropRect::new(left, rect.top, right, rect.bottom),
+        OutputDimensions {
+            width,
+            height: dims.height,
+        },
+    ))
+}
+
+#[derive(Debug, Clone, Copy)]
+struct OutputDimensions {
+    width: u32,
+    height: u32,
+}
+
+impl OutputDimensions {
+    fn area(self) -> u64 {
+        u64::from(self.width) * u64::from(self.height)
+    }
+}
+
+fn output_dimensions(rect: CropRect, source: CropDetectSource) -> Result<OutputDimensions> {
+    let width = source
+        .width
+        .checked_sub(rect.left)
+        .and_then(|v| v.checked_sub(rect.right))
+        .ok_or_else(|| invalid_crop("crop removes all source width"))?;
+    let height = source
+        .height
+        .checked_sub(rect.top)
+        .and_then(|v| v.checked_sub(rect.bottom))
+        .ok_or_else(|| invalid_crop("crop removes all source height"))?;
+    if width == 0 || height == 0 {
+        return Err(invalid_crop("crop leaves empty output"));
+    }
+    Ok(OutputDimensions { width, height })
+}
+
+fn even_u64_to_u32(value: u64) -> Option<u32> {
+    let value = value.checked_add(value % 2)?;
+    u32::try_from(value).ok()
+}
+
+fn expand_axis(start_crop: u32, end_crop: u32, expand_by: u32) -> Option<(u32, u32)> {
+    if expand_by > start_crop.saturating_add(end_crop) {
+        return None;
+    }
+    let from_start = (expand_by / 2).min(start_crop);
+    let remaining = expand_by - from_start;
+    let from_end = remaining.min(end_crop);
+    let remaining = remaining - from_end;
+    if remaining > start_crop - from_start {
+        return None;
+    }
+    Some((start_crop - from_start - remaining, end_crop - from_end))
+}
+
+fn snap_output_to_even(mut rect: CropRect, source: CropDetectSource) -> Result<CropRect> {
+    let dims = output_dimensions(rect, source)?;
+    if dims.width % 2 != 0 {
+        rect.right = rect.right.saturating_add(1);
+    }
+    if dims.height % 2 != 0 {
+        rect.bottom = rect.bottom.saturating_add(1);
+    }
+    Ok(rect)
+}
+
+fn invalid_crop(message: &str) -> VoomError {
+    VoomError::ToolExecution {
+        tool: "ffmpeg".into(),
+        message: message.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn source() -> CropDetectSource {
+        CropDetectSource::new(1920, 1080, 7200.0)
+    }
+
+    fn config(settings: &CropSettings) -> CropDetectConfig {
+        CropDetectConfig::from(settings)
+    }
+
+    #[test]
+    fn parses_cropdetect_lines_into_edge_crop() {
+        let stderr = "[Parsed_cropdetect_0 @ 0x123] crop=1920:816:0:132\n\
+                      [Parsed_cropdetect_0 @ 0x123] crop=1918:816:2:132";
+
+        let rects = parse_cropdetect_rects(stderr, source()).unwrap();
+
+        assert_eq!(rects[0], CropRect::new(0, 132, 0, 132));
+        assert_eq!(rects[1], CropRect::new(2, 132, 0, 132));
+    }
+
+    #[test]
+    fn conservative_crop_uses_smallest_edge_crop_across_samples() {
+        let rects = [
+            CropRect::new(0, 132, 0, 132),
+            CropRect::new(0, 138, 0, 126),
+            CropRect::new(10, 132, 8, 132),
+        ];
+
+        let crop = conservative_crop(&rects, source(), &config(&CropSettings::auto()))
+            .unwrap()
+            .expect("crop");
+
+        assert_eq!(crop, CropRect::new(0, 132, 0, 126));
+    }
+
+    #[test]
+    fn minimum_crop_discards_tiny_edge_changes() {
+        let rects = [CropRect::new(2, 6, 3, 8)];
+        let mut settings = CropSettings::auto();
+        settings.minimum_crop = Some(4);
+
+        let crop = conservative_crop(&rects, source(), &config(&settings))
+            .unwrap()
+            .expect("crop");
+
+        assert_eq!(crop, CropRect::new(0, 6, 0, 8));
+    }
+
+    #[test]
+    fn preserve_bottom_pixels_reduces_bottom_crop() {
+        let rects = [CropRect::new(0, 132, 0, 132)];
+        let mut settings = CropSettings::auto();
+        settings.preserve_bottom_pixels = Some(60);
+
+        let crop = conservative_crop(&rects, source(), &config(&settings))
+            .unwrap()
+            .expect("crop");
+
+        assert_eq!(crop, CropRect::new(0, 132, 0, 72));
+    }
+
+    #[test]
+    fn aspect_lock_expands_height_without_cropping_deeper() {
+        let rects = [CropRect::new(0, 132, 0, 132)];
+        let mut settings = CropSettings::auto();
+        settings.aspect_lock = vec!["21/9".to_string()];
+
+        let crop = conservative_crop(&rects, source(), &config(&settings))
+            .unwrap()
+            .expect("crop");
+
+        assert_eq!(crop, CropRect::new(0, 128, 0, 128));
+    }
+
+    #[test]
+    fn aspect_lock_expands_width_when_source_has_room() {
+        let rects = [CropRect::new(300, 0, 300, 0)];
+        let mut settings = CropSettings::auto();
+        settings.aspect_lock = vec!["4/3".to_string()];
+
+        let crop = conservative_crop(&rects, source(), &config(&settings))
+            .unwrap()
+            .expect("crop");
+
+        assert_eq!(crop, CropRect::new(240, 0, 240, 0));
+    }
+
+    #[test]
+    fn aspect_lock_ignores_unreachable_ratio() {
+        let rects = [CropRect::new(0, 132, 0, 132)];
+        let mut settings = CropSettings::auto();
+        settings.aspect_lock = vec!["1/1".to_string()];
+
+        let crop = conservative_crop(&rects, source(), &config(&settings))
+            .unwrap()
+            .expect("crop");
+
+        assert_eq!(crop, CropRect::new(0, 132, 0, 132));
+    }
+
+    #[test]
+    fn sample_starts_cover_start_middle_and_end() {
+        let starts = sample_starts(7200.0, 3, 60);
+
+        assert_eq!(starts, vec![0.0, 3570.0, 7140.0]);
+    }
+}

--- a/plugins/ffmpeg-executor/src/lib.rs
+++ b/plugins/ffmpeg-executor/src/lib.rs
@@ -4,6 +4,7 @@
 //! and metadata operations on non-MKV files (or any file requiring transcode).
 
 pub mod command;
+pub mod cropdetect;
 pub mod executor;
 pub mod hwaccel;
 pub mod probe;

--- a/plugins/policy-evaluator/src/evaluator.rs
+++ b/plugins/policy-evaluator/src/evaluator.rs
@@ -44,6 +44,7 @@ fn transcode_settings_from(s: &CompiledTranscodeSettings) -> TranscodeSettings {
         .with_scale_algorithm(s.scale_algorithm.clone())
         .with_hdr_mode(s.hdr_mode.clone())
         .with_tune(s.tune.clone())
+        .with_crop(s.crop.as_deref().cloned())
 }
 
 /// Result of evaluating a full policy against a file.

--- a/plugins/sqlite-store/src/schema.rs
+++ b/plugins/sqlite-store/src/schema.rs
@@ -15,6 +15,12 @@ CREATE TABLE IF NOT EXISTS files (
     container TEXT NOT NULL,
     duration REAL,
     bitrate INTEGER,
+    crop_left INTEGER,
+    crop_top INTEGER,
+    crop_right INTEGER,
+    crop_bottom INTEGER,
+    crop_detected_at TEXT,
+    crop_settings_fingerprint TEXT,
     tags TEXT,
     plugin_metadata TEXT,
     introspected_at TEXT NOT NULL,
@@ -353,6 +359,24 @@ fn migrate_files_columns(
     }
     if !has_column("files", "superseded_by")? {
         conn.execute_batch("ALTER TABLE files ADD COLUMN superseded_by TEXT")?;
+    }
+    if !has_column("files", "crop_left")? {
+        conn.execute_batch("ALTER TABLE files ADD COLUMN crop_left INTEGER")?;
+    }
+    if !has_column("files", "crop_top")? {
+        conn.execute_batch("ALTER TABLE files ADD COLUMN crop_top INTEGER")?;
+    }
+    if !has_column("files", "crop_right")? {
+        conn.execute_batch("ALTER TABLE files ADD COLUMN crop_right INTEGER")?;
+    }
+    if !has_column("files", "crop_bottom")? {
+        conn.execute_batch("ALTER TABLE files ADD COLUMN crop_bottom INTEGER")?;
+    }
+    if !has_column("files", "crop_detected_at")? {
+        conn.execute_batch("ALTER TABLE files ADD COLUMN crop_detected_at TEXT")?;
+    }
+    if !has_column("files", "crop_settings_fingerprint")? {
+        conn.execute_batch("ALTER TABLE files ADD COLUMN crop_settings_fingerprint TEXT")?;
     }
     Ok(())
 }

--- a/plugins/sqlite-store/src/store/file_storage.rs
+++ b/plugins/sqlite-store/src/store/file_storage.rs
@@ -58,8 +58,8 @@ impl FileStorage for SqliteStore {
         .map_err(storage_err("failed to delete old tracks"))?;
 
         tx.execute(
-            "INSERT INTO files (id, path, filename, size, content_hash, status, container, duration, bitrate, tags, plugin_metadata, introspected_at, created_at, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
+            "INSERT INTO files (id, path, filename, size, content_hash, status, container, duration, bitrate, crop_left, crop_top, crop_right, crop_bottom, crop_detected_at, crop_settings_fingerprint, tags, plugin_metadata, introspected_at, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20)
              ON CONFLICT(path) DO UPDATE SET
                 filename = excluded.filename,
                 size = excluded.size,
@@ -68,6 +68,12 @@ impl FileStorage for SqliteStore {
                 container = excluded.container,
                 duration = excluded.duration,
                 bitrate = excluded.bitrate,
+                crop_left = excluded.crop_left,
+                crop_top = excluded.crop_top,
+                crop_right = excluded.crop_right,
+                crop_bottom = excluded.crop_bottom,
+                crop_detected_at = excluded.crop_detected_at,
+                crop_settings_fingerprint = excluded.crop_settings_fingerprint,
                 tags = excluded.tags,
                 plugin_metadata = excluded.plugin_metadata,
                 introspected_at = excluded.introspected_at,
@@ -82,6 +88,18 @@ impl FileStorage for SqliteStore {
                 file.container.as_str(),
                 file.duration,
                 file.bitrate.map(i64::from),
+                file.crop_detection.as_ref().map(|d| i64::from(d.rect.left)),
+                file.crop_detection.as_ref().map(|d| i64::from(d.rect.top)),
+                file.crop_detection.as_ref().map(|d| i64::from(d.rect.right)),
+                file.crop_detection
+                    .as_ref()
+                    .map(|d| i64::from(d.rect.bottom)),
+                file.crop_detection
+                    .as_ref()
+                    .map(|d| format_datetime(&d.detected_at)),
+                file.crop_detection
+                    .as_ref()
+                    .and_then(|d| d.settings_fingerprint.as_deref()),
                 tags_json,
                 meta_json,
                 format_datetime(&file.introspected_at),
@@ -135,7 +153,7 @@ impl FileStorage for SqliteStore {
         let conn = self.conn()?;
         let file_row: Option<FileRow> = conn
             .query_row(
-                "SELECT id, path, size, content_hash, expected_hash, status, container, duration, bitrate, tags, plugin_metadata, introspected_at FROM files WHERE id = ?1",
+                "SELECT id, path, size, content_hash, expected_hash, status, container, duration, bitrate, crop_left, crop_top, crop_right, crop_bottom, crop_detected_at, crop_settings_fingerprint, tags, plugin_metadata, introspected_at FROM files WHERE id = ?1",
                 params![id.to_string()],
                 row_to_file,
             )
@@ -156,7 +174,7 @@ impl FileStorage for SqliteStore {
         let path_str = path.to_string_lossy().to_string();
         let file_row: Option<FileRow> = conn
             .query_row(
-                "SELECT id, path, size, content_hash, expected_hash, status, container, duration, bitrate, tags, plugin_metadata, introspected_at FROM files WHERE path = ?1",
+                "SELECT id, path, size, content_hash, expected_hash, status, container, duration, bitrate, crop_left, crop_top, crop_right, crop_bottom, crop_detected_at, crop_settings_fingerprint, tags, plugin_metadata, introspected_at FROM files WHERE path = ?1",
                 params![path_str],
                 row_to_file,
             )
@@ -210,9 +228,9 @@ impl FileStorage for SqliteStore {
         // When filtering by codec/language, use a subquery to apply filters before
         // LIMIT/OFFSET, ensuring consistent pagination with count_files.
         let base = if has_track_filter {
-            "SELECT DISTINCT files.id, files.path, files.size, files.content_hash, files.expected_hash, files.status, files.container, files.duration, files.bitrate, files.tags, files.plugin_metadata, files.introspected_at FROM files INNER JOIN tracks ON tracks.file_id = files.id WHERE 1=1"
+            "SELECT DISTINCT files.id, files.path, files.size, files.content_hash, files.expected_hash, files.status, files.container, files.duration, files.bitrate, files.crop_left, files.crop_top, files.crop_right, files.crop_bottom, files.crop_detected_at, files.crop_settings_fingerprint, files.tags, files.plugin_metadata, files.introspected_at FROM files INNER JOIN tracks ON tracks.file_id = files.id WHERE 1=1"
         } else {
-            "SELECT id, path, size, content_hash, expected_hash, status, container, duration, bitrate, tags, plugin_metadata, introspected_at FROM files WHERE 1=1"
+            "SELECT id, path, size, content_hash, expected_hash, status, container, duration, bitrate, crop_left, crop_top, crop_right, crop_bottom, crop_detected_at, crop_settings_fingerprint, tags, plugin_metadata, introspected_at FROM files WHERE 1=1"
         };
         let mut q = SqlQuery::new(base);
 
@@ -470,7 +488,8 @@ impl FileStorage for SqliteStore {
         let file_row: Option<FileRow> = conn
             .query_row(
                 "SELECT id, path, size, content_hash, expected_hash, status, \
-                 container, duration, bitrate, tags, plugin_metadata, introspected_at \
+                 container, duration, bitrate, crop_left, crop_top, crop_right, crop_bottom, \
+                 crop_detected_at, crop_settings_fingerprint, tags, plugin_metadata, introspected_at \
                  FROM files WHERE superseded_by = ?1 LIMIT 1",
                 params![successor_id.to_string()],
                 row_to_file,

--- a/plugins/sqlite-store/src/store/row_mappers.rs
+++ b/plugins/sqlite-store/src/store/row_mappers.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 use voom_domain::bad_file::{BadFile, BadFileSource};
 use voom_domain::errors::{Result, StorageErrorKind, VoomError};
 use voom_domain::job::{Job, JobStatus};
-use voom_domain::media::{Container, MediaFile, Track, TrackType};
+use voom_domain::media::{Container, CropDetection, CropRect, MediaFile, Track, TrackType};
 use voom_domain::transition::FileStatus;
 use voom_domain::verification::{
     VerificationMode, VerificationOutcome, VerificationRecord, VerificationRecordInput,
@@ -123,6 +123,12 @@ pub(crate) fn row_to_file(row: &Row<'_>) -> rusqlite::Result<FileRow> {
         container: row.get("container")?,
         duration: row.get("duration")?,
         bitrate,
+        crop_left: row.get("crop_left")?,
+        crop_top: row.get("crop_top")?,
+        crop_right: row.get("crop_right")?,
+        crop_bottom: row.get("crop_bottom")?,
+        crop_detected_at: row.get("crop_detected_at")?,
+        crop_settings_fingerprint: row.get("crop_settings_fingerprint")?,
         tags: row.get("tags")?,
         plugin_metadata: row.get("plugin_metadata")?,
         introspected_at: row.get("introspected_at")?,
@@ -139,6 +145,12 @@ pub(crate) struct FileRow {
     container: String,
     duration: Option<f64>,
     bitrate: Option<u32>,
+    crop_left: Option<i64>,
+    crop_top: Option<i64>,
+    crop_right: Option<i64>,
+    crop_bottom: Option<i64>,
+    crop_detected_at: Option<String>,
+    crop_settings_fingerprint: Option<String>,
     tags: Option<String>,
     plugin_metadata: Option<String>,
     introspected_at: String,
@@ -176,6 +188,7 @@ impl FileRow {
         mf.container = Container::from_extension(&self.container);
         mf.duration = self.duration.unwrap_or(0.0);
         mf.bitrate = self.bitrate;
+        mf.crop_detection = self.crop_detection()?;
         mf.tracks = tracks;
         mf.tags = tags;
         mf.plugin_metadata = plugin_metadata;
@@ -183,6 +196,39 @@ impl FileRow {
         mf.expected_hash = self.expected_hash.clone();
         mf.status = parse_file_status(&self.status)?;
         Ok(mf)
+    }
+}
+
+impl FileRow {
+    fn crop_detection(&self) -> Result<Option<CropDetection>> {
+        let Some(detected_at) = &self.crop_detected_at else {
+            return Ok(None);
+        };
+        let Some(left) = self.crop_left else {
+            return Ok(None);
+        };
+        let Some(top) = self.crop_top else {
+            return Ok(None);
+        };
+        let Some(right) = self.crop_right else {
+            return Ok(None);
+        };
+        let Some(bottom) = self.crop_bottom else {
+            return Ok(None);
+        };
+        let rect = CropRect::new(
+            u32::try_from(left).map_err(other_storage_err("invalid files.crop_left"))?,
+            u32::try_from(top).map_err(other_storage_err("invalid files.crop_top"))?,
+            u32::try_from(right).map_err(other_storage_err("invalid files.crop_right"))?,
+            u32::try_from(bottom).map_err(other_storage_err("invalid files.crop_bottom"))?,
+        );
+        let detected_at = parse_datetime(detected_at)?;
+        let detection = CropDetection::new(rect, detected_at);
+        let detection = match &self.crop_settings_fingerprint {
+            Some(fingerprint) => detection.with_settings_fingerprint(fingerprint.clone()),
+            None => detection,
+        };
+        Ok(Some(detection))
     }
 }
 

--- a/scripts/generate-test-corpus
+++ b/scripts/generate-test-corpus
@@ -2,9 +2,9 @@
 """Generate a corpus of synthetic video files with diverse characteristics.
 
 Uses ffmpeg to create tiny test files covering various containers, codecs,
-resolutions, channel layouts, subtitle formats, HDR metadata, VFR, and
-attachments — designed as a companion to select-test-corpus for functional
-testing when no real library exists.
+resolutions, channel layouts, subtitle formats, HDR metadata, VFR, black-bar
+crop detection inputs, and attachments — designed as a companion to
+select-test-corpus for functional testing when no real library exists.
 """
 
 import argparse
@@ -191,6 +191,32 @@ def build_manifest():
             "audio": [{"codec": "aac", "channels": 2}],
             "subs": [],
             "special": [],
+        },
+        {
+            "stem": "letterbox-h264",
+            "ext": "mkv",
+            "video": {
+                "codec": "libx264",
+                "size": "1920x1080",
+                "active_size": "1920x816",
+                "fps": 24,
+            },
+            "audio": [{"codec": "aac", "channels": 2}],
+            "subs": [],
+            "special": ["black_bars"],
+        },
+        {
+            "stem": "pillarbox-h264",
+            "ext": "mkv",
+            "video": {
+                "codec": "libx264",
+                "size": "1920x1080",
+                "active_size": "1440x1080",
+                "fps": 24,
+            },
+            "audio": [{"codec": "aac", "channels": 2}],
+            "subs": [],
+            "special": ["black_bars"],
         },
         {
             "stem": "hevc-surround",
@@ -673,9 +699,13 @@ def build_ffmpeg_cmd(spec, dest, duration, rng, tmpdir):
     cmd = ["ffmpeg", "-y", "-hide_banner", "-loglevel", "error"]
 
     # Video input
-    video_input = f"testsrc2=duration={duration}:size={video['size']}:rate={video['fps']}"
+    active_size = video.get("active_size", video["size"])
+    video_input = f"testsrc2=duration={duration}:size={active_size}:rate={video['fps']}"
     if "vfr" in specials:
         video_input += ",setpts='PTS+0.003*sin(N*0.15)/TB'"
+    if "black_bars" in specials:
+        output_size = video["size"].replace("x", ":")
+        video_input += f",pad={output_size}:(ow-iw)/2:(oh-ih)/2:black"
     cmd += ["-f", "lavfi", "-i", video_input]
 
     # Audio inputs (one sine per audio track)


### PR DESCRIPTION
Closes #203

## Summary
- add `crop: auto` DSL settings and carry them through policy evaluation into transcode plans
- detect and cache FFmpeg cropdetect results before video transcodes, then apply crop filters during encoding
- persist crop detections in SQLite and add black-bar fixtures to `scripts/generate-test-corpus`
- document auto-crop settings in the DSL reference and HEVC example policy

## Validation
- cargo check --workspace --all-targets
- cargo test -p voom-dsl crop -- --nocapture
- cargo test -p voom-ffmpeg-executor crop -- --nocapture
- cargo test -p voom-sqlite-store file -- --nocapture
- cargo test -p voom-cli crop -- --nocapture
- python3 -m py_compile scripts/generate-test-corpus
- git diff --check