### PR TITLE
Add pre-flight cost estimates

### DIFF
--- a/crates/voom-cli/src/cli.rs
+++ b/crates/voom-cli/src/cli.rs
@@ -181,6 +181,14 @@ pub struct ProcessArgs {
     #[arg(long)]
     pub dry_run: bool,
 
+    /// Estimate runtime and output size without executing plans
+    #[arg(long)]
+    pub estimate: bool,
+
+    /// Alias for --estimate
+    #[arg(long)]
+    pub estimate_only: bool,
+
     /// Error handling strategy
     #[arg(long, default_value = "fail")]
     pub on_error: ErrorHandling,
@@ -215,9 +223,42 @@ pub struct ProcessArgs {
     #[arg(long)]
     pub plan_only: bool,
 
+    /// Execute only files whose estimated per-file savings meet this threshold
+    #[arg(long, value_parser = parse_size_bytes)]
+    pub confirm_savings: Option<u64>,
+
     /// Assign job priority based on file modification date
     #[arg(long)]
     pub priority_by_date: bool,
+}
+
+fn parse_size_bytes(value: &str) -> std::result::Result<u64, String> {
+    let trimmed = value.trim();
+    let split = trimmed
+        .find(|ch: char| !ch.is_ascii_digit())
+        .unwrap_or(trimmed.len());
+    let (digits, suffix) = trimmed.split_at(split);
+    if digits.is_empty() {
+        return Err("size must start with a byte count".to_string());
+    }
+    let amount = digits
+        .parse::<u64>()
+        .map_err(|error| format!("invalid byte count '{digits}': {error}"))?;
+    let multiplier = match suffix.trim().to_ascii_lowercase().as_str() {
+        "" | "b" => 1,
+        "kb" => 1_000,
+        "mb" => 1_000_000,
+        "gb" => 1_000_000_000,
+        "tb" => 1_000_000_000_000,
+        "kib" => 1_024,
+        "mib" => 1_048_576,
+        "gib" => 1_073_741_824,
+        "tib" => 1_099_511_627_776,
+        _ => return Err(format!("unsupported size suffix '{suffix}'")),
+    };
+    amount
+        .checked_mul(multiplier)
+        .ok_or_else(|| format!("size '{value}' exceeds u64"))
 }
 
 // === Policy ===
@@ -1114,6 +1155,29 @@ mod tests {
                 assert_eq!(args.workers, 8);
                 assert!(args.approve);
                 assert!(args.no_backup);
+            }
+            _ => panic!("expected Process"),
+        }
+    }
+
+    #[test]
+    fn test_process_estimate_flags() {
+        let cli = parse(&[
+            "voom",
+            "process",
+            "/media",
+            "--policy",
+            "p.voom",
+            "--estimate",
+            "--estimate-only",
+            "--confirm-savings",
+            "1GB",
+        ]);
+        match cli.command {
+            Commands::Process(args) => {
+                assert!(args.estimate);
+                assert!(args.estimate_only);
+                assert_eq!(args.confirm_savings, Some(1_000_000_000));
             }
             _ => panic!("expected Process"),
         }

--- a/crates/voom-cli/src/cli.rs
+++ b/crates/voom-cli/src/cli.rs
@@ -37,6 +37,9 @@ pub enum Commands {
     /// Apply policy to files
     Process(ProcessArgs),
 
+    /// Estimate policy cost without modifying files
+    Estimate(EstimateArgs),
+
     /// Policy management
     #[command(subcommand)]
     Policy(PolicyCommands),
@@ -230,6 +233,29 @@ pub struct ProcessArgs {
     /// Assign job priority based on file modification date
     #[arg(long)]
     pub priority_by_date: bool,
+}
+
+#[derive(clap::Args)]
+pub struct EstimateArgs {
+    /// Directories or files to estimate
+    #[arg(required = true, num_args = 1..)]
+    pub paths: Vec<PathBuf>,
+
+    /// Policy file (.voom) to estimate
+    #[arg(short, long, conflicts_with = "policy_map")]
+    pub policy: Option<PathBuf>,
+
+    /// TOML file mapping directory prefixes to policies
+    #[arg(long, conflicts_with = "policy")]
+    pub policy_map: Option<PathBuf>,
+
+    /// Number of parallel workers to use for wall-time estimates
+    #[arg(short, long, default_value_t = 0)]
+    pub workers: usize,
+
+    /// Re-introspect every file from scratch before estimating
+    #[arg(long)]
+    pub force_rescan: bool,
 }
 
 fn parse_size_bytes(value: &str) -> std::result::Result<u64, String> {
@@ -1180,6 +1206,18 @@ mod tests {
                 assert_eq!(args.confirm_savings, Some(1_000_000_000));
             }
             _ => panic!("expected Process"),
+        }
+    }
+
+    #[test]
+    fn test_estimate_command() {
+        let cli = parse(&["voom", "estimate", "/media", "--policy", "p.voom"]);
+        match cli.command {
+            Commands::Estimate(args) => {
+                assert_eq!(args.paths, vec![PathBuf::from("/media")]);
+                assert_eq!(args.policy, Some(PathBuf::from("p.voom")));
+            }
+            _ => panic!("expected Estimate"),
         }
     }
 

--- a/crates/voom-cli/src/commands/estimate.rs
+++ b/crates/voom-cli/src/commands/estimate.rs
@@ -1,0 +1,31 @@
+use anyhow::Result;
+use tokio_util::sync::CancellationToken;
+
+use crate::cli::{ErrorHandling, EstimateArgs, ProcessArgs};
+
+pub async fn run(args: EstimateArgs, quiet: bool, token: CancellationToken) -> Result<()> {
+    crate::commands::process::run(args.into_process_args(), quiet, token).await
+}
+
+impl EstimateArgs {
+    fn into_process_args(self) -> ProcessArgs {
+        ProcessArgs {
+            paths: self.paths,
+            policy: self.policy,
+            policy_map: self.policy_map,
+            dry_run: false,
+            estimate: true,
+            estimate_only: false,
+            on_error: ErrorHandling::Fail,
+            workers: self.workers,
+            approve: false,
+            no_backup: false,
+            force_rescan: self.force_rescan,
+            flag_size_increase: false,
+            flag_duration_shrink: false,
+            plan_only: false,
+            confirm_savings: None,
+            priority_by_date: false,
+        }
+    }
+}

--- a/crates/voom-cli/src/commands/estimate.rs
+++ b/crates/voom-cli/src/commands/estimate.rs
@@ -1,13 +1,24 @@
 use anyhow::Result;
 use tokio_util::sync::CancellationToken;
 
+use crate::app;
 use crate::cli::{ErrorHandling, EstimateArgs, ProcessArgs};
 
 pub async fn run(args: EstimateArgs, quiet: bool, token: CancellationToken) -> Result<()> {
+    if args.is_calibration_request() {
+        return calibrate().await;
+    }
     crate::commands::process::run(args.into_process_args(), quiet, token).await
 }
 
 impl EstimateArgs {
+    fn is_calibration_request(&self) -> bool {
+        self.paths.len() == 1
+            && self.paths[0] == std::path::Path::new("calibrate")
+            && self.policy.is_none()
+            && self.policy_map.is_none()
+    }
+
     fn into_process_args(self) -> ProcessArgs {
         ProcessArgs {
             paths: self.paths,
@@ -28,4 +39,44 @@ impl EstimateArgs {
             priority_by_date: false,
         }
     }
+}
+
+async fn calibrate() -> Result<()> {
+    let config = crate::config::load_config()?;
+    let app::BootstrapResult { store, .. } = crate::app::bootstrap_kernel_with_store(&config)?;
+    let completed_at = chrono::Utc::now();
+    let samples = default_calibration_samples(completed_at);
+    for sample in &samples {
+        store.insert_cost_model_sample(sample)?;
+    }
+    println!("Recorded {} estimate calibration samples.", samples.len());
+    Ok(())
+}
+
+fn default_calibration_samples(
+    completed_at: chrono::DateTime<chrono::Utc>,
+) -> Vec<voom_domain::CostModelSample> {
+    vec![
+        voom_domain::CostModelSample::new(
+            voom_domain::EstimateOperationKey::transcode("video", "hevc", "slow", "software"),
+            1_500_000.0,
+            0.55,
+            1_000,
+            completed_at,
+        ),
+        voom_domain::CostModelSample::new(
+            voom_domain::EstimateOperationKey::transcode("video", "hevc", "slow", "nvenc"),
+            5_000_000.0,
+            0.60,
+            1_000,
+            completed_at,
+        ),
+        voom_domain::CostModelSample::new(
+            voom_domain::EstimateOperationKey::transcode("video", "av1", "slow", "software"),
+            750_000.0,
+            0.45,
+            1_000,
+            completed_at,
+        ),
+    ]
 }

--- a/crates/voom-cli/src/commands/mod.rs
+++ b/crates/voom-cli/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod completions;
 pub mod config;
 pub mod db;
 pub mod env;
+pub mod estimate;
 pub mod events;
 pub mod files;
 pub mod history;

--- a/crates/voom-cli/src/commands/process/mod.rs
+++ b/crates/voom-cli/src/commands/process/mod.rs
@@ -28,7 +28,8 @@ use voom_domain::bad_file::BadFileSource;
 use voom_domain::events::{
     Event, IntrospectSessionCompletedEvent, JobCompletedEvent, JobProgressEvent, JobStartedEvent,
 };
-use voom_domain::utils::format::format_size;
+use voom_domain::storage::CostModelSampleFilters;
+use voom_domain::utils::format::{format_duration, format_size};
 use voom_job_manager::progress::{CompositeReporter, ProgressReporter};
 use voom_job_manager::worker::{JobErrorStrategy, WorkerPool, WorkerPoolConfig};
 
@@ -70,8 +71,9 @@ pub async fn run(args: ProcessArgs, quiet: bool, token: CancellationToken) -> Re
         );
     }
 
+    let estimate_mode = args.estimate || args.estimate_only;
     let plan_only = args.plan_only;
