### PR TITLE
Expand test corpus generator coverage

### DIFF
--- a/docs/superpowers/plans/2026-05-09-test-corpus-generator.md
+++ b/docs/superpowers/plans/2026-05-09-test-corpus-generator.md
@@ -89,18 +89,12 @@ def test_select_specs_all_includes_coverage_and_stress():
 Run:
 
 ```bash
-uv run pytest -q tests/scripts/test_generate_test_corpus.py
+uv run --with pytest pytest -q tests/scripts/test_generate_test_corpus.py
 ```
 
 Expected: fails with `AttributeError: module 'generate_test_corpus' has no attribute 'select_specs'`.
 
 - [ ] **Step 3: Implement profile constants, metadata defaults, and selection**
-
-In `scripts/generate-test-corpus`, add `json` to imports because later tasks use it:
-
-```python
-import json
-```
 
 Add constants after the metadata pools:
 
@@ -175,7 +169,7 @@ specs = select_specs(manifest, args.profile, only, skip)
 Run:
 
 ```bash
-uv run pytest -q tests/scripts/test_generate_test_corpus.py
+uv run --with pytest pytest -q tests/scripts/test_generate_test_corpus.py
 ```
 
 Expected: both tests pass.
@@ -247,7 +241,7 @@ def test_build_run_manifest_records_generated_skipped_failed_and_corruptions():
 Run:
 
 ```bash
-uv run pytest -q tests/scripts/test_generate_test_corpus.py::test_build_run_manifest_records_generated_skipped_failed_and_corruptions
+uv run --with pytest pytest -q tests/scripts/test_generate_test_corpus.py::test_build_run_manifest_records_generated_skipped_failed_and_corruptions
 ```
 
 Expected: fails with missing `build_run_manifest`.
@@ -359,7 +353,7 @@ if not args.dry_run:
 Run:
 
 ```bash
-uv run pytest -q tests/scripts/test_generate_test_corpus.py
+uv run --with pytest pytest -q tests/scripts/test_generate_test_corpus.py
 ```
 
 Expected: all tests pass.
@@ -425,7 +419,7 @@ def test_build_video_input_keeps_testsrc_for_smoke_fixture():
 Run:
 
 ```bash
-uv run pytest -q tests/scripts/test_generate_test_corpus.py::test_build_video_input_uses_mandelbrot_source_and_black_bars
+uv run --with pytest pytest -q tests/scripts/test_generate_test_corpus.py::test_build_video_input_uses_mandelbrot_source_and_black_bars
 ```
 
 Expected: fails with missing `build_video_input`.
@@ -487,7 +481,7 @@ Leave the smallest smoke-only fixture on `testsrc2`.
 Run:
 
 ```bash
-uv run pytest -q tests/scripts/test_generate_test_corpus.py
+uv run --with pytest pytest -q tests/scripts/test_generate_test_corpus.py
 scripts/generate-test-corpus /tmp/voom-corpus-dry --dry-run --profile coverage --only letterbox-h264
 ```
 
@@ -546,7 +540,7 @@ def test_collect_deterministic_corruptions_selects_profile_members():
 Run:
 
 ```bash
-uv run pytest -q tests/scripts/test_generate_test_corpus.py::test_collect_deterministic_corruptions_selects_profile_members
+uv run --with pytest pytest -q tests/scripts/test_generate_test_corpus.py::test_collect_deterministic_corruptions_selects_profile_members
 ```
 
 Expected: fails with missing `collect_deterministic_corruptions`.
@@ -641,7 +635,7 @@ Include deterministic corruptions in manifest corruption entries.
 Run:
 
 ```bash
-uv run pytest -q tests/scripts/test_generate_test_corpus.py
+uv run --with pytest pytest -q tests/scripts/test_generate_test_corpus.py
 scripts/generate-test-corpus /tmp/voom-corpus-dry --dry-run --profile coverage --only corrupt-truncated-tail
 ```
 
@@ -886,7 +880,7 @@ git commit -m "Expand corpus media coverage fixtures"
 Run:
 
 ```bash
-uv run pytest -q tests/scripts/test_generate_test_corpus.py
+uv run --with pytest pytest -q tests/scripts/test_generate_test_corpus.py
 ```
 
 Expected: all tests pass.

--- a/docs/superpowers/plans/2026-05-09-test-corpus-generator.md
+++ b/docs/superpowers/plans/2026-05-09-test-corpus-generator.md
@@ -1,0 +1,966 @@
+# Test Corpus Generator Coverage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add profiled deterministic fixture coverage, procedural motion sources, deterministic corruption fixtures, and manifest output to `scripts/generate-test-corpus`.
+
+**Architecture:** Keep the generator as one CLI script, but give fixtures explicit metadata (`profiles`, `covers`, `expect`) and add small pure helper functions for selection, manifest output, and corruption planning. Tests import the script by path and exercise those helpers without invoking FFmpeg; manual verification covers real FFmpeg output.
+
+**Tech Stack:** Python 3 script, `argparse`, `json`, `pytest` for helper tests, FFmpeg/ffprobe for manual media verification.
+
+---
+
+## File Structure
+
+- Modify `scripts/generate-test-corpus`: fixture metadata, profile filtering, procedural video sources, named corruption fixtures, run manifest writing, and CLI flags.
+- Create `tests/scripts/test_generate_test_corpus.py`: pure Python tests for profile selection, manifest shape, deterministic corruption planning, and encoder skip reporting.
+- Use existing `docs/superpowers/specs/2026-05-09-test-corpus-generator-design.md` as the design reference.
+
+Do not split the generator into multiple modules in this implementation. The current repo has the script as a standalone executable, and the planned helpers are small enough to keep local.
+
+## Task 1: Add Test Harness And Profile Selection
+
+**Files:**
+- Modify: `scripts/generate-test-corpus`
+- Create: `tests/scripts/test_generate_test_corpus.py`
+
+- [ ] **Step 1: Write failing tests for profile selection**
+
+Create `tests/scripts/test_generate_test_corpus.py`:
+
+```python
+"""Tests for scripts/generate-test-corpus pure helpers."""
+
+import importlib.util
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "generate-test-corpus"
+
+
+def load_generator():
+    loader = SourceFileLoader("generate_test_corpus", str(SCRIPT_PATH))
+    spec = importlib.util.spec_from_loader("generate_test_corpus", loader)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_select_specs_filters_by_profile_only_and_skip():
+    generator = load_generator()
+    specs = [
+        {"stem": "a", "profiles": ["smoke", "coverage"]},
+        {"stem": "b", "profiles": ["coverage"]},
+        {"stem": "c", "profiles": ["stress"]},
+    ]
+
+    selected = generator.select_specs(
+        specs,
+        profile="coverage",
+        only={"a", "b", "c"},
+        skip={"b"},
+    )
+
+    assert [spec["stem"] for spec in selected] == ["a"]
+
+
+def test_select_specs_all_includes_coverage_and_stress():
+    generator = load_generator()
+    specs = [
+        {"stem": "coverage-case", "profiles": ["coverage"]},
+        {"stem": "stress-case", "profiles": ["stress"]},
+        {"stem": "smoke-case", "profiles": ["smoke", "coverage"]},
+    ]
+
+    selected = generator.select_specs(specs, profile="all", only=None, skip=set())
+
+    assert [spec["stem"] for spec in selected] == [
+        "coverage-case",
+        "stress-case",
+        "smoke-case",
+    ]
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+uv run pytest -q tests/scripts/test_generate_test_corpus.py
+```
+
+Expected: fails with `AttributeError: module 'generate_test_corpus' has no attribute 'select_specs'`.
+
+- [ ] **Step 3: Implement profile constants, metadata defaults, and selection**
+
+In `scripts/generate-test-corpus`, add `json` to imports because later tasks use it:
+
+```python
+import json
+```
+
+Add constants after the metadata pools:
+
+```python
+SCHEMA_VERSION = 1
+PROFILE_CHOICES = ("smoke", "coverage", "stress", "all")
+ALL_PROFILE_MEMBERS = {"smoke", "coverage", "stress"}
+```
+
+Add helper functions before `build_manifest()`:
+
+```python
+def fixture_filename(spec):
+    """Return the output filename for a fixture spec."""
+    return f"{spec['stem']}.{spec['ext']}"
+
+
+def profile_matches(spec, profile):
+    """Return whether a fixture belongs to the selected profile."""
+    profiles = set(spec.get("profiles", ["coverage"]))
+    if profile == "all":
+        return bool(profiles & ALL_PROFILE_MEMBERS)
+    return profile in profiles
+
+
+def select_specs(specs, profile, only, skip):
+    """Filter fixture specs by profile, --only, and --skip."""
+    selected = []
+    for spec in specs:
+        stem = spec["stem"]
+        if not profile_matches(spec, profile):
+            continue
+        if only is not None and stem not in only:
+            continue
+        if stem in skip:
+            continue
+        selected.append(spec)
+    return selected
+```
+
+Update every deterministic fixture in `build_manifest()` with explicit metadata. Use these minimum tags for existing fixtures:
+
+```python
+"profiles": ["smoke", "coverage"],
+"covers": ["video.codec.h264", "audio.codec.aac"],
+"expect": {"bad_file": False, "container": "mp4"},
+```
+
+Assign `smoke` to a small fast subset: `basic-h264-aac`, `loudness-quiet-dialogue`, `letterbox-h264`, `hevc-surround`, `vp9-opus`. Other existing deterministic fixtures get `["coverage"]` or `["coverage", "stress"]` for expensive 4K/optional encoders.
+
+Update `main()` parser:
+
+```python
+parser.add_argument(
+    "--profile",
+    choices=PROFILE_CHOICES,
+    default="coverage",
+    help="Named deterministic fixture profile to generate (default: coverage)",
+)
+```
+
+Replace the manual manifest filtering loop with:
+
+```python
+only = set(args.only.split(",")) if args.only else None
+skip = set(args.skip.split(",")) if args.skip else set()
+specs = select_specs(manifest, args.profile, only, skip)
+```
+
+- [ ] **Step 4: Run profile tests and verify they pass**
+
+Run:
+
+```bash
+uv run pytest -q tests/scripts/test_generate_test_corpus.py
+```
+
+Expected: both tests pass.
+
+- [ ] **Step 5: Run dry-run smoke command**
+
+Run:
+
+```bash
+scripts/generate-test-corpus /tmp/voom-corpus-dry --dry-run --profile smoke
+```
+
+Expected: prints only smoke-profile fixtures and exits 0.
+
+- [ ] **Step 6: Commit Task 1**
+
+```bash
+git add scripts/generate-test-corpus tests/scripts/test_generate_test_corpus.py
+git commit -m "Add corpus generator profile selection"
+```
+
+## Task 2: Add Manifest Output And Result Tracking
+
+**Files:**
+- Modify: `scripts/generate-test-corpus`
+- Modify: `tests/scripts/test_generate_test_corpus.py`
+
+- [ ] **Step 1: Write failing tests for manifest creation**
+
+Append to `tests/scripts/test_generate_test_corpus.py`:
+
+```python
+def test_build_run_manifest_records_generated_skipped_failed_and_corruptions():
+    generator = load_generator()
+
+    manifest = generator.build_run_manifest(
+        profile="coverage",
+        duration=2,
+        duration_range=(1, 5),
+        count=3,
+        generated=[
+            {
+                "filename": "basic-h264-aac.mp4",
+                "size": 1234,
+                "covers": ["video.codec.h264"],
+                "expect": {"bad_file": False},
+            }
+        ],
+        skipped=[{"filename": "av1-opus.mp4", "reason": "encoder 'libsvtav1' not available"}],
+        failed=[{"filename": "bad.mkv", "reason": "ffmpeg failed"}],
+        corruptions=[{"filename": "corrupt-truncated-tail.mkv", "type": "truncated_tail"}],
+    )
+
+    assert manifest["schema_version"] == 1
+    assert manifest["settings"]["profile"] == "coverage"
+    assert manifest["settings"]["duration"] == 2
+    assert manifest["settings"]["duration_range"] == [1, 5]
+    assert manifest["summary"] == {
+        "generated": 1,
+        "skipped": 1,
+        "failed": 1,
+        "corrupted": 1,
+    }
+    assert manifest["generated"][0]["covers"] == ["video.codec.h264"]
+```
+
+- [ ] **Step 2: Run test and verify it fails**
+
+Run:
+
+```bash
+uv run pytest -q tests/scripts/test_generate_test_corpus.py::test_build_run_manifest_records_generated_skipped_failed_and_corruptions
+```
+
+Expected: fails with missing `build_run_manifest`.
+
+- [ ] **Step 3: Implement manifest helper and write function**
+
+Add helpers before `main()`:
+
+```python
+def build_run_manifest(
+    profile,
+    duration,
+    duration_range,
+    count,
+    generated,
+    skipped,
+    failed,
+    corruptions,
+):
+    """Build the JSON-serializable run manifest."""
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "settings": {
+            "profile": profile,
+            "duration": duration,
+            "duration_range": list(duration_range),
+            "count": count,
+        },
+        "summary": {
+            "generated": len(generated),
+            "skipped": len(skipped),
+            "failed": len(failed),
+            "corrupted": len(corruptions),
+        },
+        "generated": generated,
+        "skipped": skipped,
+        "failed": failed,
+        "corruptions": corruptions,
+    }
+
+
+def write_run_manifest(dest, manifest):
+    """Write manifest.json with stable formatting."""
+    path = dest / "manifest.json"
+    path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+    return path
+```
+
+In `main()`, initialize result lists before the generation loop:
+
+```python
+generated_entries = []
+skipped_entries = []
+failed_entries = []
+```
+
+When an encoder is unavailable, append:
+
+```python
+skipped_entries.append({
+    "filename": filename,
+    "stem": stem,
+    "reason": f"encoder '{req}' not available",
+    "covers": spec.get("covers", []),
+    "expect": spec.get("expect", {}),
+})
+```
+
+When command building or FFmpeg fails, append `failed_entries` with `filename`, `stem`, `reason`, `covers`, and `expect`.
+
+When a file generates successfully, append:
+
+```python
+generated_entries.append({
+    "filename": filename,
+    "stem": stem,
+    "size": size,
+    "duration": file_duration,
+    "profiles": spec.get("profiles", ["coverage"]),
+    "covers": spec.get("covers", []),
+    "expect": spec.get("expect", {}),
+})
+```
+
+After random corruption and before the summary exits, build and write the manifest when not a dry run:
+
+```python
+corruption_entries = [
+    {"filename": filename, "type": ctype, "description": desc}
+    for filename, ctype, desc in corrupt_results
+]
+if not args.dry_run:
+    run_manifest = build_run_manifest(
+        profile=args.profile,
+        duration=args.duration,
+        duration_range=dur_range,
+        count=args.count,
+        generated=generated_entries,
+        skipped=skipped_entries,
+        failed=failed_entries,
+        corruptions=corruption_entries,
+    )
+    manifest_path = write_run_manifest(dest, run_manifest)
+    print(f"Manifest: {manifest_path}")
+```
+
+- [ ] **Step 4: Run manifest tests**
+
+Run:
+
+```bash
+uv run pytest -q tests/scripts/test_generate_test_corpus.py
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Run smoke generation and inspect manifest**
+
+Run:
+
+```bash
+trash /tmp/voom-corpus-smoke
+scripts/generate-test-corpus /tmp/voom-corpus-smoke --profile smoke --duration 1
+python3 -m json.tool /tmp/voom-corpus-smoke/manifest.json >/tmp/voom-corpus-smoke/manifest.pretty.json
+```
+
+Expected: generator exits 0, `manifest.json` exists, and `python3 -m json.tool` exits 0.
+
+- [ ] **Step 6: Commit Task 2**
+
+```bash
+git add scripts/generate-test-corpus tests/scripts/test_generate_test_corpus.py
+git commit -m "Write corpus generator run manifest"
+```
+
+## Task 3: Add Procedural Mandelbrot Video Sources
+
+**Files:**
+- Modify: `scripts/generate-test-corpus`
+- Modify: `tests/scripts/test_generate_test_corpus.py`
+
+- [ ] **Step 1: Write failing tests for video source construction**
+
+Append:
+
+```python
+def test_build_video_input_uses_mandelbrot_source_and_black_bars():
+    generator = load_generator()
+    video = {
+        "source": "mandelbrot_zoom",
+        "size": "1920x1080",
+        "active_size": "1920x816",
+        "fps": 24,
+    }
+
+    source = generator.build_video_input(video, duration=2, specials={"black_bars"})
+
+    assert source.startswith("mandelbrot=")
+    assert "rate=24" in source
+    assert "scale=1920:816" in source
+    assert "pad=1920:1080:(ow-iw)/2:(oh-ih)/2:black" in source
+
+
+def test_build_video_input_keeps_testsrc_for_smoke_fixture():
+    generator = load_generator()
+    video = {"source": "testsrc2", "size": "1280x720", "fps": 24}
+
+    source = generator.build_video_input(video, duration=2, specials=set())
+
+    assert source == "testsrc2=duration=2:size=1280x720:rate=24"
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```bash
+uv run pytest -q tests/scripts/test_generate_test_corpus.py::test_build_video_input_uses_mandelbrot_source_and_black_bars
+```
+
+Expected: fails with missing `build_video_input`.
+
+- [ ] **Step 3: Implement video source helper**
+
+Add before `build_ffmpeg_cmd()`:
+
+```python
+def build_video_input(video, duration, specials):
+    """Build a lavfi video input expression for a fixture."""
+    source = video.get("source", "testsrc2")
+    active_size = video.get("active_size", video["size"])
+    active_w, active_h = active_size.split("x", 1)
+    fps = video["fps"]
+
+    if source == "mandelbrot_zoom":
+        video_input = (
+            f"mandelbrot=size={active_size}:rate={fps}:"
+            "start_x=-0.7436438870371587:start_y=0.131825904205312:"
+            "start_scale=3:end_scale=0.0008"
+            f",trim=duration={duration},setpts=PTS-STARTPTS"
+        )
+        if active_size != video["size"]:
+            video_input += f",scale={active_w}:{active_h}"
+    elif source == "testsrc2":
+        video_input = f"testsrc2=duration={duration}:size={active_size}:rate={fps}"
+    else:
+        raise ValueError(f"unsupported video source '{source}'")
+
+    if "vfr" in specials:
+        video_input += ",setpts='PTS+0.003*sin(N*0.15)/TB'"
+    if "black_bars" in specials:
+        output_size = video["size"].replace("x", ":")
+        video_input += f",pad={output_size}:(ow-iw)/2:(oh-ih)/2:black"
+
+    return video_input
+```
+
+Replace the duplicated video input construction in `build_ffmpeg_cmd()` with:
+
+```python
+video_input = build_video_input(video, duration, specials)
+cmd += ["-f", "lavfi", "-i", video_input]
+```
+
+Update coverage fixtures that need quality-sensitive content with `"source": "mandelbrot_zoom"`:
+
+- `letterbox-h264`
+- `pillarbox-h264`
+- `4k-hevc-hdr10`
+- `vfr-h264`
+- new fixtures added in Task 5
+
+Leave the smallest smoke-only fixture on `testsrc2`.
+
+- [ ] **Step 4: Run tests and dry-run coverage**
+
+Run:
+
+```bash
+uv run pytest -q tests/scripts/test_generate_test_corpus.py
+scripts/generate-test-corpus /tmp/voom-corpus-dry --dry-run --profile coverage --only letterbox-h264
+```
+
+Expected: tests pass, dry-run command contains `mandelbrot=` for `letterbox-h264`.
+
+- [ ] **Step 5: Commit Task 3**
+
+```bash
+git add scripts/generate-test-corpus tests/scripts/test_generate_test_corpus.py
+git commit -m "Add procedural corpus video sources"
+```
+
+## Task 4: Add Deterministic Corrupt Fixtures
+
+**Files:**
+- Modify: `scripts/generate-test-corpus`
+- Modify: `tests/scripts/test_generate_test_corpus.py`
+
+- [ ] **Step 1: Write failing tests for deterministic corruption planning**
+
+Append:
+
+```python
+def test_collect_deterministic_corruptions_selects_profile_members():
+    generator = load_generator()
+    specs = [
+        {
+            "stem": "corrupt-truncated-tail",
+            "ext": "mkv",
+            "profiles": ["coverage"],
+            "corruption": {
+                "source_stem": "basic-h264-aac",
+                "source_ext": "mp4",
+                "type": "truncated_tail",
+            },
+        },
+        {
+            "stem": "corrupt-stress",
+            "ext": "mkv",
+            "profiles": ["stress"],
+            "corruption": {
+                "source_stem": "basic-h264-aac",
+                "source_ext": "mp4",
+                "type": "mid_stream",
+            },
+        },
+    ]
+
+    selected = generator.collect_deterministic_corruptions(specs, profile="coverage")
+
+    assert selected == [specs[0]]
+```
+
+- [ ] **Step 2: Run test and verify failure**
+
+Run:
+
+```bash
+uv run pytest -q tests/scripts/test_generate_test_corpus.py::test_collect_deterministic_corruptions_selects_profile_members
+```
+
+Expected: fails with missing `collect_deterministic_corruptions`.
+
+- [ ] **Step 3: Implement deterministic corrupt specs and transforms**
+
+Add corruption specs to `build_manifest()` with `corruption` metadata and no normal `video` generation. Example:
+
+```python
+{
+    "stem": "corrupt-truncated-tail",
+    "ext": "mkv",
+    "profiles": ["coverage"],
+    "covers": ["bad_file.truncated_tail"],
+    "expect": {"bad_file": True, "corruption": "truncated_tail"},
+    "corruption": {
+        "source_stem": "basic-h264-aac",
+        "source_ext": "mp4",
+        "type": "truncated_tail",
+    },
+},
+```
+
+Add deterministic corrupt fixtures:
+
+- `corrupt-truncated-tail`
+- `corrupt-zero-length`
+- `corrupt-header-damage`
+- `corrupt-midstream-bitrot`
+- `corrupt-wrong-extension`
+- `corrupt-container-metadata`
+
+Add helpers:
+
+```python
+def collect_deterministic_corruptions(specs, profile):
+    """Return corruption fixture specs selected by profile."""
+    return [
+        spec for spec in specs
+        if "corruption" in spec and profile_matches(spec, profile)
+    ]
+
+
+def materialize_corrupt_fixture(dest, spec, rng):
+    """Create a deterministic corrupt fixture from an existing valid source."""
+    corruption = spec["corruption"]
+    source = dest / f"{corruption['source_stem']}.{corruption['source_ext']}"
+    target = dest / fixture_filename(spec)
+    if not source.exists():
+        return {
+            "filename": fixture_filename(spec),
+            "type": corruption["type"],
+            "description": f"skipped; source missing: {source.name}",
+            "skipped": True,
+        }
+
+    target.write_bytes(source.read_bytes())
+    ctype = corruption["type"]
+    apply_type = "truncated" if ctype == "truncated_tail" else ctype
+    if ctype == "container_metadata":
+        apply_type = "header_damage"
+    desc = apply_corruption(target, apply_type, rng)
+    return {
+        "filename": fixture_filename(spec),
+        "type": ctype,
+        "description": desc,
+        "skipped": False,
+    }
+```
+
+Update selection so normal generation skips specs containing `corruption`:
+
+```python
+deterministic_corrupt_specs = collect_deterministic_corruptions(specs, args.profile)
+specs = [spec for spec in specs if "corruption" not in spec]
+```
+
+After valid files are generated and before random corruption, materialize deterministic corrupt fixtures:
+
+```python
+deterministic_corruptions = []
+for spec in deterministic_corrupt_specs:
+    result = materialize_corrupt_fixture(dest, spec, random.Random(args.seed + 7000))
+    deterministic_corruptions.append(result)
+    print(f"  CORRUPTED {result['filename']} — {result['type']}: {result['description']}")
+```
+
+Include deterministic corruptions in manifest corruption entries.
+
+- [ ] **Step 4: Run tests and dry-run**
+
+Run:
+
+```bash
+uv run pytest -q tests/scripts/test_generate_test_corpus.py
+scripts/generate-test-corpus /tmp/voom-corpus-dry --dry-run --profile coverage --only corrupt-truncated-tail
+```
+
+Expected: tests pass; dry-run lists the selected corruption fixture without trying to build an FFmpeg command for it.
+
+- [ ] **Step 5: Run small real corruption generation**
+
+Run:
+
+```bash
+trash /tmp/voom-corpus-corrupt
+scripts/generate-test-corpus /tmp/voom-corpus-corrupt --profile coverage --duration 1 --only basic-h264-aac,corrupt-truncated-tail
+python3 -m json.tool /tmp/voom-corpus-corrupt/manifest.json >/tmp/voom-corpus-corrupt/manifest.pretty.json
+```
+
+Expected: valid source file and `corrupt-truncated-tail.mkv` exist; manifest lists one deterministic corruption.
+
+- [ ] **Step 6: Commit Task 4**
+
+```bash
+git add scripts/generate-test-corpus tests/scripts/test_generate_test_corpus.py
+git commit -m "Add deterministic corrupt corpus fixtures"
+```
+
+## Task 5: Expand HDR, Crop, And Audio Coverage
+
+**Files:**
+- Modify: `scripts/generate-test-corpus`
+
+- [ ] **Step 1: Add HDR/color fixture specs**
+
+Add deterministic fixtures to `build_manifest()`:
+
+```python
+{
+    "stem": "hevc-hlg-10bit",
+    "ext": "mkv",
+    "profiles": ["coverage", "stress"],
+    "covers": ["video.content.mandelbrot_zoom", "video.hdr.hlg", "video.codec.hevc"],
+    "expect": {"bad_file": False, "video_codec": "hevc", "is_hdr": True, "hdr_format": "hlg"},
+    "video": {"source": "mandelbrot_zoom", "codec": "libx265", "size": "1920x1080", "fps": 24},
+    "audio": [{"codec": "aac", "channels": 2, "lang": "eng"}],
+    "subs": [],
+    "special": ["hlg"],
+},
+{
+    "stem": "hevc-sdr-10bit",
+    "ext": "mkv",
+    "profiles": ["coverage"],
+    "covers": ["video.bit_depth.10", "video.hdr.false_positive_guard", "video.codec.hevc"],
+    "expect": {"bad_file": False, "video_codec": "hevc", "is_hdr": False, "pixel_format": "yuv420p10le"},
+    "video": {"source": "mandelbrot_zoom", "codec": "libx265", "size": "1920x1080", "fps": 24},
+    "audio": [{"codec": "aac", "channels": 2, "lang": "eng"}],
+    "subs": [],
+    "special": ["sdr_10bit"],
+},
+```
+
+Update video codec handling so HDR10 and HLG choose their own HEVC metadata
+bitstream filter:
+
+```python
+hevc_metadata_bsf = None
+
+if "hlg" in specials:
+    cmd += ["-pix_fmt", "yuv420p10le"]
+    if vcodec == "libx265":
+        cmd += [
+            "-x265-params",
+            "repeat-headers=1:colorprim=bt2020:transfer=arib-std-b67:"
+            "colormatrix=bt2020nc",
+        ]
+        hevc_metadata_bsf = (
+            "hevc_metadata=colour_primaries=9:"
+            "transfer_characteristics=18:matrix_coefficients=9"
+        )
+
+if "sdr_10bit" in specials:
+    cmd += ["-pix_fmt", "yuv420p10le"]
+```
+
+Update the existing HDR10 branch to set:
+
+```python
+hevc_metadata_bsf = (
+    "hevc_metadata=colour_primaries=9:"
+    "transfer_characteristics=16:matrix_coefficients=9"
+)
+```
+
+Replace the final hard-coded HEVC metadata block with:
+
+```python
+if hevc_metadata_bsf is not None:
+    cmd += ["-bsf:v", hevc_metadata_bsf]
+```
+
+- [ ] **Step 2: Add crop fixture specs**
+
+Add:
+
+```python
+{
+    "stem": "windowbox-h264",
+    "ext": "mkv",
+    "profiles": ["coverage"],
+    "covers": ["video.crop.windowbox", "video.content.mandelbrot_zoom"],
+    "expect": {"bad_file": False, "crop": {"left": 240, "top": 120, "right": 240, "bottom": 120}},
+    "video": {
+        "source": "mandelbrot_zoom",
+        "codec": "libx264",
+        "size": "1920x1080",
+        "active_size": "1440x840",
+        "fps": 24,
+    },
+    "audio": [{"codec": "aac", "channels": 2, "lang": "eng"}],
+    "subs": [],
+    "special": ["black_bars"],
+},
+{
+    "stem": "dark-edge-no-crop",
+    "ext": "mkv",
+    "profiles": ["coverage"],
+    "covers": ["video.crop.false_positive_guard"],
+    "expect": {"bad_file": False, "crop": None},
+    "video": {"source": "mandelbrot_zoom", "codec": "libx264", "size": "1920x1080", "fps": 24},
+    "audio": [{"codec": "aac", "channels": 2, "lang": "eng"}],
+    "subs": [],
+    "special": ["dark_edges"],
+},
+```
+
+For `dark_edges`, append a mild vignette instead of black bars in `build_video_input()`:
+
+```python
+if "dark_edges" in specials:
+    video_input += ",vignette=PI/5"
+```
+
+- [ ] **Step 3: Add audio normalization fixture specs**
+
+Add:
+
+```python
+{
+    "stem": "loudness-normalized-target",
+    "ext": "mkv",
+    "profiles": ["coverage"],
+    "covers": ["audio.normalize.already_normalized", "audio.loudness.target"],
+    "expect": {"bad_file": False, "audio_lufs": -23.0},
+    "video": {"source": "mandelbrot_zoom", "codec": "libx264", "size": "1280x720", "fps": 24},
+    "audio": [{"codec": "aac", "channels": 2, "volume": 0.65, "lang": "eng"}],
+    "subs": [],
+    "special": ["audio_loudnorm_target"],
+},
+{
+    "stem": "loudness-dynamic-bursts",
+    "ext": "mkv",
+    "profiles": ["coverage"],
+    "covers": ["audio.normalize.dynamic_range", "audio.loudness.bursts"],
+    "expect": {"bad_file": False, "audio_tracks": 1},
+    "video": {"source": "mandelbrot_zoom", "codec": "libx264", "size": "1280x720", "fps": 24},
+    "audio": [{"codec": "aac", "channels": 2, "lang": "eng", "source": "dynamic_bursts"}],
+    "subs": [],
+    "special": ["loudness"],
+},
+{
+    "stem": "surround-7-1-flac",
+    "ext": "mkv",
+    "profiles": ["coverage", "stress"],
+    "covers": ["audio.channels.7_1", "audio.codec.flac"],
+    "expect": {"bad_file": False, "audio_tracks": 1},
+    "video": {"source": "mandelbrot_zoom", "codec": "libx264", "size": "1280x720", "fps": 24},
+    "audio": [{"codec": "flac", "channels": 8, "lang": "eng"}],
+    "subs": [],
+    "special": [],
+},
+```
+
+Add audio source helper if needed:
+
+```python
+def build_audio_input(audio, index, duration):
+    """Build a lavfi audio input expression for a fixture."""
+    source = audio.get("source", "sine")
+    if source == "dynamic_bursts":
+        return (
+            f"aevalsrc='if(between(mod(t,1),0,0.15),0.9*sin(2*PI*880*t),"
+            f"0.04*sin(2*PI*220*t))':duration={duration}:sample_rate=48000"
+        )
+    audio_filter = f"sine=frequency={440 + index * 110}:duration={duration}:sample_rate=48000"
+    if "volume" in audio:
+        audio_filter += f",volume={audio['volume']}"
+    return audio_filter
+```
+
+Use `build_audio_input(audio, i, duration)` in `build_ffmpeg_cmd()`.
+
+For `audio_loudnorm_target`, add an audio filter on stream 0:
+
+```python
+if "audio_loudnorm_target" in specials:
+    cmd += ["-af:a:0", "loudnorm=I=-23:TP=-2:LRA=11"]
+```
+
+- [ ] **Step 4: Run dry-run checks for new fixtures**
+
+Run:
+
+```bash
+scripts/generate-test-corpus /tmp/voom-corpus-dry --dry-run --profile coverage --only hevc-hlg-10bit,hevc-sdr-10bit,windowbox-h264,dark-edge-no-crop,loudness-normalized-target,loudness-dynamic-bursts
+```
+
+Expected: exits 0 and prints FFmpeg commands containing the expected source/filter markers.
+
+- [ ] **Step 5: Run focused real generation**
+
+Run:
+
+```bash
+trash /tmp/voom-corpus-expanded
+scripts/generate-test-corpus /tmp/voom-corpus-expanded --profile coverage --duration 1 --only windowbox-h264,loudness-dynamic-bursts
+python3 -m json.tool /tmp/voom-corpus-expanded/manifest.json >/tmp/voom-corpus-expanded/manifest.pretty.json
+```
+
+Expected: exits 0 and writes two generated fixture entries.
+
+- [ ] **Step 6: Commit Task 5**
+
+```bash
+git add scripts/generate-test-corpus
+git commit -m "Expand corpus media coverage fixtures"
+```
+
+## Task 6: Final Verification And Cleanup
+
+**Files:**
+- Modify only if verification reveals issues: `scripts/generate-test-corpus`, `tests/scripts/test_generate_test_corpus.py`
+
+- [ ] **Step 1: Run Python helper tests**
+
+Run:
+
+```bash
+uv run pytest -q tests/scripts/test_generate_test_corpus.py
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Run dry-run profiles**
+
+Run:
+
+```bash
+scripts/generate-test-corpus /tmp/voom-corpus-dry --dry-run --profile smoke
+scripts/generate-test-corpus /tmp/voom-corpus-dry --dry-run --profile coverage
+scripts/generate-test-corpus /tmp/voom-corpus-dry --dry-run --profile stress
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 3: Run real smoke generation**
+
+Run:
+
+```bash
+trash /tmp/voom-corpus-smoke
+scripts/generate-test-corpus /tmp/voom-corpus-smoke --profile smoke --duration 1
+python3 -m json.tool /tmp/voom-corpus-smoke/manifest.json >/tmp/voom-corpus-smoke/manifest.pretty.json
+```
+
+Expected: exits 0 and manifest JSON validates.
+
+- [ ] **Step 4: Review generated coverage tags**
+
+Run:
+
+```bash
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+manifest = json.loads(Path("/tmp/voom-corpus-smoke/manifest.json").read_text())
+tags = sorted({tag for item in manifest["generated"] for tag in item["covers"]})
+print("\n".join(tags))
+PY
+```
+
+Expected: prints non-empty coverage tags.
+
+- [ ] **Step 5: Run formatter/lint checks applicable to touched Python**
+
+Run:
+
+```bash
+ruff format scripts/generate-test-corpus tests/scripts/test_generate_test_corpus.py
+ruff check scripts/generate-test-corpus tests/scripts/test_generate_test_corpus.py
+```
+
+Expected: both commands exit 0. If `ruff` is unavailable in the environment, record that in the final implementation summary and rely on the passing pytest and dry-run checks.
+
+- [ ] **Step 6: Review diff for scope and complexity**
+
+Run:
+
+```bash
+git diff --stat
+git diff -- scripts/generate-test-corpus tests/scripts/test_generate_test_corpus.py
+```
+
+Expected: changes are limited to the generator and its tests; no VOOM runtime code changed.
+
+- [ ] **Step 7: Commit final fixes if any**
+
+If Step 5 or Step 6 required edits:
+
+```bash
+git add scripts/generate-test-corpus tests/scripts/test_generate_test_corpus.py
+git commit -m "Polish corpus generator coverage"
+```
+
+If no edits were required, do not create an empty commit.

--- a/docs/superpowers/plans/2026-05-10-test-corpus-simplification.md
+++ b/docs/superpowers/plans/2026-05-10-test-corpus-simplification.md
@@ -1,0 +1,338 @@
+# Test Corpus Generator Simplification Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans
+> or superpowers:subagent-driven-development to implement this plan task-by-task.
+> Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Address the simplification review recommendations for
+`scripts/generate-test-corpus` without changing generated fixture behavior,
+manifest shape, or CLI behavior.
+
+**Architecture:** Keep the corpus generator as a single executable script. Replace
+duplicated manifest and corruption planning logic with small local helpers, convert
+hand-written state containers to dataclasses, reduce avoidable FFmpeg process work,
+and simplify tests that repeatedly load the script module.
+
+**Tech Stack:** Python 3 script, standard library only, pytest helper tests, Ruff
+format/check.
+
+---
+
+## File Structure
+
+- Modify `scripts/generate-test-corpus`: helper consolidation, dataclasses,
+  FFmpeg availability check, and optional in-place corruption I/O.
+- Modify `tests/scripts/test_generate_test_corpus.py`: generator fixture and
+  monkeypatch-based corruption type overrides.
+
+Do not split the script into modules and do not add dependencies. This is a
+simplification pass over the current implementation, not a feature pass.
+
+## Task 1: Consolidate Issue Manifest Entries
+
+**Files:**
+- Modify `scripts/generate-test-corpus`
+- Modify `tests/scripts/test_generate_test_corpus.py`
+
+- [ ] Add a helper that captures the shared skipped/failed entry shape:
+
+```python
+def build_issue_entry(spec, filename, reason):
+    """Return a skipped/failed manifest entry."""
+    return {
+        "filename": filename,
+        "stem": spec["stem"],
+        "reason": reason,
+        "covers": spec.get("covers", []),
+        "expect": spec.get("expect", {}),
+    }
+```
+
+- [ ] Replace calls to `build_failed_generation_entry()` and
+  `build_skipped_generation_entry()` with `build_issue_entry()`.
+- [ ] Remove `build_failed_generation_entry()` and
+  `build_skipped_generation_entry()`.
+- [ ] Leave `build_generation_entry()` separate because it has generated-file
+  fields (`size`, `duration`, `profiles`) that skipped/failed entries do not.
+- [ ] Either keep `build_skipped_corruption_entry()` if that name helps call-site
+  clarity, or make it a tiny wrapper around `build_issue_entry()`:
+
+```python
+def build_skipped_corruption_entry(spec, result):
+    """Return a skipped manifest entry for an unmaterialized corruption fixture."""
+    return build_issue_entry(spec, result["filename"], result["description"])
+```
+
+- [ ] Run the focused tests:
+
+```bash
+uv run --with pytest pytest -q tests/scripts/test_generate_test_corpus.py
+```
+
+Expected: all tests pass with unchanged skipped/failed manifest entries.
+
+## Task 2: Centralize Corruption Filename Planning
+
+**Files:**
+- Modify `scripts/generate-test-corpus`
+- Modify `tests/scripts/test_generate_test_corpus.py`
+
+- [ ] Add a pure helper near the corruption helpers:
+
+```python
+def corruption_final_path(file_path, corruption_type):
+    """Return the path a corruption operation will leave behind."""
+    if corruption_type != "wrong_extension":
+        return file_path
+    if file_path.suffix == ".mkv":
+        return file_path.with_suffix(".mp4")
+    return file_path.with_suffix(".mkv")
+```
+
+- [ ] Update `apply_corruption()` to use `corruption_final_path()` for
+  `wrong_extension` instead of duplicating extension selection.
+- [ ] Update `materialize_deterministic_corruptions()` dry-run final filename
+  prediction to call `corruption_final_path(Path(filename), applied_type)`, where
+  `applied_type` is the actual type passed to `apply_corruption()`.
+- [ ] Add or adjust tests to cover `.mp4 -> .mkv`, `.mkv -> .mp4`, and unchanged
+  paths for non-rename corruption types.
+- [ ] Run the focused tests:
+
+```bash
+uv run --with pytest pytest -q tests/scripts/test_generate_test_corpus.py
+```
+
+Expected: deterministic dry-runs and materialized wrong-extension corruptions
+still report the same final filenames.
+
+## Task 3: Convert State Containers To Dataclasses
+
+**Files:**
+- Modify `scripts/generate-test-corpus`
+
+- [ ] Add the import:
+
+```python
+from dataclasses import dataclass, field
+```
+
+- [ ] Replace `PreparedSpecs`, `GenerationOptions`, `GenerationResult`, and
+  `CorruptionResult` hand-written classes with dataclasses:
+
+```python
+@dataclass
+class PreparedSpecs:
+    """Fixture specs selected for a run."""
+
+    specs: list
+    deterministic_corrupt_specs: list
+    random_specs: list
+
+
+@dataclass
+class GenerationOptions:
+    """Options needed while materializing normal fixtures."""
+
+    dest: Path
+    duration: int
+    seed: int
+    dry_run: bool
+    verbose: bool
+    available: set
+    total: int
+
+
+@dataclass
+class GenerationResult:
+    """Mutable counts and manifest entries accumulated during a run."""
+
+    ok_count: int = 0
+    skip_count: int = 0
+    fail_count: int = 0
+    total_size: int = 0
+    generated_entries: list = field(default_factory=list)
+    skipped_entries: list = field(default_factory=list)
+    failed_entries: list = field(default_factory=list)
+
+
+@dataclass
+class CorruptionResult:
+    """Counts and corruption entries accumulated during corruption steps."""
+
+    ok_count: int = 0
+    skip_count: int = 0
+    skipped_entries: list = field(default_factory=list)
+    corrupt_results: list = field(default_factory=list)
+```
+
+- [ ] Prefer broad built-in annotations only if the repo tooling accepts them;
+  avoid adding complex type aliases in this pass.
+- [ ] Run tests and Ruff:
+
+```bash
+uv run --with pytest pytest -q tests/scripts/test_generate_test_corpus.py
+uv run --with ruff ruff format --check scripts/generate-test-corpus tests/scripts/test_generate_test_corpus.py
+uv run --with ruff ruff check scripts/generate-test-corpus tests/scripts/test_generate_test_corpus.py
+```
+
+Expected: behavior unchanged; no mutable default warnings or formatting changes.
+
+## Task 4: Simplify FFmpeg Availability Check
+
+**Files:**
+- Modify `scripts/generate-test-corpus`
+- Modify `tests/scripts/test_generate_test_corpus.py`
+
+- [ ] Replace the extra `ffmpeg -version` subprocess in
+  `ensure_ffmpeg_available()` with `shutil.which("ffmpeg")`.
+- [ ] Keep the existing error message and exit behavior:
+
+```python
+def ensure_ffmpeg_available():
+    """Exit with a clear message if ffmpeg is unavailable."""
+    if shutil.which("ffmpeg") is None:
+        print("Error: ffmpeg not found in PATH", file=sys.stderr)
+        sys.exit(1)
+```
+
+- [ ] Leave `probe_encoders()` responsible for the one real FFmpeg probe.
+- [ ] Add a small test that monkeypatches `shutil.which` to return `None` and
+  asserts `SystemExit(1)` plus the stderr message.
+- [ ] Add a small test that monkeypatches `shutil.which` to return a path and
+  asserts the helper returns normally.
+- [ ] Run the focused tests:
+
+```bash
+uv run --with pytest pytest -q tests/scripts/test_generate_test_corpus.py
+```
+
+Expected: availability behavior remains the same, while startup avoids one
+redundant FFmpeg subprocess.
+
+## Task 5: Simplify Test Module Loading
+
+**Files:**
+- Modify `tests/scripts/test_generate_test_corpus.py`
+
+- [ ] Convert repeated `load_generator()` calls to a pytest fixture:
+
+```python
+import pytest
+
+
+@pytest.fixture
+def generator():
+    return load_generator()
+```
+
+- [ ] Update tests to accept `generator` as an argument instead of assigning
+  `generator = load_generator()` inside each test.
+- [ ] Replace manual `CORRUPTION_TYPES` save/restore logic with `monkeypatch`:
+
+```python
+monkeypatch.setattr(generator, "CORRUPTION_TYPES", [corruption_type])
+```
+
+- [ ] Keep tests behavior-focused. Do not assert implementation details that
+  would make future refactors harder.
+- [ ] Run the focused tests:
+
+```bash
+uv run --with pytest pytest -q tests/scripts/test_generate_test_corpus.py
+```
+
+Expected: same coverage with less repeated setup code.
+
+## Task 6: Optional In-Place Corruption I/O Simplification
+
+**Files:**
+- Modify `scripts/generate-test-corpus`
+- Modify `tests/scripts/test_generate_test_corpus.py`
+
+Only do this task if it stays small and all existing corruption tests continue to
+pass. The behavior must remain deterministic for a fixed seed.
+
+- [ ] Update truncation to use `Path.open("r+b")` and `truncate(new_size)` rather
+  than reading and rewriting the prefix.
+- [ ] Update zero-length corruption to use `truncate(0)`.
+- [ ] Update header corruption to open `r+b`, generate the same number of random
+  bytes, seek to 0, and write only the damaged header block.
+- [ ] Update mid-stream corruption to open `r+b`, generate the same number of
+  random bytes, seek to the selected offset, and write only that block.
+- [ ] Keep RNG draw counts the same as today:
+  - `truncated`: one `randint(10, 80)`
+  - `header_damage`: one `randint(64, 512)` plus one byte draw per damaged byte
+  - `mid_stream`: one block-size draw, one offset draw, plus one byte draw per
+    overwritten byte
+- [ ] If any fixture output or tests become unstable, skip this task and record
+  it as deferred. The first five tasks address the low-risk recommendations.
+- [ ] Run the focused tests:
+
+```bash
+uv run --with pytest pytest -q tests/scripts/test_generate_test_corpus.py
+```
+
+Expected: corruptions keep the same final names, sizes, and deterministic
+metadata; I/O no longer rewrites whole files for partial corruptions.
+
+## Task 7: Final Verification And Commit
+
+**Files:**
+- Modify `scripts/generate-test-corpus`
+- Modify `tests/scripts/test_generate_test_corpus.py`
+
+- [ ] Run formatting, linting, and focused tests:
+
+```bash
+uv run --with ruff ruff format scripts/generate-test-corpus tests/scripts/test_generate_test_corpus.py
+uv run --with ruff ruff format --check scripts/generate-test-corpus tests/scripts/test_generate_test_corpus.py
+uv run --with ruff ruff check scripts/generate-test-corpus tests/scripts/test_generate_test_corpus.py
+uv run --with pytest pytest -q tests/scripts/test_generate_test_corpus.py
+```
+
+- [ ] Run a no-media-output dry-run smoke check:
+
+```bash
+scripts/generate-test-corpus /tmp/voom-corpus-simplify-dry --dry-run --profile smoke
+```
+
+Expected: exits 0 and lists the same smoke profile commands as before.
+
+- [ ] If Task 6 was implemented, run a small real corruption smoke check:
+
+```bash
+tmpdir="$(mktemp -d)"
+scripts/generate-test-corpus "$tmpdir" --profile coverage --only basic-h264-aac --duration 1
+scripts/generate-test-corpus "$tmpdir" --profile coverage --only corrupt-wrong-extension --duration 1
+```
+
+Expected: `corrupt-wrong-extension` materializes with the same final name and
+manifest metadata as before.
+
+- [ ] Review the diff for behavior changes:
+
+```bash
+git diff -- scripts/generate-test-corpus tests/scripts/test_generate_test_corpus.py
+```
+
+Confirm the diff is limited to simplification and tests. Do not add new corpus
+features in this branch.
+
+- [ ] Commit the simplification:
+
+```bash
+git add scripts/generate-test-corpus tests/scripts/test_generate_test_corpus.py
+git commit -m "Simplify corpus generator helpers"
+```
+
+## Risk Notes
+
+- Corruption filename planning must use the applied corruption type, not the
+  external deterministic corruption label. For example, `truncated_tail` maps to
+  `truncated`, while `wrong_extension` stays `wrong_extension`.
+- Dry-run output is user-facing enough to preserve. Avoid changing wording except
+  where centralizing logic requires the same final filename detail.
+- Dataclasses should not introduce shared mutable defaults. Use
+  `field(default_factory=list)` for mutable result lists.
+- Do not add static typing that forces a wider annotation cleanup. The target is
+  readable simplification, not a typing migration.

--- a/docs/superpowers/specs/2026-05-09-test-corpus-generator-design.md
+++ b/docs/superpowers/specs/2026-05-09-test-corpus-generator-design.md
@@ -1,0 +1,215 @@
+# Test Corpus Generator Coverage Design
+
+## Purpose
+
+Improve `scripts/generate-test-corpus` so it produces deterministic media
+fixtures that cover the supported VOOM feature surface while preserving fast
+CI-friendly generation. The generator should also continue to support optional
+random files and random corruption for fuzz-style local testing.
+
+The corpus must include procedural motion content, not only static images or
+test bars. The default procedural source should be high-detail generated video,
+such as Mandelbrot/fractal zoom content, tuned by resolution so quality loss is
+visible after later transcoding and frame preview workflows.
+
+## Scope
+
+This design only changes the corpus generation script and its generated
+manifest. It does not change VOOM processing, introspection, transcoding,
+reporting, or GUI behavior.
+
+## Generator Shape
+
+Keep `scripts/generate-test-corpus` as the single entry point. Refactor the
+deterministic fixture manifest so each fixture declares explicit metadata:
+
+- `stem` and `ext`
+- `profiles`
+- `covers`
+- `expect`
+- `video`, `audio`, `subs`, and `special` generation settings
+- optional encoder requirements
+- optional fixture-specific duration
+
+Example fixture shape:
+
+```python
+{
+    "stem": "mandelbrot-hdr10-4k",
+    "ext": "mkv",
+    "profiles": ["coverage", "stress"],
+    "covers": [
+        "video.content.mandelbrot_zoom",
+        "video.resolution.4k",
+        "video.hdr.hdr10",
+        "video.codec.hevc",
+    ],
+    "expect": {
+        "bad_file": False,
+        "video_codec": "hevc",
+        "is_hdr": True,
+        "hdr_format": "hdr10",
+        "width": 3840,
+        "height": 2160,
+    },
+    "video": {...},
+    "audio": [...],
+    "subs": [...],
+    "special": [...],
+}
+```
+
+Add `--profile smoke|coverage|stress|all`.
+
+- `smoke`: a minimal fast set for CI, roughly five to eight short files.
+- `coverage`: all named product-feature fixtures with short durations.
+- `stress`: slow or heavy fixtures such as 4K HDR, many-track files, and larger
+  variants of corruption cases.
+- `all`: coverage plus stress.
+
+Default to `coverage` for local runs. Existing `--only`, `--skip`, `--count`,
+`--duration`, `--duration-range`, and `--corrupt` behavior should continue to
+work. `--only` and `--skip` apply after profile selection.
+
+## Manifest Output
+
+Write a `manifest.json` sidecar into the destination directory for non-dry-run
+generation. The manifest records:
+
+- manifest `schema_version`
+- selected profile and command-relevant settings
+- generated files
+- skipped files and skip reasons
+- failed files and failure summaries
+- coverage tags per fixture
+- expected traits per fixture
+- deterministic and random corruption details
+
+Integration tests should consume this manifest instead of duplicating fixture
+knowledge in test code.
+
+## Fixture Families
+
+### Video Content
+
+Use procedural FFmpeg sources. Mandelbrot/fractal zoom content is the primary
+source for meaningful motion and fine detail. Keep `testsrc2` only for cheap
+smoke fixtures where content quality is not the point.
+
+Resolution tiers should be tuned so later transcoding visibly loses quality:
+
+- SD fixtures should expose blocking and ringing.
+- 1080p fixtures should include high-frequency detail and smooth motion.
+- 4K fixtures should stress codec behavior with dense texture and motion.
+- VFR fixtures should use procedural motion plus timestamp variation.
+
+### HDR And Color
+
+Add named fixtures for:
+
+- HDR10 HEVC, 10-bit, BT.2020, PQ transfer.
+- HLG HEVC, 10-bit, BT.2020, ARIB STD-B67 transfer.
+- SDR 10-bit HEVC that must not be classified as HDR.
+- Incomplete HDR-like metadata only if FFmpeg and ffprobe expose enough fields
+  to assert conservative detection clearly.
+
+Avoid fake Dolby Vision fixtures unless VOOM can detect real Dolby Vision
+metadata from generated files.
+
+### Black Bars And Crop Detection
+
+Add named crop fixtures:
+
+- Letterbox.
+- Pillarbox.
+- Windowbox.
+- No-bars content with dark edges, to catch false positives.
+- Intermittent black frames or black transitions if crop sampling needs that
+  edge case.
+
+### Audio Normalization
+
+Add named fixtures for:
+
+- Quiet dialogue-like mix.
+- Hot compressed mix.
+- Already normalized target generated with FFmpeg `loudnorm`.
+- Dynamic range and silence-plus-bursts.
+- 5.1 and 7.1 preservation.
+- Commentary and alternate-language tracks.
+- AAC, AC3, EAC3, FLAC, and Opus where the local FFmpeg build supports them.
+
+Relative loudness fixtures test behavior coverage. The already-normalized
+fixture gives reporting and skip behavior a stable measurable target.
+
+### Subtitles And Attachments
+
+Keep and expand existing coverage:
+
+- SRT, ASS, and WebVTT subtitles.
+- Forced, default, and commentary subtitle metadata.
+- Font attachment.
+- Cover and poster image attachments.
+- Multi-language audio and subtitle combinations.
+
+### Corruption
+
+Add deterministic named corrupt fixtures by generating a valid source file and
+then applying a named corruption transform into a separate output file.
+
+Corruption cases:
+
+- Truncated tail.
+- Zero-length file.
+- Header damage.
+- Midstream bit rot.
+- Wrong extension.
+- Corrupt metadata or container header where feasible.
+- Valid container with damaged media stream where feasible.
+
+Keep `--corrupt N/%` as optional random post-processing fuzz against random
+generated files. Random corruption must not replace deterministic corrupt
+fixtures.
+
+## Behavior And Boundaries
+
+`--duration` applies to deterministic fixtures unless a fixture declares its own
+duration. Heavy fixtures may cap or override duration to keep runtime
+controlled. Random fixtures continue to use `--duration-range`.
+
+Encoder-dependent fixtures skip cleanly when the local FFmpeg build lacks the
+required encoder. The skip reason is recorded in `manifest.json`.
+
+Validation inside the generator stays lightweight:
+
+- Verify FFmpeg exists.
+- Probe available encoders.
+- Generate files.
+- Apply deterministic and optional random corruptions.
+- Write the manifest.
+
+The generator should not run VOOM or deeply assert ffprobe output. Integration
+tests can use `manifest.json` for that.
+
+## Testing And Rollout
+
+Implement in small steps:
+
+1. Add fixture metadata, profile selection, and `manifest.json` output while
+   preserving current fixtures.
+2. Add procedural Mandelbrot/video-source support and move selected fixtures to
+   it.
+3. Add deterministic corrupt fixtures.
+4. Expand HDR, crop, and audio fixture coverage.
+5. Add focused tests or dry-run checks for profile selection, manifest output,
+   corruption reporting, and encoder skip reporting.
+
+Verification for the script should use cheap checks:
+
+- `scripts/generate-test-corpus /tmp/voom-corpus-dry --dry-run --profile smoke`
+- `scripts/generate-test-corpus /tmp/voom-corpus-dry --dry-run --profile coverage`
+- `scripts/generate-test-corpus /tmp/voom-corpus-smoke --profile smoke --duration 1`
+- JSON validation of the generated `manifest.json`
+
+Run broader VOOM or media-processing tests only when they directly consume the
+generated corpus behavior.

--- a/scripts/generate-test-corpus
+++ b/scripts/generate-test-corpus
@@ -876,10 +876,14 @@ def materialize_corrupt_fixture(dest, spec, rng):
     return {
         "original_filename": original_filename,
         "filename": final_path.name,
+        "stem": spec["stem"],
         "source_filename": source_filename,
         "type": corruption_type,
         "description": desc,
         "size": final_path.stat().st_size,
+        "profiles": spec.get("profiles", ["coverage"]),
+        "covers": spec.get("covers", []),
+        "expect": spec.get("expect", {}),
         "skipped": False,
     }
 
@@ -937,10 +941,9 @@ def build_corruption_manifest_entries(corrupt_results):
             "description": result["description"],
             "size": result["size"],
         }
-        if result.get("source_filename"):
-            entry["source_filename"] = result["source_filename"]
-        if result.get("skipped"):
-            entry["skipped"] = True
+        for key in ("stem", "source_filename", "profiles", "covers", "expect"):
+            if key in result:
+                entry[key] = result[key]
         entries.append(entry)
     return entries
 
@@ -1758,9 +1761,16 @@ def main():
             corruption = spec["corruption"]
             corruption_type = corruption["type"]
             source_filename = f"{corruption['source_stem']}.{corruption['source_ext']}"
+            final_filename = filename
+            if corruption_type == "wrong_extension":
+                final_filename = Path(filename).with_suffix(".mkv").name
+            final_detail = ""
+            if final_filename != filename:
+                final_detail = f"; final filename {final_filename}"
             print(f"[{start + offset}/{total}] {filename}")
             print(
-                f"  deterministic corruption: {corruption_type} from {source_filename}"
+                "  deterministic corruption: "
+                f"{corruption_type} from {source_filename}{final_detail}"
             )
             print()
             ok_count += 1

--- a/scripts/generate-test-corpus
+++ b/scripts/generate-test-corpus
@@ -308,8 +308,8 @@ def select_specs(specs, profile, only, skip):
     return selected
 
 
-def build_manifest():
-    """Return the list of file specs to generate."""
+def build_basic_manifest_specs():
+    """Return baseline and audio-focused fixture specs."""
     return [
         {
             "stem": "basic-h264-aac",
@@ -344,6 +344,12 @@ def build_manifest():
             "subs": [],
             "special": ["loudness"],
         },
+    ]
+
+
+def build_video_feature_specs():
+    """Return video-feature and common codec fixture specs."""
+    return [
         {
             "stem": "letterbox-h264",
             "ext": "mkv",
@@ -415,6 +421,12 @@ def build_manifest():
             "subs": [{"format": "webvtt", "lang": "eng"}],
             "special": [],
         },
+    ]
+
+
+def build_container_feature_specs():
+    """Return HDR, container, and optional codec fixture specs."""
+    return [
         {
             "stem": "4k-hevc-hdr10",
             "ext": "mkv",
@@ -503,6 +515,15 @@ def build_manifest():
             "requires_encoder": "truehd",
         },
     ]
+
+
+def build_manifest():
+    """Return the list of file specs to generate."""
+    return (
+        build_basic_manifest_specs()
+        + build_video_feature_specs()
+        + build_container_feature_specs()
+    )
 
 
 def build_random_audio(file_rng):