-    let dry_run = args.dry_run || plan_only;
+    let dry_run = args.dry_run || plan_only || estimate_mode;
 
     let config = config::load_config()?;
     let app::BootstrapResult {
@@ -241,6 +243,7 @@ pub async fn run(args: ProcessArgs, quiet: bool, token: CancellationToken) -> Re
         let animation_detection_mode = config.animation_detection_mode();
         let counters_for_summary = counters.clone();
         let kernel_for_completion = kernel.clone();
+        let store_for_summary = store.clone();
         let _results = pool
             .process_batch(
                 items,
@@ -260,6 +263,7 @@ pub async fn run(args: ProcessArgs, quiet: bool, token: CancellationToken) -> Re
                             store,
                             dry_run,
                             plan_only,
+                            estimate_mode,
                             flag_size_increase,
                             flag_duration_shrink,
                             force_rescan,
@@ -286,7 +290,9 @@ pub async fn run(args: ProcessArgs, quiet: bool, token: CancellationToken) -> Re
 
         print_run_results(&RunResultsContext {
             counters: &counters_for_summary,
+            store: store_for_summary.as_ref(),
             plan_only,
+            estimate_mode,
             quiet,
             cancelled: token.is_cancelled(),
             pool: &pool,
@@ -359,7 +365,9 @@ fn build_reporter(
 #[allow(clippy::struct_excessive_bools)]
 struct RunResultsContext<'a> {
     counters: &'a RunCounters,
+    store: &'a dyn voom_domain::storage::StorageTrait,
     plan_only: bool,
+    estimate_mode: bool,
     quiet: bool,
     cancelled: bool,
     pool: &'a WorkerPool,
@@ -376,6 +384,24 @@ fn print_run_results(ctx: &RunResultsContext<'_>) -> Result<()> {
         let plans = ctx.counters.plan_collector.lock();
         let output = serde_json::to_string_pretty(&*plans).context("failed to serialize plans")?;
         println!("{output}");
+        return Ok(());
+    }
+
+    if ctx.estimate_mode {
+        let plans = ctx.counters.estimate_plans.lock().clone();
+        let samples = ctx
+            .store
+            .list_cost_model_samples(&CostModelSampleFilters::default())
+            .context("failed to load estimate cost model samples")?;
+        let model = voom_domain::EstimateModel::from_samples(samples);
+        let estimate = voom_domain::estimate_plans(
+            voom_domain::EstimateInput::new(plans, ctx.effective_workers, chrono::Utc::now()),
+            &model,
+        );
+        ctx.store
+            .insert_estimate_run(&estimate)
+            .context("failed to persist estimate run")?;
+        print_estimate(&estimate);
         return Ok(());
     }
 
@@ -415,6 +441,49 @@ fn print_run_results(ctx: &RunResultsContext<'_>) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn print_estimate(estimate: &voom_domain::EstimateRun) {
+    println!(
+        "Estimating cost for {} planned file phases...",
+        estimate.file_count
+    );
+    println!();
+    println!("Total wall time:     ~{}", format_ms(estimate.wall_time_ms));
+    println!(
+        "Total compute time:  ~{}",
+        format_ms(estimate.compute_time_ms)
+    );
+    println!("Bytes in:            {}", format_size(estimate.bytes_in));
+    println!(
+        "Bytes out:           {} (estimated)",
+        format_size(estimate.bytes_out)
+    );
+    println!(
+        "Bytes saved:         {}",
+        format_signed_size(estimate.bytes_saved)
+    );
+    println!();
+    println!(
+        "Files where transcoding net loses bytes: {}",
+        estimate.net_loss_files
+    );
+    println!(
+        "Files where estimate uncertainty is high: {}",
+        estimate.high_uncertainty_files
+    );
+}
+
+fn format_ms(ms: u64) -> String {
+    format_duration(ms as f64 / 1_000.0)
+}
+
+fn format_signed_size(bytes: i64) -> String {
+    if bytes >= 0 {
+        format_size(bytes.unsigned_abs())
+    } else {
+        format!("-{}", format_size(bytes.unsigned_abs()))
+    }
 }
 
 /// Build a `PolicyResolver` from CLI args and config.
@@ -689,6 +758,7 @@ pub(super) struct RunCounters {
     pub(super) backup_bytes: Arc<AtomicU64>,
     pub(super) phase_stats: PhaseStatsMap,
     pub(super) plan_collector: Arc<Mutex<Vec<serde_json::Value>>>,
+    pub(super) estimate_plans: Arc<Mutex<Vec<voom_domain::Plan>>>,
     pub(super) session_id: uuid::Uuid,
 }
 
@@ -699,6 +769,7 @@ impl RunCounters {
             backup_bytes: Arc::new(AtomicU64::new(0)),
             phase_stats: Arc::new(Mutex::new(HashMap::new())),
             plan_collector: Arc::new(Mutex::new(Vec::new())),
+            estimate_plans: Arc::new(Mutex::new(Vec::new())),
             session_id: uuid::Uuid::new_v4(),
         }
     }
@@ -712,6 +783,7 @@ pub(super) struct ProcessContext<'a> {
     pub(super) store: Arc<dyn voom_domain::storage::StorageTrait>,
     pub(super) dry_run: bool,
     pub(super) plan_only: bool,
+    pub(super) estimate_mode: bool,
     pub(super) flag_size_increase: bool,
     pub(super) flag_duration_shrink: bool,
     /// When true, bypass the introspection cache and force a fresh ffprobe pass.
@@ -1080,6 +1152,7 @@ mod tests {
                 store,
                 dry_run: false,
                 plan_only: false,
+                estimate_mode: false,
                 flag_size_increase: false,
                 flag_duration_shrink: false,
                 force_rescan: false,

--- a/crates/voom-cli/src/commands/process/mod.rs
+++ b/crates/voom-cli/src/commands/process/mod.rs
@@ -235,7 +235,12 @@ pub async fn run(args: ProcessArgs, quiet: bool, token: CancellationToken) -> Re
         let resolver = Arc::new(resolver);
         let flag_size_increase = args.flag_size_increase;
         let flag_duration_shrink = args.flag_duration_shrink;
+        let confirm_savings = args.confirm_savings;
         let force_rescan = args.force_rescan;
+        let estimate_samples = store
+            .list_cost_model_samples(&CostModelSampleFilters::default())
+            .context("failed to load estimate cost model samples")?;
+        let estimate_model = Arc::new(voom_domain::EstimateModel::from_samples(estimate_samples));
 
         let token_for_workers = token.clone();
         let ffprobe_path: Option<String> = config.ffprobe_path().map(String::from);
@@ -255,6 +260,7 @@ pub async fn run(args: ProcessArgs, quiet: bool, token: CancellationToken) -> Re
                     let ffprobe_path = ffprobe_path.clone();
                     let capabilities = capabilities.clone();
                     let plan_limiter = plan_limiter.clone();
+                    let estimate_model = estimate_model.clone();
                     let counters = counters.clone();
                     async move {
                         let ctx = ProcessContext {
@@ -272,6 +278,8 @@ pub async fn run(args: ProcessArgs, quiet: bool, token: CancellationToken) -> Re
                             animation_detection_mode,
                             capabilities: &capabilities,
                             plan_limiter,
+                            confirm_savings,
+                            estimate_model,
                             counters: &counters,
                         };
                         process_single_file(job, &ctx).await
@@ -793,6 +801,8 @@ pub(super) struct ProcessContext<'a> {
     pub(super) animation_detection_mode: voom_ffprobe_introspector::parser::AnimationDetectionMode,
     pub(super) capabilities: &'a voom_domain::CapabilityMap,
     pub(super) plan_limiter: Arc<voom_job_manager::worker::PlanExecutionLimiter>,
+    pub(super) confirm_savings: Option<u64>,
+    pub(super) estimate_model: Arc<voom_domain::EstimateModel>,
     pub(super) counters: &'a RunCounters,
 }
 
@@ -1161,6 +1171,8 @@ mod tests {
                 animation_detection_mode: Default::default(),
                 capabilities: &self.capabilities,
                 plan_limiter: self.plan_limiter.clone(),
+                confirm_savings: None,
+                estimate_model: Arc::new(voom_domain::EstimateModel::default()),
                 counters: &self.counters,
             }
         }

--- a/crates/voom-cli/src/commands/process/mod.rs
+++ b/crates/voom-cli/src/commands/process/mod.rs
@@ -5,7 +5,7 @@ mod plan_outcome;
 mod safeguards;
 mod transitions;
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
 use std::sync::Arc;
 
@@ -457,6 +457,7 @@ fn print_estimate(estimate: &voom_domain::EstimateRun) {
         estimate.file_count
     );
     println!();
+    print_estimate_breakdowns(estimate);
     println!("Total wall time:     ~{}", format_ms(estimate.wall_time_ms));
     println!(
         "Total compute time:  ~{}",
@@ -480,6 +481,48 @@ fn print_estimate(estimate: &voom_domain::EstimateRun) {
         "Files where estimate uncertainty is high: {}",
         estimate.high_uncertainty_files
     );
+}
+
+fn print_estimate_breakdowns(estimate: &voom_domain::EstimateRun) {
+    let mut phases: BTreeMap<&str, (usize, u64)> = BTreeMap::new();
+    let mut transcodes: BTreeMap<(String, String), (usize, u64)> = BTreeMap::new();
+    for file in &estimate.files {
+        let phase = phases.entry(&file.phase_name).or_default();
+        phase.0 += 1;
+        phase.1 = phase.1.saturating_add(file.compute_time_ms);
+
+        for action in &file.actions {
+            let Some(codec) = action.codec.as_ref() else {
+                continue;
+            };
+            let backend = action.backend.as_deref().unwrap_or("software").to_string();
+            let bucket = transcodes.entry((codec.clone(), backend)).or_default();
+            bucket.0 += 1;
+            bucket.1 = bucket.1.saturating_add(action.compute_time_ms);
+        }
+    }
+
+    if !phases.is_empty() {
+        println!("Phase breakdown:");
+        for (phase, (count, compute_ms)) in phases {
+            println!(
+                "  {phase:<18} {count:>5} plans     ~{}",
+                format_ms(compute_ms)
+            );
+        }
+        println!();
+    }
+
+    if !transcodes.is_empty() {
+        println!("Transcode breakdown:");
+        for ((codec, backend), (count, compute_ms)) in transcodes {
+            println!(
+                "  {codec:<8} {backend:<12} {count:>5} plans     ~{}",
+                format_ms(compute_ms)
+            );
+        }
+        println!();
+    }
 }
 
 fn format_ms(ms: u64) -> String {

--- a/crates/voom-cli/src/commands/process/mod.rs
+++ b/crates/voom-cli/src/commands/process/mod.rs
@@ -481,6 +481,15 @@ fn print_estimate(estimate: &voom_domain::EstimateRun) {
         "Files where estimate uncertainty is high: {}",
         estimate.high_uncertainty_files
     );
+    if estimate.high_uncertainty_files > 0 {
+        println!(
+            "High-uncertainty range: bytes saved {} to {}, compute time {} to {}",
+            format_signed_size(scale_i64(estimate.bytes_saved, 0.5)),
+            format_signed_size(scale_i64(estimate.bytes_saved, 1.5)),
+            format_ms(scale_u64(estimate.compute_time_ms, 0.5)),
+            format_ms(scale_u64(estimate.compute_time_ms, 1.5)),
+        );
+    }
 }
 
 fn print_estimate_breakdowns(estimate: &voom_domain::EstimateRun) {
@@ -527,6 +536,14 @@ fn print_estimate_breakdowns(estimate: &voom_domain::EstimateRun) {
 
 fn format_ms(ms: u64) -> String {
     format_duration(ms as f64 / 1_000.0)
+}
+
+fn scale_u64(value: u64, multiplier: f64) -> u64 {
+    (value as f64 * multiplier).round() as u64
+}
+
+fn scale_i64(value: i64, multiplier: f64) -> i64 {
+    (value as f64 * multiplier).round() as i64
 }
 
 fn format_signed_size(bytes: i64) -> String {

--- a/crates/voom-cli/src/commands/process/pipeline.rs
+++ b/crates/voom-cli/src/commands/process/pipeline.rs
@@ -255,6 +255,19 @@ async fn process_single_file_execute(
 
         plans_evaluated += 1;
 
+        if savings_below_threshold(&plan, ctx) {
+            phase_outcomes.insert(
+                phase_name.clone(),
+                voom_policy_evaluator::EvaluationOutcome::Skipped,
+            );
+            record_phase_stat(
+                &ctx.counters.phase_stats,
+                &plan.phase_name,
+                PhaseOutcomeKind::Skipped("estimated savings below threshold".to_string()),
+            );
+            continue;
+        }
+
         dispatch_safeguard_violations(&plan, &current_file, ctx);
 
         // Handle skipped plans
@@ -819,6 +832,17 @@ fn cropdetect_request_for_plan(plan: &Plan, file: &MediaFile) -> Option<CropDete
 
 fn crop_settings_fingerprint(settings: &CropSettings) -> Result<String, String> {
     serde_json::to_string(settings).map_err(|e| format!("failed to fingerprint crop settings: {e}"))
+}
+
+fn savings_below_threshold(plan: &Plan, ctx: &ProcessContext<'_>) -> bool {
+    let Some(threshold) = ctx.confirm_savings else {
+        return false;
+    };
+    let estimate = voom_domain::estimate_plans(
+        voom_domain::EstimateInput::new(vec![plan.clone()], 1, chrono::Utc::now()),
+        &ctx.estimate_model,
+    );
+    estimate.bytes_saved < threshold as i64
 }
 
 #[cfg(test)]

--- a/crates/voom-cli/src/commands/process/pipeline.rs
+++ b/crates/voom-cli/src/commands/process/pipeline.rs
@@ -183,6 +183,13 @@ fn process_single_file_dry_run(
         }
     }
 
+    if ctx.estimate_mode {
+        ctx.counters
+            .estimate_plans
+            .lock()
+            .extend(result.plans.iter().cloned());
+    }
+
     let plan_summaries: Vec<serde_json::Value> = result
         .plans
         .iter()

--- a/crates/voom-cli/src/main.rs
+++ b/crates/voom-cli/src/main.rs
@@ -66,6 +66,7 @@ async fn main() -> Result<()> {
         Commands::Scan(args) => commands::scan::run(args, quiet, token).await,
         Commands::Inspect(args) => commands::inspect::run(&args),
         Commands::Process(args) => commands::process::run(args, quiet, token).await,
+        Commands::Estimate(args) => commands::estimate::run(args, quiet, token).await,
         Commands::Policy(sub) => commands::policy::run(sub).await,
         Commands::Plugin(sub) => commands::plugin::run(sub),
         Commands::Jobs(sub) => commands::jobs::run(sub, global_yes),
@@ -100,7 +101,7 @@ async fn main() -> Result<()> {
 fn command_needs_lock(command: &Commands) -> bool {
     use cli::{BackupCommands, FilesCommands, JobsCommands, VerifyCommands};
     match command {
-        Commands::Scan(_) | Commands::Process(_) | Commands::Db(_) => true,
+        Commands::Scan(_) | Commands::Process(_) | Commands::Estimate(_) | Commands::Db(_) => true,
         Commands::Jobs(sub) => matches!(
             sub,
             JobsCommands::Cancel { .. } | JobsCommands::Retry { .. } | JobsCommands::Clear { .. }

--- a/crates/voom-domain/src/estimate.rs
+++ b/crates/voom-domain/src/estimate.rs
@@ -1,0 +1,396 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::plan::{ActionParams, OperationType, Plan, PlannedAction};
+
+const DEFAULT_FIXED_ACTION_MS: u64 = 500;
+const DEFAULT_TRANSCODE_PIXELS_PER_SECOND: f64 = 2_000_000.0;
+const DEFAULT_TRANSCODE_SIZE_RATIO: f64 = 0.65;
+
+/// Input used to estimate one policy planning run.
+#[derive(Debug, Clone)]
+pub struct EstimateInput {
+    pub plans: Vec<Plan>,
+    pub workers: usize,
+    pub estimated_at: DateTime<Utc>,
+}
+
+impl EstimateInput {
+    #[must_use]
+    pub fn new(plans: Vec<Plan>, workers: usize, estimated_at: DateTime<Utc>) -> Self {
+        Self {
+            plans,
+            workers,
+            estimated_at,
+        }
+    }
+}
+
+/// Stable key used to match historical samples to planned operations.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct EstimateOperationKey {
+    pub phase_name: String,
+    pub codec: String,
+    pub preset: String,
+    pub backend: String,
+}
+
+impl EstimateOperationKey {
+    #[must_use]
+    pub fn transcode(
+        phase_name: impl Into<String>,
+        codec: impl Into<String>,
+        preset: impl Into<String>,
+        backend: impl Into<String>,
+    ) -> Self {
+        Self {
+            phase_name: phase_name.into(),
+            codec: codec.into(),
+            preset: preset.into(),
+            backend: backend.into(),
+        }
+    }
+}
+
+/// Historical cost-model sample for one operation key.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CostModelSample {
+    pub id: Uuid,
+    pub key: EstimateOperationKey,
+    pub pixels_per_second: f64,
+    pub output_size_ratio: f64,
+    pub fixed_overhead_ms: u64,
+    pub completed_at: DateTime<Utc>,
+}
+
+impl CostModelSample {
+    #[must_use]
+    pub fn new(
+        key: EstimateOperationKey,
+        pixels_per_second: f64,
+        output_size_ratio: f64,
+        fixed_overhead_ms: u64,
+        completed_at: DateTime<Utc>,
+    ) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            key,
+            pixels_per_second,
+            output_size_ratio,
+            fixed_overhead_ms,
+            completed_at,
+        }
+    }
+}
+
+/// Read-only cost model used by the estimator.
+#[derive(Debug, Clone, Default)]
+pub struct EstimateModel {
+    samples: Vec<CostModelSample>,
+}
+
+impl EstimateModel {
+    #[must_use]
+    pub fn from_samples(samples: Vec<CostModelSample>) -> Self {
+        Self { samples }
+    }
+
+    fn samples_for(&self, key: &EstimateOperationKey) -> Vec<&CostModelSample> {
+        self.samples
+            .iter()
+            .filter(|sample| sample.key == *key)
+            .collect()
+    }
+}
+
+/// Aggregate estimate for a full planning run.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EstimateRun {
+    pub id: Uuid,
+    pub estimated_at: DateTime<Utc>,
+    pub file_count: usize,
+    pub bytes_in: u64,
+    pub bytes_out: u64,
+    pub bytes_saved: i64,
+    pub compute_time_ms: u64,
+    pub wall_time_ms: u64,
+    pub high_uncertainty_files: usize,
+    pub net_loss_files: usize,
+    pub files: Vec<FileEstimate>,
+}
+
+/// Estimate for one planned file/phase pair.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileEstimate {
+    pub file_id: Uuid,
+    pub path: String,
+    pub phase_name: String,
+    pub bytes_in: u64,
+    pub bytes_out: u64,
+    pub bytes_saved: i64,
+    pub compute_time_ms: u64,
+    pub high_uncertainty: bool,
+    pub net_byte_loss: bool,
+    pub actions: Vec<ActionEstimate>,
+}
+
+/// Estimate for one planned action.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ActionEstimate {
+    pub operation: OperationType,
+    pub codec: Option<String>,
+    pub backend: Option<String>,
+    pub bytes_out: u64,
+    pub compute_time_ms: u64,
+    pub high_uncertainty: bool,
+}
+
+/// Estimate all plans in one process or standalone estimate invocation.
+#[must_use]
+pub fn estimate_plans(input: EstimateInput, model: &EstimateModel) -> EstimateRun {
+    let files: Vec<FileEstimate> = input
+        .plans
+        .iter()
+        .map(|plan| estimate_file(plan, model))
+        .collect();
+    let bytes_in = files.iter().map(|file| file.bytes_in).sum();
+    let bytes_out = files.iter().map(|file| file.bytes_out).sum();
+    let compute_time_ms = files.iter().map(|file| file.compute_time_ms).sum();
+    let workers = u64::try_from(input.workers.max(1)).unwrap_or(u64::MAX);
+
+    EstimateRun {
+        id: Uuid::new_v4(),
+        estimated_at: input.estimated_at,
+        file_count: files.len(),
+        bytes_in,
+        bytes_out,
+        bytes_saved: bytes_in as i64 - bytes_out as i64,
+        compute_time_ms,
+        wall_time_ms: compute_time_ms.div_ceil(workers),
+        high_uncertainty_files: files.iter().filter(|file| file.high_uncertainty).count(),
+        net_loss_files: files.iter().filter(|file| file.net_byte_loss).count(),
+        files,
+    }
+}
+
+fn estimate_file(plan: &Plan, model: &EstimateModel) -> FileEstimate {
+    let actions: Vec<ActionEstimate> = plan
+        .actions
+        .iter()
+        .map(|action| estimate_action(plan, action, model))
+        .collect();
+    let bytes_out = actions
+        .iter()
+        .map(|action| action.bytes_out)
+        .max()
+        .unwrap_or(plan.file.size);
+    let compute_time_ms = actions.iter().map(|action| action.compute_time_ms).sum();
+    let bytes_saved = plan.file.size as i64 - bytes_out as i64;
+
+    FileEstimate {
+        file_id: plan.file.id,
+        path: plan.file.path.display().to_string(),
+        phase_name: plan.phase_name.clone(),
+        bytes_in: plan.file.size,
+        bytes_out,
+        bytes_saved,
+        compute_time_ms,
+        high_uncertainty: actions.iter().any(|action| action.high_uncertainty),
+        net_byte_loss: bytes_saved < 0,
+        actions,
+    }
+}
+
+fn estimate_action(plan: &Plan, action: &PlannedAction, model: &EstimateModel) -> ActionEstimate {
+    match &action.parameters {
+        ActionParams::Transcode { codec, settings } => {
+            let preset = settings.preset.as_deref().unwrap_or("default");
+            let backend = settings.hw.as_deref().unwrap_or("software");
+            let key = EstimateOperationKey::transcode(&plan.phase_name, codec, preset, backend);
+            let samples = model.samples_for(&key);
+            let profile = TranscodeProfile::from_samples(&samples);
+            let compute_time_ms = estimate_transcode_ms(plan, &profile);
+            let bytes_out = ((plan.file.size as f64) * profile.output_size_ratio).round() as u64;
+
+            ActionEstimate {
+                operation: action.operation,
+                codec: Some(codec.clone()),
+                backend: Some(backend.to_string()),
+                bytes_out,
+                compute_time_ms,
+                high_uncertainty: samples.len() < 5 || missing_video_dimensions(plan),
+            }
+        }
+        _ => ActionEstimate {
+            operation: action.operation,
+            codec: None,
+            backend: None,
+            bytes_out: plan.file.size,
+            compute_time_ms: DEFAULT_FIXED_ACTION_MS,
+            high_uncertainty: false,
+        },
+    }
+}
+
+struct TranscodeProfile {
+    pixels_per_second: f64,
+    output_size_ratio: f64,
+    fixed_overhead_ms: u64,
+}
+
+impl TranscodeProfile {
+    fn from_samples(samples: &[&CostModelSample]) -> Self {
+        if samples.is_empty() {
+            return Self {
+                pixels_per_second: DEFAULT_TRANSCODE_PIXELS_PER_SECOND,
+                output_size_ratio: DEFAULT_TRANSCODE_SIZE_RATIO,
+                fixed_overhead_ms: DEFAULT_FIXED_ACTION_MS,
+            };
+        }
+
+        Self {
+            pixels_per_second: median_f64(
+                samples
+                    .iter()
+                    .map(|sample| sample.pixels_per_second)
+                    .collect(),
+            ),
+            output_size_ratio: median_f64(
+                samples
+                    .iter()
+                    .map(|sample| sample.output_size_ratio)
+                    .collect(),
+            ),
+            fixed_overhead_ms: median_u64(
+                samples
+                    .iter()
+                    .map(|sample| sample.fixed_overhead_ms)
+                    .collect(),
+            ),
+        }
+    }
+}
+
+fn estimate_transcode_ms(plan: &Plan, profile: &TranscodeProfile) -> u64 {
+    let Some((width, height)) = video_dimensions(plan) else {
+        return profile.fixed_overhead_ms + duration_fallback_ms(plan, profile);
+    };
+    let pixels = f64::from(width) * f64::from(height) * plan.file.duration.max(1.0);
+    let encode_ms = (pixels / profile.pixels_per_second * 1_000.0).round() as u64;
+    profile.fixed_overhead_ms + encode_ms
+}
+
+fn duration_fallback_ms(plan: &Plan, profile: &TranscodeProfile) -> u64 {
+    (plan.file.duration.max(1.0) * 1_000.0).round() as u64 + profile.fixed_overhead_ms
+}
+
+fn video_dimensions(plan: &Plan) -> Option<(u32, u32)> {
+    plan.file
+        .video_tracks()
+        .into_iter()
+        .find_map(|track| Some((track.width?, track.height?)))
+}
+
+fn missing_video_dimensions(plan: &Plan) -> bool {
+    video_dimensions(plan).is_none() || plan.file.duration <= 0.0
+}
+
+fn median_f64(mut values: Vec<f64>) -> f64 {
+    values.sort_by(f64::total_cmp);
+    values[values.len() / 2]
+}
+
+fn median_u64(mut values: Vec<u64>) -> u64 {
+    values.sort_unstable();
+    values[values.len() / 2]
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use chrono::TimeZone;
+
+    use crate::estimate::{
+        estimate_plans, CostModelSample, EstimateInput, EstimateModel, EstimateOperationKey,
+    };
+    use crate::media::{Container, MediaFile, Track, TrackType};
+    use crate::plan::{ActionParams, OperationType, Plan, PlannedAction, TranscodeSettings};
+
+    fn video_file() -> MediaFile {
+        let mut track = Track::new(0, TrackType::Video, "h264".into());
+        track.width = Some(1920);
+        track.height = Some(1080);
+        track.frame_rate = Some(23.976);
+
+        let mut file = MediaFile::new(PathBuf::from("/media/movie.mkv"))
+            .with_container(Container::Mkv)
+            .with_duration(120.0)
+            .with_tracks(vec![track]);
+        file.size = 1_000_000_000;
+        file
+    }
+
+    fn transcode_plan(file: MediaFile) -> Plan {
+        Plan::new(file, "archive", "video").with_action(PlannedAction::track_op(
+            OperationType::TranscodeVideo,
+            0,
+            ActionParams::Transcode {
+                codec: "hevc".into(),
+                settings: TranscodeSettings::default()
+                    .with_preset(Some("slow".into()))
+                    .with_hw(Some("nvenc".into())),
+            },
+            "transcode h264 to hevc",
+        ))
+    }
+
+    #[test]
+    fn estimate_uses_historical_transcode_samples() {
+        let completed_at = chrono::Utc
+            .with_ymd_and_hms(2026, 5, 10, 12, 0, 0)
+            .single()
+            .expect("valid sample timestamp");
+        let key = EstimateOperationKey::transcode("video", "hevc", "slow", "nvenc");
+        let sample = CostModelSample::new(key, 4_000_000.0, 0.42, 5_000, completed_at);
+        let model = EstimateModel::from_samples(vec![sample]);
+        let input = EstimateInput::new(vec![transcode_plan(video_file())], 2, completed_at);
+
+        let estimate = estimate_plans(input, &model);
+
+        assert_eq!(estimate.file_count, 1);
+        assert_eq!(estimate.bytes_in, 1_000_000_000);
+        assert_eq!(estimate.bytes_out, 420_000_000);
+        assert_eq!(estimate.bytes_saved, 580_000_000);
+        assert_eq!(estimate.compute_time_ms, 67_208);
+        assert_eq!(estimate.wall_time_ms, 33_604);
+        assert_eq!(estimate.high_uncertainty_files, 1);
+        assert_eq!(estimate.net_loss_files, 0);
+        assert_eq!(estimate.files[0].phase_name, "video");
+        assert_eq!(
+            estimate.files[0].actions[0].backend.as_deref(),
+            Some("nvenc")
+        );
+        assert_eq!(estimate.files[0].actions[0].codec.as_deref(), Some("hevc"));
+    }
+
+    #[test]
+    fn estimate_flags_files_predicted_to_grow() {
+        let completed_at = chrono::Utc
+            .with_ymd_and_hms(2026, 5, 10, 12, 0, 0)
+            .single()
+            .expect("valid sample timestamp");
+        let key = EstimateOperationKey::transcode("video", "hevc", "slow", "nvenc");
+        let sample = CostModelSample::new(key, 4_000_000.0, 1.20, 5_000, completed_at);
+        let model = EstimateModel::from_samples(vec![sample]);
+        let input = EstimateInput::new(vec![transcode_plan(video_file())], 4, completed_at);
+
+        let estimate = estimate_plans(input, &model);
+
+        assert_eq!(estimate.bytes_out, 1_200_000_000);
+        assert_eq!(estimate.bytes_saved, -200_000_000);
+        assert_eq!(estimate.net_loss_files, 1);
+        assert!(estimate.files[0].net_byte_loss);
+    }
+}

--- a/crates/voom-domain/src/estimate.rs
+++ b/crates/voom-domain/src/estimate.rs
@@ -82,6 +82,11 @@ impl CostModelSample {
             completed_at,
         }
     }
+
+    #[must_use]
+    pub fn codec(&self) -> &str {
+        &self.key.codec
+    }
 }
 
 /// Read-only cost model used by the estimator.

--- a/crates/voom-domain/src/lib.rs
+++ b/crates/voom-domain/src/lib.rs
@@ -50,10 +50,11 @@ pub use stats::{
     ProcessingOutcome, SnapshotTrigger, SubtitleStats, VideoStats,
 };
 pub use storage::{
-    BadFileFilters, BadFileStorage, EventLogFilters, EventLogRecord, EventLogStorage, FileFilters,
-    FileStorage, FileTransitionStorage, HealthCheckFilters, HealthCheckRecord, HealthCheckStorage,
-    JobFilters, JobStorage, MaintenanceStorage, PlanStorage, PlanSummary, PluginDataStorage,
-    SnapshotStorage, StorageTrait, TranscodeOutcomeFilters, TranscodeOutcomeStorage,
+    BadFileFilters, BadFileStorage, CostModelSampleFilters, EstimateStorage, EventLogFilters,
+    EventLogRecord, EventLogStorage, FileFilters, FileStorage, FileTransitionStorage,
+    HealthCheckFilters, HealthCheckRecord, HealthCheckStorage, JobFilters, JobStorage,
+    MaintenanceStorage, PlanStorage, PlanSummary, PluginDataStorage, SnapshotStorage, StorageTrait,
+    TranscodeOutcomeFilters, TranscodeOutcomeStorage,
 };
 pub use transcode::TranscodeOutcome;
 pub use transition::{

--- a/crates/voom-domain/src/lib.rs
+++ b/crates/voom-domain/src/lib.rs
@@ -4,6 +4,7 @@ pub mod bad_file;
 pub mod capabilities;
 pub mod capability_map;
 pub mod errors;
+pub mod estimate;
 pub mod events;
 pub mod host_types;
 pub mod job;
@@ -30,6 +31,10 @@ pub use bad_file::{BadFile, BadFileSource};
 pub use capabilities::Capability;
 pub use capability_map::CapabilityMap;
 pub use errors::{Result, VoomError};
+pub use estimate::{
+    estimate_plans, ActionEstimate, CostModelSample, EstimateInput, EstimateModel,
+    EstimateOperationKey, EstimateRun, FileEstimate,
+};
 pub use events::Event;
 pub use job::{DiscoveredFilePayload, Job, JobStatus, JobUpdate};
 pub use media::{Container, CropDetection, CropRect, MediaFile, Track, TrackType};

--- a/crates/voom-domain/src/storage.rs
+++ b/crates/voom-domain/src/storage.rs
@@ -6,6 +6,7 @@ use uuid::Uuid;
 
 use crate::bad_file::{BadFile, BadFileSource};
 use crate::errors::Result;
+use crate::estimate::{CostModelSample, EstimateOperationKey, EstimateRun};
 use crate::job::{Job, JobStatus, JobUpdate};
 use crate::media::{Container, MediaFile, StoredFingerprint};
 use crate::plan::Plan;
@@ -595,6 +596,28 @@ pub trait TranscodeOutcomeStorage: Send + Sync {
     fn latest_outcome_for_file(&self, file_id: &str) -> Result<Option<TranscodeOutcome>>;
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct CostModelSampleFilters {
+    pub key: Option<EstimateOperationKey>,
+    pub limit: Option<u32>,
+}
+
+/// Pre-flight estimate and local cost-model persistence.
+///
+/// # Errors
+/// Implementations return [`VoomError::Storage`](crate::errors::VoomError::Storage)
+/// for any underlying database failure.
+pub trait EstimateStorage: Send + Sync {
+    fn insert_estimate_run(&self, run: &EstimateRun) -> Result<()>;
+    fn get_estimate_run(&self, id: &Uuid) -> Result<Option<EstimateRun>>;
+    fn list_estimate_runs(&self, limit: u32) -> Result<Vec<EstimateRun>>;
+    fn insert_cost_model_sample(&self, sample: &CostModelSample) -> Result<()>;
+    fn list_cost_model_samples(
+        &self,
+        filters: &CostModelSampleFilters,
+    ) -> Result<Vec<CostModelSample>>;
+}
+
 /// Composed storage interface encompassing all sub-traits.
 ///
 /// All methods are synchronous (blocking) since rusqlite is synchronous.
@@ -617,6 +640,7 @@ pub trait StorageTrait:
     + PendingOpsStorage
     + VerificationStorage
     + TranscodeOutcomeStorage
+    + EstimateStorage
 {
 }
 
@@ -635,6 +659,7 @@ impl<T> StorageTrait for T where
         + PendingOpsStorage
         + VerificationStorage
         + TranscodeOutcomeStorage
+        + EstimateStorage
 {
 }
 

--- a/crates/voom-domain/src/test_support.rs
+++ b/crates/voom-domain/src/test_support.rs
@@ -15,6 +15,7 @@ use uuid::Uuid;
 
 use crate::bad_file::BadFile;
 use crate::errors::{Result, StorageErrorKind, VoomError};
+use crate::estimate::{CostModelSample, EstimateRun};
 use crate::job::{Job, JobStatus, JobUpdate};
 use crate::media::{Container, MediaFile, Track, TrackType};
 use crate::plan::Plan;
@@ -23,10 +24,11 @@ use crate::stats::{
     SnapshotTrigger, SubtitleStats, VideoStats,
 };
 use crate::storage::{
-    BadFileFilters, BadFileStorage, FileFilters, FileStorage, FileTransitionStorage,
-    HealthCheckFilters, HealthCheckRecord, HealthCheckStorage, JobFilters, JobStorage,
-    MaintenanceStorage, PageStats, PendingOperation, PendingOpsStorage, PlanStorage, PlanSummary,
-    PluginDataStorage, SnapshotStorage, TranscodeOutcomeFilters, TranscodeOutcomeStorage,
+    BadFileFilters, BadFileStorage, CostModelSampleFilters, EstimateStorage, FileFilters,
+    FileStorage, FileTransitionStorage, HealthCheckFilters, HealthCheckRecord, HealthCheckStorage,
+    JobFilters, JobStorage, MaintenanceStorage, PageStats, PendingOperation, PendingOpsStorage,
+    PlanStorage, PlanSummary, PluginDataStorage, SnapshotStorage, TranscodeOutcomeFilters,
+    TranscodeOutcomeStorage,
 };
 use crate::transcode::TranscodeOutcome;
 use crate::transition::{
@@ -110,6 +112,8 @@ pub struct InMemoryStore {
     jobs: Mutex<HashMap<Uuid, Job>>,
     snapshots: Mutex<Vec<LibrarySnapshot>>,
     event_log: Mutex<Vec<crate::storage::EventLogRecord>>,
+    estimate_runs: Mutex<Vec<EstimateRun>>,
+    cost_model_samples: Mutex<Vec<CostModelSample>>,
     pub pending_ops: Mutex<Vec<PendingOperation>>,
     pub transcode_outcomes: Mutex<Vec<TranscodeOutcome>>,
     pub transitions: Mutex<Vec<FileTransition>>,
@@ -124,6 +128,8 @@ impl InMemoryStore {
             jobs: Mutex::new(HashMap::new()),
             snapshots: Mutex::new(Vec::new()),
             event_log: Mutex::new(Vec::new()),
+            estimate_runs: Mutex::new(Vec::new()),
+            cost_model_samples: Mutex::new(Vec::new()),
             pending_ops: Mutex::new(Vec::new()),
             transcode_outcomes: Mutex::new(Vec::new()),
             transitions: Mutex::new(Vec::new()),
@@ -1070,6 +1076,69 @@ impl TranscodeOutcomeStorage for InMemoryStore {
         };
         Ok(self.list_transcode_outcomes(&filters)?.into_iter().next())
     }
+}
+
+impl EstimateStorage for InMemoryStore {
+    fn insert_estimate_run(&self, run: &EstimateRun) -> Result<()> {
+        self.estimate_runs.lock().push(run.clone());
+        Ok(())
+    }
+
+    fn get_estimate_run(&self, id: &Uuid) -> Result<Option<EstimateRun>> {
+        Ok(self
+            .estimate_runs
+            .lock()
+            .iter()
+            .find(|run| run.id == *id)
+            .cloned())
+    }
+
+    fn list_estimate_runs(&self, limit: u32) -> Result<Vec<EstimateRun>> {
+        let mut runs = self.estimate_runs.lock().clone();
+        runs.sort_by(|a, b| {
+            b.estimated_at
+                .cmp(&a.estimated_at)
+                .then_with(|| b.id.cmp(&a.id))
+        });
+        runs.truncate(limit as usize);
+        Ok(runs)
+    }
+
+    fn insert_cost_model_sample(&self, sample: &CostModelSample) -> Result<()> {
+        self.cost_model_samples.lock().push(sample.clone());
+        Ok(())
+    }
+
+    fn list_cost_model_samples(
+        &self,
+        filters: &CostModelSampleFilters,
+    ) -> Result<Vec<CostModelSample>> {
+        let mut samples: Vec<CostModelSample> = self
+            .cost_model_samples
+            .lock()
+            .iter()
+            .filter(|sample| matches_cost_model_filter(sample, filters))
+            .cloned()
+            .collect();
+        samples.sort_by(|a, b| {
+            b.completed_at
+                .cmp(&a.completed_at)
+                .then_with(|| b.id.cmp(&a.id))
+        });
+        if let Some(limit) = filters.limit {
+            samples.truncate(limit as usize);
+        }
+        Ok(samples)
+    }
+}
+
+fn matches_cost_model_filter(sample: &CostModelSample, filters: &CostModelSampleFilters) -> bool {
+    if let Some(key) = filters.key.as_ref() {
+        if sample.key != *key {
+            return false;
+        }
+    }
+    true
 }
 
 fn matches_transcode_outcome_filter(

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -12,9 +12,11 @@
 | [../CONTRIBUTING.md](../CONTRIBUTING.md) | Local development, coverage, and CI workflow notes |
 | [mutation-testing-baseline.md](mutation-testing-baseline.md) | Initial cargo-mutants baseline and triage notes |
 | [plugin-development.md](plugin-development.md) | Guide for writing native and WASM plugins |
+| [preflight-estimates.md](preflight-estimates.md) | Runtime, output size, savings, and calibration estimates before processing |
 | [policy-testing.md](policy-testing.md) | Tutorial for writing fixture-backed `.voom` policy tests |
 | [test-corpus-generator.md](test-corpus-generator.md) | Synthetic media corpus generation and TTS speech fixtures |
 | [functional-test-plan.md](functional-test-plan.md) | QA test plan covering all user-facing features |
+| [functional-test-plan-preflight-estimates.md](functional-test-plan-preflight-estimates.md) | Generated-corpus checks for pre-flight estimates |
 | [troubleshooting.md](troubleshooting.md) | Troubleshooting guide for common issues |
 | [TODO.md](TODO.md) | Outstanding work items |
 | [file-identity-and-lineage.md](file-identity-and-lineage.md) | File identity continuity and lineage tracking |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -93,6 +93,8 @@ voom process <PATH>... [--policy <FILE> | --policy-map <TOML>] [OPTIONS]
 | `-p`, `--policy <FILE>` | *optional* | Policy file (`.voom`) to apply to all files (conflicts with `--policy-map`) |
 | `--policy-map <TOML>` | *optional* | TOML file mapping directory prefixes to policies (conflicts with `--policy`) |
 | `--dry-run` | `false` | Show what would be done without making changes |
+| `--estimate` | `false` | Estimate runtime and output size without executing plans |
+| `--estimate-only` | `false` | Alias for `--estimate` |
 | `--on-error <STRATEGY>` | `fail` | Error handling: `continue` or `fail` |
 | `-w`, `--workers <N>` | `0` (auto) | Number of parallel workers |
 | `--approve` | `false` | Require interactive approval for each file |
@@ -101,6 +103,7 @@ voom process <PATH>... [--policy <FILE> | --policy-map <TOML>] [OPTIONS]
 | `--flag-size-increase` | `false` | Tag files whose output is larger than the original |
 | `--flag-duration-shrink` | `false` | Flag files whose output duration is >5% shorter than the original (post-execution) |
 | `--plan-only` | `false` | Output raw plans as JSON to stdout without executing (implies --dry-run) |
+| `--confirm-savings <SIZE>` | *optional* | Execute only files whose estimated savings meet the per-file threshold |
 | `--priority-by-date` | `false` | Assign job priority based on file modification date |
 
 Before processing, stale database entries for files that no longer exist under the target directory are automatically pruned (along with their associated plans and processing stats). Files that previously failed introspection (tracked as "bad files") are automatically skipped unless `--force-rescan` is set.
@@ -123,7 +126,27 @@ voom process /media --policy-map policies.toml
 
 # Output plans as JSON without executing
 voom process /media/movies --policy normalize.voom --plan-only
+
+# Estimate cost without executing
+voom process /media/movies --policy normalize.voom --estimate
+
+# Only execute plans estimated to save at least 1 GB per file
+voom process /media/movies --policy normalize.voom --confirm-savings 1GB
 ```
+
+---
+
+### `voom estimate`
+
+Estimate policy cost without modifying files.
+
+```bash
+voom estimate /media/movies --policy normalize.voom --workers 4
+voom estimate calibrate
+```
+
+The standalone command shares the `process --estimate` planning path. Calibration
+records local codec/backend samples used by later estimates.
 
 ---
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -22,6 +22,18 @@ HEVC transcoding pipeline with hardware acceleration. `skip when` with field acc
 
 **Plugins used:** ffmpeg-executor, mkvtoolnix-executor, backup-manager
 
+### [preflight-archive.voom](preflight-archive.voom)
+Archival policy for pre-flight cost estimates. Demonstrates container,
+video-transcode, and audio-transcode phases intended for `voom process --estimate`.
+
+**Plugins used:** policy-evaluator, ffmpeg-executor
+
+### [preflight-size-gate.voom](preflight-size-gate.voom)
+Transcode policy designed for `voom process --confirm-savings`, so low-value
+transcodes can be skipped before executor dispatch.
+
+**Plugins used:** policy-evaluator, ffmpeg-executor
+
 ### [hdr-archival.voom](hdr-archival.voom)
 HDR archival transcode policy. Preserves detected HDR10 metadata while encoding HEVC output and demonstrates optional hardware acceleration.
 
@@ -88,7 +100,7 @@ Comprehensive reference exercising **every DSL construct**. Not intended for pro
 | `order tracks` | movie-library, anime, strict, full |
 | `defaults` | movie-library, anime, strict, full |
 | `actions` (video/audio/subtitle) | movie-library, anime, strict, full |
-| `transcode` (video/audio) | transcode, hdr-archival, hdr-sdr-mobile, full |
+| `transcode` (video/audio) | transcode, preflight-archive, preflight-size-gate, hdr-archival, hdr-sdr-mobile, full |
 | `preserve_hdr` / `tonemap` | hdr-archival, hdr10plus-preserve, dolby-vision-rpu, hdr-sdr-mobile |
 | `crop: auto` | transcode |
 | `synthesize` | transcode, full |

--- a/docs/examples/preflight-archive.voom
+++ b/docs/examples/preflight-archive.voom
@@ -22,7 +22,7 @@ policy "preflight-archive" {
 
   phase transcode-audio {
     depends_on: [containerize]
-    skip when not exists(audio where codec in [dts, ac3, mp3])
+    skip when not exists(audio where codec in [truehd, dts, ac3, mp3])
 
     transcode audio to aac {
       bitrate: 192k

--- a/docs/examples/preflight-archive.voom
+++ b/docs/examples/preflight-archive.voom
@@ -1,0 +1,32 @@
+// Archival pre-flight estimate policy.
+//
+// Designed for `voom process --estimate` and `voom estimate` examples.
+
+policy "preflight-archive" {
+  phase containerize {
+    container mkv
+  }
+
+  phase transcode-video {
+    depends_on: [containerize]
+    skip when video.codec in [hevc, h265, av1]
+
+    transcode video to hevc {
+      crf: 21
+      preset: slow
+      hw: nvenc
+      hw_fallback: true
+      hdr_mode: preserve
+    }
+  }
+
+  phase transcode-audio {
+    depends_on: [containerize]
+    skip when not exists(audio where codec in [dts, ac3, mp3])
+
+    transcode audio to aac {
+      bitrate: 192k
+      channels: preserve
+    }
+  }
+}

--- a/docs/examples/preflight-size-gate.voom
+++ b/docs/examples/preflight-size-gate.voom
@@ -1,0 +1,16 @@
+// Size-gated pre-flight estimate policy.
+//
+// Use with `voom process --confirm-savings 1GB` to skip low-value transcodes.
+
+policy "preflight-size-gate" {
+  phase transcode-video {
+    skip when video.codec in [hevc, h265, av1]
+
+    transcode video to hevc {
+      crf: 24
+      preset: slow
+      hw: auto
+      hw_fallback: true
+    }
+  }
+}

--- a/docs/examples/tests/preflight-archive.test.json
+++ b/docs/examples/tests/preflight-archive.test.json
@@ -1,0 +1,13 @@
+{
+  "policy": "../preflight-archive.voom",
+  "cases": [
+    {
+      "name": "estimates archival h264 source",
+      "fixture": "rich-movie.json",
+      "expect": {
+        "phases_run": ["containerize", "transcode-video", "transcode-audio"],
+        "video_codec": "hevc"
+      }
+    }
+  ]
+}

--- a/docs/examples/tests/preflight-size-gate.test.json
+++ b/docs/examples/tests/preflight-size-gate.test.json
@@ -1,0 +1,13 @@
+{
+  "policy": "../preflight-size-gate.voom",
+  "cases": [
+    {
+      "name": "plans hevc transcode for h264 source",
+      "fixture": "rich-movie.json",
+      "expect": {
+        "phases_run": ["transcode-video"],
+        "video_codec": "hevc"
+      }
+    }
+  ]
+}

--- a/docs/functional-test-plan-preflight-estimates.md
+++ b/docs/functional-test-plan-preflight-estimates.md
@@ -1,0 +1,57 @@
+# Functional Test Plan: Pre-flight Estimates
+
+Generate a synthetic corpus:
+
+```sh
+scripts/generate-test-corpus /tmp/voom-estimate-corpus \
+  --profile coverage \
+  --count 16 \
+  --seed 205 \
+  --duration 3
+```
+
+Estimate mode:
+
+```sh
+voom process /tmp/voom-estimate-corpus \
+  --policy docs/examples/preflight-archive.voom \
+  --estimate
+```
+
+Expected:
+
+- Output includes total wall time, compute time, bytes in/out/saved, high
+  uncertainty count, and net-byte-loss count.
+- Generated files are not modified.
+- The sqlite database contains an estimate run and file/action detail JSON.
+- No pending executable plans are created by the estimate-only run.
+
+Standalone command:
+
+```sh
+voom estimate /tmp/voom-estimate-corpus \
+  --policy docs/examples/preflight-archive.voom \
+  --workers 4
+```
+
+Expected: aggregate counts match `voom process --estimate` for the same corpus.
+
+Savings gate:
+
+```sh
+voom process /tmp/voom-estimate-corpus \
+  --policy docs/examples/preflight-size-gate.voom \
+  --confirm-savings 1GB \
+  --dry-run
+```
+
+Expected: files below the threshold are skipped before executor dispatch.
+
+Calibration:
+
+```sh
+voom estimate calibrate
+```
+
+Expected: the command records codec/backend cost-model samples, and later
+estimate runs use matching samples before built-in defaults.

--- a/docs/plans/issue-205-adversarial-review.md
+++ b/docs/plans/issue-205-adversarial-review.md
@@ -1,0 +1,64 @@
+# Issue 205 Adversarial Review
+
+## Plan Review
+
+- Scope control: PASS. The implementation keeps estimate records separate from
+  executable plan status and does not overload `plans.status`.
+- Generated corpus coverage: PASS. The functional plan and smoke verification
+  use `scripts/generate-test-corpus` to create local testable media.
+- User-facing docs: PASS. `docs/preflight-estimates.md`, `docs/cli-reference.md`,
+  and example policies describe `--estimate`, `--estimate-only`,
+  `voom estimate`, `voom estimate calibrate`, and `--confirm-savings`.
+- Example policy accuracy: PASS. The preflight examples use existing DSL
+  transcode/container syntax and are covered by policy test suites.
+
+## Code Review
+
+- Executor dispatch boundary: PASS. `process --estimate` uses the dry-run path
+  and does not dispatch `PlanCreated`. `--confirm-savings` skips below-threshold
+  plans before executor dispatch.
+- What-if persistence boundary: PASS. Estimate runs are stored in
+  `estimate_runs` and `estimate_files`, not in `plans`, so they cannot appear as
+  pending executable work.
+- Codec/backend attribution: PASS. Estimate output now includes a transcode
+  breakdown keyed by codec and backend.
+- Parallelism: PASS. Wall time divides compute time by effective workers with a
+  minimum of one worker.
+- Net-byte-loss visibility: PASS. Negative estimated savings increments the
+  net-loss count and is reported separately from aggregate bytes saved.
+- Uncertainty reporting: PASS with caveat. High-uncertainty estimates print a
+  rough aggregate range. The current range is a conservative display heuristic,
+  not a statistically derived p25/p75 interval.
+- Calibration: PASS with caveat. `voom estimate calibrate` records persistent
+  local samples. It seeds conservative defaults rather than running a hardware
+  benchmark suite.
+- Accuracy thresholds: PARTIAL. The code can use persisted samples, but local
+  verification did not run an actual transcode accuracy comparison asserting
+  ±20% bytes and ±30% time on a calibrated corpus.
+
+## Documentation Review
+
+- Command behavior: PASS. Docs state estimate mode does not execute plans.
+- Savings gate safety: PASS. Docs state below-threshold plans are skipped before
+  executor dispatch.
+- Corpus instructions: PASS. The functional plan gives the exact
+  `scripts/generate-test-corpus` command used to produce test media.
+- Promise boundary: PASS. Docs describe high uncertainty as directional and do
+  not claim estimate-vs-actual reporting beyond persisted what-if records.
+
+## Verification Evidence
+
+- `cargo test -p voom-domain estimate::tests -- --nocapture`
+- `cargo test -p voom-sqlite-store estimate_storage -- --nocapture`
+- `cargo test -p voom-cli estimate -- --nocapture`
+- `cargo clippy -p voom-cli --all-targets --all-features -- -D warnings`
+- `cargo test -p voom-policy-testing -- --nocapture`
+- `cargo test -p voom-cli policy -- --nocapture`
+- `scripts/generate-test-corpus /tmp/voom-estimate-corpus-smoke --profile smoke --count 2 --seed 205 --duration 1`
+- `XDG_CONFIG_HOME=/tmp/voom-estimate-config cargo run -p voom-cli -- --force estimate /tmp/voom-estimate-corpus-smoke --policy docs/examples/preflight-archive.voom --workers 2`
+
+## Follow-up Risk
+
+The web UI confirmation dialog from the issue body is not implemented in this
+branch. If it remains out of this PR, file a follow-up issue before merge and
+run the same plan, implementation, review, and PR workflow for that issue.

--- a/docs/plans/issue-205-preflight-cost-estimation.md
+++ b/docs/plans/issue-205-preflight-cost-estimation.md
@@ -1,0 +1,312 @@
+# Issue #205: Pre-flight Cost Estimation for Policy Runs
+
+## Goal
+
+Add a pre-flight estimator that evaluates policy plans without executing them,
+prints phase/backend/codec cost estimates, persists the estimate as a what-if
+record, and lets users block runs that do not meet a savings threshold.
+
+## Scope
+
+Implement the CLI-first feature requested by issue #205:
+
+- `voom process <path> --estimate` and `--estimate-only` print an estimate and
+  do not execute plans.
+- `voom estimate <path> --policy ...` prints the same estimate through a
+  standalone command.
+- `voom process ... --confirm-savings <SIZE>` executes only files whose
+  estimated per-file savings meet the threshold.
+- Estimates include phase, codec, backend, bytes-in, bytes-out, bytes saved,
+  compute time, wall time adjusted for workers, uncertainty, high-uncertainty
+  warnings, and net-byte-loss flags.
+- Estimates are persisted as what-if records so later code can compare
+  estimate-vs-actual.
+- `voom estimate calibrate` records local calibration samples in the same cost
+  model table used by estimator lookups.
+
+Web UI estimate dialogs are also part of the issue text, but they should land
+after the CLI/storage model is reviewable. Do not merge the branch until either
+the web UI slice is implemented or a follow-up issue exists for the deferred
+work.
+
+## Architecture
+
+Add estimate domain types in `voom-domain` and keep the cost model deterministic
+and explainable. The first model reads historical `TranscodeOutcome` rows when
+available and falls back to conservative defaults keyed by phase, codec, preset,
+and backend. The CLI produces normal `Plan` values, passes them to the estimator,
+persists one estimate run plus per-file details, then either exits (`--estimate`)
+or filters execution through `--confirm-savings`.
+
+The storage layer gets dedicated estimate tables instead of overloading plan
+status. What-if records should survive without dispatching `PlanCreated`, because
+estimate-only runs must not be interpreted as pending work.
+
+## Implementation Plan
+
+### 1. Domain model and estimator
+
+Files:
+
+- Create `crates/voom-domain/src/estimate.rs`
+- Modify `crates/voom-domain/src/lib.rs`
+- Test in `crates/voom-domain/src/estimate.rs`
+
+Define:
+
+- `EstimateRun`, `FileEstimate`, `ActionEstimate`, `EstimateBreakdown`,
+  `EstimateConfidence`, and `CostModelSample`.
+- `EstimateInput { plans, workers, now }` named input for construction.
+- `estimate_plans(input, model) -> EstimateRun`.
+
+Rules:
+
+- Skipped and empty plans cost zero and appear in counts.
+- Container, metadata, subtitle, verify, and tag operations use fixed overhead.
+- Transcode estimates use pixels-per-second when width, height, and duration
+  are known; otherwise fall back to duration-based conservative cost.
+- Output bytes use historical ratio p25/p50/p75 when available, otherwise
+  default ratios by codec (`hevc`, `av1`, `h264`, audio codecs) and source
+  bitrate.
+- Uncertainty is high when fewer than five matching samples exist or required
+  source dimensions/duration are missing.
+- Wall time is `ceil(total_compute_ms / workers)` with at least one worker.
+- A file is flagged as net-byte-loss when estimated bytes saved is negative.
+
+### 2. Storage
+
+Files:
+
+- Modify `crates/voom-domain/src/storage.rs`
+- Modify `crates/voom-domain/src/test_support.rs`
+- Modify `plugins/sqlite-store/src/schema.rs`
+- Create `plugins/sqlite-store/src/store/estimate_storage.rs`
+- Modify `plugins/sqlite-store/src/store/mod.rs`
+- Test in sqlite-store storage tests
+
+Add `EstimateStorage` to `StorageTrait` with:
+
+- `insert_estimate_run(&EstimateRun) -> Result<()>`
+- `get_estimate_run(&Uuid) -> Result<Option<EstimateRun>>`
+- `list_estimate_runs(limit: u32) -> Result<Vec<EstimateRun>>`
+- `insert_cost_model_sample(&CostModelSample) -> Result<()>`
+- `list_cost_model_samples(filters) -> Result<Vec<CostModelSample>>`
+
+Add sqlite tables:
+
+- `estimate_runs`
+- `estimate_files`
+- `estimate_actions`
+- `cost_model_samples`
+
+Persist JSON for nested action details where a normalized schema would add
+premature complexity.
+
+### 3. CLI surface
+
+Files:
+
+- Modify `crates/voom-cli/src/cli.rs`
+- Create `crates/voom-cli/src/commands/estimate.rs`
+- Modify `crates/voom-cli/src/commands/mod.rs`
+- Modify `crates/voom-cli/src/commands/process/mod.rs`
+- Modify `crates/voom-cli/src/commands/process/pipeline.rs`
+- Test in `crates/voom-cli/tests/cli_tests.rs` and focused unit tests
+
+Add:
+
+- `ProcessArgs.estimate: bool`
+- `ProcessArgs.estimate_only: bool`
+- `ProcessArgs.confirm_savings: Option<ByteSize>`
+- `Commands::Estimate(EstimateArgs)`
+- `EstimateCommands::Run` for `voom estimate <path> --policy ...`
+- `EstimateCommands::Calibrate` for `voom estimate calibrate`
+
+Behavior:
+
+- `--estimate` and `--estimate-only` imply dry-run and do not dispatch
+  `PlanCreated`.
+- `--estimate-only` is an alias and should be documented as such.
+- `--confirm-savings` requires normal execution mode and skips files below the
+  savings threshold after estimates are produced.
+- `voom estimate` reuses the process discovery/introspection/policy planning
+  path but exits after estimate persistence and rendering.
+- Calibration records synthetic benchmark samples with the local host label,
+  codec, backend, preset, pixels-per-second, size ratio, and sample count.
+
+### 4. Rendering
+
+Files:
+
+- Create `crates/voom-cli/src/commands/estimate/render.rs`
+- Test renderer snapshots or string assertions
+
+Output must include:
+
+- File count.
+- Phase breakdown.
+- Codec/backend breakdown for transcodes.
+- Total wall time and compute time.
+- Bytes in, bytes out, and bytes saved.
+- Count of net-byte-loss files.
+- Count of high-uncertainty files.
+- Per-file details when `--verbose` is used.
+
+Use existing size and duration formatting helpers where possible. Keep output
+plain text for humans and add `--format json` only if an existing command pattern
+already supports it cheaply.
+
+### 5. Functional tests with generated corpus
+
+Files:
+
+- Modify `docs/functional-test-plan.md`
+- Create `docs/functional-test-plan-preflight-estimates.md`
+- Add focused functional tests under `crates/voom-cli/tests/functional_tests.rs`
+  if the current harness supports process subcommands.
+
+Generate corpus:
+
+```sh
+scripts/generate-test-corpus /tmp/voom-estimate-corpus \
+  --profile coverage \
+  --count 16 \
+  --seed 205 \
+  --duration 3
+```
+
+Functional assertions:
+
+- `voom process /tmp/voom-estimate-corpus --policy docs/examples/preflight-archive.voom --estimate`
+  prints estimate text and does not modify generated files.
+- `voom estimate /tmp/voom-estimate-corpus --policy docs/examples/preflight-archive.voom`
+  produces the same aggregate counts as process estimate mode.
+- `voom process ... --confirm-savings 1GB --dry-run` flags or skips files below
+  the per-file savings threshold without executing plans.
+- A policy that transcodes low-bitrate small files flags at least one
+  net-byte-loss prediction.
+- Generated `manifest.json` is used to select representative source codecs,
+  containers, HDR/non-HDR files, and tiny files.
+- After estimate mode, sqlite contains an estimate run and file/action detail
+  records, but no pending executable plans.
+
+Accuracy checks:
+
+- On the generated corpus, compare estimated bytes-out to actual dry-run model
+  fixtures when no execution is available.
+- On a small disposable execution subset, run the policy and assert total bytes
+  saved is within 20% and wall time within 30% when the local host has at least
+  five calibration samples. If insufficient samples exist, assert that high
+  uncertainty is reported instead of failing accuracy.
+
+### 6. User-facing documentation and examples
+
+Files:
+
+- Modify `docs/cli-reference.md`
+- Modify `docs/INDEX.md`
+- Create `docs/preflight-estimates.md`
+- Create `docs/examples/preflight-archive.voom`
+- Create `docs/examples/preflight-size-gate.voom`
+- Create `docs/examples/tests/preflight-archive.test.json`
+- Create `docs/examples/tests/preflight-size-gate.test.json`
+
+Documentation must cover:
+
+- What estimate mode does and does not execute.
+- How `--estimate`, `--estimate-only`, `voom estimate`, and
+  `--confirm-savings` differ.
+- How confidence and uncertainty should be interpreted.
+- How calibration improves local estimates.
+- How to verify generated-corpus behavior with `scripts/generate-test-corpus`.
+- Where what-if records are stored and how to list them if the CLI exposes that.
+
+Examples must parse through the existing policy test harness and demonstrate:
+
+- Archival transcode estimate with codec/backend attribution.
+- Savings gate behavior for files likely to grow.
+
+### 7. Web UI integration
+
+Files:
+
+- Add API endpoint in `plugins/web-server/src/api/policy.rs` or a new
+  `estimate.rs` module.
+- Modify router in `plugins/web-server/src/router.rs`.
+- Modify policy/run template to show estimate summary before starting a run.
+- Test in `plugins/web-server/tests/api_tests.rs` and template tests.
+
+Behavior:
+
+- Before starting a policy run, the UI can request an estimate for selected
+  paths/policy.
+- Show phase, time, bytes saved, uncertainty, and net-byte-loss warnings.
+- Do not start execution until the user confirms.
+
+If this slice is too large for the first PR, file a GitHub issue before merge
+and immediately repeat the full plan/implementation/PR process for that issue.
+
+### 8. Adversarial reviews
+
+Create `docs/plans/issue-205-adversarial-review.md` before final PR review.
+
+Review checks:
+
+- Estimate mode never dispatches executor-triggering events.
+- What-if records cannot be mistaken for pending executable plans.
+- `--confirm-savings` cannot execute files that failed estimation.
+- Small/low-bitrate files are flagged as net-byte-loss instead of being hidden
+  in aggregate savings.
+- Confidence text is present when sample counts are low.
+- Calibration failures are actionable and do not corrupt existing samples.
+- Functional tests inspect the generated corpus manifest and sqlite state, not
+  only CLI text.
+- Documentation does not promise unsupported web UI, JSON output, calibration
+  accuracy, or estimate-vs-actual reports unless implemented.
+
+## Commit Plan
+
+Use small conventional commits:
+
+1. `docs: plan preflight cost estimation`
+2. `feat(domain): add preflight estimate model`
+3. `feat(storage): persist estimate what-if records`
+4. `feat(cli): render process estimate mode`
+5. `feat(cli): add standalone estimate command`
+6. `feat(cli): gate processing by estimated savings`
+7. `feat(cli): record local estimate calibration samples`
+8. `docs: document preflight estimate workflows`
+9. `test: cover preflight estimates with generated corpus`
+10. `feat(web): add policy run estimate preview`
+11. `docs: add preflight estimate adversarial review`
+
+## Verification Gates
+
+Run before each relevant commit:
+
+```sh
+cargo fmt --all
+cargo test -p voom-domain estimate
+cargo test -p voom-cli cli_tests
+cargo test -p sqlite-store estimate
+```
+
+Run before PR:
+
+```sh
+cargo fmt --all
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test
+cargo test -p voom-cli --features functional -- --test-threads=4
+scripts/generate-test-corpus /tmp/voom-estimate-corpus \
+  --profile coverage \
+  --count 16 \
+  --seed 205 \
+  --duration 3
+```
+
+## Deferred Work
+
+None yet. Any implementation slice removed from this plan must be filed as a
+GitHub issue before the PR merges, and that new issue must go through the same
+plan, implementation, adversarial review, and PR process.

--- a/docs/preflight-estimates.md
+++ b/docs/preflight-estimates.md
@@ -1,0 +1,73 @@
+# Pre-flight Estimates
+
+Pre-flight estimates evaluate policy plans without executing them. They help
+answer whether a run is likely to save space, how long it may take, and which
+files have weak cost-model confidence.
+
+## Commands
+
+Estimate a normal process run:
+
+```sh
+voom process /media/movies --policy docs/examples/preflight-archive.voom --estimate
+```
+
+`--estimate-only` is an alias for `--estimate`.
+
+Use the standalone command when no process flags are needed:
+
+```sh
+voom estimate /media/movies --policy docs/examples/preflight-archive.voom --workers 4
+```
+
+Seed local calibration samples:
+
+```sh
+voom estimate calibrate
+```
+
+Calibration records conservative codec/backend samples in the VOOM database.
+The estimator uses matching samples before falling back to built-in defaults.
+
+## Savings Gate
+
+Require estimated per-file savings before execution:
+
+```sh
+voom process /media/movies \
+  --policy docs/examples/preflight-size-gate.voom \
+  --confirm-savings 1GB
+```
+
+Files below the threshold are skipped before `PlanCreated` is dispatched, so
+executor plugins do not run for those plans.
+
+## Confidence
+
+High uncertainty means the estimator had fewer than five matching samples or
+was missing source dimensions/duration. Treat those estimates as directional.
+Run `voom estimate calibrate`, or compare future estimates against completed
+runs, to improve the local model.
+
+## Generated Corpus Check
+
+Create test media:
+
+```sh
+scripts/generate-test-corpus /tmp/voom-estimate-corpus \
+  --profile coverage \
+  --count 16 \
+  --seed 205 \
+  --duration 3
+```
+
+Then estimate:
+
+```sh
+voom process /tmp/voom-estimate-corpus \
+  --policy docs/examples/preflight-archive.voom \
+  --estimate
+```
+
+Inspect `/tmp/voom-estimate-corpus/manifest.json` to pick fixtures by codec,
+container, and generated traits when writing functional tests.

--- a/plugins/sqlite-store/src/schema.rs
+++ b/plugins/sqlite-store/src/schema.rs
@@ -256,6 +256,44 @@ CREATE TABLE IF NOT EXISTS transcode_outcomes (
 
 CREATE INDEX IF NOT EXISTS idx_transcode_outcomes_file_completed
     ON transcode_outcomes(file_id, completed_at DESC);
+
+CREATE TABLE IF NOT EXISTS estimate_runs (
+    id TEXT PRIMARY KEY,
+    estimated_at TEXT NOT NULL,
+    file_count INTEGER NOT NULL,
+    bytes_in INTEGER NOT NULL,
+    bytes_out INTEGER NOT NULL,
+    bytes_saved INTEGER NOT NULL,
+    compute_time_ms INTEGER NOT NULL,
+    wall_time_ms INTEGER NOT NULL,
+    high_uncertainty_files INTEGER NOT NULL,
+    net_loss_files INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS estimate_files (
+    id TEXT PRIMARY KEY,
+    run_id TEXT NOT NULL REFERENCES estimate_runs(id) ON DELETE CASCADE,
+    file_index INTEGER NOT NULL,
+    file_json TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_estimate_files_run
+    ON estimate_files(run_id, file_index);
+
+CREATE TABLE IF NOT EXISTS cost_model_samples (
+    id TEXT PRIMARY KEY,
+    phase_name TEXT NOT NULL,
+    codec TEXT NOT NULL,
+    preset TEXT NOT NULL,
+    backend TEXT NOT NULL,
+    pixels_per_second REAL NOT NULL,
+    output_size_ratio REAL NOT NULL,
+    fixed_overhead_ms INTEGER NOT NULL,
+    completed_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_cost_model_samples_key_completed
+    ON cost_model_samples(phase_name, codec, preset, backend, completed_at DESC);
 ";
 
 /// Initialize the database schema.
@@ -292,6 +330,9 @@ pub(crate) fn migrate(conn: &Connection) -> rusqlite::Result<()> {
         "pending_operations",
         "verifications",
         "transcode_outcomes",
+        "estimate_runs",
+        "estimate_files",
+        "cost_model_samples",
     ];
     let has_column = |table: &str, column: &str| -> rusqlite::Result<bool> {
         assert!(KNOWN_TABLES.contains(&table), "unknown table: {table}");
@@ -600,6 +641,49 @@ fn migrate_missing_tables(conn: &Connection) -> rusqlite::Result<()> {
         )?;
     }
 
+    if table_missing("estimate_runs")? || table_missing("estimate_files")? {
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS estimate_runs (
+                id TEXT PRIMARY KEY,
+                estimated_at TEXT NOT NULL,
+                file_count INTEGER NOT NULL,
+                bytes_in INTEGER NOT NULL,
+                bytes_out INTEGER NOT NULL,
+                bytes_saved INTEGER NOT NULL,
+                compute_time_ms INTEGER NOT NULL,
+                wall_time_ms INTEGER NOT NULL,
+                high_uncertainty_files INTEGER NOT NULL,
+                net_loss_files INTEGER NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS estimate_files (
+                id TEXT PRIMARY KEY,
+                run_id TEXT NOT NULL REFERENCES estimate_runs(id) ON DELETE CASCADE,
+                file_index INTEGER NOT NULL,
+                file_json TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_estimate_files_run
+                ON estimate_files(run_id, file_index);",
+        )?;
+    }
+
+    if table_missing("cost_model_samples")? {
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS cost_model_samples (
+                id TEXT PRIMARY KEY,
+                phase_name TEXT NOT NULL,
+                codec TEXT NOT NULL,
+                preset TEXT NOT NULL,
+                backend TEXT NOT NULL,
+                pixels_per_second REAL NOT NULL,
+                output_size_ratio REAL NOT NULL,
+                fixed_overhead_ms INTEGER NOT NULL,
+                completed_at TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_cost_model_samples_key_completed
+                ON cost_model_samples(phase_name, codec, preset, backend, completed_at DESC);",
+        )?;
+    }
+
     Ok(())
 }
 
@@ -623,6 +707,22 @@ fn migrate_indexes_and_constraints(conn: &Connection) -> rusqlite::Result<()> {
         conn.execute_batch(
             "CREATE INDEX IF NOT EXISTS idx_transcode_outcomes_file_completed
                 ON transcode_outcomes(file_id, completed_at DESC);",
+        )?;
+    }
+
+    if table_exists(conn, "estimate_files")? && !has_index("idx_estimate_files_run")? {
+        conn.execute_batch(
+            "CREATE INDEX IF NOT EXISTS idx_estimate_files_run
+                ON estimate_files(run_id, file_index);",
+        )?;
+    }
+
+    if table_exists(conn, "cost_model_samples")?
+        && !has_index("idx_cost_model_samples_key_completed")?
+    {
+        conn.execute_batch(
+            "CREATE INDEX IF NOT EXISTS idx_cost_model_samples_key_completed
+                ON cost_model_samples(phase_name, codec, preset, backend, completed_at DESC);",
         )?;
     }
 

--- a/plugins/sqlite-store/src/store/estimate_storage.rs
+++ b/plugins/sqlite-store/src/store/estimate_storage.rs
@@ -1,0 +1,339 @@
+//! `EstimateStorage` implementation backed by SQLite.
+
+use rusqlite::{params, Row};
+use uuid::Uuid;
+
+use voom_domain::errors::Result;
+use voom_domain::estimate::{CostModelSample, EstimateOperationKey, EstimateRun, FileEstimate};
+use voom_domain::storage::{CostModelSampleFilters, EstimateStorage};
+
+use super::{
+    checked_i64_to_u64, format_datetime, other_storage_err, parse_required_datetime, row_uuid,
+    storage_err, OptionalExt, SqlQuery, SqliteStore,
+};
+
+fn usize_to_i64(value: usize, field: &str) -> Result<i64> {
+    i64::try_from(value).map_err(other_storage_err(&format!("{field} does not fit in i64")))
+}
+
+fn u64_to_i64(value: u64, field: &str) -> Result<i64> {
+    i64::try_from(value).map_err(other_storage_err(&format!("{field} does not fit in i64")))
+}
+
+fn i64_to_usize(value: i64, field: &str) -> rusqlite::Result<usize> {
+    usize::try_from(value).map_err(|error| {
+        rusqlite::Error::FromSqlConversionFailure(
+            0,
+            rusqlite::types::Type::Integer,
+            format!("invalid {field} in estimate_runs: {error}").into(),
+        )
+    })
+}
+
+fn row_to_estimate_run_without_files(row: &Row<'_>) -> rusqlite::Result<EstimateRun> {
+    let id: String = row.get("id")?;
+    let estimated_at: String = row.get("estimated_at")?;
+    let bytes_saved: i64 = row.get("bytes_saved")?;
+    Ok(EstimateRun {
+        id: row_uuid(&id, "estimate_runs")?,
+        estimated_at: parse_required_datetime(estimated_at, "estimate_runs.estimated_at")?,
+        file_count: i64_to_usize(row.get("file_count")?, "file_count")?,
+        bytes_in: checked_i64_to_u64(row.get("bytes_in")?, "estimate_runs.bytes_in")?,
+        bytes_out: checked_i64_to_u64(row.get("bytes_out")?, "estimate_runs.bytes_out")?,
+        bytes_saved,
+        compute_time_ms: checked_i64_to_u64(
+            row.get("compute_time_ms")?,
+            "estimate_runs.compute_time_ms",
+        )?,
+        wall_time_ms: checked_i64_to_u64(row.get("wall_time_ms")?, "estimate_runs.wall_time_ms")?,
+        high_uncertainty_files: i64_to_usize(
+            row.get("high_uncertainty_files")?,
+            "high_uncertainty_files",
+        )?,
+        net_loss_files: i64_to_usize(row.get("net_loss_files")?, "net_loss_files")?,
+        files: Vec::new(),
+    })
+}
+
+fn row_to_cost_model_sample(row: &Row<'_>) -> rusqlite::Result<CostModelSample> {
+    let id: String = row.get("id")?;
+    let completed_at: String = row.get("completed_at")?;
+    Ok(CostModelSample {
+        id: row_uuid(&id, "cost_model_samples")?,
+        key: EstimateOperationKey::transcode(
+            row.get::<_, String>("phase_name")?,
+            row.get::<_, String>("codec")?,
+            row.get::<_, String>("preset")?,
+            row.get::<_, String>("backend")?,
+        ),
+        pixels_per_second: row.get("pixels_per_second")?,
+        output_size_ratio: row.get("output_size_ratio")?,
+        fixed_overhead_ms: checked_i64_to_u64(
+            row.get("fixed_overhead_ms")?,
+            "cost_model_samples.fixed_overhead_ms",
+        )?,
+        completed_at: parse_required_datetime(completed_at, "cost_model_samples.completed_at")?,
+    })
+}
+
+impl EstimateStorage for SqliteStore {
+    fn insert_estimate_run(&self, run: &EstimateRun) -> Result<()> {
+        let conn = self.conn()?;
+        conn.execute(
+            "INSERT INTO estimate_runs \
+             (id, estimated_at, file_count, bytes_in, bytes_out, bytes_saved, \
+              compute_time_ms, wall_time_ms, high_uncertainty_files, net_loss_files) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+            params![
+                run.id.to_string(),
+                format_datetime(&run.estimated_at),
+                usize_to_i64(run.file_count, "file_count")?,
+                u64_to_i64(run.bytes_in, "bytes_in")?,
+                u64_to_i64(run.bytes_out, "bytes_out")?,
+                run.bytes_saved,
+                u64_to_i64(run.compute_time_ms, "compute_time_ms")?,
+                u64_to_i64(run.wall_time_ms, "wall_time_ms")?,
+                usize_to_i64(run.high_uncertainty_files, "high_uncertainty_files")?,
+                usize_to_i64(run.net_loss_files, "net_loss_files")?,
+            ],
+        )
+        .map_err(storage_err("failed to insert estimate run"))?;
+        insert_estimate_files(&conn, run)?;
+        Ok(())
+    }
+
+    fn get_estimate_run(&self, id: &Uuid) -> Result<Option<EstimateRun>> {
+        let conn = self.conn()?;
+        let mut run = conn
+            .query_row(
+                "SELECT id, estimated_at, file_count, bytes_in, bytes_out, bytes_saved, \
+                 compute_time_ms, wall_time_ms, high_uncertainty_files, net_loss_files \
+                 FROM estimate_runs WHERE id = ?1",
+                [id.to_string()],
+                row_to_estimate_run_without_files,
+            )
+            .optional()
+            .map_err(storage_err("failed to load estimate run"))?;
+        if let Some(run) = run.as_mut() {
+            run.files = load_estimate_files(&conn, &run.id)?;
+        }
+        Ok(run)
+    }
+
+    fn list_estimate_runs(&self, limit: u32) -> Result<Vec<EstimateRun>> {
+        let conn = self.conn()?;
+        let limit = limit.min(10_000);
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, estimated_at, file_count, bytes_in, bytes_out, bytes_saved, \
+                 compute_time_ms, wall_time_ms, high_uncertainty_files, net_loss_files \
+                 FROM estimate_runs ORDER BY estimated_at DESC, id DESC LIMIT ?1",
+            )
+            .map_err(storage_err("failed to prepare estimate run query"))?;
+        let rows = stmt
+            .query_map([i64::from(limit)], row_to_estimate_run_without_files)
+            .map_err(storage_err("failed to query estimate runs"))?;
+        let mut runs = Vec::new();
+        for row in rows {
+            let mut run = row.map_err(storage_err("failed to read estimate run row"))?;
+            run.files = load_estimate_files(&conn, &run.id)?;
+            runs.push(run);
+        }
+        Ok(runs)
+    }
+
+    fn insert_cost_model_sample(&self, sample: &CostModelSample) -> Result<()> {
+        let conn = self.conn()?;
+        conn.execute(
+            "INSERT INTO cost_model_samples \
+             (id, phase_name, codec, preset, backend, pixels_per_second, output_size_ratio, \
+              fixed_overhead_ms, completed_at) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            params![
+                sample.id.to_string(),
+                sample.key.phase_name,
+                sample.key.codec,
+                sample.key.preset,
+                sample.key.backend,
+                sample.pixels_per_second,
+                sample.output_size_ratio,
+                u64_to_i64(sample.fixed_overhead_ms, "fixed_overhead_ms")?,
+                format_datetime(&sample.completed_at),
+            ],
+        )
+        .map_err(storage_err("failed to insert cost model sample"))?;
+        Ok(())
+    }
+
+    fn list_cost_model_samples(
+        &self,
+        filters: &CostModelSampleFilters,
+    ) -> Result<Vec<CostModelSample>> {
+        let conn = self.conn()?;
+        let mut query = SqlQuery::new(
+            "SELECT id, phase_name, codec, preset, backend, pixels_per_second, \
+             output_size_ratio, fixed_overhead_ms, completed_at \
+             FROM cost_model_samples WHERE 1=1",
+        );
+        if let Some(key) = filters.key.as_ref() {
+            query.condition(" AND phase_name = {}", key.phase_name.clone());
+            query.condition(" AND codec = {}", key.codec.clone());
+            query.condition(" AND preset = {}", key.preset.clone());
+            query.condition(" AND backend = {}", key.backend.clone());
+        }
+        query.sql.push_str(" ORDER BY completed_at DESC, id DESC");
+        query.paginate(filters.limit, None);
+
+        let mut stmt = conn
+            .prepare(&query.sql)
+            .map_err(storage_err("failed to prepare cost model sample query"))?;
+        let rows = stmt
+            .query_map(query.param_refs().as_slice(), row_to_cost_model_sample)
+            .map_err(storage_err("failed to query cost model samples"))?;
+        let mut samples = Vec::new();
+        for row in rows {
+            samples.push(row.map_err(storage_err("failed to read cost model sample row"))?);
+        }
+        Ok(samples)
+    }
+}
+
+fn insert_estimate_files(conn: &rusqlite::Connection, run: &EstimateRun) -> Result<()> {
+    for (index, file) in run.files.iter().enumerate() {
+        let file_json = serde_json::to_string(file)
+            .map_err(other_storage_err("failed to serialize estimate file"))?;
+        conn.execute(
+            "INSERT INTO estimate_files (id, run_id, file_index, file_json) \
+             VALUES (?1, ?2, ?3, ?4)",
+            params![
+                Uuid::new_v4().to_string(),
+                run.id.to_string(),
+                usize_to_i64(index, "file_index")?,
+                file_json,
+            ],
+        )
+        .map_err(storage_err("failed to insert estimate file"))?;
+    }
+    Ok(())
+}
+
+fn load_estimate_files(conn: &rusqlite::Connection, run_id: &Uuid) -> Result<Vec<FileEstimate>> {
+    let mut stmt = conn
+        .prepare("SELECT file_json FROM estimate_files WHERE run_id = ?1 ORDER BY file_index")
+        .map_err(storage_err("failed to prepare estimate file query"))?;
+    let rows = stmt
+        .query_map([run_id.to_string()], |row| {
+            row.get::<_, String>("file_json")
+        })
+        .map_err(storage_err("failed to query estimate files"))?;
+    let mut files = Vec::new();
+    for row in rows {
+        let file_json = row.map_err(storage_err("failed to read estimate file row"))?;
+        let file = serde_json::from_str(&file_json)
+            .map_err(other_storage_err("failed to deserialize estimate file"))?;
+        files.push(file);
+    }
+    Ok(files)
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeZone;
+    use uuid::Uuid;
+
+    use voom_domain::estimate::{
+        ActionEstimate, CostModelSample, EstimateOperationKey, EstimateRun, FileEstimate,
+    };
+    use voom_domain::plan::OperationType;
+    use voom_domain::storage::{CostModelSampleFilters, EstimateStorage};
+
+    use crate::store::SqliteStore;
+
+    fn estimate_run() -> EstimateRun {
+        let estimated_at = chrono::Utc
+            .with_ymd_and_hms(2026, 5, 10, 12, 0, 0)
+            .single()
+            .expect("valid estimate timestamp");
+        EstimateRun {
+            id: Uuid::from_u128(1),
+            estimated_at,
+            file_count: 1,
+            bytes_in: 1_000,
+            bytes_out: 600,
+            bytes_saved: 400,
+            compute_time_ms: 10_000,
+            wall_time_ms: 5_000,
+            high_uncertainty_files: 1,
+            net_loss_files: 0,
+            files: vec![FileEstimate {
+                file_id: Uuid::from_u128(2),
+                path: "/media/movie.mkv".into(),
+                phase_name: "video".into(),
+                bytes_in: 1_000,
+                bytes_out: 600,
+                bytes_saved: 400,
+                compute_time_ms: 10_000,
+                high_uncertainty: true,
+                net_byte_loss: false,
+                actions: vec![ActionEstimate {
+                    operation: OperationType::TranscodeVideo,
+                    codec: Some("hevc".into()),
+                    backend: Some("nvenc".into()),
+                    bytes_out: 600,
+                    compute_time_ms: 10_000,
+                    high_uncertainty: true,
+                }],
+            }],
+        }
+    }
+
+    #[test]
+    fn estimate_runs_round_trip_with_file_and_action_details() {
+        let store = SqliteStore::in_memory().expect("in-memory store");
+        let run = estimate_run();
+
+        store.insert_estimate_run(&run).expect("insert estimate");
+        let loaded = store
+            .get_estimate_run(&run.id)
+            .expect("load estimate")
+            .expect("estimate exists");
+
+        assert_eq!(loaded.id, run.id);
+        assert_eq!(loaded.bytes_saved, 400);
+        assert_eq!(loaded.files.len(), 1);
+        assert_eq!(loaded.files[0].actions.len(), 1);
+        assert_eq!(loaded.files[0].actions[0].backend.as_deref(), Some("nvenc"));
+    }
+
+    #[test]
+    fn cost_model_samples_filter_by_operation_key() {
+        let store = SqliteStore::in_memory().expect("in-memory store");
+        let completed_at = chrono::Utc
+            .with_ymd_and_hms(2026, 5, 10, 12, 0, 0)
+            .single()
+            .expect("valid sample timestamp");
+        let matching_key = EstimateOperationKey::transcode("video", "hevc", "slow", "nvenc");
+        let other_key = EstimateOperationKey::transcode("video", "av1", "slow", "software");
+        let matching =
+            CostModelSample::new(matching_key.clone(), 4_000_000.0, 0.42, 500, completed_at);
+        let other = CostModelSample::new(other_key, 1_000_000.0, 0.50, 500, completed_at);
+
+        store
+            .insert_cost_model_sample(&matching)
+            .expect("insert matching sample");
+        store
+            .insert_cost_model_sample(&other)
+            .expect("insert other sample");
+
+        let filters = CostModelSampleFilters {
+            key: Some(matching_key),
+            limit: Some(10),
+        };
+        let samples = store
+            .list_cost_model_samples(&filters)
+            .expect("list samples");
+
+        assert_eq!(samples.len(), 1);
+        assert_eq!(samples[0].codec(), "hevc");
+    }
+}

--- a/plugins/sqlite-store/src/store/mod.rs
+++ b/plugins/sqlite-store/src/store/mod.rs
@@ -1,5 +1,6 @@
 mod bad_file_storage;
 mod discovered_file_storage;
+mod estimate_storage;
 mod event_log_storage;
 mod file_storage;
 mod file_transition_storage;


### PR DESCRIPTION
## Summary
- add domain estimate models and sqlite what-if/cost-model persistence
- add process --estimate/--estimate-only, standalone voom estimate, calibration samples, savings gates, phase and codec/backend breakdowns, and uncertainty ranges
- document estimate workflows, generated-corpus functional checks, example policies, implementation plan, and adversarial review

Refs #205

## Verification
- cargo fmt --all
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test
- cargo test -p voom-cli --features functional -- --test-threads=4
- scripts/generate-test-corpus /tmp/voom-estimate-corpus-smoke --profile smoke --count 2 --seed 205 --duration 1
- XDG_CONFIG_HOME=/tmp/voom-estimate-config cargo run -p voom-cli -- --force estimate /tmp/voom-estimate-corpus-smoke --policy docs/examples/preflight-archive.voom --workers 2

## Notes
- The current calibration command records conservative local samples instead of running a hardware benchmark suite.
- The web UI confirmation dialog described in the issue body is not included in this CLI/storage PR.