@@ -972,81 +993,14 @@ def write_minimal_png(path):
 # ---------------------------------------------------------------------------
 
 
-def build_ffmpeg_cmd(spec, dest, duration, rng, tmpdir):
-    """Build the ffmpeg command list for a given file spec.
-
-    Returns (cmd_list, temp_files_to_cleanup).
-    """
-    outfile = dest / f"{spec['stem']}.{spec['ext']}"
-    cmd = ["ffmpeg", "-y", "-hide_banner"]
-
+def build_input_options(spec, duration, tmpdir):
+    """Return ffmpeg input and stream mapping options for a file spec."""
+    cmd = []
     specials = set(spec.get("special", []))
     video = spec["video"]
     audios = spec["audio"]
     subs = spec.get("subs", [])
 
-    # --- Video input ---
-    vf_filters = [
-        f"testsrc2=duration={duration}:size={video['size']}:rate={video['fps']}"
-    ]
-    if "vfr" in specials:
-        # Vary PTS to create variable frame rate
-        vf_filters.append("setpts='PTS+0.002*sin(N*0.1)/TB'")
-    cmd += ["-f", "lavfi", "-i", ",".join(vf_filters)]
-
-    # --- Audio inputs ---
-    for i, audio in enumerate(audios):
-        ch = audio["channels"]
-        if ch <= 2:
-            cmd += [
-                "-f",
-                "lavfi",
-                "-i",
-                f"sine=frequency={440 + i * 110}:duration={duration}:sample_rate=48000",
-            ]
-        else:
-            # Generate 5.1/7.1 by merging multiple sine sources
-            freqs = [220, 330, 440, 550, 660, 770, 880, 990][:ch]
-            filter_parts = []
-            for j, freq in enumerate(freqs):
-                filter_parts.append(
-                    f"sine=frequency={freq}:duration={duration}:sample_rate=48000"
-                )
-            amerge_input = "|".join(filter_parts)
-            cmd += ["-f", "lavfi", "-i", f"amovie='{amerge_input}'" if False else ""]
-            # Actually, use a complex filter approach — replace last two args
-            cmd = cmd[:-2]
-            cmd += [
-                "-f",
-                "lavfi",
-                "-i",
-                f"sine=frequency=440:duration={duration}:sample_rate=48000",
-            ]
-
-    # --- Subtitle inputs ---
-    sub_files = []
-    for i, sub in enumerate(subs):
-        fmt = sub["format"]
-        ext = "vtt" if fmt == "webvtt" else fmt
-        sub_path = Path(tmpdir) / f"sub_{spec['stem']}_{i}.{ext}"
-        SUB_WRITERS[fmt](sub_path, min(duration, 59))
-        sub_files.append(sub_path)
-        cmd += ["-i", str(sub_path)]
-
-    # --- Map streams ---
-    cmd += ["-map", "0:v"]
-    for i in range(len(audios)):
-        cmd += ["-map", f"{1 if audios[0]['channels'] <= 2 or i == 0 else 1}:a"]
-        # For multi-channel that fell back to mono input, we'll handle below
-    # For multi-audio with >2 channels, we generated a single sine for all.
-    # Remap: all audio inputs are at indices 1..len(audios)
-    # Actually, let's simplify: generate one sine input per audio track
-    # and use pan filter for multichannel.
-
-    # --- Rebuild command cleanly ---
-    cmd = ["ffmpeg", "-y", "-hide_banner", "-loglevel", "error"]
-
-    # Video input
     active_size = video.get("active_size", video["size"])
     video_input = f"testsrc2=duration={duration}:size={active_size}:rate={video['fps']}"
     if "vfr" in specials:
@@ -1088,7 +1042,11 @@ def build_ffmpeg_cmd(spec, dest, duration, rng, tmpdir):
         cmd += ["-map", f"{stream_idx}"]
         stream_idx += 1
 
-    # --- Video codec ---
+    return cmd
+
+
+def add_video_codec_options(cmd, video, specials):
+    """Append video codec and HDR options. Return whether HDR bitstream is needed."""
     vcodec = video["codec"]
     cmd += ["-c:v", vcodec]
     if vcodec == "libx264":
@@ -1120,8 +1078,11 @@ def build_ffmpeg_cmd(spec, dest, duration, rng, tmpdir):
                 "max-cll=1000,400",
             ]
             needs_hevc_hdr_bsf = True
+    return needs_hevc_hdr_bsf
 
-    # --- Audio codecs ---
+
+def add_audio_codec_options(cmd, audios):
+    """Append audio codec options."""
     for i, audio in enumerate(audios):
         cmd += [f"-c:a:{i}", audio["codec"]]
         ch = audio["channels"]
@@ -1145,7 +1106,9 @@ def build_ffmpeg_cmd(spec, dest, duration, rng, tmpdir):
             # truehd encoder doesn't take bitrate; set sample format
             cmd += ["-strict", "-2"]
 
-    # --- Subtitle codecs ---
+
+def add_subtitle_codec_options(cmd, spec, subs):
+    """Append subtitle codec options."""
     for i, sub in enumerate(subs):
         fmt = sub["format"]
         if spec["ext"] == "mkv":
@@ -1160,17 +1123,19 @@ def build_ffmpeg_cmd(spec, dest, duration, rng, tmpdir):
         elif spec["ext"] == "webm":
             cmd += [f"-c:s:{i}", "webvtt"]
 
-    # --- Container-level metadata ---
+
+def add_container_metadata(cmd, rng):
+    """Append container-level metadata."""
     cmd += ["-metadata", f"title={rng.choice(TITLE_POOL)}"]
     cmd += ["-metadata", f"encoder={rng.choice(ENCODER_POOL)}"]
     cmd += ["-metadata", f"creation_time={random_timestamp(rng)}"]
 
-    # --- Track-level metadata & dispositions ---
-    # Video track is stream 0
+
+def add_track_metadata(cmd, audios, subs, rng):
+    """Append track-level metadata and dispositions."""
     cmd += ["-metadata:s:v:0", f"handler_name={rng.choice(HANDLER_POOL)}"]
     cmd += ["-metadata:s:v:0", f"language={rng.choice(LANG_POOL)}"]
 
-    # Audio tracks
     for i, audio in enumerate(audios):
         lang = audio.get("lang", rng.choice(LANG_POOL))
         title = audio.get("title", rng.choice(AUDIO_TITLE_POOL))
@@ -1193,7 +1158,9 @@ def build_ffmpeg_cmd(spec, dest, duration, rng, tmpdir):
         elif i == 0:
             cmd += [f"-disposition:s:{i}", "default"]
 
-    # --- Attachments ---
+
+def add_attachments(cmd, specials, tmpdir):
+    """Append attachment options and create temporary attachment files."""
     if "attachment" in specials:
         # Font attachment
         font_path = Path(tmpdir) / "DummyFont.ttf"
@@ -1241,6 +1208,27 @@ def build_ffmpeg_cmd(spec, dest, duration, rng, tmpdir):
             "-metadata:s:t:0",
             "filename=cover.jpg",
         ]
+
+
+def build_ffmpeg_cmd(spec, dest, duration, rng, tmpdir):
+    """Build the ffmpeg command list for a given file spec.
+
+    Returns (cmd_list, temp_files_to_cleanup).
+    """
+    outfile = dest / f"{spec['stem']}.{spec['ext']}"
+    specials = set(spec.get("special", []))
+    audios = spec["audio"]
+    subs = spec.get("subs", [])
+
+    cmd = ["ffmpeg", "-y", "-hide_banner", "-loglevel", "error"]
+    cmd += build_input_options(spec, duration, tmpdir)
+
+    needs_hevc_hdr_bsf = add_video_codec_options(cmd, spec["video"], specials)
+    add_audio_codec_options(cmd, audios)
+    add_subtitle_codec_options(cmd, spec, subs)
+    add_container_metadata(cmd, rng)
+    add_track_metadata(cmd, audios, subs, rng)
+    add_attachments(cmd, specials, tmpdir)
 
     if needs_hevc_hdr_bsf:
         cmd += [

--- a/scripts/generate-test-corpus
+++ b/scripts/generate-test-corpus
@@ -8,6 +8,7 @@ select-test-corpus for functional testing when no real library exists.
 """
 
 import argparse
+import json
 import random
 import subprocess
 import sys
@@ -504,6 +505,45 @@ def build_random_specs(count, seed, duration_range):
         })
 
     return specs
+
+
+def build_run_manifest(
+    profile,
+    duration,
+    duration_range,
+    count,
+    generated,
+    skipped,
+    failed,
+    corruptions,
+):
+    """Build the JSON-serializable run manifest."""
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "settings": {
+            "profile": profile,
+            "duration": duration,
+            "duration_range": list(duration_range),
+            "count": count,
+        },
+        "summary": {
+            "generated": len(generated),
+            "skipped": len(skipped),
+            "failed": len(failed),
+            "corrupted": len(corruptions),
+        },
+        "generated": generated,
+        "skipped": skipped,
+        "failed": failed,
+        "corruptions": corruptions,
+    }
+
+
+def write_run_manifest(dest, manifest):
+    """Write manifest.json with stable formatting."""
+    path = dest / "manifest.json"
+    path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+    return path
 
 
 # ---------------------------------------------------------------------------
@@ -1104,6 +1144,9 @@ def main():
     skip_count = 0
     fail_count = 0
     total_size = 0
+    generated_entries = []
+    skipped_entries = []
+    failed_entries = []
 
     with tempfile.TemporaryDirectory(prefix="voom-corpus-") as tmpdir:
         for idx, spec in enumerate(specs, 1):
@@ -1114,6 +1157,13 @@ def main():
             req = spec.get("requires_encoder")
             if req and available and req not in available:
                 print(f"[{idx}/{total}] Skipping {filename} — encoder '{req}' not available")
+                skipped_entries.append({
+                    "filename": filename,
+                    "stem": stem,
+                    "reason": f"encoder '{req}' not available",
+                    "covers": spec.get("covers", []),
+                    "expect": spec.get("expect", {}),
+                })
                 skip_count += 1
                 continue
 
@@ -1126,6 +1176,13 @@ def main():
                 cmd, outfile = build_ffmpeg_cmd(spec, dest, file_duration, file_rng, tmpdir)
             except Exception as e:
                 print(f"[{idx}/{total}] FAILED {filename} — error building command: {e}")
+                failed_entries.append({
+                    "filename": filename,
+                    "stem": stem,
+                    "reason": f"error building command: {e}",
+                    "covers": spec.get("covers", []),
+                    "expect": spec.get("expect", {}),
+                })
                 fail_count += 1
                 continue
 
@@ -1158,19 +1215,49 @@ def main():
                         lines = stderr.decode("utf-8", errors="replace").strip().splitlines()
                         for line in lines[-5:]:
                             print(f"  {line}")
+                    failed_entries.append({
+                        "filename": filename,
+                        "stem": stem,
+                        "reason": f"ffmpeg failed with exit code {result.returncode}",
+                        "covers": spec.get("covers", []),
+                        "expect": spec.get("expect", {}),
+                    })
                     fail_count += 1
                     continue
 
                 size = outfile.stat().st_size
                 total_size += size
                 print(f"OK ({format_size(size)})")
+                generated_entries.append({
+                    "filename": filename,
+                    "stem": stem,
+                    "size": size,
+                    "duration": file_duration,
+                    "profiles": spec.get("profiles", ["coverage"]),
+                    "covers": spec.get("covers", []),
+                    "expect": spec.get("expect", {}),
+                })
                 ok_count += 1
 
             except subprocess.TimeoutExpired:
                 print("FAILED (timeout)")
+                failed_entries.append({
+                    "filename": filename,
+                    "stem": stem,
+                    "reason": "ffmpeg timed out",
+                    "covers": spec.get("covers", []),
+                    "expect": spec.get("expect", {}),
+                })
                 fail_count += 1
             except Exception as e:
                 print(f"FAILED ({e})")
+                failed_entries.append({
+                    "filename": filename,
+                    "stem": stem,
+                    "reason": f"ffmpeg failed: {e}",
+                    "covers": spec.get("covers", []),
+                    "expect": spec.get("expect", {}),
+                })
                 fail_count += 1
 
     # Apply corruption to selected random files
@@ -1179,6 +1266,24 @@ def main():
         corrupt_results = select_and_corrupt(dest, random_specs, corrupt_count, args.seed)
         for filename, ctype, desc in corrupt_results:
             print(f"  CORRUPTED {filename} — {ctype}: {desc}")
+
+    corruption_entries = [
+        {"filename": filename, "type": ctype, "description": desc}
+        for filename, ctype, desc in corrupt_results
+    ]
+    if not args.dry_run:
+        run_manifest = build_run_manifest(
+            profile=args.profile,
+            duration=args.duration,
+            duration_range=dur_range,
+            count=args.count,
+            generated=generated_entries,
+            skipped=skipped_entries,
+            failed=failed_entries,
+            corruptions=corruption_entries,
+        )
+        manifest_path = write_run_manifest(dest, run_manifest)
+        print(f"Manifest: {manifest_path}")
 
     # Summary
     print()

--- a/scripts/generate-test-corpus
+++ b/scripts/generate-test-corpus
@@ -358,6 +358,7 @@ def build_video_feature_specs():
             "expect": {"bad_file": False, "container": "mkv", "crop": "letterbox"},
             "video": {
                 "codec": "libx264",
+                "source": "mandelbrot_zoom",
                 "size": "1920x1080",
                 "active_size": "1920x816",
                 "fps": 24,
@@ -374,6 +375,7 @@ def build_video_feature_specs():
             "expect": {"bad_file": False, "container": "mkv", "crop": "pillarbox"},
             "video": {
                 "codec": "libx264",
+                "source": "mandelbrot_zoom",
                 "size": "1920x1080",
                 "active_size": "1440x1080",
                 "fps": 24,
@@ -433,7 +435,12 @@ def build_container_feature_specs():
             "profiles": ["coverage", "stress"],
             "covers": ["video.codec.hevc", "video.resolution.4k", "video.hdr.hdr10"],
             "expect": {"bad_file": False, "container": "mkv", "is_hdr": True},
-            "video": {"codec": "libx265", "size": "3840x2160", "fps": 24},
+            "video": {
+                "codec": "libx265",
+                "source": "mandelbrot_zoom",
+                "size": "3840x2160",
+                "fps": 24,
+            },
             "audio": [{"codec": "eac3", "channels": 6}],
             "subs": [{"format": "ass", "lang": "eng"}],
             "special": ["hdr10"],
@@ -463,7 +470,12 @@ def build_container_feature_specs():
             "profiles": ["coverage"],
             "covers": ["video.frame_rate.variable", "video.codec.h264"],
             "expect": {"bad_file": False, "container": "mp4"},
-            "video": {"codec": "libx264", "size": "1280x720", "fps": 30},
+            "video": {
+                "codec": "libx264",
+                "source": "mandelbrot_zoom",
+                "size": "1280x720",
+                "fps": 30,
+            },
             "audio": [{"codec": "aac", "channels": 2}],
             "subs": [],
             "special": ["vfr"],
@@ -993,6 +1005,36 @@ def write_minimal_png(path):
 # ---------------------------------------------------------------------------
 
 
+def build_video_input(video, duration, specials):
+    """Build a lavfi video input expression for a fixture."""
+    source = video.get("source", "testsrc2")
+    active_size = video.get("active_size", video["size"])
+    active_w, active_h = active_size.split("x", 1)
+    fps = video["fps"]
+
+    if source == "mandelbrot_zoom":
+        video_input = (
+            f"mandelbrot=size={active_size}:rate={fps}:"
+            "start_x=-0.7436438870371587:start_y=0.131825904205312:"
+            "start_scale=3:end_scale=0.0008"
+            f",trim=duration={duration},setpts=PTS-STARTPTS"
+        )
+        if active_size != video["size"]:
+            video_input += f",scale={active_w}:{active_h}"
+    elif source == "testsrc2":
+        video_input = f"testsrc2=duration={duration}:size={active_size}:rate={fps}"
+    else:
+        raise ValueError(f"unsupported video source '{source}'")
+
+    if "vfr" in specials:
+        video_input += ",setpts='PTS+0.003*sin(N*0.15)/TB'"
+    if "black_bars" in specials:
+        output_size = video["size"].replace("x", ":")
+        video_input += f",pad={output_size}:(ow-iw)/2:(oh-ih)/2:black"
+
+    return video_input
+
+
 def build_input_options(spec, duration, tmpdir):
     """Return ffmpeg input and stream mapping options for a file spec."""
     cmd = []
@@ -1001,14 +1043,7 @@ def build_input_options(spec, duration, tmpdir):
     audios = spec["audio"]
     subs = spec.get("subs", [])
 
-    active_size = video.get("active_size", video["size"])
-    video_input = f"testsrc2=duration={duration}:size={active_size}:rate={video['fps']}"
-    if "vfr" in specials:
-        video_input += ",setpts='PTS+0.003*sin(N*0.15)/TB'"
-    if "black_bars" in specials:
-        output_size = video["size"].replace("x", ":")
-        video_input += f",pad={output_size}:(ow-iw)/2:(oh-ih)/2:black"
-    cmd += ["-f", "lavfi", "-i", video_input]
+    cmd += ["-f", "lavfi", "-i", build_video_input(video, duration, specials)]
 
     # Audio inputs (one sine per audio track)
     for i, audio in enumerate(audios):

--- a/scripts/generate-test-corpus
+++ b/scripts/generate-test-corpus
@@ -357,6 +357,67 @@ def build_basic_manifest_specs():
     ]
 
 
+def build_audio_feature_specs():
+    """Return expanded audio fixture specs."""
+    return [
+        {
+            "stem": "loudness-normalized-target",
+            "ext": "mkv",
+            "profiles": ["coverage"],
+            "covers": ["audio.normalize.already_normalized", "audio.loudness.target"],
+            "expect": {"bad_file": False, "audio_lufs": -23.0},
+            "video": {
+                "source": "mandelbrot_zoom",
+                "codec": "libx264",
+                "size": "1280x720",
+                "fps": 24,
+            },
+            "audio": [{"codec": "aac", "channels": 2, "volume": 0.65, "lang": "eng"}],
+            "subs": [],
+            "special": ["audio_loudnorm_target"],
+        },
+        {
+            "stem": "loudness-dynamic-bursts",
+            "ext": "mkv",
+            "profiles": ["coverage"],
+            "covers": ["audio.normalize.dynamic_range", "audio.loudness.bursts"],
+            "expect": {"bad_file": False, "audio_tracks": 1},
+            "video": {
+                "source": "mandelbrot_zoom",
+                "codec": "libx264",
+                "size": "1280x720",
+                "fps": 24,
+            },
+            "audio": [
+                {
+                    "codec": "aac",
+                    "channels": 2,
+                    "lang": "eng",
+                    "source": "dynamic_bursts",
+                }
+            ],
+            "subs": [],
+            "special": ["loudness"],
+        },
+        {
+            "stem": "surround-7-1-flac",
+            "ext": "mkv",
+            "profiles": ["coverage", "stress"],
+            "covers": ["audio.channels.7_1", "audio.codec.flac"],
+            "expect": {"bad_file": False, "audio_tracks": 1},
+            "video": {
+                "source": "mandelbrot_zoom",
+                "codec": "libx264",
+                "size": "1280x720",
+                "fps": 24,
+            },
+            "audio": [{"codec": "flac", "channels": 8, "lang": "eng"}],
+            "subs": [],
+            "special": [],
+        },
+    ]
+
+
 def build_video_feature_specs():
     """Return video-feature and common codec fixture specs."""
     return [
@@ -436,25 +497,51 @@ def build_video_feature_specs():
     ]
 
 
-def build_container_feature_specs():
-    """Return HDR, container, and optional codec fixture specs."""
+def build_crop_feature_specs():
+    """Return expanded crop fixture specs."""
     return [
         {
-            "stem": "4k-hevc-hdr10",
+            "stem": "windowbox-h264",
             "ext": "mkv",
-            "profiles": ["coverage", "stress"],
-            "covers": ["video.codec.hevc", "video.resolution.4k", "video.hdr.hdr10"],
-            "expect": {"bad_file": False, "container": "mkv", "is_hdr": True},
+            "profiles": ["coverage"],
+            "covers": ["video.crop.windowbox", "video.content.mandelbrot_zoom"],
+            "expect": {
+                "bad_file": False,
+                "crop": {"left": 240, "top": 120, "right": 240, "bottom": 120},
+            },
             "video": {
-                "codec": "libx265",
                 "source": "mandelbrot_zoom",
-                "size": "3840x2160",
+                "codec": "libx264",
+                "size": "1920x1080",
+                "active_size": "1440x840",
                 "fps": 24,
             },
-            "audio": [{"codec": "eac3", "channels": 6}],
-            "subs": [{"format": "ass", "lang": "eng"}],
-            "special": ["hdr10"],
+            "audio": [{"codec": "aac", "channels": 2, "lang": "eng"}],
+            "subs": [],
+            "special": ["black_bars"],
         },
+        {
+            "stem": "dark-edge-no-crop",
+            "ext": "mkv",
+            "profiles": ["coverage"],
+            "covers": ["video.crop.false_positive_guard"],
+            "expect": {"bad_file": False, "crop": None},
+            "video": {
+                "source": "mandelbrot_zoom",
+                "codec": "libx264",
+                "size": "1920x1080",
+                "fps": 24,
+            },
+            "audio": [{"codec": "aac", "channels": 2, "lang": "eng"}],
+            "subs": [],
+            "special": ["dark_edges"],
+        },
+    ]
+
+
+def build_container_feature_specs():
+    """Return container and optional codec fixture specs."""
+    return [
         {
             "stem": "multichannel-flac",
             "ext": "mkv",
@@ -535,6 +622,78 @@ def build_container_feature_specs():
             "subs": [{"format": "srt", "lang": "eng", "forced": True}],
             "special": [],
             "requires_encoder": "truehd",
+        },
+    ]
+
+
+def build_hdr_color_specs():
+    """Return expanded HDR and color fixture specs."""
+    return [
+        {
+            "stem": "4k-hevc-hdr10",
+            "ext": "mkv",
+            "profiles": ["coverage", "stress"],
+            "covers": ["video.codec.hevc", "video.resolution.4k", "video.hdr.hdr10"],
+            "expect": {"bad_file": False, "container": "mkv", "is_hdr": True},
+            "video": {
+                "codec": "libx265",
+                "source": "mandelbrot_zoom",
+                "size": "3840x2160",
+                "fps": 24,
+            },
+            "audio": [{"codec": "eac3", "channels": 6}],
+            "subs": [{"format": "ass", "lang": "eng"}],
+            "special": ["hdr10"],
+        },
+        {
+            "stem": "hevc-hlg-10bit",
+            "ext": "mkv",
+            "profiles": ["coverage", "stress"],
+            "covers": [
+                "video.content.mandelbrot_zoom",
+                "video.hdr.hlg",
+                "video.codec.hevc",
+            ],
+            "expect": {
+                "bad_file": False,
+                "video_codec": "hevc",
+                "is_hdr": True,
+                "hdr_format": "hlg",
+            },
+            "video": {
+                "source": "mandelbrot_zoom",
+                "codec": "libx265",
+                "size": "1920x1080",
+                "fps": 24,
+            },
+            "audio": [{"codec": "aac", "channels": 2, "lang": "eng"}],
+            "subs": [],
+            "special": ["hlg"],
+        },
+        {
+            "stem": "hevc-sdr-10bit",
+            "ext": "mkv",
+            "profiles": ["coverage"],
+            "covers": [
+                "video.bit_depth.10",
+                "video.hdr.false_positive_guard",
+                "video.codec.hevc",
+            ],
+            "expect": {
+                "bad_file": False,
+                "video_codec": "hevc",
+                "is_hdr": False,
+                "pixel_format": "yuv420p10le",
+            },
+            "video": {
+                "source": "mandelbrot_zoom",
+                "codec": "libx265",
+                "size": "1920x1080",
+                "fps": 24,
+            },
+            "audio": [{"codec": "aac", "channels": 2, "lang": "eng"}],
+            "subs": [],
+            "special": ["sdr_10bit"],
         },
     ]
 
@@ -621,7 +780,10 @@ def build_manifest():
     """Return the list of file specs to generate."""
     return (
         build_basic_manifest_specs()
+        + build_audio_feature_specs()
         + build_video_feature_specs()
+        + build_crop_feature_specs()
+        + build_hdr_color_specs()
         + build_container_feature_specs()
         + build_corrupt_fixture_specs()
     )
@@ -1199,8 +1361,26 @@ def build_video_input(video, duration, specials):
     if "black_bars" in specials:
         output_size = video["size"].replace("x", ":")
         video_input += f",pad={output_size}:(ow-iw)/2:(oh-ih)/2:black"
+    if "dark_edges" in specials:
+        video_input += ",vignette=PI/5"
 
     return video_input
+
+
+def build_audio_input(audio, index, duration):
+    """Build a lavfi audio input expression for a fixture."""
+    source = audio.get("source", "sine")
+    if source == "dynamic_bursts":
+        return (
+            f"aevalsrc='if(between(mod(t,1),0,0.15),0.9*sin(2*PI*880*t),"
+            f"0.04*sin(2*PI*220*t))':duration={duration}:sample_rate=48000"
+        )
+    audio_filter = (
+        f"sine=frequency={440 + index * 110}:duration={duration}:sample_rate=48000"
+    )
+    if "volume" in audio:
+        audio_filter += f",volume={audio['volume']}"
+    return audio_filter
 
 
 def build_input_options(spec, duration, tmpdir):
@@ -1215,12 +1395,7 @@ def build_input_options(spec, duration, tmpdir):
 
     # Audio inputs (one sine per audio track)
     for i, audio in enumerate(audios):
-        audio_filter = (
-            f"sine=frequency={440 + i * 110}:duration={duration}:sample_rate=48000"
-        )
-        if "volume" in audio:
-            audio_filter += f",volume={audio['volume']}"
-        cmd += ["-f", "lavfi", "-i", audio_filter]
+        cmd += ["-f", "lavfi", "-i", build_audio_input(audio, i, duration)]
 
     # Subtitle inputs
     sub_files = []
@@ -1249,7 +1424,7 @@ def build_input_options(spec, duration, tmpdir):
 
 
 def add_video_codec_options(cmd, video, specials):
-    """Append video codec and HDR options. Return whether HDR bitstream is needed."""
+    """Append video codec and HDR options. Return the HEVC metadata filter."""
     vcodec = video["codec"]
     cmd += ["-c:v", vcodec]
     if vcodec == "libx264":
@@ -1264,8 +1439,7 @@ def add_video_codec_options(cmd, video, specials):
     elif vcodec == "mpeg2video":
         cmd += ["-b:v", "1M"]
 
-    # HDR10 metadata
-    needs_hevc_hdr_bsf = False
+    hevc_metadata_bsf = None
     if "hdr10" in specials:
         cmd += [
             "-pix_fmt",
@@ -1280,8 +1454,28 @@ def add_video_codec_options(cmd, video, specials):
                 "R(34000,16000)WP(15635,16450)L(10000000,1):"
                 "max-cll=1000,400",
             ]
-            needs_hevc_hdr_bsf = True
-    return needs_hevc_hdr_bsf
+            hevc_metadata_bsf = (
+                "hevc_metadata=colour_primaries=9:"
+                "transfer_characteristics=16:matrix_coefficients=9"
+            )
+
+    if "hlg" in specials:
+        cmd += ["-pix_fmt", "yuv420p10le"]
+        if vcodec == "libx265":
+            cmd += [
+                "-x265-params",
+                "repeat-headers=1:colorprim=bt2020:transfer=arib-std-b67:"
+                "colormatrix=bt2020nc",
+            ]
+            hevc_metadata_bsf = (
+                "hevc_metadata=colour_primaries=9:"
+                "transfer_characteristics=18:matrix_coefficients=9"
+            )
+
+    if "sdr_10bit" in specials:
+        cmd += ["-pix_fmt", "yuv420p10le"]
+
+    return hevc_metadata_bsf
 
 
 def add_audio_codec_options(cmd, audios):
@@ -1308,6 +1502,12 @@ def add_audio_codec_options(cmd, audios):
         elif audio["codec"] == "truehd":
             # truehd encoder doesn't take bitrate; set sample format
             cmd += ["-strict", "-2"]
+
+
+def add_audio_filter_options(cmd, specials):
+    """Append audio filter options."""
+    if "audio_loudnorm_target" in specials:
+        cmd += ["-af:a:0", "loudnorm=I=-23:TP=-2:LRA=11"]
 
 
 def add_subtitle_codec_options(cmd, spec, subs):
@@ -1426,19 +1626,16 @@ def build_ffmpeg_cmd(spec, dest, duration, rng, tmpdir):
     cmd = ["ffmpeg", "-y", "-hide_banner", "-loglevel", "error"]
     cmd += build_input_options(spec, duration, tmpdir)
 
-    needs_hevc_hdr_bsf = add_video_codec_options(cmd, spec["video"], specials)
+    hevc_metadata_bsf = add_video_codec_options(cmd, spec["video"], specials)
     add_audio_codec_options(cmd, audios)
+    add_audio_filter_options(cmd, specials)
     add_subtitle_codec_options(cmd, spec, subs)
     add_container_metadata(cmd, rng)
     add_track_metadata(cmd, audios, subs, rng)
     add_attachments(cmd, specials, tmpdir)
 
-    if needs_hevc_hdr_bsf:
-        cmd += [
-            "-bsf:v",
-            "hevc_metadata=colour_primaries=9:"
-            "transfer_characteristics=16:matrix_coefficients=9",
-        ]
+    if hevc_metadata_bsf is not None:
+        cmd += ["-bsf:v", hevc_metadata_bsf]
 
     # --- Duration limit ---
     cmd += ["-t", str(duration)]

--- a/scripts/generate-test-corpus
+++ b/scripts/generate-test-corpus
@@ -8,6 +8,7 @@ select-test-corpus for functional testing when no real library exists.
 """
 
 import argparse
+import json
 import os
 import random
 import subprocess
@@ -51,6 +52,10 @@ HANDLER_POOL = [
     "VideoHandler", "SoundHandler", "Apple Video Media Handler",
     "GPAC ISO Video Handler", "GPAC ISO Audio Handler",
 ]
+
+SCHEMA_VERSION = 1
+PROFILE_CHOICES = ("smoke", "coverage", "stress", "all")
+ALL_PROFILE_MEMBERS = {"smoke", "coverage", "stress"}
 
 # ---------------------------------------------------------------------------
 # Naming pools for random file generation
@@ -181,12 +186,43 @@ def random_timestamp(rng):
 # File manifest
 # ---------------------------------------------------------------------------
 
+def fixture_filename(spec):
+    """Return the output filename for a fixture spec."""
+    return f"{spec['stem']}.{spec['ext']}"
+
+
+def profile_matches(spec, profile):
+    """Return whether a fixture belongs to the selected profile."""
+    profiles = set(spec.get("profiles", ["coverage"]))
+    if profile == "all":
+        return bool(profiles & ALL_PROFILE_MEMBERS)
+    return profile in profiles
+
+
+def select_specs(specs, profile, only, skip):
+    """Filter fixture specs by profile, --only, and --skip."""
+    selected = []
+    for spec in specs:
+        stem = spec["stem"]
+        if not profile_matches(spec, profile):
+            continue
+        if only is not None and stem not in only:
+            continue
+        if stem in skip:
+            continue
+        selected.append(spec)
+    return selected
+
+
 def build_manifest():
     """Return the list of file specs to generate."""
     return [
         {
             "stem": "basic-h264-aac",
             "ext": "mp4",
+            "profiles": ["smoke", "coverage"],
+            "covers": ["video.codec.h264", "audio.codec.aac"],
+            "expect": {"bad_file": False, "container": "mp4"},
             "video": {"codec": "libx264", "size": "1920x1080", "fps": 24},
             "audio": [{"codec": "aac", "channels": 2}],
             "subs": [],
@@ -195,6 +231,9 @@ def build_manifest():
         {
             "stem": "loudness-quiet-dialogue",
             "ext": "mkv",
+            "profiles": ["smoke", "coverage"],
+            "covers": ["audio.loudness.quiet_dialogue", "video.codec.h264"],
+            "expect": {"bad_file": False, "container": "mkv", "audio_tracks": 1},
             "video": {"codec": "libx264", "size": "1280x720", "fps": 24},
             "audio": [{"codec": "aac", "channels": 2, "volume": 0.12, "lang": "eng"}],
             "subs": [],
@@ -203,6 +242,9 @@ def build_manifest():
         {
             "stem": "loudness-hot-mix",
             "ext": "mkv",
+            "profiles": ["coverage"],
+            "covers": ["audio.loudness.hot_mix", "video.codec.h264"],
+            "expect": {"bad_file": False, "container": "mkv", "audio_tracks": 1},
             "video": {"codec": "libx264", "size": "1280x720", "fps": 24},
             "audio": [{"codec": "aac", "channels": 2, "volume": 1.8, "lang": "eng"}],
             "subs": [],
@@ -211,6 +253,9 @@ def build_manifest():
         {
             "stem": "letterbox-h264",
             "ext": "mkv",
+            "profiles": ["smoke", "coverage"],
+            "covers": ["video.crop.letterbox", "video.codec.h264"],
+            "expect": {"bad_file": False, "container": "mkv", "crop": "letterbox"},
             "video": {
                 "codec": "libx264",
                 "size": "1920x1080",
@@ -224,6 +269,9 @@ def build_manifest():
         {
             "stem": "pillarbox-h264",
             "ext": "mkv",
+            "profiles": ["coverage"],
+            "covers": ["video.crop.pillarbox", "video.codec.h264"],
+            "expect": {"bad_file": False, "container": "mkv", "crop": "pillarbox"},
             "video": {
                 "codec": "libx264",
                 "size": "1920x1080",
@@ -237,6 +285,9 @@ def build_manifest():
         {
             "stem": "hevc-surround",
             "ext": "mkv",
+            "profiles": ["smoke", "coverage"],
+            "covers": ["video.codec.hevc", "audio.channels.5_1", "subtitle.forced"],
+            "expect": {"bad_file": False, "container": "mkv", "audio_tracks": 2},
             "video": {"codec": "libx265", "size": "1920x1080", "fps": 24},
             "audio": [
                 {"codec": "ac3", "channels": 6},
@@ -251,6 +302,9 @@ def build_manifest():
         {
             "stem": "sd-mpeg2",
             "ext": "avi",
+            "profiles": ["coverage"],
+            "covers": ["video.codec.mpeg2", "video.resolution.sd", "audio.codec.mp3"],
+            "expect": {"bad_file": False, "container": "avi"},
             "video": {"codec": "mpeg2video", "size": "720x480", "fps": 30},
             "audio": [{"codec": "mp3", "channels": 1}],
             "subs": [],
@@ -259,6 +313,9 @@ def build_manifest():
         {
             "stem": "vp9-opus",
             "ext": "webm",
+            "profiles": ["smoke", "coverage"],
+            "covers": ["video.codec.vp9", "audio.codec.opus", "subtitle.format.webvtt"],
+            "expect": {"bad_file": False, "container": "webm"},
             "video": {"codec": "libvpx-vp9", "size": "1280x720", "fps": 24},
             "audio": [{"codec": "libopus", "channels": 2}],
             "subs": [{"format": "webvtt", "lang": "eng"}],
@@ -267,6 +324,9 @@ def build_manifest():
         {
             "stem": "4k-hevc-hdr10",
             "ext": "mkv",
+            "profiles": ["coverage", "stress"],
+            "covers": ["video.codec.hevc", "video.resolution.4k", "video.hdr.hdr10"],
+            "expect": {"bad_file": False, "container": "mkv", "is_hdr": True},
             "video": {"codec": "libx265", "size": "3840x2160", "fps": 24},
             "audio": [{"codec": "eac3", "channels": 6}],
             "subs": [{"format": "ass", "lang": "eng"}],
@@ -275,6 +335,9 @@ def build_manifest():
         {
             "stem": "multichannel-flac",
             "ext": "mkv",
+            "profiles": ["coverage"],
+            "covers": ["audio.codec.flac", "audio.channels.stereo", "audio.commentary"],
+            "expect": {"bad_file": False, "container": "mkv", "audio_tracks": 2},
             "video": {"codec": "libx264", "size": "1920x1080", "fps": 24},
             "audio": [
                 {"codec": "flac", "channels": 2},
@@ -287,6 +350,9 @@ def build_manifest():
         {
             "stem": "vfr-h264",
             "ext": "mp4",
+            "profiles": ["coverage"],
+            "covers": ["video.frame_rate.variable", "video.codec.h264"],
+            "expect": {"bad_file": False, "container": "mp4"},
             "video": {"codec": "libx264", "size": "1280x720", "fps": 30},
             "audio": [{"codec": "aac", "channels": 2}],
             "subs": [],
@@ -295,6 +361,9 @@ def build_manifest():
         {
             "stem": "attachment",
             "ext": "mkv",
+            "profiles": ["coverage"],
+            "covers": ["container.attachment.font", "container.attachment.image"],
+            "expect": {"bad_file": False, "container": "mkv", "attachments": True},
             "video": {"codec": "libx264", "size": "1280x720", "fps": 24},
             "audio": [{"codec": "aac", "channels": 2}],
             "subs": [{"format": "srt", "lang": "eng"}],
@@ -303,6 +372,9 @@ def build_manifest():
         {
             "stem": "cover-art",
             "ext": "mkv",
+            "profiles": ["coverage"],
+            "covers": ["container.attachment.cover_art"],
+            "expect": {"bad_file": False, "container": "mkv", "cover_art": True},
             "video": {"codec": "libx264", "size": "1920x1080", "fps": 24},
             "audio": [{"codec": "aac", "channels": 2}],
             "subs": [],
@@ -311,6 +383,9 @@ def build_manifest():
         {
             "stem": "av1-opus",
             "ext": "mp4",
+            "profiles": ["coverage", "stress"],
+            "covers": ["video.codec.av1", "audio.codec.opus", "encoder.optional"],
+            "expect": {"bad_file": False, "container": "mp4"},
             "video": {"codec": "libsvtav1", "size": "1280x720", "fps": 24},
             "audio": [{"codec": "libopus", "channels": 2}],
             "subs": [],
@@ -320,6 +395,9 @@ def build_manifest():
         {
             "stem": "hevc-truehd",
             "ext": "mkv",
+            "profiles": ["coverage", "stress"],
+            "covers": ["video.codec.hevc", "audio.codec.truehd", "encoder.optional"],
+            "expect": {"bad_file": False, "container": "mkv"},
             "video": {"codec": "libx265", "size": "1920x1080", "fps": 24},
             "audio": [{"codec": "truehd", "channels": 2}],
             "subs": [{"format": "srt", "lang": "eng", "forced": True}],
@@ -943,6 +1021,12 @@ def main():
         help="Comma-separated list of file stems to skip",
     )
     parser.add_argument(
+        "--profile",
+        choices=PROFILE_CHOICES,
+        default="coverage",
+        help="Named deterministic fixture profile to generate (default: coverage)",
+    )
+    parser.add_argument(
         "--seed", type=int, default=42, metavar="N",
         help="RNG seed for metadata randomization (default: 42)",
     )
@@ -995,14 +1079,7 @@ def main():
     # Filter manifest
     only = set(args.only.split(",")) if args.only else None
     skip = set(args.skip.split(",")) if args.skip else set()
-
-    specs = []
-    for spec in manifest:
-        if only and spec["stem"] not in only:
-            continue
-        if spec["stem"] in skip:
-            continue
-        specs.append(spec)
+    specs = select_specs(manifest, args.profile, only, skip)
 
     # Generate random specs if --count is set
     random_specs = []

--- a/scripts/generate-test-corpus
+++ b/scripts/generate-test-corpus
@@ -508,6 +508,7 @@ def build_random_specs(count, seed, duration_range):
 
 
 def build_run_manifest(
+    *,
     profile,
     duration,
     duration_range,

--- a/scripts/generate-test-corpus
+++ b/scripts/generate-test-corpus
@@ -8,8 +8,6 @@ select-test-corpus for functional testing when no real library exists.
 """
 
 import argparse
-import json
-import os
 import random
 import subprocess
 import sys
@@ -412,7 +410,6 @@ def build_random_specs(count, seed, duration_range):
 
     Uses only safe codecs (h264/h265, aac/ac3/mp3/flac) in MKV/MP4 containers.
     """
-    rng = random.Random(seed)
     used_names = set()
     used_signatures = set()
     specs = []
@@ -762,10 +759,6 @@ def build_ffmpeg_cmd(spec, dest, duration, rng, tmpdir):
             cmd += ["-f", "lavfi", "-i", f"amovie='{amerge_input}'" if False else ""]
             # Actually, use a complex filter approach — replace last two args
             cmd = cmd[:-2]
-            sine_filter = ";".join(
-                f"sine=frequency={freq}:duration={duration}:sample_rate=48000"
-                for freq in freqs
-            )
             cmd += ["-f", "lavfi", "-i",
                     f"sine=frequency=440:duration={duration}:sample_rate=48000"]
 
@@ -885,7 +878,7 @@ def build_ffmpeg_cmd(spec, dest, duration, rng, tmpdir):
             cmd += [f"-b:a:{i}", "128k"]
         elif audio["codec"] == "truehd":
             # truehd encoder doesn't take bitrate; set sample format
-            cmd += [f"-strict", "-2"]
+            cmd += ["-strict", "-2"]
 
     # --- Subtitle codecs ---
     for i, sub in enumerate(subs):
@@ -1073,7 +1066,6 @@ def main():
         sys.exit(1)
 
     dest = Path(args.dest)
-    rng = random.Random(args.seed)
     manifest = build_manifest()
 
     # Filter manifest

--- a/scripts/generate-test-corpus
+++ b/scripts/generate-test-corpus
@@ -554,17 +554,17 @@ CORRUPTION_TYPES = ["truncated", "header_damage", "mid_stream", "zero_length", "
 
 
 def apply_corruption(file_path, corruption_type, rng):
-    """Corrupt a generated file in-place. Returns a description string."""
+    """Corrupt a generated file in-place. Returns (description, final_path)."""
     size = file_path.stat().st_size
     if size == 0:
-        return "skipped (already empty)"
+        return "skipped (already empty)", file_path
 
     if corruption_type == "truncated":
         cut_pct = rng.randint(10, 80)
         new_size = max(1, size * cut_pct // 100)
         data = file_path.read_bytes()[:new_size]
         file_path.write_bytes(data)
-        return f"truncated to {cut_pct}% ({new_size} bytes)"
+        return f"truncated to {cut_pct}% ({new_size} bytes)", file_path
 
     elif corruption_type == "header_damage":
         damage_size = min(rng.randint(64, 512), size)
@@ -572,7 +572,7 @@ def apply_corruption(file_path, corruption_type, rng):
         for i in range(damage_size):
             data[i] = rng.randint(0, 255)
         file_path.write_bytes(bytes(data))
-        return f"header damaged ({damage_size} bytes)"
+        return f"header damaged ({damage_size} bytes)", file_path
 
     elif corruption_type == "mid_stream":
         block_size = min(rng.randint(1024, 4096), size // 2)
@@ -582,11 +582,11 @@ def apply_corruption(file_path, corruption_type, rng):
         for i in range(min(block_size, len(data) - offset)):
             data[offset + i] = rng.randint(0, 255)
         file_path.write_bytes(bytes(data))
-        return f"mid-stream corruption ({block_size} bytes at offset {offset})"
+        return f"mid-stream corruption ({block_size} bytes at offset {offset})", file_path
 
     elif corruption_type == "zero_length":
         file_path.write_bytes(b"")
-        return "truncated to zero bytes"
+        return "truncated to zero bytes", file_path
 
     elif corruption_type == "wrong_extension":
         current_ext = file_path.suffix
@@ -598,15 +598,15 @@ def apply_corruption(file_path, corruption_type, rng):
             new_ext = ".mkv"
         new_path = file_path.with_suffix(new_ext)
         file_path.rename(new_path)
-        return f"extension changed {current_ext} -> {new_ext}"
+        return f"extension changed {current_ext} -> {new_ext}", new_path
 
-    return "unknown corruption type"
+    return "unknown corruption type", file_path
 
 
 def select_and_corrupt(dest, random_specs, corrupt_count, seed):
     """Select `corrupt_count` files from `random_specs` and corrupt them.
 
-    Returns list of (filename, corruption_type, description) tuples.
+    Returns corruption result dictionaries with final filenames and sizes.
     """
     if corrupt_count <= 0 or not random_specs:
         return []
@@ -621,8 +621,14 @@ def select_and_corrupt(dest, random_specs, corrupt_count, seed):
         if not filepath.exists():
             continue
         ctype = rng.choice(CORRUPTION_TYPES)
-        desc = apply_corruption(filepath, ctype, rng)
-        results.append((filename, ctype, desc))
+        desc, final_path = apply_corruption(filepath, ctype, rng)
+        results.append({
+            "original_filename": filename,
+            "filename": final_path.name,
+            "type": ctype,
+            "description": desc,
+            "size": final_path.stat().st_size,
+        })
 
     return results
 
@@ -1264,12 +1270,26 @@ def main():
     corrupt_results = []
     if corrupt_count > 0 and not args.dry_run:
         corrupt_results = select_and_corrupt(dest, random_specs, corrupt_count, args.seed)
-        for filename, ctype, desc in corrupt_results:
+        generated_by_filename = {entry["filename"]: entry for entry in generated_entries}
+        for result in corrupt_results:
+            filename = result["filename"]
+            ctype = result["type"]
+            desc = result["description"]
             print(f"  CORRUPTED {filename} — {ctype}: {desc}")
 
+            entry = generated_by_filename.get(result["original_filename"])
+            if entry is not None:
+                entry["filename"] = filename
+                entry["size"] = result["size"]
+
     corruption_entries = [
-        {"filename": filename, "type": ctype, "description": desc}
-        for filename, ctype, desc in corrupt_results
+        {
+            "filename": result["filename"],
+            "type": result["type"],
+            "description": result["description"],
+            "size": result["size"],
+        }
+        for result in corrupt_results
     ]
     if not args.dry_run:
         run_manifest = build_run_manifest(

--- a/scripts/generate-test-corpus
+++ b/scripts/generate-test-corpus
@@ -864,11 +864,14 @@ def materialize_corrupt_fixture(dest, spec, rng):
             "skipped": True,
         }
 
-    shutil.copyfile(source_path, target_path)
     applied_type = DETERMINISTIC_CORRUPTION_TYPES.get(
         corruption_type,
         corruption_type,
     )
+    if applied_type not in CORRUPTION_TYPES:
+        raise ValueError(f"unknown deterministic corruption type: {corruption_type}")
+
+    shutil.copyfile(source_path, target_path)
     desc, final_path = apply_corruption(target_path, applied_type, rng)
     return {
         "original_filename": original_filename,
@@ -940,6 +943,17 @@ def build_corruption_manifest_entries(corrupt_results):
             entry["skipped"] = True
         entries.append(entry)
     return entries
+
+
+def build_skipped_corruption_entry(spec, result):
+    """Return a skipped manifest entry for an unmaterialized corruption fixture."""
+    return {
+        "filename": result["filename"],
+        "stem": spec["stem"],
+        "reason": result["description"],
+        "covers": spec.get("covers", []),
+        "expect": spec.get("expect", {}),
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -1741,20 +1755,29 @@ def main():
         start = len(specs)
         for offset, spec in enumerate(deterministic_corrupt_specs, 1):
             filename = fixture_filename(spec)
-            corruption_type = spec["corruption"]["type"]
+            corruption = spec["corruption"]
+            corruption_type = corruption["type"]
+            source_filename = f"{corruption['source_stem']}.{corruption['source_ext']}"
             print(f"[{start + offset}/{total}] {filename}")
-            print(f"  deterministic corruption: {corruption_type}")
+            print(
+                f"  deterministic corruption: {corruption_type} from {source_filename}"
+            )
             print()
             ok_count += 1
     else:
         corrupt_rng = random.Random(args.seed + 19999)
         for spec in deterministic_corrupt_specs:
             result = materialize_corrupt_fixture(dest, spec, corrupt_rng)
-            deterministic_corrupt_results.append(result)
             filename = result["filename"]
             ctype = result["type"]
             desc = result["description"]
-            print(f"  CORRUPTED {filename} — {ctype}: {desc}")
+            if result["skipped"]:
+                skipped_entries.append(build_skipped_corruption_entry(spec, result))
+                skip_count += 1
+                print(f"  SKIPPED {filename} — {ctype}: {desc}")
+            else:
+                deterministic_corrupt_results.append(result)
+                print(f"  CORRUPTED {filename} — {ctype}: {desc}")
 
     # Apply corruption to selected random files
     random_corrupt_results = []

--- a/scripts/generate-test-corpus
+++ b/scripts/generate-test-corpus
@@ -14,6 +14,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+from dataclasses import dataclass, field
 from pathlib import Path
 
 
@@ -956,48 +957,52 @@ def apply_corruption(file_path, corruption_type, rng):
     if corruption_type == "truncated":
         cut_pct = rng.randint(10, 80)
         new_size = max(1, size * cut_pct // 100)
-        data = file_path.read_bytes()[:new_size]
-        file_path.write_bytes(data)
+        with file_path.open("r+b") as file:
+            file.truncate(new_size)
         return f"truncated to {cut_pct}% ({new_size} bytes)", file_path
 
     elif corruption_type == "header_damage":
         damage_size = min(rng.randint(64, 512), size)
-        data = bytearray(file_path.read_bytes())
-        for i in range(damage_size):
-            data[i] = rng.randint(0, 255)
-        file_path.write_bytes(bytes(data))
+        damaged_header = bytes(rng.randint(0, 255) for _ in range(damage_size))
+        with file_path.open("r+b") as file:
+            file.seek(0)
+            file.write(damaged_header)
         return f"header damaged ({damage_size} bytes)", file_path
 
     elif corruption_type == "mid_stream":
         block_size = min(rng.randint(1024, 4096), size // 2)
         quarter = max(1, size // 4)
         offset = rng.randint(quarter, max(quarter, size - quarter - block_size))
-        data = bytearray(file_path.read_bytes())
-        for i in range(min(block_size, len(data) - offset)):
-            data[offset + i] = rng.randint(0, 255)
-        file_path.write_bytes(bytes(data))
+        overwrite_size = min(block_size, size - offset)
+        damaged_block = bytes(rng.randint(0, 255) for _ in range(overwrite_size))
+        with file_path.open("r+b") as file:
+            file.seek(offset)
+            file.write(damaged_block)
         return (
             f"mid-stream corruption ({block_size} bytes at offset {offset})",
             file_path,
         )
 
     elif corruption_type == "zero_length":
-        file_path.write_bytes(b"")
+        with file_path.open("r+b") as file:
+            file.truncate(0)
         return "truncated to zero bytes", file_path
 
     elif corruption_type == "wrong_extension":
-        current_ext = file_path.suffix
-        if current_ext == ".mkv":
-            new_ext = ".mp4"
-        elif current_ext == ".mp4":
-            new_ext = ".mkv"
-        else:
-            new_ext = ".mkv"
-        new_path = file_path.with_suffix(new_ext)
+        new_path = corruption_final_path(file_path, corruption_type)
         file_path.rename(new_path)
-        return f"extension changed {current_ext} -> {new_ext}", new_path
+        return f"extension changed {file_path.suffix} -> {new_path.suffix}", new_path
 
     return "unknown corruption type", file_path
+
+
+def corruption_final_path(file_path, corruption_type):
+    """Return the path a corruption operation will leave behind."""
+    if corruption_type != "wrong_extension":
+        return file_path
+    if file_path.suffix == ".mkv":
+        return file_path.with_suffix(".mp4")
+    return file_path.with_suffix(".mkv")
 
 
 DETERMINISTIC_CORRUPTION_TYPES = {
@@ -1112,13 +1117,7 @@ def build_corruption_manifest_entries(corrupt_results):
 
 def build_skipped_corruption_entry(spec, result):
     """Return a skipped manifest entry for an unmaterialized corruption fixture."""
-    return {
-        "filename": result["filename"],
-        "stem": spec["stem"],
-        "reason": result["description"],
-        "covers": spec.get("covers", []),
-        "expect": spec.get("expect", {}),
-    }
+    return build_issue_entry(spec, result["filename"], result["description"])
 
 
 # ---------------------------------------------------------------------------
@@ -1663,49 +1662,49 @@ def format_size(n):
     return f"{n:.1f} TiB"
 
 
+@dataclass
 class PreparedSpecs:
     """Fixture specs selected for a run."""
 
-    def __init__(self, *, specs, deterministic_corrupt_specs, random_specs):
-        self.specs = specs
-        self.deterministic_corrupt_specs = deterministic_corrupt_specs
-        self.random_specs = random_specs
+    specs: list
+    deterministic_corrupt_specs: list
+    random_specs: list
 
 
+@dataclass
 class GenerationOptions:
     """Options needed while materializing normal fixtures."""
 
-    def __init__(self, *, dest, duration, seed, dry_run, verbose, available, total):
-        self.dest = dest
-        self.duration = duration
-        self.seed = seed
-        self.dry_run = dry_run
-        self.verbose = verbose
-        self.available = available
-        self.total = total
+    dest: Path
+    duration: int
+    seed: int
+    dry_run: bool
+    verbose: bool
+    available: set
+    total: int
 
 
+@dataclass
 class GenerationResult:
     """Mutable counts and manifest entries accumulated during a run."""
 
-    def __init__(self):
-        self.ok_count = 0
-        self.skip_count = 0
-        self.fail_count = 0
-        self.total_size = 0
-        self.generated_entries = []
-        self.skipped_entries = []
-        self.failed_entries = []
+    ok_count: int = 0
+    skip_count: int = 0
+    fail_count: int = 0
+    total_size: int = 0
+    generated_entries: list = field(default_factory=list)
+    skipped_entries: list = field(default_factory=list)
+    failed_entries: list = field(default_factory=list)
 
 
+@dataclass
 class CorruptionResult:
     """Counts and corruption entries accumulated during corruption steps."""
 
-    def __init__(self):
-        self.ok_count = 0
-        self.skip_count = 0
-        self.skipped_entries = []
-        self.corrupt_results = []
+    ok_count: int = 0
+    skip_count: int = 0
+    skipped_entries: list = field(default_factory=list)
+    corrupt_results: list = field(default_factory=list)
 
 
 def build_arg_parser():
@@ -1852,9 +1851,7 @@ def prepare_specs(args, manifest, duration_range):
 
 def ensure_ffmpeg_available():
     """Exit with a clear message if ffmpeg is unavailable."""
-    try:
-        subprocess.run(["ffmpeg", "-version"], capture_output=True, timeout=10)
-    except FileNotFoundError:
+    if shutil.which("ffmpeg") is None:
         print("Error: ffmpeg not found in PATH", file=sys.stderr)
         sys.exit(1)
 
@@ -1883,19 +1880,8 @@ def build_generation_entry(spec, filename, size, duration):
     }
 
 
-def build_failed_generation_entry(spec, filename, reason):
-    """Return a failed-file manifest entry."""
-    return {
-        "filename": filename,
-        "stem": spec["stem"],
-        "reason": reason,
-        "covers": spec.get("covers", []),
-        "expect": spec.get("expect", {}),
-    }
-
-
-def build_skipped_generation_entry(spec, filename, reason):
-    """Return a skipped-file manifest entry."""
+def build_issue_entry(spec, filename, reason):
+    """Return a skipped/failed manifest entry."""
     return {
         "filename": filename,
         "stem": spec["stem"],
@@ -1930,7 +1916,7 @@ def generate_normal_spec(*, spec, idx, tmpdir, options, result):
             f"[{idx}/{options.total}] Skipping {filename} — encoder '{req}' not available"
         )
         result.skipped_entries.append(
-            build_skipped_generation_entry(
+            build_issue_entry(
                 spec,
                 filename,
                 f"encoder '{req}' not available",
@@ -1955,9 +1941,7 @@ def generate_normal_spec(*, spec, idx, tmpdir, options, result):
             f"[{idx}/{options.total}] FAILED {filename} — error building command: {e}"
         )
         result.failed_entries.append(
-            build_failed_generation_entry(
-                spec, filename, f"error building command: {e}"
-            )
+            build_issue_entry(spec, filename, f"error building command: {e}")
         )
         result.fail_count += 1
         return
@@ -1997,9 +1981,7 @@ def run_ffmpeg_for_spec(*, cmd, outfile, spec, filename, duration, options, resu
                 for line in lines[-5:]:
                     print(f"  {line}")
             reason = f"ffmpeg failed with exit code {run_result.returncode}"
-            result.failed_entries.append(
-                build_failed_generation_entry(spec, filename, reason)
-            )
+            result.failed_entries.append(build_issue_entry(spec, filename, reason))
             result.fail_count += 1
             return
 
@@ -2014,13 +1996,13 @@ def run_ffmpeg_for_spec(*, cmd, outfile, spec, filename, duration, options, resu
     except subprocess.TimeoutExpired:
         print("FAILED (timeout)")
         result.failed_entries.append(
-            build_failed_generation_entry(spec, filename, "ffmpeg timed out")
+            build_issue_entry(spec, filename, "ffmpeg timed out")
         )
         result.fail_count += 1
     except Exception as e:
         print(f"FAILED ({e})")
         result.failed_entries.append(
-            build_failed_generation_entry(spec, filename, f"ffmpeg failed: {e}")
+            build_issue_entry(spec, filename, f"ffmpeg failed: {e}")
         )
         result.fail_count += 1
 
@@ -2034,9 +2016,11 @@ def materialize_deterministic_corruptions(*, specs, dest, seed, dry_run, start, 
             corruption = spec["corruption"]
             corruption_type = corruption["type"]
             source_filename = f"{corruption['source_stem']}.{corruption['source_ext']}"
-            final_filename = filename
-            if corruption_type == "wrong_extension":
-                final_filename = Path(filename).with_suffix(".mkv").name
+            applied_type = DETERMINISTIC_CORRUPTION_TYPES.get(
+                corruption_type,
+                corruption_type,
+            )
+            final_filename = corruption_final_path(Path(filename), applied_type).name
             final_detail = ""
             if final_filename != filename:
                 final_detail = f"; final filename {final_filename}"

--- a/scripts/generate-test-corpus
+++ b/scripts/generate-test-corpus
@@ -544,7 +544,7 @@ def build_corrupt_fixture_specs():
     return [
         {
             "stem": "corrupt-truncated-tail",
-            "ext": "mkv",
+            "ext": "mp4",
             "profiles": ["coverage"],
             "covers": ["bad_file.truncated_tail"],
             "expect": {"bad_file": True, "corruption": "truncated_tail"},
@@ -556,7 +556,7 @@ def build_corrupt_fixture_specs():
         },
         {
             "stem": "corrupt-zero-length",
-            "ext": "mkv",
+            "ext": "mp4",
             "profiles": ["coverage"],
             "covers": ["bad_file.zero_length"],
             "expect": {"bad_file": True, "corruption": "zero_length"},
@@ -568,7 +568,7 @@ def build_corrupt_fixture_specs():
         },
         {
             "stem": "corrupt-header-damage",
-            "ext": "mkv",
+            "ext": "mp4",
             "profiles": ["coverage"],
             "covers": ["bad_file.header_damage"],
             "expect": {"bad_file": True, "corruption": "header_damage"},
@@ -580,7 +580,7 @@ def build_corrupt_fixture_specs():
         },
         {
             "stem": "corrupt-midstream-bitrot",
-            "ext": "mkv",
+            "ext": "mp4",
             "profiles": ["coverage"],
             "covers": ["bad_file.mid_stream"],
             "expect": {"bad_file": True, "corruption": "mid_stream"},
@@ -604,7 +604,7 @@ def build_corrupt_fixture_specs():
         },
         {
             "stem": "corrupt-container-metadata",
-            "ext": "mkv",
+            "ext": "mp4",
             "profiles": ["coverage"],
             "covers": ["bad_file.container_metadata"],
             "expect": {"bad_file": True, "corruption": "container_metadata"},
@@ -1814,7 +1814,10 @@ def main():
     # Summary
     print()
     if args.dry_run:
-        print(f"Dry run complete: {ok_count} files would be generated")
+        action = (
+            "generated/materialized" if deterministic_corrupt_specs else "generated"
+        )
+        print(f"Dry run complete: {ok_count} files would be {action}")
     else:
         parts = [f"{ok_count} generated"]
         if skip_count:

--- a/scripts/generate-test-corpus
+++ b/scripts/generate-test-corpus
@@ -10,6 +10,7 @@ select-test-corpus for functional testing when no real library exists.
 import argparse
 import json
 import random
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -308,6 +309,15 @@ def select_specs(specs, profile, only, skip):
     return selected
 
 
+def collect_deterministic_corruptions(specs, profile):
+    """Return corruption fixture specs selected by profile."""
+    return [
+        spec
+        for spec in specs
+        if "corruption" in spec and profile_matches(spec, profile)
+    ]
+
+
 def build_basic_manifest_specs():
     """Return baseline and audio-focused fixture specs."""
     return [
@@ -529,12 +539,91 @@ def build_container_feature_specs():
     ]
 
 
+def build_corrupt_fixture_specs():
+    """Return deterministic corrupt fixture specs."""
+    return [
+        {
+            "stem": "corrupt-truncated-tail",
+            "ext": "mkv",
+            "profiles": ["coverage"],
+            "covers": ["bad_file.truncated_tail"],
+            "expect": {"bad_file": True, "corruption": "truncated_tail"},
+            "corruption": {
+                "source_stem": "basic-h264-aac",
+                "source_ext": "mp4",
+                "type": "truncated_tail",
+            },
+        },
+        {
+            "stem": "corrupt-zero-length",
+            "ext": "mkv",
+            "profiles": ["coverage"],
+            "covers": ["bad_file.zero_length"],
+            "expect": {"bad_file": True, "corruption": "zero_length"},
+            "corruption": {
+                "source_stem": "basic-h264-aac",
+                "source_ext": "mp4",
+                "type": "zero_length",
+            },
+        },
+        {
+            "stem": "corrupt-header-damage",
+            "ext": "mkv",
+            "profiles": ["coverage"],
+            "covers": ["bad_file.header_damage"],
+            "expect": {"bad_file": True, "corruption": "header_damage"},
+            "corruption": {
+                "source_stem": "basic-h264-aac",
+                "source_ext": "mp4",
+                "type": "header_damage",
+            },
+        },
+        {
+            "stem": "corrupt-midstream-bitrot",
+            "ext": "mkv",
+            "profiles": ["coverage"],
+            "covers": ["bad_file.mid_stream"],
+            "expect": {"bad_file": True, "corruption": "mid_stream"},
+            "corruption": {
+                "source_stem": "basic-h264-aac",
+                "source_ext": "mp4",
+                "type": "mid_stream",
+            },
+        },
+        {
+            "stem": "corrupt-wrong-extension",
+            "ext": "mp4",
+            "profiles": ["coverage"],
+            "covers": ["bad_file.wrong_extension"],
+            "expect": {"bad_file": True, "corruption": "wrong_extension"},
+            "corruption": {
+                "source_stem": "basic-h264-aac",
+                "source_ext": "mp4",
+                "type": "wrong_extension",
+            },
+        },
+        {
+            "stem": "corrupt-container-metadata",
+            "ext": "mkv",
+            "profiles": ["coverage"],
+            "covers": ["bad_file.container_metadata"],
+            "expect": {"bad_file": True, "corruption": "container_metadata"},
+            "corruption": {
+                "source_stem": "basic-h264-aac",
+                "source_ext": "mp4",
+                "type": "container_metadata",
+            },
+        },
+    ]
+
+
 def build_manifest():
     """Return the list of file specs to generate."""
     return (
         build_basic_manifest_specs()
         + build_video_feature_specs()
         + build_container_feature_specs()
+        + build_corrupt_fixture_specs()
     )
 
 
@@ -749,6 +838,49 @@ def apply_corruption(file_path, corruption_type, rng):
     return "unknown corruption type", file_path
 
 
+DETERMINISTIC_CORRUPTION_TYPES = {
+    "truncated_tail": "truncated",
+    "container_metadata": "header_damage",
+}
+
+
+def materialize_corrupt_fixture(dest, spec, rng):
+    """Copy a source fixture and apply a deterministic corruption transform."""
+    corruption = spec["corruption"]
+    source_filename = f"{corruption['source_stem']}.{corruption['source_ext']}"
+    original_filename = fixture_filename(spec)
+    source_path = dest / source_filename
+    target_path = dest / original_filename
+    corruption_type = corruption["type"]
+
+    if not source_path.exists():
+        return {
+            "original_filename": original_filename,
+            "filename": original_filename,
+            "source_filename": source_filename,
+            "type": corruption_type,
+            "description": f"skipped (source missing: {source_filename})",
+            "size": 0,
+            "skipped": True,
+        }
+
+    shutil.copyfile(source_path, target_path)
+    applied_type = DETERMINISTIC_CORRUPTION_TYPES.get(
+        corruption_type,
+        corruption_type,
+    )
+    desc, final_path = apply_corruption(target_path, applied_type, rng)
+    return {
+        "original_filename": original_filename,
+        "filename": final_path.name,
+        "source_filename": source_filename,
+        "type": corruption_type,
+        "description": desc,
+        "size": final_path.stat().st_size,
+        "skipped": False,
+    }
+
+
 def select_and_corrupt(dest, random_specs, corrupt_count, seed):
     """Select `corrupt_count` files from `random_specs` and corrupt them.
 
@@ -789,6 +921,25 @@ def update_generated_entries_for_corruptions(generated_entries, corrupt_results)
         if entry is not None:
             entry["filename"] = result["filename"]
             entry["size"] = result["size"]
+
+
+def build_corruption_manifest_entries(corrupt_results):
+    """Return manifest entries for deterministic and random corruption results."""
+    entries = []
+    for result in corrupt_results:
+        entry = {
+            "original_filename": result["original_filename"],
+            "filename": result["filename"],
+            "type": result["type"],
+            "description": result["description"],
+            "size": result["size"],
+        }
+        if result.get("source_filename"):
+            entry["source_filename"] = result["source_filename"]
+        if result.get("skipped"):
+            entry["skipped"] = True
+        entries.append(entry)
+    return entries
 
 
 # ---------------------------------------------------------------------------
@@ -1403,6 +1554,11 @@ def main():
     only = set(args.only.split(",")) if args.only else None
     skip = set(args.skip.split(",")) if args.skip else set()
     specs = select_specs(manifest, args.profile, only, skip)
+    deterministic_corrupt_specs = collect_deterministic_corruptions(
+        specs,
+        args.profile,
+    )
+    specs = [spec for spec in specs if "corruption" not in spec]
 
     # Generate random specs if --count is set
     random_specs = []
@@ -1415,7 +1571,7 @@ def main():
         )
         specs.extend(random_specs)
 
-    if not specs and args.count == 0:
+    if not specs and not deterministic_corrupt_specs and args.count == 0:
         print("No files to generate (check --only / --skip filters).", file=sys.stderr)
         sys.exit(1)
 
@@ -1437,7 +1593,7 @@ def main():
     if not args.dry_run:
         dest.mkdir(parents=True, exist_ok=True)
 
-    total = len(specs)
+    total = len(specs) + len(deterministic_corrupt_specs)
     ok_count = 0
     skip_count = 0
     fail_count = 0
@@ -1580,29 +1736,44 @@ def main():
                 )
                 fail_count += 1
 
-    # Apply corruption to selected random files
-    corrupt_results = []
-    if corrupt_count > 0 and not args.dry_run:
-        corrupt_results = select_and_corrupt(
-            dest, random_specs, corrupt_count, args.seed
-        )
-        update_generated_entries_for_corruptions(generated_entries, corrupt_results)
-        for result in corrupt_results:
+    deterministic_corrupt_results = []
+    if args.dry_run:
+        start = len(specs)
+        for offset, spec in enumerate(deterministic_corrupt_specs, 1):
+            filename = fixture_filename(spec)
+            corruption_type = spec["corruption"]["type"]
+            print(f"[{start + offset}/{total}] {filename}")
+            print(f"  deterministic corruption: {corruption_type}")
+            print()
+            ok_count += 1
+    else:
+        corrupt_rng = random.Random(args.seed + 19999)
+        for spec in deterministic_corrupt_specs:
+            result = materialize_corrupt_fixture(dest, spec, corrupt_rng)
+            deterministic_corrupt_results.append(result)
             filename = result["filename"]
             ctype = result["type"]
             desc = result["description"]
             print(f"  CORRUPTED {filename} — {ctype}: {desc}")
 
-    corruption_entries = [
-        {
-            "original_filename": result["original_filename"],
-            "filename": result["filename"],
-            "type": result["type"],
-            "description": result["description"],
-            "size": result["size"],
-        }
-        for result in corrupt_results
-    ]
+    # Apply corruption to selected random files
+    random_corrupt_results = []
+    if corrupt_count > 0 and not args.dry_run:
+        random_corrupt_results = select_and_corrupt(
+            dest, random_specs, corrupt_count, args.seed
+        )
+        update_generated_entries_for_corruptions(
+            generated_entries,
+            random_corrupt_results,
+        )
+        for result in random_corrupt_results:
+            filename = result["filename"]
+            ctype = result["type"]
+            desc = result["description"]
+            print(f"  CORRUPTED {filename} — {ctype}: {desc}")
+
+    corrupt_results = deterministic_corrupt_results + random_corrupt_results
+    corruption_entries = build_corruption_manifest_entries(corrupt_results)
     if not args.dry_run:
         run_manifest = build_run_manifest(
             profile=args.profile,

--- a/scripts/generate-test-corpus
+++ b/scripts/generate-test-corpus
@@ -1485,11 +1485,12 @@ def add_audio_codec_options(cmd, audios):
         ch = audio["channels"]
         if ch == 1:
             cmd += [f"-ac:a:{i}", "1"]
+        elif ch == 2:
+            cmd += [f"-ac:a:{i}", "2", f"-channel_layout:a:{i}", "stereo"]
         elif ch == 6:
             cmd += [f"-ac:a:{i}", "6", f"-channel_layout:a:{i}", "5.1"]
         elif ch == 8:
             cmd += [f"-ac:a:{i}", "8", f"-channel_layout:a:{i}", "7.1"]
-        # else stereo is default
 
         if audio["codec"] == "aac":
             cmd += [f"-b:a:{i}", "128k"]

--- a/scripts/generate-test-corpus
+++ b/scripts/generate-test-corpus
@@ -505,7 +505,58 @@ def build_manifest():
     ]
 
 
-def build_random_specs(count, seed, duration_range):
+def build_random_audio(file_rng):
+    """Build randomized audio tracks for a random corpus spec."""
+    audio_codecs = ["aac", "ac3", "mp3", "flac"]
+    audio_channels = [1, 2, 6]
+    audio = []
+    for j in range(file_rng.randint(1, 3)):
+        codec = file_rng.choice(audio_codecs)
+        # flac/mp3 don't support this generator's 6-channel settings.
+        if codec in {"flac", "mp3"}:
+            ch = file_rng.choice([1, 2])
+        else:
+            ch = file_rng.choice(audio_channels)
+        track = {"codec": codec, "channels": ch}
+        if j > 0:
+            track["lang"] = file_rng.choice(LANG_POOL)
+            track["title"] = file_rng.choice(AUDIO_TITLE_POOL)
+        audio.append(track)
+    return audio
+
+
+def build_random_subtitles(file_rng, ext):
+    """Build randomized subtitle tracks for a random corpus spec."""
+    sub_formats = ["srt", "ass"]
+    num_subs = file_rng.randint(0, 2) if ext == "mkv" else 0
+    subs = []
+    for _ in range(num_subs):
+        sub = {
+            "format": file_rng.choice(sub_formats),
+            "lang": file_rng.choice(LANG_POOL),
+        }
+        if file_rng.random() < 0.10:
+            sub["forced"] = True
+        subs.append(sub)
+    return subs
+
+
+def random_spec_signature(duration, video, ext, audio, subs):
+    """Return the uniqueness signature for a random corpus spec."""
+    audio_sig = tuple((track["codec"], track["channels"]) for track in audio)
+    sub_sig = tuple((sub["format"], sub.get("lang", "und")) for sub in subs)
+    return (
+        duration,
+        video["codec"],
+        video["size"],
+        video["fps"],
+        ext,
+        audio_sig,
+        sub_sig,
+    )
+
+
+def build_random_specs(count, seed, duration_range, profile="coverage"):
     """Generate `count` random file specs with unique names and varied properties.
 
     Uses only safe codecs (h264/h265, aac/ac3/mp3/flac) in MKV/MP4 containers.
@@ -517,9 +568,6 @@ def build_random_specs(count, seed, duration_range):
     video_codecs = ["libx264", "libx265"]
     resolutions = ["640x360", "854x480", "1280x720", "1920x1080", "3840x2160"]
     fps_choices = [24, 25, 30]
-    audio_codecs = ["aac", "ac3", "mp3", "flac"]
-    audio_channels = [1, 2, 6]
-    sub_formats = ["srt", "ass"]
     containers = ["mkv", "mp4"]
     dur_min, dur_max = duration_range
 
@@ -529,73 +577,20 @@ def build_random_specs(count, seed, duration_range):
 
         ext = file_rng.choice(containers)
         stem = generate_filename(file_rng, used_names)
-
-        # Video
         video = {
             "codec": file_rng.choice(video_codecs),
             "size": file_rng.choice(resolutions),
             "fps": file_rng.choice(fps_choices),
         }
-
-        # Audio: 1-3 tracks
-        num_audio = file_rng.randint(1, 3)
-        audio = []
-        for j in range(num_audio):
-            codec = file_rng.choice(audio_codecs)
-            # flac/mp3 don't support this generator's 6-channel settings.
-            if codec in {"flac", "mp3"}:
-                ch = file_rng.choice([1, 2])
-            else:
-                ch = file_rng.choice(audio_channels)
-            track = {"codec": codec, "channels": ch}
-            if j > 0:
-                track["lang"] = file_rng.choice(LANG_POOL)
-                track["title"] = file_rng.choice(AUDIO_TITLE_POOL)
-            audio.append(track)
-
-        # Subtitles: 0-2 tracks (only for MKV; MP4 subtitle support is limited)
-        if ext == "mkv":
-            num_subs = file_rng.randint(0, 2)
-        else:
-            num_subs = 0
-        subs = []
-        for j in range(num_subs):
-            sub = {
-                "format": file_rng.choice(sub_formats),
-                "lang": file_rng.choice(LANG_POOL),
-            }
-            if file_rng.random() < 0.10:
-                sub["forced"] = True
-            subs.append(sub)
-
-        # Duration for this file (stored on spec, used in generation loop)
+        audio = build_random_audio(file_rng)
+        subs = build_random_subtitles(file_rng, ext)
         duration = file_rng.randint(dur_min, dur_max)
-
-        # Build content signature for hash uniqueness
-        audio_sig = tuple((t["codec"], t["channels"]) for t in audio)
-        sub_sig = tuple((s["format"], s.get("lang", "und")) for s in subs)
-        signature = (
-            duration,
-            video["codec"],
-            video["size"],
-            video["fps"],
-            ext,
-            audio_sig,
-            sub_sig,
-        )
+        signature = random_spec_signature(duration, video, ext, audio, subs)
 
         while signature in used_signatures:
             # Bump duration until we find an unused signature
             duration = duration + 1
-            signature = (
-                duration,
-                video["codec"],
-                video["size"],
-                video["fps"],
-                ext,
-                audio_sig,
-                sub_sig,
-            )
+            signature = random_spec_signature(duration, video, ext, audio, subs)
 
         used_signatures.add(signature)
 
@@ -607,6 +602,7 @@ def build_random_specs(count, seed, duration_range):
                 "audio": audio,
                 "subs": subs,
                 "special": [],
+                "profiles": [profile],
                 "duration_override": duration,
             }
         )
@@ -843,108 +839,108 @@ SUB_WRITERS = {
 # ---------------------------------------------------------------------------
 
 
+MINIMAL_JPEG_BYTES = bytes(
+    [
+        # SOI
+        0xFF,
+        0xD8,
+        # APP0 (JFIF marker)
+        0xFF,
+        0xE0,
+        0x00,
+        0x10,
+        0x4A,
+        0x46,
+        0x49,
+        0x46,
+        0x00,
+        0x01,
+        0x01,
+        0x00,
+        0x00,
+        0x01,
+        0x00,
+        0x01,
+        0x00,
+        0x00,
+        # DQT (quantization table, all ones)
+        0xFF,
+        0xDB,
+        0x00,
+        0x43,
+        0x00,
+        *([0x01] * 64),
+        # SOF0 (1x1, 8-bit, 1 component)
+        0xFF,
+        0xC0,
+        0x00,
+        0x0B,
+        0x08,
+        0x00,
+        0x01,
+        0x00,
+        0x01,
+        0x01,
+        0x01,
+        0x11,
+        0x00,
+        # DHT (Huffman table)
+        0xFF,
+        0xC4,
+        0x00,
+        0x1F,
+        0x00,
+        0x00,
+        0x01,
+        0x05,
+        0x01,
+        0x01,
+        0x01,
+        0x01,
+        0x01,
+        0x01,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x01,
+        0x02,
+        0x03,
+        0x04,
+        0x05,
+        0x06,
+        0x07,
+        0x08,
+        0x09,
+        0x0A,
+        0x0B,
+        # SOS + compressed data
+        0xFF,
+        0xDA,
+        0x00,
+        0x08,
+        0x01,
+        0x01,
+        0x00,
+        0x00,
+        0x3F,
+        0x00,
+        0x7B,
+        0x40,
+        # EOI
+        0xFF,
+        0xD9,
+    ]
+)
+
+
 def write_minimal_jpeg(path):
     """Write a minimal valid 1x1 white JPEG file (~125 bytes)."""
-    # SOI + JFIF APP0 + quantization table + SOF0 + DHT + SOS + data + EOI
-    path.write_bytes(
-        bytes(
-            [
-                # SOI
-                0xFF,
-                0xD8,
-                # APP0 (JFIF marker)
-                0xFF,
-                0xE0,
-                0x00,
-                0x10,
-                0x4A,
-                0x46,
-                0x49,
-                0x46,
-                0x00,
-                0x01,
-                0x01,
-                0x00,
-                0x00,
-                0x01,
-                0x00,
-                0x01,
-                0x00,
-                0x00,
-                # DQT (quantization table, all ones)
-                0xFF,
-                0xDB,
-                0x00,
-                0x43,
-                0x00,
-                *([0x01] * 64),
-                # SOF0 (1x1, 8-bit, 1 component)
-                0xFF,
-                0xC0,
-                0x00,
-                0x0B,
-                0x08,
-                0x00,
-                0x01,
-                0x00,
-                0x01,
-                0x01,
-                0x01,
-                0x11,
-                0x00,
-                # DHT (Huffman table)
-                0xFF,
-                0xC4,
-                0x00,
-                0x1F,
-                0x00,
-                0x00,
-                0x01,
-                0x05,
-                0x01,
-                0x01,
-                0x01,
-                0x01,
-                0x01,
-                0x01,
-                0x00,
-                0x00,
-                0x00,
-                0x00,
-                0x00,
-                0x00,
-                0x00,
-                0x00,
-                0x01,
-                0x02,
-                0x03,
-                0x04,
-                0x05,
-                0x06,
-                0x07,
-                0x08,
-                0x09,
-                0x0A,
-                0x0B,
-                # SOS + compressed data
-                0xFF,
-                0xDA,
-                0x00,
-                0x08,
-                0x01,
-                0x01,
-                0x00,
-                0x00,
-                0x3F,
-                0x00,
-                0x7B,
-                0x40,
-                # EOI
-                0xFF,
-                0xD9,
-            ]
-        )
-    )
+    path.write_bytes(MINIMAL_JPEG_BYTES)
 
 
 def write_minimal_png(path):
@@ -1388,7 +1384,12 @@ def main():
     # Generate random specs if --count is set
     random_specs = []
     if args.count > 0:
-        random_specs = build_random_specs(args.count, args.seed, dur_range)
+        random_specs = build_random_specs(
+            args.count,
+            args.seed,
+            dur_range,
+            profile=args.profile,
+        )
         specs.extend(random_specs)
 
     if not specs and args.count == 0:

--- a/scripts/generate-test-corpus
+++ b/scripts/generate-test-corpus
@@ -21,35 +21,71 @@ from pathlib import Path
 # ---------------------------------------------------------------------------
 
 TITLE_POOL = [
-    "The Silent Echo", "Orbital Descent S02E07", "Crimson Meridian",
-    "Waypoint Zero", "The Last Cartographer", "Neon Reef",
-    "Parallax S01E03 — Inversion", "Dustwalker", "Abyssal Reach",
-    "Iron Chorus", "The Vanishing Gradient", "Solstice Run",
+    "The Silent Echo",
+    "Orbital Descent S02E07",
+    "Crimson Meridian",
+    "Waypoint Zero",
+    "The Last Cartographer",
+    "Neon Reef",
+    "Parallax S01E03 — Inversion",
+    "Dustwalker",
+    "Abyssal Reach",
+    "Iron Chorus",
+    "The Vanishing Gradient",
+    "Solstice Run",
 ]
 
 ENCODER_POOL = [
-    "libebml v1.4.4 + libmatroska v1.7.1", "Lavf60.3.100",
-    "HandBrake 1.7.3 2024011800", "MakeMKV v1.17.6",
-    "x264 core 164 r3108", "mkvmerge v82.0",
+    "libebml v1.4.4 + libmatroska v1.7.1",
+    "Lavf60.3.100",
+    "HandBrake 1.7.3 2024011800",
+    "MakeMKV v1.17.6",
+    "x264 core 164 r3108",
+    "mkvmerge v82.0",
 ]
 
-LANG_POOL = ["eng", "spa", "fra", "deu", "jpn", "und", "zho", "por", "ita",
-             "kor", "rus", "ara"]
+LANG_POOL = [
+    "eng",
+    "spa",
+    "fra",
+    "deu",
+    "jpn",
+    "und",
+    "zho",
+    "por",
+    "ita",
+    "kor",
+    "rus",
+    "ara",
+]
 
 AUDIO_TITLE_POOL = [
-    "English 5.1 Surround", "Director's Commentary", "Music & Effects",
-    "Descriptive Audio", "Stereo", "Original Mix", "DTS-HD MA 7.1",
-    "AAC Stereo", "Commentary by Director",
+    "English 5.1 Surround",
+    "Director's Commentary",
+    "Music & Effects",
+    "Descriptive Audio",
+    "Stereo",
+    "Original Mix",
+    "DTS-HD MA 7.1",
+    "AAC Stereo",
+    "Commentary by Director",
 ]
 
 SUB_TITLE_POOL = [
-    "English (SDH)", "Forced Signs & Songs", "Full Subtitles",
-    "Commentary Subtitles", "Closed Captions", "Hearing Impaired",
+    "English (SDH)",
+    "Forced Signs & Songs",
+    "Full Subtitles",
+    "Commentary Subtitles",
+    "Closed Captions",
+    "Hearing Impaired",
 ]
 
 HANDLER_POOL = [
-    "VideoHandler", "SoundHandler", "Apple Video Media Handler",
-    "GPAC ISO Video Handler", "GPAC ISO Audio Handler",
+    "VideoHandler",
+    "SoundHandler",
+    "Apple Video Media Handler",
+    "GPAC ISO Video Handler",
+    "GPAC ISO Audio Handler",
 ]
 
 SCHEMA_VERSION = 1
@@ -61,47 +97,105 @@ ALL_PROFILE_MEMBERS = {"smoke", "coverage", "stress"}
 # ---------------------------------------------------------------------------
 
 MOVIE_TITLE_POOL = [
-    "The Silent Echo", "Crimson Meridian", "Neon Reef",
-    "Orbital Descent", "Dustwalker", "Iron Chorus",
-    "Abyssal Reach", "The Vanishing Gradient", "Solstice Run",
-    "Waypoint Zero", "The Last Cartographer", "Parallax",
-    "Black Meridian", "The Obsidian Gate", "Phantom Corridor",
-    "Static Bloom", "Voidrunner", "The Copper Key",
-    "Fractured Light", "Signal Drift", "Terminal Velocity",
-    "Hollow Earth", "The Glass Frontier", "Midnight Protocol",
-    "Starfall", "The Iron Bloom", "Chroma Shift",
-    "Deep Current", "The Pale Beyond", "Atlas Point",
+    "The Silent Echo",
+    "Crimson Meridian",
+    "Neon Reef",
+    "Orbital Descent",
+    "Dustwalker",
+    "Iron Chorus",
+    "Abyssal Reach",
+    "The Vanishing Gradient",
+    "Solstice Run",
+    "Waypoint Zero",
+    "The Last Cartographer",
+    "Parallax",
+    "Black Meridian",
+    "The Obsidian Gate",
+    "Phantom Corridor",
+    "Static Bloom",
+    "Voidrunner",
+    "The Copper Key",
+    "Fractured Light",
+    "Signal Drift",
+    "Terminal Velocity",
+    "Hollow Earth",
+    "The Glass Frontier",
+    "Midnight Protocol",
+    "Starfall",
+    "The Iron Bloom",
+    "Chroma Shift",
+    "Deep Current",
+    "The Pale Beyond",
+    "Atlas Point",
 ]
 
 FOREIGN_TITLE_POOL = [
-    "Café Páramo", "Über den Wolken", "La Dernière Nuit",
-    "El Sueño Eterno", "Der letzte Horizont", "Le Cercle Rouge",
-    "Nocturne d'Argent", "Sous les étoiles", "Die Stille Welt",
-    "Märchenstunde", "Añoranza", "Éclipse Totale",
-    "Flüsterwald", "Pièce Montée", "Täuschung",
+    "Café Páramo",
+    "Über den Wolken",
+    "La Dernière Nuit",
+    "El Sueño Eterno",
+    "Der letzte Horizont",
+    "Le Cercle Rouge",
+    "Nocturne d'Argent",
+    "Sous les étoiles",
+    "Die Stille Welt",
+    "Märchenstunde",
+    "Añoranza",
+    "Éclipse Totale",
+    "Flüsterwald",
+    "Pièce Montée",
+    "Täuschung",
 ]
 
 EPISODE_TITLE_POOL = [
-    "The Last Stand", "Inversion", "Pilot", "Reckoning",
-    "Zero Hour", "Convergence", "Fallout", "Awakening",
-    "Crossfire", "Echoes", "The Signal", "Chrysalis",
+    "The Last Stand",
+    "Inversion",
+    "Pilot",
+    "Reckoning",
+    "Zero Hour",
+    "Convergence",
+    "Fallout",
+    "Awakening",
+    "Crossfire",
+    "Echoes",
+    "The Signal",
+    "Chrysalis",
 ]
 
 QUALITY_TAGS = ["480p", "720p", "1080p", "2160p", "4K"]
 
 SOURCE_TAGS = [
-    "BluRay", "WEB-DL", "HDTV", "REMUX", "BDRip",
-    "DVDRip", "WEBRip", "AMZN", "NF",
+    "BluRay",
+    "WEB-DL",
+    "HDTV",
+    "REMUX",
+    "BDRip",
+    "DVDRip",
+    "WEBRip",
+    "AMZN",
+    "NF",
 ]
 
 GROUP_TAGS = [
-    "SPARKS", "YTS.MX", "RARBG", "FGT", "EVO",
-    "FLUX", "NOGRP", "AMIABLE", "ROVERS", "GECKOS",
+    "SPARKS",
+    "YTS.MX",
+    "RARBG",
+    "FGT",
+    "EVO",
+    "FLUX",
+    "NOGRP",
+    "AMIABLE",
+    "ROVERS",
+    "GECKOS",
 ]
 
 EDITION_TAGS = [
-    "Extended Cut", "Director's Cut", "Theatrical",
-    "Unrated", "Remastered", "IMAX",
+    "Extended Cut",
+    "Director's Cut",
+    "Theatrical",
+    "Unrated",
+    "Remastered",
+    "IMAX",
 ]
 
 
@@ -184,6 +278,7 @@ def random_timestamp(rng):
 # ---------------------------------------------------------------------------
 # File manifest
 # ---------------------------------------------------------------------------
+
 
 def fixture_filename(spec):
     """Return the output filename for a fixture spec."""
@@ -340,8 +435,12 @@ def build_manifest():
             "video": {"codec": "libx264", "size": "1920x1080", "fps": 24},
             "audio": [
                 {"codec": "flac", "channels": 2},
-                {"codec": "ac3", "channels": 6, "title": "Director's Commentary",
-                 "disposition": "comment"},
+                {
+                    "codec": "ac3",
+                    "channels": 6,
+                    "title": "Director's Commentary",
+                    "disposition": "comment",
+                },
             ],
             "subs": [{"format": "srt", "lang": "eng"}],
             "special": [],
@@ -473,36 +572,44 @@ def build_random_specs(count, seed, duration_range):
         duration = file_rng.randint(dur_min, dur_max)
 
         # Build content signature for hash uniqueness
-        audio_sig = tuple(
-            (t["codec"], t["channels"]) for t in audio
-        )
-        sub_sig = tuple(
-            (s["format"], s.get("lang", "und")) for s in subs
-        )
+        audio_sig = tuple((t["codec"], t["channels"]) for t in audio)
+        sub_sig = tuple((s["format"], s.get("lang", "und")) for s in subs)
         signature = (
-            duration, video["codec"], video["size"],
-            video["fps"], ext, audio_sig, sub_sig,
+            duration,
+            video["codec"],
+            video["size"],
+            video["fps"],
+            ext,
+            audio_sig,
+            sub_sig,
         )
 
         while signature in used_signatures:
             # Bump duration until we find an unused signature
             duration = duration + 1
             signature = (
-                duration, video["codec"], video["size"],
-                video["fps"], ext, audio_sig, sub_sig,
+                duration,
+                video["codec"],
+                video["size"],
+                video["fps"],
+                ext,
+                audio_sig,
+                sub_sig,
             )
 
         used_signatures.add(signature)
 
-        specs.append({
-            "stem": stem,
-            "ext": ext,
-            "video": video,
-            "audio": audio,
-            "subs": subs,
-            "special": [],
-            "duration_override": duration,
-        })
+        specs.append(
+            {
+                "stem": stem,
+                "ext": ext,
+                "video": video,
+                "audio": audio,
+                "subs": subs,
+                "special": [],
+                "duration_override": duration,
+            }
+        )
 
     return specs
 
@@ -551,7 +658,13 @@ def write_run_manifest(dest, manifest):
 # File corruption for error-path testing
 # ---------------------------------------------------------------------------
 
-CORRUPTION_TYPES = ["truncated", "header_damage", "mid_stream", "zero_length", "wrong_extension"]
+CORRUPTION_TYPES = [
+    "truncated",
+    "header_damage",
+    "mid_stream",
+    "zero_length",
+    "wrong_extension",
+]
 
 
 def apply_corruption(file_path, corruption_type, rng):
@@ -583,7 +696,10 @@ def apply_corruption(file_path, corruption_type, rng):
         for i in range(min(block_size, len(data) - offset)):
             data[offset + i] = rng.randint(0, 255)
         file_path.write_bytes(bytes(data))
-        return f"mid-stream corruption ({block_size} bytes at offset {offset})", file_path
+        return (
+            f"mid-stream corruption ({block_size} bytes at offset {offset})",
+            file_path,
+        )
 
     elif corruption_type == "zero_length":
         file_path.write_bytes(b"")
@@ -623,13 +739,15 @@ def select_and_corrupt(dest, random_specs, corrupt_count, seed):
             continue
         ctype = rng.choice(CORRUPTION_TYPES)
         desc, final_path = apply_corruption(filepath, ctype, rng)
-        results.append({
-            "original_filename": filename,
-            "filename": final_path.name,
-            "type": ctype,
-            "description": desc,
-            "size": final_path.stat().st_size,
-        })
+        results.append(
+            {
+                "original_filename": filename,
+                "filename": final_path.name,
+                "type": ctype,
+                "description": desc,
+                "size": final_path.stat().st_size,
+            }
+        )
 
     return results
 
@@ -648,12 +766,15 @@ def update_generated_entries_for_corruptions(generated_entries, corrupt_results)
 # Encoder availability
 # ---------------------------------------------------------------------------
 
+
 def probe_encoders():
     """Return the set of available ffmpeg encoder names."""
     try:
         result = subprocess.run(
             ["ffmpeg", "-encoders", "-hide_banner"],
-            capture_output=True, text=True, timeout=10,
+            capture_output=True,
+            text=True,
+            timeout=10,
         )
         encoders = set()
         for line in result.stdout.splitlines():
@@ -672,12 +793,11 @@ def probe_encoders():
 # Subtitle temp file helpers
 # ---------------------------------------------------------------------------
 
+
 def write_srt(path, duration):
     """Write a minimal SRT subtitle file."""
     path.write_text(
-        "1\n"
-        f"00:00:00,000 --> 00:00:{duration:02d},000\n"
-        "Test subtitle line\n\n"
+        f"1\n00:00:00,000 --> 00:00:{duration:02d},000\nTest subtitle line\n\n"
     )
 
 
@@ -707,9 +827,7 @@ def write_ass(path, duration):
 def write_vtt(path, duration):
     """Write a minimal WebVTT subtitle file."""
     path.write_text(
-        "WEBVTT\n\n"
-        f"00:00:00.000 --> 00:00:{duration:02d}.000\n"
-        "Test subtitle line\n\n"
+        f"WEBVTT\n\n00:00:00.000 --> 00:00:{duration:02d}.000\nTest subtitle line\n\n"
     )
 
 
@@ -724,32 +842,109 @@ SUB_WRITERS = {
 # Image attachment helpers
 # ---------------------------------------------------------------------------
 
+
 def write_minimal_jpeg(path):
     """Write a minimal valid 1x1 white JPEG file (~125 bytes)."""
     # SOI + JFIF APP0 + quantization table + SOF0 + DHT + SOS + data + EOI
-    path.write_bytes(bytes([
-        # SOI
-        0xFF, 0xD8,
-        # APP0 (JFIF marker)
-        0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00,
-        0x01, 0x01, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00,
-        # DQT (quantization table, all ones)
-        0xFF, 0xDB, 0x00, 0x43, 0x00,
-        *([0x01] * 64),
-        # SOF0 (1x1, 8-bit, 1 component)
-        0xFF, 0xC0, 0x00, 0x0B, 0x08, 0x00, 0x01, 0x00, 0x01,
-        0x01, 0x01, 0x11, 0x00,
-        # DHT (Huffman table)
-        0xFF, 0xC4, 0x00, 0x1F, 0x00, 0x00, 0x01, 0x05, 0x01,
-        0x01, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05,
-        0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B,
-        # SOS + compressed data
-        0xFF, 0xDA, 0x00, 0x08, 0x01, 0x01, 0x00, 0x00, 0x3F,
-        0x00, 0x7B, 0x40,
-        # EOI
-        0xFF, 0xD9,
-    ]))
+    path.write_bytes(
+        bytes(
+            [
+                # SOI
+                0xFF,
+                0xD8,
+                # APP0 (JFIF marker)
+                0xFF,
+                0xE0,
+                0x00,
+                0x10,
+                0x4A,
+                0x46,
+                0x49,
+                0x46,
+                0x00,
+                0x01,
+                0x01,
+                0x00,
+                0x00,
+                0x01,
+                0x00,
+                0x01,
+                0x00,
+                0x00,
+                # DQT (quantization table, all ones)
+                0xFF,
+                0xDB,
+                0x00,
+                0x43,
+                0x00,
+                *([0x01] * 64),
+                # SOF0 (1x1, 8-bit, 1 component)
+                0xFF,
+                0xC0,
+                0x00,
+                0x0B,
+                0x08,
+                0x00,
+                0x01,
+                0x00,
+                0x01,
+                0x01,
+                0x01,
+                0x11,
+                0x00,
+                # DHT (Huffman table)
+                0xFF,
+                0xC4,
+                0x00,
+                0x1F,
+                0x00,
+                0x00,
+                0x01,
+                0x05,
+                0x01,
+                0x01,
+                0x01,
+                0x01,
+                0x01,
+                0x01,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x01,
+                0x02,
+                0x03,
+                0x04,
+                0x05,
+                0x06,
+                0x07,
+                0x08,
+                0x09,
+                0x0A,
+                0x0B,
+                # SOS + compressed data
+                0xFF,
+                0xDA,
+                0x00,
+                0x08,
+                0x01,
+                0x01,
+                0x00,
+                0x00,
+                0x3F,
+                0x00,
+                0x7B,
+                0x40,
+                # EOI
+                0xFF,
+                0xD9,
+            ]
+        )
+    )
 
 
 def write_minimal_png(path):
@@ -757,21 +952,21 @@ def write_minimal_png(path):
     import struct
     import zlib
 
-    sig = b'\x89PNG\r\n\x1a\n'
+    sig = b"\x89PNG\r\n\x1a\n"
 
     # IHDR: 1x1, 8-bit grayscale
-    ihdr_data = struct.pack('>IIBBBBB', 1, 1, 8, 0, 0, 0, 0)
-    ihdr = struct.pack('>I', 13) + b'IHDR' + ihdr_data
-    ihdr += struct.pack('>I', zlib.crc32(b'IHDR' + ihdr_data) & 0xFFFFFFFF)
+    ihdr_data = struct.pack(">IIBBBBB", 1, 1, 8, 0, 0, 0, 0)
+    ihdr = struct.pack(">I", 13) + b"IHDR" + ihdr_data
+    ihdr += struct.pack(">I", zlib.crc32(b"IHDR" + ihdr_data) & 0xFFFFFFFF)
 
     # IDAT: filter byte 0 + single white pixel 0xFF
-    raw = zlib.compress(b'\x00\xFF')
-    idat = struct.pack('>I', len(raw)) + b'IDAT' + raw
-    idat += struct.pack('>I', zlib.crc32(b'IDAT' + raw) & 0xFFFFFFFF)
+    raw = zlib.compress(b"\x00\xff")
+    idat = struct.pack(">I", len(raw)) + b"IDAT" + raw
+    idat += struct.pack(">I", zlib.crc32(b"IDAT" + raw) & 0xFFFFFFFF)
 
     # IEND
-    iend = struct.pack('>I', 0) + b'IEND'
-    iend += struct.pack('>I', zlib.crc32(b'IEND') & 0xFFFFFFFF)
+    iend = struct.pack(">I", 0) + b"IEND"
+    iend += struct.pack(">I", zlib.crc32(b"IEND") & 0xFFFFFFFF)
 
     path.write_bytes(sig + ihdr + idat + iend)
 
@@ -779,6 +974,7 @@ def write_minimal_png(path):
 # ---------------------------------------------------------------------------
 # ffmpeg command builder
 # ---------------------------------------------------------------------------
+
 
 def build_ffmpeg_cmd(spec, dest, duration, rng, tmpdir):
     """Build the ffmpeg command list for a given file spec.
@@ -794,7 +990,9 @@ def build_ffmpeg_cmd(spec, dest, duration, rng, tmpdir):
     subs = spec.get("subs", [])
 
     # --- Video input ---
-    vf_filters = [f"testsrc2=duration={duration}:size={video['size']}:rate={video['fps']}"]
+    vf_filters = [
+        f"testsrc2=duration={duration}:size={video['size']}:rate={video['fps']}"
+    ]
     if "vfr" in specials:
         # Vary PTS to create variable frame rate
         vf_filters.append("setpts='PTS+0.002*sin(N*0.1)/TB'")
@@ -804,20 +1002,30 @@ def build_ffmpeg_cmd(spec, dest, duration, rng, tmpdir):
     for i, audio in enumerate(audios):
         ch = audio["channels"]
         if ch <= 2:
-            cmd += ["-f", "lavfi", "-i",
-                    f"sine=frequency={440 + i * 110}:duration={duration}:sample_rate=48000"]
+            cmd += [
+                "-f",
+                "lavfi",
+                "-i",
+                f"sine=frequency={440 + i * 110}:duration={duration}:sample_rate=48000",
+            ]
         else:
             # Generate 5.1/7.1 by merging multiple sine sources
             freqs = [220, 330, 440, 550, 660, 770, 880, 990][:ch]
             filter_parts = []
             for j, freq in enumerate(freqs):
-                filter_parts.append(f"sine=frequency={freq}:duration={duration}:sample_rate=48000")
+                filter_parts.append(
+                    f"sine=frequency={freq}:duration={duration}:sample_rate=48000"
+                )
             amerge_input = "|".join(filter_parts)
             cmd += ["-f", "lavfi", "-i", f"amovie='{amerge_input}'" if False else ""]
             # Actually, use a complex filter approach — replace last two args
             cmd = cmd[:-2]
-            cmd += ["-f", "lavfi", "-i",
-                    f"sine=frequency=440:duration={duration}:sample_rate=48000"]
+            cmd += [
+                "-f",
+                "lavfi",
+                "-i",
+                f"sine=frequency=440:duration={duration}:sample_rate=48000",
+            ]
 
     # --- Subtitle inputs ---
     sub_files = []
@@ -854,11 +1062,12 @@ def build_ffmpeg_cmd(spec, dest, duration, rng, tmpdir):
 
     # Audio inputs (one sine per audio track)
     for i, audio in enumerate(audios):
-        audio_filter = f"sine=frequency={440 + i * 110}:duration={duration}:sample_rate=48000"
+        audio_filter = (
+            f"sine=frequency={440 + i * 110}:duration={duration}:sample_rate=48000"
+        )
         if "volume" in audio:
             audio_filter += f",volume={audio['volume']}"
-        cmd += ["-f", "lavfi", "-i",
-                audio_filter]
+        cmd += ["-f", "lavfi", "-i", audio_filter]
 
     # Subtitle inputs
     sub_files = []
@@ -902,15 +1111,18 @@ def build_ffmpeg_cmd(spec, dest, duration, rng, tmpdir):
     needs_hevc_hdr_bsf = False
     if "hdr10" in specials:
         cmd += [
-            "-pix_fmt", "yuv420p10le",
+            "-pix_fmt",
+            "yuv420p10le",
         ]
         if vcodec == "libx265":
-            cmd += ["-x265-params",
-                    "hdr-opt=1:repeat-headers=1:colorprim=bt2020:"
-                    "transfer=smpte2084:colormatrix=bt2020nc:"
-                    "master-display=G(13250,34500)B(7500,3000)"
-                    "R(34000,16000)WP(15635,16450)L(10000000,1):"
-                    "max-cll=1000,400"]
+            cmd += [
+                "-x265-params",
+                "hdr-opt=1:repeat-headers=1:colorprim=bt2020:"
+                "transfer=smpte2084:colormatrix=bt2020nc:"
+                "master-display=G(13250,34500)B(7500,3000)"
+                "R(34000,16000)WP(15635,16450)L(10000000,1):"
+                "max-cll=1000,400",
+            ]
             needs_hevc_hdr_bsf = True
 
     # --- Audio codecs ---
@@ -991,28 +1203,48 @@ def build_ffmpeg_cmd(spec, dest, duration, rng, tmpdir):
         font_path = Path(tmpdir) / "DummyFont.ttf"
         # Create a minimal dummy file (not a real font, but ffmpeg accepts it)
         font_path.write_bytes(b"\x00\x01\x00\x00" + b"\x00" * 28)
-        cmd += ["-attach", str(font_path),
-                "-metadata:s:t:0", "mimetype=font/sfnt",
-                "-metadata:s:t:0", "filename=DummyFont.ttf"]
+        cmd += [
+            "-attach",
+            str(font_path),
+            "-metadata:s:t:0",
+            "mimetype=font/sfnt",
+            "-metadata:s:t:0",
+            "filename=DummyFont.ttf",
+        ]
         # JPEG cover image
         cover_path = Path(tmpdir) / "cover.jpg"
         write_minimal_jpeg(cover_path)
-        cmd += ["-attach", str(cover_path),
-                "-metadata:s:t:1", "mimetype=image/jpeg",
-                "-metadata:s:t:1", "filename=cover.jpg"]
+        cmd += [
+            "-attach",
+            str(cover_path),
+            "-metadata:s:t:1",
+            "mimetype=image/jpeg",
+            "-metadata:s:t:1",
+            "filename=cover.jpg",
+        ]
         # PNG poster image
         poster_path = Path(tmpdir) / "poster.png"
         write_minimal_png(poster_path)
-        cmd += ["-attach", str(poster_path),
-                "-metadata:s:t:2", "mimetype=image/png",
-                "-metadata:s:t:2", "filename=poster.png"]
+        cmd += [
+            "-attach",
+            str(poster_path),
+            "-metadata:s:t:2",
+            "mimetype=image/png",
+            "-metadata:s:t:2",
+            "filename=poster.png",
+        ]
 
     if "cover_art" in specials:
         cover_path = Path(tmpdir) / "cover.jpg"
         write_minimal_jpeg(cover_path)
-        cmd += ["-attach", str(cover_path),
-                "-metadata:s:t:0", "mimetype=image/jpeg",
-                "-metadata:s:t:0", "filename=cover.jpg"]
+        cmd += [
+            "-attach",
+            str(cover_path),
+            "-metadata:s:t:0",
+            "mimetype=image/jpeg",
+            "-metadata:s:t:0",
+            "filename=cover.jpg",
+        ]
 
     if needs_hevc_hdr_bsf:
         cmd += [
@@ -1034,6 +1266,7 @@ def build_ffmpeg_cmd(spec, dest, duration, rng, tmpdir):
 # Main
 # ---------------------------------------------------------------------------
 
+
 def format_size(n):
     """Format bytes as a human-readable string."""
     if n < 1024:
@@ -1051,23 +1284,30 @@ def main():
         description="Generate synthetic video files with diverse characteristics for testing.",
     )
     parser.add_argument(
-        "dest", metavar="DEST",
+        "dest",
+        metavar="DEST",
         help="Directory to generate files into (created if needed)",
     )
     parser.add_argument(
-        "--duration", type=int, default=2, metavar="SECS",
+        "--duration",
+        type=int,
+        default=2,
+        metavar="SECS",
         help="Duration of each file in seconds (default: 2)",
     )
     parser.add_argument(
-        "--dry-run", action="store_true",
+        "--dry-run",
+        action="store_true",
         help="Show ffmpeg commands without running them",
     )
     parser.add_argument(
-        "--only", metavar="NAMES",
+        "--only",
+        metavar="NAMES",
         help="Comma-separated list of file stems to generate (default: all)",
     )
     parser.add_argument(
-        "--skip", metavar="NAMES",
+        "--skip",
+        metavar="NAMES",
         help="Comma-separated list of file stems to skip",
     )
     parser.add_argument(
@@ -1077,23 +1317,34 @@ def main():
         help="Named deterministic fixture profile to generate (default: coverage)",
     )
     parser.add_argument(
-        "--seed", type=int, default=42, metavar="N",
+        "--seed",
+        type=int,
+        default=42,
+        metavar="N",
         help="RNG seed for metadata randomization (default: 42)",
     )
     parser.add_argument(
-        "--verbose", action="store_true",
+        "--verbose",
+        action="store_true",
         help="Show full ffmpeg output",
     )
     parser.add_argument(
-        "--count", type=int, default=0, metavar="N",
+        "--count",
+        type=int,
+        default=0,
+        metavar="N",
         help="Generate N additional random files alongside the manifest",
     )
     parser.add_argument(
-        "--duration-range", default="1-5", metavar="MIN-MAX",
+        "--duration-range",
+        default="1-5",
+        metavar="MIN-MAX",
         help="Duration range in seconds for random files (default: 1-5)",
     )
     parser.add_argument(
-        "--corrupt", default="0", metavar="N_OR_PCT",
+        "--corrupt",
+        default="0",
+        metavar="N_OR_PCT",
         help="Corrupt N files (or N%% of --count) from the random set",
     )
     args = parser.parse_args()
@@ -1105,8 +1356,10 @@ def main():
         if dur_range[0] < 1 or dur_range[1] < dur_range[0]:
             raise ValueError
     except (ValueError, IndexError):
-        print(f"Error: --duration-range must be MIN-MAX (e.g., 1-5), got '{args.duration_range}'",
-              file=sys.stderr)
+        print(
+            f"Error: --duration-range must be MIN-MAX (e.g., 1-5), got '{args.duration_range}'",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     # Parse corrupt count
@@ -1118,8 +1371,10 @@ def main():
         corrupt_count = int(corrupt_str)
 
     if corrupt_count > 0 and args.count < corrupt_count:
-        print(f"Error: --corrupt {corrupt_count} requires --count >= {corrupt_count}",
-              file=sys.stderr)
+        print(
+            f"Error: --corrupt {corrupt_count} requires --count >= {corrupt_count}",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     dest = Path(args.dest)
@@ -1150,8 +1405,10 @@ def main():
     # Probe available encoders
     available = probe_encoders()
     if not available:
-        print("Warning: could not probe ffmpeg encoders, will try all files",
-              file=sys.stderr)
+        print(
+            "Warning: could not probe ffmpeg encoders, will try all files",
+            file=sys.stderr,
+        )
 
     if not args.dry_run:
         dest.mkdir(parents=True, exist_ok=True)
@@ -1173,14 +1430,18 @@ def main():
             # Check encoder availability
             req = spec.get("requires_encoder")
             if req and available and req not in available:
-                print(f"[{idx}/{total}] Skipping {filename} — encoder '{req}' not available")
-                skipped_entries.append({
-                    "filename": filename,
-                    "stem": stem,
-                    "reason": f"encoder '{req}' not available",
-                    "covers": spec.get("covers", []),
-                    "expect": spec.get("expect", {}),
-                })
+                print(
+                    f"[{idx}/{total}] Skipping {filename} — encoder '{req}' not available"
+                )
+                skipped_entries.append(
+                    {
+                        "filename": filename,
+                        "stem": stem,
+                        "reason": f"encoder '{req}' not available",
+                        "covers": spec.get("covers", []),
+                        "expect": spec.get("expect", {}),
+                    }
+                )
                 skip_count += 1
                 continue
 
@@ -1190,16 +1451,22 @@ def main():
             file_duration = spec.get("duration_override", args.duration)
 
             try:
-                cmd, outfile = build_ffmpeg_cmd(spec, dest, file_duration, file_rng, tmpdir)
+                cmd, outfile = build_ffmpeg_cmd(
+                    spec, dest, file_duration, file_rng, tmpdir
+                )
             except Exception as e:
-                print(f"[{idx}/{total}] FAILED {filename} — error building command: {e}")
-                failed_entries.append({
-                    "filename": filename,
-                    "stem": stem,
-                    "reason": f"error building command: {e}",
-                    "covers": spec.get("covers", []),
-                    "expect": spec.get("expect", {}),
-                })
+                print(
+                    f"[{idx}/{total}] FAILED {filename} — error building command: {e}"
+                )
+                failed_entries.append(
+                    {
+                        "filename": filename,
+                        "stem": stem,
+                        "reason": f"error building command: {e}",
+                        "covers": spec.get("covers", []),
+                        "expect": spec.get("expect", {}),
+                    }
+                )
                 fail_count += 1
                 continue
 
@@ -1229,58 +1496,72 @@ def main():
                     stderr = result.stderr if not args.verbose else ""
                     if stderr:
                         # Show last few lines of stderr
-                        lines = stderr.decode("utf-8", errors="replace").strip().splitlines()
+                        lines = (
+                            stderr.decode("utf-8", errors="replace")
+                            .strip()
+                            .splitlines()
+                        )
                         for line in lines[-5:]:
                             print(f"  {line}")
-                    failed_entries.append({
-                        "filename": filename,
-                        "stem": stem,
-                        "reason": f"ffmpeg failed with exit code {result.returncode}",
-                        "covers": spec.get("covers", []),
-                        "expect": spec.get("expect", {}),
-                    })
+                    failed_entries.append(
+                        {
+                            "filename": filename,
+                            "stem": stem,
+                            "reason": f"ffmpeg failed with exit code {result.returncode}",
+                            "covers": spec.get("covers", []),
+                            "expect": spec.get("expect", {}),
+                        }
+                    )
                     fail_count += 1
                     continue
 
                 size = outfile.stat().st_size
                 total_size += size
                 print(f"OK ({format_size(size)})")
-                generated_entries.append({
-                    "filename": filename,
-                    "stem": stem,
-                    "size": size,
-                    "duration": file_duration,
-                    "profiles": spec.get("profiles", ["coverage"]),
-                    "covers": spec.get("covers", []),
-                    "expect": spec.get("expect", {}),
-                })
+                generated_entries.append(
+                    {
+                        "filename": filename,
+                        "stem": stem,
+                        "size": size,
+                        "duration": file_duration,
+                        "profiles": spec.get("profiles", ["coverage"]),
+                        "covers": spec.get("covers", []),
+                        "expect": spec.get("expect", {}),
+                    }
+                )
                 ok_count += 1
 
             except subprocess.TimeoutExpired:
                 print("FAILED (timeout)")
-                failed_entries.append({
-                    "filename": filename,
-                    "stem": stem,
-                    "reason": "ffmpeg timed out",
-                    "covers": spec.get("covers", []),
-                    "expect": spec.get("expect", {}),
-                })
+                failed_entries.append(
+                    {
+                        "filename": filename,
+                        "stem": stem,
+                        "reason": "ffmpeg timed out",
+                        "covers": spec.get("covers", []),
+                        "expect": spec.get("expect", {}),
+                    }
+                )
                 fail_count += 1
             except Exception as e:
                 print(f"FAILED ({e})")
-                failed_entries.append({
-                    "filename": filename,
-                    "stem": stem,
-                    "reason": f"ffmpeg failed: {e}",
-                    "covers": spec.get("covers", []),
-                    "expect": spec.get("expect", {}),
-                })
+                failed_entries.append(
+                    {
+                        "filename": filename,
+                        "stem": stem,
+                        "reason": f"ffmpeg failed: {e}",
+                        "covers": spec.get("covers", []),
+                        "expect": spec.get("expect", {}),
+                    }
+                )
                 fail_count += 1
 
     # Apply corruption to selected random files
     corrupt_results = []
     if corrupt_count > 0 and not args.dry_run:
-        corrupt_results = select_and_corrupt(dest, random_specs, corrupt_count, args.seed)
+        corrupt_results = select_and_corrupt(
+            dest, random_specs, corrupt_count, args.seed
+        )
         update_generated_entries_for_corruptions(generated_entries, corrupt_results)
         for result in corrupt_results:
             filename = result["filename"]
@@ -1290,6 +1571,7 @@ def main():
 
     corruption_entries = [
         {
+            "original_filename": result["original_filename"],
             "filename": result["filename"],
             "type": result["type"],
             "description": result["description"],

--- a/scripts/generate-test-corpus
+++ b/scripts/generate-test-corpus
@@ -1663,7 +1663,53 @@ def format_size(n):
     return f"{n:.1f} TiB"
 
 
-def main():
+class PreparedSpecs:
+    """Fixture specs selected for a run."""
+
+    def __init__(self, *, specs, deterministic_corrupt_specs, random_specs):
+        self.specs = specs
+        self.deterministic_corrupt_specs = deterministic_corrupt_specs
+        self.random_specs = random_specs
+
+
+class GenerationOptions:
+    """Options needed while materializing normal fixtures."""
+
+    def __init__(self, *, dest, duration, seed, dry_run, verbose, available, total):
+        self.dest = dest
+        self.duration = duration
+        self.seed = seed
+        self.dry_run = dry_run
+        self.verbose = verbose
+        self.available = available
+        self.total = total
+
+
+class GenerationResult:
+    """Mutable counts and manifest entries accumulated during a run."""
+
+    def __init__(self):
+        self.ok_count = 0
+        self.skip_count = 0
+        self.fail_count = 0
+        self.total_size = 0
+        self.generated_entries = []
+        self.skipped_entries = []
+        self.failed_entries = []
+
+
+class CorruptionResult:
+    """Counts and corruption entries accumulated during corruption steps."""
+
+    def __init__(self):
+        self.ok_count = 0
+        self.skip_count = 0
+        self.skipped_entries = []
+        self.corrupt_results = []
+
+
+def build_arg_parser():
+    """Build the command-line argument parser."""
     parser = argparse.ArgumentParser(
         prog="generate-test-corpus",
         description="Generate synthetic video files with diverse characteristics for testing.",
@@ -1732,14 +1778,32 @@ def main():
         metavar="N_OR_PCT",
         help="Corrupt N files (or N%% of --count) from the random set",
     )
-    args = parser.parse_args()
+    return parser
 
-    # Parse duration range
+
+def parse_duration_range(value):
+    """Parse a MIN-MAX duration range."""
+    dur_parts = value.split("-")
+    dur_range = (int(dur_parts[0]), int(dur_parts[1]))
+    if dur_range[0] < 1 or dur_range[1] < dur_range[0]:
+        raise ValueError
+    return dur_range
+
+
+def parse_corrupt_count(value, count):
+    """Parse a corruption count or percentage against the random file count."""
+    corrupt_str = value.strip()
+    if corrupt_str.endswith("%"):
+        corrupt_pct = float(corrupt_str[:-1]) / 100.0
+        return max(0, int(corrupt_pct * count + 0.999))  # round up
+    return int(corrupt_str)
+
+
+def parse_run_arguments(parser):
+    """Parse CLI arguments and derived duration/corruption settings."""
+    args = parser.parse_args()
     try:
-        dur_parts = args.duration_range.split("-")
-        dur_range = (int(dur_parts[0]), int(dur_parts[1]))
-        if dur_range[0] < 1 or dur_range[1] < dur_range[0]:
-            raise ValueError
+        dur_range = parse_duration_range(args.duration_range)
     except (ValueError, IndexError):
         print(
             f"Error: --duration-range must be MIN-MAX (e.g., 1-5), got '{args.duration_range}'",
@@ -1747,14 +1811,7 @@ def main():
         )
         sys.exit(1)
 
-    # Parse corrupt count
-    corrupt_str = args.corrupt.strip()
-    if corrupt_str.endswith("%"):
-        corrupt_pct = float(corrupt_str[:-1]) / 100.0
-        corrupt_count = max(0, int(corrupt_pct * args.count + 0.999))  # round up
-    else:
-        corrupt_count = int(corrupt_str)
-
+    corrupt_count = parse_corrupt_count(args.corrupt, args.count)
     if corrupt_count > 0 and args.count < corrupt_count:
         print(
             f"Error: --corrupt {corrupt_count} requires --count >= {corrupt_count}",
@@ -1762,10 +1819,11 @@ def main():
         )
         sys.exit(1)
 
-    dest = Path(args.dest)
-    manifest = build_manifest()
+    return args, dur_range, corrupt_count
 
-    # Filter manifest
+
+def prepare_specs(args, manifest, duration_range):
+    """Select deterministic specs and append requested random specs."""
     only = set(args.only.split(",")) if args.only else None
     skip = set(args.skip.split(",")) if args.skip else set()
     specs = select_specs(manifest, args.profile, only, skip)
@@ -1775,186 +1833,203 @@ def main():
     )
     specs = [spec for spec in specs if "corruption" not in spec]
 
-    # Generate random specs if --count is set
     random_specs = []
     if args.count > 0:
         random_specs = build_random_specs(
             args.count,
             args.seed,
-            dur_range,
+            duration_range,
             profile=args.profile,
         )
         specs.extend(random_specs)
 
-    if not specs and not deterministic_corrupt_specs and args.count == 0:
-        print("No files to generate (check --only / --skip filters).", file=sys.stderr)
-        sys.exit(1)
+    return PreparedSpecs(
+        specs=specs,
+        deterministic_corrupt_specs=deterministic_corrupt_specs,
+        random_specs=random_specs,
+    )
 
-    # Check ffmpeg availability
+
+def ensure_ffmpeg_available():
+    """Exit with a clear message if ffmpeg is unavailable."""
     try:
         subprocess.run(["ffmpeg", "-version"], capture_output=True, timeout=10)
     except FileNotFoundError:
         print("Error: ffmpeg not found in PATH", file=sys.stderr)
         sys.exit(1)
 
-    # Probe available encoders
-    available = probe_encoders()
-    if not available:
-        print(
-            "Warning: could not probe ffmpeg encoders, will try all files",
-            file=sys.stderr,
-        )
 
-    if not args.dry_run:
-        dest.mkdir(parents=True, exist_ok=True)
+def quote_command(cmd):
+    """Quote command arguments with spaces or shell-significant separators."""
+    quoted = []
+    for arg in cmd:
+        if " " in arg or "'" in arg or "=" in arg:
+            quoted.append(f"'{arg}'")
+        else:
+            quoted.append(arg)
+    return " ".join(quoted)
 
-    total = len(specs) + len(deterministic_corrupt_specs)
-    ok_count = 0
-    skip_count = 0
-    fail_count = 0
-    total_size = 0
-    generated_entries = []
-    skipped_entries = []
-    failed_entries = []
 
+def build_generation_entry(spec, filename, size, duration):
+    """Return a generated-file manifest entry."""
+    return {
+        "filename": filename,
+        "stem": spec["stem"],
+        "size": size,
+        "duration": duration,
+        "profiles": spec.get("profiles", ["coverage"]),
+        "covers": spec.get("covers", []),
+        "expect": spec.get("expect", {}),
+    }
+
+
+def build_failed_generation_entry(spec, filename, reason):
+    """Return a failed-file manifest entry."""
+    return {
+        "filename": filename,
+        "stem": spec["stem"],
+        "reason": reason,
+        "covers": spec.get("covers", []),
+        "expect": spec.get("expect", {}),
+    }
+
+
+def build_skipped_generation_entry(spec, filename, reason):
+    """Return a skipped-file manifest entry."""
+    return {
+        "filename": filename,
+        "stem": spec["stem"],
+        "reason": reason,
+        "covers": spec.get("covers", []),
+        "expect": spec.get("expect", {}),
+    }
+
+
+def generate_normal_specs(*, specs, options):
+    """Generate non-corrupt fixtures and return run counts plus manifest entries."""
+    result = GenerationResult()
     with tempfile.TemporaryDirectory(prefix="voom-corpus-") as tmpdir:
         for idx, spec in enumerate(specs, 1):
-            stem = spec["stem"]
-            filename = f"{stem}.{spec['ext']}"
+            generate_normal_spec(
+                spec=spec,
+                idx=idx,
+                tmpdir=tmpdir,
+                options=options,
+                result=result,
+            )
+    return result
 
-            # Check encoder availability
-            req = spec.get("requires_encoder")
-            if req and available and req not in available:
-                print(
-                    f"[{idx}/{total}] Skipping {filename} — encoder '{req}' not available"
-                )
-                skipped_entries.append(
-                    {
-                        "filename": filename,
-                        "stem": stem,
-                        "reason": f"encoder '{req}' not available",
-                        "covers": spec.get("covers", []),
-                        "expect": spec.get("expect", {}),
-                    }
-                )
-                skip_count += 1
-                continue
 
-            # Reset RNG per-file but derived from seed + index for reproducibility
-            file_rng = random.Random(args.seed + idx)
+def generate_normal_spec(*, spec, idx, tmpdir, options, result):
+    """Generate one normal fixture and update accumulated result state."""
+    stem = spec["stem"]
+    filename = f"{stem}.{spec['ext']}"
+    req = spec.get("requires_encoder")
+    if req and options.available and req not in options.available:
+        print(
+            f"[{idx}/{options.total}] Skipping {filename} — encoder '{req}' not available"
+        )
+        result.skipped_entries.append(
+            build_skipped_generation_entry(
+                spec,
+                filename,
+                f"encoder '{req}' not available",
+            )
+        )
+        result.skip_count += 1
+        return
 
-            file_duration = spec.get("duration_override", args.duration)
+    file_rng = random.Random(options.seed + idx)
+    file_duration = spec.get("duration_override", options.duration)
 
-            try:
-                cmd, outfile = build_ffmpeg_cmd(
-                    spec, dest, file_duration, file_rng, tmpdir
-                )
-            except Exception as e:
-                print(
-                    f"[{idx}/{total}] FAILED {filename} — error building command: {e}"
-                )
-                failed_entries.append(
-                    {
-                        "filename": filename,
-                        "stem": stem,
-                        "reason": f"error building command: {e}",
-                        "covers": spec.get("covers", []),
-                        "expect": spec.get("expect", {}),
-                    }
-                )
-                fail_count += 1
-                continue
+    try:
+        cmd, outfile = build_ffmpeg_cmd(
+            spec,
+            options.dest,
+            file_duration,
+            file_rng,
+            tmpdir,
+        )
+    except Exception as e:
+        print(
+            f"[{idx}/{options.total}] FAILED {filename} — error building command: {e}"
+        )
+        result.failed_entries.append(
+            build_failed_generation_entry(
+                spec, filename, f"error building command: {e}"
+            )
+        )
+        result.fail_count += 1
+        return
 
-            if args.dry_run:
-                print(f"[{idx}/{total}] {filename}")
-                # Quote args with spaces for readability
-                quoted = []
-                for arg in cmd:
-                    if " " in arg or "'" in arg or "=" in arg:
-                        quoted.append(f"'{arg}'")
-                    else:
-                        quoted.append(arg)
-                print(f"  {' '.join(quoted)}")
-                print()
-                ok_count += 1
-                continue
+    if options.dry_run:
+        print(f"[{idx}/{options.total}] {filename}")
+        print(f"  {quote_command(cmd)}")
+        print()
+        result.ok_count += 1
+        return
 
-            print(f"[{idx}/{total}] Generating {filename}...", end=" ", flush=True)
-            try:
-                result = subprocess.run(
-                    cmd,
-                    capture_output=not args.verbose,
-                    timeout=120,
-                )
-                if result.returncode != 0:
-                    print("FAILED")
-                    stderr = result.stderr if not args.verbose else ""
-                    if stderr:
-                        # Show last few lines of stderr
-                        lines = (
-                            stderr.decode("utf-8", errors="replace")
-                            .strip()
-                            .splitlines()
-                        )
-                        for line in lines[-5:]:
-                            print(f"  {line}")
-                    failed_entries.append(
-                        {
-                            "filename": filename,
-                            "stem": stem,
-                            "reason": f"ffmpeg failed with exit code {result.returncode}",
-                            "covers": spec.get("covers", []),
-                            "expect": spec.get("expect", {}),
-                        }
-                    )
-                    fail_count += 1
-                    continue
+    print(f"[{idx}/{options.total}] Generating {filename}...", end=" ", flush=True)
+    run_ffmpeg_for_spec(
+        cmd=cmd,
+        outfile=outfile,
+        spec=spec,
+        filename=filename,
+        duration=file_duration,
+        options=options,
+        result=result,
+    )
 
-                size = outfile.stat().st_size
-                total_size += size
-                print(f"OK ({format_size(size)})")
-                generated_entries.append(
-                    {
-                        "filename": filename,
-                        "stem": stem,
-                        "size": size,
-                        "duration": file_duration,
-                        "profiles": spec.get("profiles", ["coverage"]),
-                        "covers": spec.get("covers", []),
-                        "expect": spec.get("expect", {}),
-                    }
-                )
-                ok_count += 1
 
-            except subprocess.TimeoutExpired:
-                print("FAILED (timeout)")
-                failed_entries.append(
-                    {
-                        "filename": filename,
-                        "stem": stem,
-                        "reason": "ffmpeg timed out",
-                        "covers": spec.get("covers", []),
-                        "expect": spec.get("expect", {}),
-                    }
-                )
-                fail_count += 1
-            except Exception as e:
-                print(f"FAILED ({e})")
-                failed_entries.append(
-                    {
-                        "filename": filename,
-                        "stem": stem,
-                        "reason": f"ffmpeg failed: {e}",
-                        "covers": spec.get("covers", []),
-                        "expect": spec.get("expect", {}),
-                    }
-                )
-                fail_count += 1
+def run_ffmpeg_for_spec(*, cmd, outfile, spec, filename, duration, options, result):
+    """Run ffmpeg for one fixture and update accumulated result state."""
+    try:
+        run_result = subprocess.run(
+            cmd,
+            capture_output=not options.verbose,
+            timeout=120,
+        )
+        if run_result.returncode != 0:
+            print("FAILED")
+            stderr = run_result.stderr if not options.verbose else ""
+            if stderr:
+                lines = stderr.decode("utf-8", errors="replace").strip().splitlines()
+                for line in lines[-5:]:
+                    print(f"  {line}")
+            reason = f"ffmpeg failed with exit code {run_result.returncode}"
+            result.failed_entries.append(
+                build_failed_generation_entry(spec, filename, reason)
+            )
+            result.fail_count += 1
+            return
 
-    deterministic_corrupt_results = []
-    if args.dry_run:
-        start = len(specs)
-        for offset, spec in enumerate(deterministic_corrupt_specs, 1):
+        size = outfile.stat().st_size
+        result.total_size += size
+        print(f"OK ({format_size(size)})")
+        result.generated_entries.append(
+            build_generation_entry(spec, filename, size, duration)
+        )
+        result.ok_count += 1
+
+    except subprocess.TimeoutExpired:
+        print("FAILED (timeout)")
+        result.failed_entries.append(
+            build_failed_generation_entry(spec, filename, "ffmpeg timed out")
+        )
+        result.fail_count += 1
+    except Exception as e:
+        print(f"FAILED ({e})")
+        result.failed_entries.append(
+            build_failed_generation_entry(spec, filename, f"ffmpeg failed: {e}")
+        )
+        result.fail_count += 1
+
+
+def materialize_deterministic_corruptions(*, specs, dest, seed, dry_run, start, total):
+    """Materialize deterministic corruption fixtures and return run results."""
+    result = CorruptionResult()
+    if dry_run:
+        for offset, spec in enumerate(specs, 1):
             filename = fixture_filename(spec)
             corruption = spec["corruption"]
             corruption_type = corruption["type"]
@@ -1971,57 +2046,96 @@ def main():
                 f"{corruption_type} from {source_filename}{final_detail}"
             )
             print()
-            ok_count += 1
-    else:
-        corrupt_rng = random.Random(args.seed + 19999)
-        for spec in deterministic_corrupt_specs:
-            result = materialize_corrupt_fixture(dest, spec, corrupt_rng)
-            filename = result["filename"]
-            ctype = result["type"]
-            desc = result["description"]
-            if result["skipped"]:
-                skipped_entries.append(build_skipped_corruption_entry(spec, result))
-                skip_count += 1
-                print(f"  SKIPPED {filename} — {ctype}: {desc}")
-            else:
-                deterministic_corrupt_results.append(result)
-                print(f"  CORRUPTED {filename} — {ctype}: {desc}")
+            result.ok_count += 1
+        return result
 
-    # Apply corruption to selected random files
-    random_corrupt_results = []
-    if corrupt_count > 0 and not args.dry_run:
-        random_corrupt_results = select_and_corrupt(
-            dest, random_specs, corrupt_count, args.seed
-        )
-        update_generated_entries_for_corruptions(
-            generated_entries,
-            random_corrupt_results,
-        )
-        for result in random_corrupt_results:
-            filename = result["filename"]
-            ctype = result["type"]
-            desc = result["description"]
+    corrupt_rng = random.Random(seed + 19999)
+    for spec in specs:
+        corrupt_result = materialize_corrupt_fixture(dest, spec, corrupt_rng)
+        filename = corrupt_result["filename"]
+        ctype = corrupt_result["type"]
+        desc = corrupt_result["description"]
+        if corrupt_result["skipped"]:
+            result.skipped_entries.append(
+                build_skipped_corruption_entry(spec, corrupt_result)
+            )
+            result.skip_count += 1
+            print(f"  SKIPPED {filename} — {ctype}: {desc}")
+        else:
+            result.corrupt_results.append(corrupt_result)
             print(f"  CORRUPTED {filename} — {ctype}: {desc}")
+    return result
 
-    corrupt_results = deterministic_corrupt_results + random_corrupt_results
-    corruption_entries = build_corruption_manifest_entries(corrupt_results)
-    if not args.dry_run:
-        run_manifest = build_run_manifest(
-            profile=args.profile,
-            duration=args.duration,
-            duration_range=dur_range,
-            count=args.count,
-            generated=generated_entries,
-            skipped=skipped_entries,
-            failed=failed_entries,
-            corruptions=corruption_entries,
-        )
-        manifest_path = write_run_manifest(dest, run_manifest)
-        print(f"Manifest: {manifest_path}")
 
-    # Summary
+def materialize_random_corruptions(
+    *,
+    dest,
+    random_specs,
+    corrupt_count,
+    seed,
+    dry_run,
+    generated_entries,
+):
+    """Apply requested random corruptions and return corruption results."""
+    if corrupt_count <= 0 or dry_run:
+        return []
+
+    corrupt_results = select_and_corrupt(dest, random_specs, corrupt_count, seed)
+    update_generated_entries_for_corruptions(generated_entries, corrupt_results)
+    for result in corrupt_results:
+        filename = result["filename"]
+        ctype = result["type"]
+        desc = result["description"]
+        print(f"  CORRUPTED {filename} — {ctype}: {desc}")
+    return corrupt_results
+
+
+def finalize_run_manifest(
+    *,
+    dry_run,
+    dest,
+    profile,
+    duration,
+    duration_range,
+    count,
+    generated,
+    skipped,
+    failed,
+    corruptions,
+):
+    """Write the run manifest for non-dry runs."""
+    if dry_run:
+        return None
+
+    run_manifest = build_run_manifest(
+        profile=profile,
+        duration=duration,
+        duration_range=duration_range,
+        count=count,
+        generated=generated,
+        skipped=skipped,
+        failed=failed,
+        corruptions=corruptions,
+    )
+    manifest_path = write_run_manifest(dest, run_manifest)
+    print(f"Manifest: {manifest_path}")
+    return manifest_path
+
+
+def print_run_summary(
+    *,
+    dry_run,
+    ok_count,
+    skip_count,
+    fail_count,
+    total_size,
+    corrupt_results,
+    deterministic_corrupt_specs,
+    dest,
+):
+    """Print the final run summary."""
     print()
-    if args.dry_run:
+    if dry_run:
         action = (
             "generated/materialized" if deterministic_corrupt_specs else "generated"
         )
@@ -2040,6 +2154,93 @@ def main():
 
     if skip_count:
         print(f"Destination: {dest}")
+
+
+def main():
+    parser = build_arg_parser()
+    args, dur_range, corrupt_count = parse_run_arguments(parser)
+    dest = Path(args.dest)
+    prepared = prepare_specs(args, build_manifest(), dur_range)
+    if (
+        not prepared.specs
+        and not prepared.deterministic_corrupt_specs
+        and args.count == 0
+    ):
+        print("No files to generate (check --only / --skip filters).", file=sys.stderr)
+        sys.exit(1)
+
+    ensure_ffmpeg_available()
+    available = probe_encoders()
+    if not available:
+        print(
+            "Warning: could not probe ffmpeg encoders, will try all files",
+            file=sys.stderr,
+        )
+
+    if not args.dry_run:
+        dest.mkdir(parents=True, exist_ok=True)
+
+    total = len(prepared.specs) + len(prepared.deterministic_corrupt_specs)
+    generation = generate_normal_specs(
+        specs=prepared.specs,
+        options=GenerationOptions(
+            dest=dest,
+            duration=args.duration,
+            seed=args.seed,
+            dry_run=args.dry_run,
+            verbose=args.verbose,
+            available=available,
+            total=total,
+        ),
+    )
+    deterministic_corruption = materialize_deterministic_corruptions(
+        specs=prepared.deterministic_corrupt_specs,
+        dest=dest,
+        seed=args.seed,
+        dry_run=args.dry_run,
+        start=len(prepared.specs),
+        total=total,
+    )
+    random_corrupt_results = materialize_random_corruptions(
+        dest=dest,
+        random_specs=prepared.random_specs,
+        corrupt_count=corrupt_count,
+        seed=args.seed,
+        dry_run=args.dry_run,
+        generated_entries=generation.generated_entries,
+    )
+
+    corrupt_results = deterministic_corruption.corrupt_results + random_corrupt_results
+    skipped_entries = (
+        generation.skipped_entries + deterministic_corruption.skipped_entries
+    )
+    corruption_entries = build_corruption_manifest_entries(corrupt_results)
+    finalize_run_manifest(
+        dry_run=args.dry_run,
+        dest=dest,
+        profile=args.profile,
+        duration=args.duration,
+        duration_range=dur_range,
+        count=args.count,
+        generated=generation.generated_entries,
+        skipped=skipped_entries,
+        failed=generation.failed_entries,
+        corruptions=corruption_entries,
+    )
+
+    ok_count = generation.ok_count + deterministic_corruption.ok_count
+    skip_count = generation.skip_count + deterministic_corruption.skip_count
+    fail_count = generation.fail_count
+    print_run_summary(
+        dry_run=args.dry_run,
+        ok_count=ok_count,
+        skip_count=skip_count,
+        fail_count=fail_count,
+        total_size=generation.total_size,
+        corrupt_results=corrupt_results,
+        deterministic_corrupt_specs=prepared.deterministic_corrupt_specs,
+        dest=dest,
+    )
 
     sys.exit(fail_count)
 

--- a/scripts/generate-test-corpus
+++ b/scripts/generate-test-corpus
@@ -633,6 +633,16 @@ def select_and_corrupt(dest, random_specs, corrupt_count, seed):
     return results
 
 
+def update_generated_entries_for_corruptions(generated_entries, corrupt_results):
+    """Update generated entries with final filenames and sizes after corruption."""
+    generated_by_filename = {entry["filename"]: entry for entry in generated_entries}
+    for result in corrupt_results:
+        entry = generated_by_filename.get(result["original_filename"])
+        if entry is not None:
+            entry["filename"] = result["filename"]
+            entry["size"] = result["size"]
+
+
 # ---------------------------------------------------------------------------
 # Encoder availability
 # ---------------------------------------------------------------------------
@@ -1270,17 +1280,12 @@ def main():
     corrupt_results = []
     if corrupt_count > 0 and not args.dry_run:
         corrupt_results = select_and_corrupt(dest, random_specs, corrupt_count, args.seed)
-        generated_by_filename = {entry["filename"]: entry for entry in generated_entries}
+        update_generated_entries_for_corruptions(generated_entries, corrupt_results)
         for result in corrupt_results:
             filename = result["filename"]
             ctype = result["type"]
             desc = result["description"]
             print(f"  CORRUPTED {filename} — {ctype}: {desc}")
-
-            entry = generated_by_filename.get(result["original_filename"])
-            if entry is not None:
-                entry["filename"] = filename
-                entry["size"] = result["size"]
 
     corruption_entries = [
         {

--- a/tests/scripts/test_generate_test_corpus.py
+++ b/tests/scripts/test_generate_test_corpus.py
@@ -111,7 +111,7 @@ def test_build_run_manifest_records_generated_skipped_failed_and_corruptions():
             }
         ],
         corruptions=[
-            {"filename": "corrupt-truncated-tail.mkv", "type": "truncated_tail"}
+            {"filename": "corrupt-truncated-tail.mp4", "type": "truncated_tail"}
         ],
     )
 
@@ -212,7 +212,7 @@ def test_collect_deterministic_corruptions_selects_profile_members():
     specs = [
         {
             "stem": "corrupt-truncated-tail",
-            "ext": "mkv",
+            "ext": "mp4",
             "profiles": ["coverage"],
             "corruption": {
                 "source_stem": "basic-h264-aac",
@@ -260,7 +260,7 @@ def test_materialize_corrupt_fixture_creates_final_file(tmp_path):
     source.write_bytes(bytes(range(256)) * 16)
     spec = {
         "stem": "corrupt-truncated-tail",
-        "ext": "mkv",
+        "ext": "mp4",
         "corruption": {
             "source_stem": "basic-h264-aac",
             "source_ext": "mp4",
@@ -271,8 +271,8 @@ def test_materialize_corrupt_fixture_creates_final_file(tmp_path):
     result = generator.materialize_corrupt_fixture(tmp_path, spec, random.Random(7))
 
     final_path = tmp_path / result["filename"]
-    assert result["original_filename"] == "corrupt-truncated-tail.mkv"
-    assert result["filename"] == "corrupt-truncated-tail.mkv"
+    assert result["original_filename"] == "corrupt-truncated-tail.mp4"
+    assert result["filename"] == "corrupt-truncated-tail.mp4"
     assert result["type"] == "truncated_tail"
     assert result["size"] == final_path.stat().st_size
     assert result["skipped"] is False
@@ -283,7 +283,7 @@ def test_materialize_corrupt_fixture_reports_missing_source(tmp_path):
     generator = load_generator()
     spec = {
         "stem": "corrupt-truncated-tail",
-        "ext": "mkv",
+        "ext": "mp4",
         "corruption": {
             "source_stem": "basic-h264-aac",
             "source_ext": "mp4",
@@ -294,15 +294,15 @@ def test_materialize_corrupt_fixture_reports_missing_source(tmp_path):
     result = generator.materialize_corrupt_fixture(tmp_path, spec, random.Random(7))
 
     assert result == {
-        "original_filename": "corrupt-truncated-tail.mkv",
-        "filename": "corrupt-truncated-tail.mkv",
+        "original_filename": "corrupt-truncated-tail.mp4",
+        "filename": "corrupt-truncated-tail.mp4",
         "source_filename": "basic-h264-aac.mp4",
         "type": "truncated_tail",
         "description": "skipped (source missing: basic-h264-aac.mp4)",
         "size": 0,
         "skipped": True,
     }
-    assert not (tmp_path / "corrupt-truncated-tail.mkv").exists()
+    assert not (tmp_path / "corrupt-truncated-tail.mp4").exists()
 
 
 def test_materialize_corrupt_fixture_reports_wrong_extension_final_name(tmp_path):

--- a/tests/scripts/test_generate_test_corpus.py
+++ b/tests/scripts/test_generate_test_corpus.py
@@ -83,13 +83,32 @@ def test_build_run_manifest_records_generated_skipped_failed_and_corruptions():
         generated=[
             {
                 "filename": "basic-h264-aac.mp4",
+                "stem": "basic-h264-aac",
                 "size": 1234,
+                "duration": 2,
+                "profiles": ["coverage"],
                 "covers": ["video.codec.h264"],
                 "expect": {"bad_file": False},
             }
         ],
-        skipped=[{"filename": "av1-opus.mp4", "reason": "encoder 'libsvtav1' not available"}],
-        failed=[{"filename": "bad.mkv", "reason": "ffmpeg failed"}],
+        skipped=[
+            {
+                "filename": "av1-opus.mp4",
+                "stem": "av1-opus",
+                "reason": "encoder 'libsvtav1' not available",
+                "covers": ["video.codec.av1"],
+                "expect": {"bad_file": False},
+            }
+        ],
+        failed=[
+            {
+                "filename": "bad.mkv",
+                "stem": "bad",
+                "reason": "ffmpeg failed",
+                "covers": ["audio.codec.truehd"],
+                "expect": {"bad_file": False},
+            }
+        ],
         corruptions=[{"filename": "corrupt-truncated-tail.mkv", "type": "truncated_tail"}],
     )
 
@@ -104,3 +123,5 @@ def test_build_run_manifest_records_generated_skipped_failed_and_corruptions():
         "corrupted": 1,
     }
     assert manifest["generated"][0]["covers"] == ["video.codec.h264"]
+    assert manifest["skipped"][0]["covers"] == ["video.codec.av1"]
+    assert manifest["failed"][0]["covers"] == ["audio.codec.truehd"]

--- a/tests/scripts/test_generate_test_corpus.py
+++ b/tests/scripts/test_generate_test_corpus.py
@@ -206,6 +206,36 @@ def test_select_and_corrupt_reports_final_filenames_and_sizes(tmp_path):
         assert entry["size"] == result["size"]
 
 
+def test_collect_deterministic_corruptions_selects_profile_members():
+    generator = load_generator()
+    specs = [
+        {
+            "stem": "corrupt-truncated-tail",
+            "ext": "mkv",
+            "profiles": ["coverage"],
+            "corruption": {
+                "source_stem": "basic-h264-aac",
+                "source_ext": "mp4",
+                "type": "truncated_tail",
+            },
+        },
+        {
+            "stem": "corrupt-stress",
+            "ext": "mkv",
+            "profiles": ["stress"],
+            "corruption": {
+                "source_stem": "basic-h264-aac",
+                "source_ext": "mp4",
+                "type": "mid_stream",
+            },
+        },
+    ]
+
+    selected = generator.collect_deterministic_corruptions(specs, profile="coverage")
+
+    assert selected == [specs[0]]
+
+
 def test_build_video_input_uses_mandelbrot_source_and_black_bars():
     generator = load_generator()
     video = {

--- a/tests/scripts/test_generate_test_corpus.py
+++ b/tests/scripts/test_generate_test_corpus.py
@@ -51,3 +51,22 @@ def test_select_specs_all_includes_coverage_and_stress():
         "stress-case",
         "smoke-case",
     ]
+
+
+def test_build_manifest_smoke_profile_is_expected_fast_subset():
+    generator = load_generator()
+
+    selected = generator.select_specs(
+        generator.build_manifest(),
+        profile="smoke",
+        only=None,
+        skip=set(),
+    )
+
+    assert [spec["stem"] for spec in selected] == [
+        "basic-h264-aac",
+        "loudness-quiet-dialogue",
+        "letterbox-h264",
+        "hevc-surround",
+        "vp9-opus",
+    ]

--- a/tests/scripts/test_generate_test_corpus.py
+++ b/tests/scripts/test_generate_test_corpus.py
@@ -127,6 +127,16 @@ def test_build_run_manifest_records_generated_skipped_failed_and_corruptions():
     assert manifest["failed"][0]["covers"] == ["audio.codec.truehd"]
 
 
+def test_write_run_manifest_uses_stable_json_format(tmp_path):
+    generator = load_generator()
+    manifest = {"z": 1, "a": {"b": 2}}
+
+    path = generator.write_run_manifest(tmp_path, manifest)
+
+    assert path == tmp_path / "manifest.json"
+    assert path.read_text() == '{\n  "a": {\n    "b": 2\n  },\n  "z": 1\n}\n'
+
+
 def test_select_and_corrupt_reports_final_filenames_and_sizes(tmp_path):
     generator = load_generator()
     specs = [

--- a/tests/scripts/test_generate_test_corpus.py
+++ b/tests/scripts/test_generate_test_corpus.py
@@ -279,6 +279,36 @@ def test_materialize_corrupt_fixture_creates_final_file(tmp_path):
     assert final_path.exists()
 
 
+def test_deterministic_corruption_manifest_entry_retains_fixture_metadata(tmp_path):
+    generator = load_generator()
+    source = tmp_path / "basic-h264-aac.mp4"
+    source.write_bytes(bytes(range(256)) * 16)
+    spec = {
+        "stem": "corrupt-truncated-tail",
+        "ext": "mp4",
+        "profiles": ["coverage"],
+        "covers": ["bad_file.truncated_tail"],
+        "expect": {"bad_file": True, "corruption": "truncated_tail"},
+        "corruption": {
+            "source_stem": "basic-h264-aac",
+            "source_ext": "mp4",
+            "type": "truncated_tail",
+        },
+    }
+
+    result = generator.materialize_corrupt_fixture(tmp_path, spec, random.Random(7))
+    entry = generator.build_corruption_manifest_entries([result])[0]
+
+    final_path = tmp_path / "corrupt-truncated-tail.mp4"
+    assert entry["stem"] == "corrupt-truncated-tail"
+    assert entry["filename"] == "corrupt-truncated-tail.mp4"
+    assert entry["source_filename"] == "basic-h264-aac.mp4"
+    assert entry["covers"] == ["bad_file.truncated_tail"]
+    assert entry["expect"]["bad_file"] is True
+    assert entry["profiles"] == ["coverage"]
+    assert entry["size"] == final_path.stat().st_size
+
+
 def test_materialize_corrupt_fixture_reports_missing_source(tmp_path):
     generator = load_generator()
     spec = {

--- a/tests/scripts/test_generate_test_corpus.py
+++ b/tests/scripts/test_generate_test_corpus.py
@@ -109,7 +109,9 @@ def test_build_run_manifest_records_generated_skipped_failed_and_corruptions():
                 "expect": {"bad_file": False},
             }
         ],
-        corruptions=[{"filename": "corrupt-truncated-tail.mkv", "type": "truncated_tail"}],
+        corruptions=[
+            {"filename": "corrupt-truncated-tail.mkv", "type": "truncated_tail"}
+        ],
     )
 
     assert manifest["schema_version"] == 1
@@ -178,7 +180,9 @@ def test_select_and_corrupt_reports_final_filenames_and_sizes(tmp_path):
         assert final_path.exists()
         assert result["size"] == final_path.stat().st_size
 
-    renamed = next(result for result in corruptions if result["type"] == "wrong_extension")
+    renamed = next(
+        result for result in corruptions if result["type"] == "wrong_extension"
+    )
     assert renamed["original_filename"] == "rename-case.mp4"
     assert renamed["filename"] == "rename-case.mkv"
     assert not (tmp_path / renamed["original_filename"]).exists()

--- a/tests/scripts/test_generate_test_corpus.py
+++ b/tests/scripts/test_generate_test_corpus.py
@@ -125,3 +125,68 @@ def test_build_run_manifest_records_generated_skipped_failed_and_corruptions():
     assert manifest["generated"][0]["covers"] == ["video.codec.h264"]
     assert manifest["skipped"][0]["covers"] == ["video.codec.av1"]
     assert manifest["failed"][0]["covers"] == ["audio.codec.truehd"]
+
+
+def test_select_and_corrupt_reports_final_filenames_and_sizes(tmp_path):
+    generator = load_generator()
+    specs = [
+        {"stem": "zero-case", "ext": "mkv"},
+        {"stem": "truncated-case", "ext": "mkv"},
+        {"stem": "rename-case", "ext": "mp4"},
+    ]
+
+    for spec in specs:
+        path = tmp_path / f"{spec['stem']}.{spec['ext']}"
+        path.write_bytes(bytes(range(256)) * 8)
+
+    corruptions = []
+    original_types = generator.CORRUPTION_TYPES
+    try:
+        for index, corruption_type in enumerate(
+            ["zero_length", "truncated", "wrong_extension"]
+        ):
+            generator.CORRUPTION_TYPES = [corruption_type]
+            corruptions.extend(
+                generator.select_and_corrupt(
+                    tmp_path,
+                    [specs[index]],
+                    corrupt_count=1,
+                    seed=12,
+                )
+            )
+    finally:
+        generator.CORRUPTION_TYPES = original_types
+
+    assert {result["type"] for result in corruptions} == {
+        "zero_length",
+        "truncated",
+        "wrong_extension",
+    }
+
+    for result in corruptions:
+        final_path = tmp_path / result["filename"]
+        assert final_path.exists()
+        assert result["size"] == final_path.stat().st_size
+
+    renamed = next(result for result in corruptions if result["type"] == "wrong_extension")
+    assert renamed["original_filename"] == "rename-case.mp4"
+    assert renamed["filename"] == "rename-case.mkv"
+    assert not (tmp_path / renamed["original_filename"]).exists()
+
+    zeroed = next(result for result in corruptions if result["type"] == "zero_length")
+    assert zeroed["size"] == 0
+
+    generated_entries = [
+        {
+            "filename": f"{spec['stem']}.{spec['ext']}",
+            "size": 2048,
+        }
+        for spec in specs
+    ]
+
+    generator.update_generated_entries_for_corruptions(generated_entries, corruptions)
+
+    entries_by_name = {entry["filename"]: entry for entry in generated_entries}
+    for result in corruptions:
+        entry = entries_by_name[result["filename"]]
+        assert entry["size"] == result["size"]

--- a/tests/scripts/test_generate_test_corpus.py
+++ b/tests/scripts/test_generate_test_corpus.py
@@ -5,6 +5,8 @@ import random
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
+import pytest
+
 
 SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "generate-test-corpus"
 
@@ -19,8 +21,12 @@ def load_generator():
     return module
 
 
-def test_select_specs_filters_by_profile_only_and_skip():
-    generator = load_generator()
+@pytest.fixture
+def generator():
+    return load_generator()
+
+
+def test_select_specs_filters_by_profile_only_and_skip(generator):
     specs = [
         {"stem": "a", "profiles": ["smoke", "coverage"]},
         {"stem": "b", "profiles": ["coverage"]},
@@ -37,8 +43,7 @@ def test_select_specs_filters_by_profile_only_and_skip():
     assert [spec["stem"] for spec in selected] == ["a"]
 
 
-def test_select_specs_all_includes_coverage_and_stress():
-    generator = load_generator()
+def test_select_specs_all_includes_coverage_and_stress(generator):
     specs = [
         {"stem": "coverage-case", "profiles": ["coverage"]},
         {"stem": "stress-case", "profiles": ["stress"]},
@@ -54,9 +59,7 @@ def test_select_specs_all_includes_coverage_and_stress():
     ]
 
 
-def test_build_manifest_smoke_profile_is_expected_fast_subset():
-    generator = load_generator()
-
+def test_build_manifest_smoke_profile_is_expected_fast_subset(generator):
     selected = generator.select_specs(
         generator.build_manifest(),
         profile="smoke",
@@ -73,9 +76,7 @@ def test_build_manifest_smoke_profile_is_expected_fast_subset():
     ]
 
 
-def test_build_run_manifest_records_generated_skipped_failed_and_corruptions():
-    generator = load_generator()
-
+def test_build_run_manifest_records_generated_skipped_failed_and_corruptions(generator):
     manifest = generator.build_run_manifest(
         profile="coverage",
         duration=2,
@@ -130,8 +131,7 @@ def test_build_run_manifest_records_generated_skipped_failed_and_corruptions():
     assert manifest["failed"][0]["covers"] == ["audio.codec.truehd"]
 
 
-def test_write_run_manifest_uses_stable_json_format(tmp_path):
-    generator = load_generator()
+def test_write_run_manifest_uses_stable_json_format(generator, tmp_path):
     manifest = {"z": 1, "a": {"b": 2}}
 
     path = generator.write_run_manifest(tmp_path, manifest)
@@ -140,8 +140,33 @@ def test_write_run_manifest_uses_stable_json_format(tmp_path):
     assert path.read_text() == '{\n  "a": {\n    "b": 2\n  },\n  "z": 1\n}\n'
 
 
-def test_select_and_corrupt_reports_final_filenames_and_sizes(tmp_path):
-    generator = load_generator()
+def test_corruption_final_path_renames_mp4_to_mkv(generator):
+    path = Path("fixture.mp4")
+
+    final_path = generator.corruption_final_path(path, "wrong_extension")
+
+    assert final_path == Path("fixture.mkv")
+
+
+def test_corruption_final_path_renames_mkv_to_mp4(generator):
+    path = Path("fixture.mkv")
+
+    final_path = generator.corruption_final_path(path, "wrong_extension")
+
+    assert final_path == Path("fixture.mp4")
+
+
+def test_corruption_final_path_keeps_non_rename_corruptions(generator):
+    path = Path("fixture.mp4")
+
+    final_path = generator.corruption_final_path(path, "truncated")
+
+    assert final_path == path
+
+
+def test_select_and_corrupt_reports_final_filenames_and_sizes(
+    generator, monkeypatch, tmp_path
+):
     specs = [
         {"stem": "zero-case", "ext": "mkv"},
         {"stem": "truncated-case", "ext": "mkv"},
@@ -153,22 +178,18 @@ def test_select_and_corrupt_reports_final_filenames_and_sizes(tmp_path):
         path.write_bytes(bytes(range(256)) * 8)
 
     corruptions = []
-    original_types = generator.CORRUPTION_TYPES
-    try:
-        for index, corruption_type in enumerate(
-            ["zero_length", "truncated", "wrong_extension"]
-        ):
-            generator.CORRUPTION_TYPES = [corruption_type]
-            corruptions.extend(
-                generator.select_and_corrupt(
-                    tmp_path,
-                    [specs[index]],
-                    corrupt_count=1,
-                    seed=12,
-                )
+    for index, corruption_type in enumerate(
+        ["zero_length", "truncated", "wrong_extension"]
+    ):
+        monkeypatch.setattr(generator, "CORRUPTION_TYPES", [corruption_type])
+        corruptions.extend(
+            generator.select_and_corrupt(
+                tmp_path,
+                [specs[index]],
+                corrupt_count=1,
+                seed=12,
             )
-    finally:
-        generator.CORRUPTION_TYPES = original_types
+        )
 
     assert {result["type"] for result in corruptions} == {
         "zero_length",
@@ -207,8 +228,7 @@ def test_select_and_corrupt_reports_final_filenames_and_sizes(tmp_path):
         assert entry["size"] == result["size"]
 
 
-def test_collect_deterministic_corruptions_selects_profile_members():
-    generator = load_generator()
+def test_collect_deterministic_corruptions_selects_profile_members(generator):
     specs = [
         {
             "stem": "corrupt-truncated-tail",
@@ -237,9 +257,7 @@ def test_collect_deterministic_corruptions_selects_profile_members():
     assert selected == [specs[0]]
 
 
-def test_build_manifest_includes_required_corrupt_fixtures():
-    generator = load_generator()
-
+def test_build_manifest_includes_required_corrupt_fixtures(generator):
     corrupt_names = {
         spec["stem"] for spec in generator.build_manifest() if "corruption" in spec
     }
@@ -254,8 +272,7 @@ def test_build_manifest_includes_required_corrupt_fixtures():
     }
 
 
-def test_materialize_corrupt_fixture_creates_final_file(tmp_path):
-    generator = load_generator()
+def test_materialize_corrupt_fixture_creates_final_file(generator, tmp_path):
     source = tmp_path / "basic-h264-aac.mp4"
     source.write_bytes(bytes(range(256)) * 16)
     spec = {
@@ -279,8 +296,9 @@ def test_materialize_corrupt_fixture_creates_final_file(tmp_path):
     assert final_path.exists()
 
 
-def test_deterministic_corruption_manifest_entry_retains_fixture_metadata(tmp_path):
-    generator = load_generator()
+def test_deterministic_corruption_manifest_entry_retains_fixture_metadata(
+    generator, tmp_path
+):
     source = tmp_path / "basic-h264-aac.mp4"
     source.write_bytes(bytes(range(256)) * 16)
     spec = {
@@ -309,8 +327,7 @@ def test_deterministic_corruption_manifest_entry_retains_fixture_metadata(tmp_pa
     assert entry["size"] == final_path.stat().st_size
 
 
-def test_materialize_corrupt_fixture_reports_missing_source(tmp_path):
-    generator = load_generator()
+def test_materialize_corrupt_fixture_reports_missing_source(generator, tmp_path):
     spec = {
         "stem": "corrupt-truncated-tail",
         "ext": "mp4",
@@ -335,8 +352,9 @@ def test_materialize_corrupt_fixture_reports_missing_source(tmp_path):
     assert not (tmp_path / "corrupt-truncated-tail.mp4").exists()
 
 
-def test_materialize_corrupt_fixture_reports_wrong_extension_final_name(tmp_path):
-    generator = load_generator()
+def test_materialize_corrupt_fixture_reports_wrong_extension_final_name(
+    generator, tmp_path
+):
     source = tmp_path / "basic-h264-aac.mp4"
     source.write_bytes(bytes(range(256)) * 16)
     spec = {
@@ -359,8 +377,25 @@ def test_materialize_corrupt_fixture_reports_wrong_extension_final_name(tmp_path
     assert not (tmp_path / result["original_filename"]).exists()
 
 
-def test_build_video_input_uses_mandelbrot_source_and_black_bars():
-    generator = load_generator()
+def test_ensure_ffmpeg_available_exits_when_binary_missing(
+    generator, monkeypatch, capsys
+):
+    monkeypatch.setattr(generator.shutil, "which", lambda name: None)
+
+    with pytest.raises(SystemExit) as exc_info:
+        generator.ensure_ffmpeg_available()
+
+    assert exc_info.value.code == 1
+    assert capsys.readouterr().err == "Error: ffmpeg not found in PATH\n"
+
+
+def test_ensure_ffmpeg_available_returns_when_binary_exists(generator, monkeypatch):
+    monkeypatch.setattr(generator.shutil, "which", lambda name: "/usr/bin/ffmpeg")
+
+    generator.ensure_ffmpeg_available()
+
+
+def test_build_video_input_uses_mandelbrot_source_and_black_bars(generator):
     video = {
         "source": "mandelbrot_zoom",
         "size": "1920x1080",
@@ -376,8 +411,7 @@ def test_build_video_input_uses_mandelbrot_source_and_black_bars():
     assert "pad=1920:1080:(ow-iw)/2:(oh-ih)/2:black" in source
 
 
-def test_build_video_input_keeps_testsrc_for_smoke_fixture():
-    generator = load_generator()
+def test_build_video_input_keeps_testsrc_for_smoke_fixture(generator):
     video = {"source": "testsrc2", "size": "1280x720", "fps": 24}
 
     source = generator.build_video_input(video, duration=2, specials=set())
@@ -385,8 +419,7 @@ def test_build_video_input_keeps_testsrc_for_smoke_fixture():
     assert source == "testsrc2=duration=2:size=1280x720:rate=24"
 
 
-def test_build_video_input_dark_edges_adds_vignette_without_black_bars():
-    generator = load_generator()
+def test_build_video_input_dark_edges_adds_vignette_without_black_bars(generator):
     video = {
         "source": "mandelbrot_zoom",
         "size": "1920x1080",
@@ -399,9 +432,7 @@ def test_build_video_input_dark_edges_adds_vignette_without_black_bars():
     assert "pad=1920:1080:(ow-iw)/2:(oh-ih)/2:black" not in source
 
 
-def test_build_audio_input_dynamic_bursts_uses_aevalsrc_expression():
-    generator = load_generator()
-
+def test_build_audio_input_dynamic_bursts_uses_aevalsrc_expression(generator):
     source = generator.build_audio_input(
         {"source": "dynamic_bursts"},
         index=0,
@@ -414,8 +445,7 @@ def test_build_audio_input_dynamic_bursts_uses_aevalsrc_expression():
     assert "0.04*sin(2*PI*220*t)" in source
 
 
-def test_build_ffmpeg_cmd_adds_loudnorm_filter_for_target_fixture(tmp_path):
-    generator = load_generator()
+def test_build_ffmpeg_cmd_adds_loudnorm_filter_for_target_fixture(generator, tmp_path):
     spec = next(
         spec
         for spec in generator.build_manifest()
@@ -434,8 +464,7 @@ def test_build_ffmpeg_cmd_adds_loudnorm_filter_for_target_fixture(tmp_path):
     assert cmd[cmd.index("-af:a:0") + 1] == "loudnorm=I=-23:TP=-2:LRA=11"
 
 
-def test_add_audio_codec_options_sets_explicit_stereo_for_two_channels():
-    generator = load_generator()
+def test_add_audio_codec_options_sets_explicit_stereo_for_two_channels(generator):
     cmd = []
 
     generator.add_audio_codec_options(

--- a/tests/scripts/test_generate_test_corpus.py
+++ b/tests/scripts/test_generate_test_corpus.py
@@ -204,3 +204,29 @@ def test_select_and_corrupt_reports_final_filenames_and_sizes(tmp_path):
     for result in corruptions:
         entry = entries_by_name[result["filename"]]
         assert entry["size"] == result["size"]
+
+
+def test_build_video_input_uses_mandelbrot_source_and_black_bars():
+    generator = load_generator()
+    video = {
+        "source": "mandelbrot_zoom",
+        "size": "1920x1080",
+        "active_size": "1920x816",
+        "fps": 24,
+    }
+
+    source = generator.build_video_input(video, duration=2, specials={"black_bars"})
+
+    assert source.startswith("mandelbrot=")
+    assert "rate=24" in source
+    assert "scale=1920:816" in source
+    assert "pad=1920:1080:(ow-iw)/2:(oh-ih)/2:black" in source
+
+
+def test_build_video_input_keeps_testsrc_for_smoke_fixture():
+    generator = load_generator()
+    video = {"source": "testsrc2", "size": "1280x720", "fps": 24}
+
+    source = generator.build_video_input(video, duration=2, specials=set())
+
+    assert source == "testsrc2=duration=2:size=1280x720:rate=24"

--- a/tests/scripts/test_generate_test_corpus.py
+++ b/tests/scripts/test_generate_test_corpus.py
@@ -70,3 +70,37 @@ def test_build_manifest_smoke_profile_is_expected_fast_subset():
         "hevc-surround",
         "vp9-opus",
     ]
+
+
+def test_build_run_manifest_records_generated_skipped_failed_and_corruptions():
+    generator = load_generator()
+
+    manifest = generator.build_run_manifest(
+        profile="coverage",
+        duration=2,
+        duration_range=(1, 5),
+        count=3,
+        generated=[
+            {
+                "filename": "basic-h264-aac.mp4",
+                "size": 1234,
+                "covers": ["video.codec.h264"],
+                "expect": {"bad_file": False},
+            }
+        ],
+        skipped=[{"filename": "av1-opus.mp4", "reason": "encoder 'libsvtav1' not available"}],
+        failed=[{"filename": "bad.mkv", "reason": "ffmpeg failed"}],
+        corruptions=[{"filename": "corrupt-truncated-tail.mkv", "type": "truncated_tail"}],
+    )
+
+    assert manifest["schema_version"] == 1
+    assert manifest["settings"]["profile"] == "coverage"
+    assert manifest["settings"]["duration"] == 2
+    assert manifest["settings"]["duration_range"] == [1, 5]
+    assert manifest["summary"] == {
+        "generated": 1,
+        "skipped": 1,
+        "failed": 1,
+        "corrupted": 1,
+    }
+    assert manifest["generated"][0]["covers"] == ["video.codec.h264"]

--- a/tests/scripts/test_generate_test_corpus.py
+++ b/tests/scripts/test_generate_test_corpus.py
@@ -1,6 +1,7 @@
 """Tests for scripts/generate-test-corpus pure helpers."""
 
 import importlib.util
+import random
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
@@ -234,6 +235,98 @@ def test_collect_deterministic_corruptions_selects_profile_members():
     selected = generator.collect_deterministic_corruptions(specs, profile="coverage")
 
     assert selected == [specs[0]]
+
+
+def test_build_manifest_includes_required_corrupt_fixtures():
+    generator = load_generator()
+
+    corrupt_names = {
+        spec["stem"] for spec in generator.build_manifest() if "corruption" in spec
+    }
+
+    assert corrupt_names == {
+        "corrupt-truncated-tail",
+        "corrupt-zero-length",
+        "corrupt-header-damage",
+        "corrupt-midstream-bitrot",
+        "corrupt-wrong-extension",
+        "corrupt-container-metadata",
+    }
+
+
+def test_materialize_corrupt_fixture_creates_final_file(tmp_path):
+    generator = load_generator()
+    source = tmp_path / "basic-h264-aac.mp4"
+    source.write_bytes(bytes(range(256)) * 16)
+    spec = {
+        "stem": "corrupt-truncated-tail",
+        "ext": "mkv",
+        "corruption": {
+            "source_stem": "basic-h264-aac",
+            "source_ext": "mp4",
+            "type": "truncated_tail",
+        },
+    }
+
+    result = generator.materialize_corrupt_fixture(tmp_path, spec, random.Random(7))
+
+    final_path = tmp_path / result["filename"]
+    assert result["original_filename"] == "corrupt-truncated-tail.mkv"
+    assert result["filename"] == "corrupt-truncated-tail.mkv"
+    assert result["type"] == "truncated_tail"
+    assert result["size"] == final_path.stat().st_size
+    assert result["skipped"] is False
+    assert final_path.exists()
+
+
+def test_materialize_corrupt_fixture_reports_missing_source(tmp_path):
+    generator = load_generator()
+    spec = {
+        "stem": "corrupt-truncated-tail",
+        "ext": "mkv",
+        "corruption": {
+            "source_stem": "basic-h264-aac",
+            "source_ext": "mp4",
+            "type": "truncated_tail",
+        },
+    }
+
+    result = generator.materialize_corrupt_fixture(tmp_path, spec, random.Random(7))
+
+    assert result == {
+        "original_filename": "corrupt-truncated-tail.mkv",
+        "filename": "corrupt-truncated-tail.mkv",
+        "source_filename": "basic-h264-aac.mp4",
+        "type": "truncated_tail",
+        "description": "skipped (source missing: basic-h264-aac.mp4)",
+        "size": 0,
+        "skipped": True,
+    }
+    assert not (tmp_path / "corrupt-truncated-tail.mkv").exists()
+
+
+def test_materialize_corrupt_fixture_reports_wrong_extension_final_name(tmp_path):
+    generator = load_generator()
+    source = tmp_path / "basic-h264-aac.mp4"
+    source.write_bytes(bytes(range(256)) * 16)
+    spec = {
+        "stem": "corrupt-wrong-extension",
+        "ext": "mp4",
+        "corruption": {
+            "source_stem": "basic-h264-aac",
+            "source_ext": "mp4",
+            "type": "wrong_extension",
+        },
+    }
+
+    result = generator.materialize_corrupt_fixture(tmp_path, spec, random.Random(7))
+
+    final_path = tmp_path / "corrupt-wrong-extension.mkv"
+    assert result["original_filename"] == "corrupt-wrong-extension.mp4"
+    assert result["filename"] == "corrupt-wrong-extension.mkv"
+    assert result["size"] == final_path.stat().st_size
+    assert final_path.exists()
+    assert not (tmp_path / result["original_filename"]).exists()
 
 
 def test_build_video_input_uses_mandelbrot_source_and_black_bars():

--- a/tests/scripts/test_generate_test_corpus.py
+++ b/tests/scripts/test_generate_test_corpus.py
@@ -1,0 +1,53 @@
+"""Tests for scripts/generate-test-corpus pure helpers."""
+
+import importlib.util
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "generate-test-corpus"
+
+
+def load_generator():
+    loader = SourceFileLoader("generate_test_corpus", str(SCRIPT_PATH))
+    spec = importlib.util.spec_from_loader("generate_test_corpus", loader)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_select_specs_filters_by_profile_only_and_skip():
+    generator = load_generator()
+    specs = [
+        {"stem": "a", "profiles": ["smoke", "coverage"]},
+        {"stem": "b", "profiles": ["coverage"]},
+        {"stem": "c", "profiles": ["stress"]},
+    ]
+
+    selected = generator.select_specs(
+        specs,
+        profile="coverage",
+        only={"a", "b", "c"},
+        skip={"b"},
+    )
+
+    assert [spec["stem"] for spec in selected] == ["a"]
+
+
+def test_select_specs_all_includes_coverage_and_stress():
+    generator = load_generator()
+    specs = [
+        {"stem": "coverage-case", "profiles": ["coverage"]},
+        {"stem": "stress-case", "profiles": ["stress"]},
+        {"stem": "smoke-case", "profiles": ["smoke", "coverage"]},
+    ]
+
+    selected = generator.select_specs(specs, profile="all", only=None, skip=set())
+
+    assert [spec["stem"] for spec in selected] == [
+        "coverage-case",
+        "stress-case",
+        "smoke-case",
+    ]

--- a/tests/scripts/test_generate_test_corpus.py
+++ b/tests/scripts/test_generate_test_corpus.py
@@ -383,3 +383,67 @@ def test_build_video_input_keeps_testsrc_for_smoke_fixture():
     source = generator.build_video_input(video, duration=2, specials=set())
 
     assert source == "testsrc2=duration=2:size=1280x720:rate=24"
+
+
+def test_build_video_input_dark_edges_adds_vignette_without_black_bars():
+    generator = load_generator()
+    video = {
+        "source": "mandelbrot_zoom",
+        "size": "1920x1080",
+        "fps": 24,
+    }
+
+    source = generator.build_video_input(video, duration=2, specials={"dark_edges"})
+
+    assert "vignette=PI/5" in source
+    assert "pad=1920:1080:(ow-iw)/2:(oh-ih)/2:black" not in source
+
+
+def test_build_audio_input_dynamic_bursts_uses_aevalsrc_expression():
+    generator = load_generator()
+
+    source = generator.build_audio_input(
+        {"source": "dynamic_bursts"},
+        index=0,
+        duration=2,
+    )
+
+    assert source.startswith("aevalsrc=")
+    assert "between(mod(t,1),0,0.15)" in source
+    assert "0.9*sin(2*PI*880*t)" in source
+    assert "0.04*sin(2*PI*220*t)" in source
+
+
+def test_build_ffmpeg_cmd_adds_loudnorm_filter_for_target_fixture(tmp_path):
+    generator = load_generator()
+    spec = next(
+        spec
+        for spec in generator.build_manifest()
+        if spec["stem"] == "loudness-normalized-target"
+    )
+
+    cmd, _ = generator.build_ffmpeg_cmd(
+        spec,
+        tmp_path,
+        duration=2,
+        rng=random.Random(1),
+        tmpdir=tmp_path,
+    )
+
+    assert "-af:a:0" in cmd
+    assert cmd[cmd.index("-af:a:0") + 1] == "loudnorm=I=-23:TP=-2:LRA=11"
+
+
+def test_add_audio_codec_options_sets_explicit_stereo_for_two_channels():
+    generator = load_generator()
+    cmd = []
+
+    generator.add_audio_codec_options(
+        cmd,
+        [{"codec": "aac", "channels": 2}],
+    )
+
+    assert "-ac:a:0" in cmd
+    assert cmd[cmd.index("-ac:a:0") + 1] == "2"
+    assert "-channel_layout:a:0" in cmd
+    assert cmd[cmd.index("-channel_layout:a:0") + 1] == "stereo"


### PR DESCRIPTION
## Summary
- add profiled corpus generation with smoke, coverage, stress, and all profiles
- add procedural Mandelbrot motion sources, HDR/10-bit fixtures, crop fixtures, expanded audio/loudness fixtures, deterministic corrupt fixtures, and manifest output
- simplify generator helpers after review by consolidating manifest issue entries, centralizing corruption filename planning, using dataclasses, and removing a redundant ffmpeg probe

## Verification
- `uv run --with ruff ruff format --check scripts/generate-test-corpus tests/scripts/test_generate_test_corpus.py`
- `uv run --with ruff ruff check scripts/generate-test-corpus tests/scripts/test_generate_test_corpus.py`
- `uv run --with pytest pytest -q tests/scripts/test_generate_test_corpus.py`
- `scripts/generate-test-corpus /tmp/voom-corpus-all.af4LjN --profile all --duration 1 --count 6 --duration-range 1-2 --corrupt 50%`
- `just functional-test`