### PR TITLE
Show preflight estimate records in Web UI

### DIFF
--- a/plugins/web-server/src/api/estimates.rs
+++ b/plugins/web-server/src/api/estimates.rs
@@ -1,0 +1,67 @@
+//! Pre-flight estimate API endpoints.
+
+use axum::extract::{Path, Query, State};
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::errors::{spawn_store_op, WebError};
+use crate::state::AppState;
+
+const DEFAULT_ESTIMATE_LIMIT: u32 = 25;
+const MAX_ESTIMATE_LIMIT: u32 = 500;
+
+#[derive(Debug, Deserialize)]
+#[non_exhaustive]
+pub struct ListEstimatesParams {
+    pub limit: Option<u32>,
+}
+
+#[derive(Debug, Serialize)]
+#[non_exhaustive]
+pub struct EstimateListResponse {
+    pub estimates: Vec<voom_domain::EstimateRun>,
+    pub total: usize,
+}
+
+/// GET /api/estimates -- list persisted pre-flight what-if records.
+#[tracing::instrument(skip(state))]
+pub async fn list_estimates(
+    State(state): State<AppState>,
+    Query(params): Query<ListEstimatesParams>,
+) -> Result<Json<EstimateListResponse>, WebError> {
+    let store = state.store.clone();
+    let limit = params
+        .limit
+        .unwrap_or(DEFAULT_ESTIMATE_LIMIT)
+        .min(MAX_ESTIMATE_LIMIT);
+    let estimates = spawn_store_op(move || store.list_estimate_runs(limit)).await?;
+    let total = estimates.len();
+
+    Ok(Json(EstimateListResponse { estimates, total }))
+}
+
+/// GET /api/estimates/:id -- fetch one persisted pre-flight what-if record.
+#[tracing::instrument(skip(state))]
+pub async fn get_estimate(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<voom_domain::EstimateRun>, WebError> {
+    let store = state.store.clone();
+    let estimate = spawn_store_op(move || store.get_estimate_run(&id)).await?;
+
+    estimate
+        .map(Json)
+        .ok_or_else(|| WebError::NotFound(format!("Estimate {id} not found")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_estimates_params_defaults() {
+        let params: ListEstimatesParams = serde_json::from_str("{}").unwrap();
+        assert!(params.limit.is_none());
+    }
+}

--- a/plugins/web-server/src/api/mod.rs
+++ b/plugins/web-server/src/api/mod.rs
@@ -1,5 +1,6 @@
 //! REST API handlers (JSON).
 
+pub mod estimates;
 pub mod files;
 pub mod health;
 pub mod jobs;

--- a/plugins/web-server/src/router.rs
+++ b/plugins/web-server/src/router.rs
@@ -21,6 +21,8 @@ static ALPINE_JS: &[u8] = include_bytes!("../static/alpine-3.14.8.min.js");
 pub fn build_router(state: AppState) -> Router {
     let api_routes = Router::new()
         .route("/files", get(api::files::list_files))
+        .route("/estimates", get(api::estimates::list_estimates))
+        .route("/estimates/:id", get(api::estimates::get_estimate))
         .route(
             "/files/:id",
             get(api::files::get_file).delete(api::files::delete_file),
@@ -54,6 +56,7 @@ pub fn build_router(state: AppState) -> Router {
         .route("/library", get(templates::library))
         .route("/files/:id", get(templates::file_detail))
         .route("/integrity", get(templates::integrity))
+        .route("/estimates", get(templates::estimates))
         .route("/policies", get(templates::policies))
         .route("/policies/:name/edit", get(templates::policy_editor))
         .route("/jobs", get(templates::jobs))

--- a/plugins/web-server/src/server.rs
+++ b/plugins/web-server/src/server.rs
@@ -153,6 +153,7 @@ pub fn embedded_templates() -> Result<tera::Tera, ServerError> {
         "library.html",
         "file_detail.html",
         "integrity.html",
+        "estimates.html",
         "policies.html",
         "policy_editor.html",
         "jobs.html",

--- a/plugins/web-server/src/templates.rs
+++ b/plugins/web-server/src/templates.rs
@@ -165,6 +165,16 @@ pub async fn integrity(
     render(&state.templates, "integrity.html", &mut ctx, &nonce)
 }
 
+/// GET /estimates -- Pre-flight estimate records
+pub async fn estimates(
+    State(state): State<AppState>,
+    Extension(nonce): Extension<CspNonce>,
+) -> HtmlResult {
+    let mut ctx = tera::Context::new();
+    ctx.insert("current_page", "estimates");
+    render(&state.templates, "estimates.html", &mut ctx, &nonce)
+}
+
 fn latest_error_files(
     store: &dyn voom_domain::storage::StorageTrait,
     records: Vec<voom_domain::verification::VerificationRecord>,
@@ -325,6 +335,14 @@ mod tests {
         let tera = make_tera();
         let mut ctx = tera::Context::new();
         let result = render(&tera, "plugins.html", &mut ctx, &test_nonce());
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_render_estimates_page() {
+        let tera = make_tera();
+        let mut ctx = tera::Context::new();
+        let result = render(&tera, "estimates.html", &mut ctx, &test_nonce());
         assert!(result.is_ok());
     }
 

--- a/plugins/web-server/templates/base.html
+++ b/plugins/web-server/templates/base.html
@@ -357,6 +357,7 @@
         }
 
         .htmx-indicator { display: none; }
+        [x-cloak] { display: none !important; }
         .htmx-request .htmx-indicator,
         .htmx-request.htmx-indicator { display: inline-block; }
     </style>
@@ -377,6 +378,9 @@
             </a></li>
             <li><a href="/integrity" {% if current_page | default(value="") == "integrity" %}class="active"{% endif %}>
                 <span class="icon">&#9888;</span> Integrity
+            </a></li>
+            <li><a href="/estimates" {% if current_page | default(value="") == "estimates" %}class="active"{% endif %}>
+                <span class="icon">&#9711;</span> Estimates
             </a></li>
             <li><a href="/policies" {% if current_page | default(value="") == "policies" %}class="active"{% endif %}>
                 <span class="icon">&#9881;</span> Policies

--- a/plugins/web-server/templates/estimates.html
+++ b/plugins/web-server/templates/estimates.html
@@ -1,0 +1,151 @@
+{% extends "base.html" %}
+
+{% block title %}Estimates — VOOM{% endblock %}
+
+{% block content %}
+<div class="page-header">
+    <h1>Estimates</h1>
+    <p>Pre-flight policy run records</p>
+</div>
+
+<div x-data="estimateRecords()" x-init="refresh()" class="card">
+    <div class="card-header">
+        <h2>Recent Estimates</h2>
+        <button class="btn btn-secondary btn-sm" type="button" @click="refresh()">Refresh</button>
+    </div>
+
+    <template x-if="error">
+        <p class="text-danger">Estimate records unavailable.</p>
+    </template>
+
+    <template x-if="!error && estimates.length === 0">
+        <div class="empty-state">
+            <p>No estimate records found.</p>
+        </div>
+    </template>
+
+    <template x-if="estimates.length > 0">
+        <table>
+            <thead>
+                <tr>
+                    <th>Run</th>
+                    <th>Files</th>
+                    <th>Wall</th>
+                    <th>Compute</th>
+                    <th>Bytes Saved</th>
+                    <th>Uncertain</th>
+                    <th>Net Loss</th>
+                    <th>Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+                <template x-for="estimate in estimates" :key="estimate.id">
+                    <tr>
+                        <td>
+                            <span class="mono truncate" :title="estimate.id" x-text="estimate.id.slice(0, 12)"></span>
+                        </td>
+                        <td x-text="estimate.file_count"></td>
+                        <td x-text="formatDurationMs(estimate.wall_time_ms)"></td>
+                        <td x-text="formatDurationMs(estimate.compute_time_ms)"></td>
+                        <td :class="estimate.bytes_saved < 0 ? 'text-danger-strong' : 'text-success-strong'"
+                            x-text="formatSignedSize(estimate.bytes_saved)"></td>
+                        <td x-text="estimate.high_uncertainty_files"></td>
+                        <td x-text="estimate.net_loss_files"></td>
+                        <td>
+                            <button class="btn btn-secondary btn-sm" type="button" @click="openDetail(estimate.id)">
+                                Review
+                            </button>
+                        </td>
+                    </tr>
+                </template>
+            </tbody>
+        </table>
+    </template>
+
+    <div x-show="detail" x-cloak
+         style="position: fixed; inset: 0; z-index: 300; background: rgba(0,0,0,0.6); display: flex; align-items: center; justify-content: center; padding: 1rem;">
+        <section style="width: min(760px, 100%); max-height: 90vh; overflow: auto; background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem;">
+            <div class="card-header">
+                <h2>Estimate Review</h2>
+                <button class="btn btn-secondary btn-sm" type="button" @click="detail = null">Close</button>
+            </div>
+            <template x-if="detail">
+                <div>
+                    <div class="card-grid">
+                        <div class="stat-card success">
+                            <div class="stat-value" x-text="formatSignedSize(detail.bytes_saved)"></div>
+                            <div class="stat-label">Bytes Saved</div>
+                        </div>
+                        <div class="stat-card info">
+                            <div class="stat-value" x-text="formatDurationMs(detail.wall_time_ms)"></div>
+                            <div class="stat-label">Wall Time</div>
+                        </div>
+                        <div class="stat-card warning">
+                            <div class="stat-value" x-text="detail.high_uncertainty_files"></div>
+                            <div class="stat-label">Uncertain</div>
+                        </div>
+                        <div class="stat-card danger">
+                            <div class="stat-value" x-text="detail.net_loss_files"></div>
+                            <div class="stat-label">Net Loss</div>
+                        </div>
+                    </div>
+
+                    <table>
+                        <tbody>
+                            <tr><td>Files</td><td x-text="detail.file_count"></td></tr>
+                            <tr><td>Bytes In</td><td x-text="formatSize(detail.bytes_in)"></td></tr>
+                            <tr><td>Bytes Out</td><td x-text="formatSize(detail.bytes_out)"></td></tr>
+                            <tr><td>Compute Time</td><td x-text="formatDurationMs(detail.compute_time_ms)"></td></tr>
+                        </tbody>
+                    </table>
+                </div>
+            </template>
+        </section>
+    </div>
+</div>
+
+<script nonce="{{ csp_nonce }}">
+function estimateRecords() {
+    return {
+        estimates: [],
+        detail: null,
+        error: null,
+        refresh() {
+            fetch('/api/estimates')
+                .then(r => {
+                    if (!r.ok) throw new Error('request failed');
+                    return r.json();
+                })
+                .then(d => { this.estimates = d.estimates || []; this.error = null; })
+                .catch(() => { this.error = 'unavailable'; });
+        },
+        openDetail(id) {
+            fetch('/api/estimates/' + id)
+                .then(r => {
+                    if (!r.ok) throw new Error('request failed');
+                    return r.json();
+                })
+                .then(d => { this.detail = d; this.error = null; })
+                .catch(() => { this.error = 'unavailable'; });
+        }
+    };
+}
+
+function formatDurationMs(ms) {
+    return formatDuration(Math.round((ms || 0) / 1000));
+}
+
+function formatSize(bytes) {
+    const absolute = Math.abs(bytes || 0);
+    if (absolute === 0) return '0 B';
+    const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    const i = Math.min(Math.floor(Math.log(absolute) / Math.log(1024)), units.length - 1);
+    return (absolute / Math.pow(1024, i)).toFixed(i > 0 ? 1 : 0) + ' ' + units[i];
+}
+
+function formatSignedSize(bytes) {
+    if ((bytes || 0) < 0) return '-' + formatSize(bytes);
+    return formatSize(bytes);
+}
+</script>
+{% endblock %}

--- a/plugins/web-server/tests/api_tests.rs
+++ b/plugins/web-server/tests/api_tests.rs
@@ -8,6 +8,7 @@ use uuid::Uuid;
 
 use voom_domain::job::{Job, JobType};
 use voom_domain::media::{Container, MediaFile};
+use voom_domain::storage::EstimateStorage;
 use voom_domain::test_support::InMemoryStore;
 use voom_domain::verification::{
     VerificationMode, VerificationOutcome, VerificationRecord, VerificationRecordInput,
@@ -52,6 +53,22 @@ fn make_verification_at(
         content_hash: Some("abc123".into()),
         details: Some("verification details".into()),
     })
+}
+
+fn make_estimate_run() -> voom_domain::EstimateRun {
+    voom_domain::EstimateRun {
+        id: Uuid::new_v4(),
+        estimated_at: chrono::Utc::now(),
+        file_count: 2,
+        bytes_in: 1_000_000_000,
+        bytes_out: 600_000_000,
+        bytes_saved: 400_000_000,
+        compute_time_ms: 120_000,
+        wall_time_ms: 60_000,
+        high_uncertainty_files: 1,
+        net_loss_files: 0,
+        files: Vec::new(),
+    }
 }
 
 fn make_server(store: InMemoryStore) -> TestServer {
@@ -192,6 +209,44 @@ async fn test_job_stats() {
     assert!(!body["counts"].as_array().unwrap().is_empty());
 }
 
+// === Estimate API Tests ===
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_estimates_returns_persisted_what_if_records() {
+    let store = InMemoryStore::new();
+    let estimate = make_estimate_run();
+    store.insert_estimate_run(&estimate).unwrap();
+    let server = make_server(store);
+
+    let resp = server.get("/api/estimates").await;
+    resp.assert_status_ok();
+    let body: serde_json::Value = resp.json();
+
+    assert_eq!(body["total"], 1);
+    assert_eq!(body["estimates"][0]["id"], estimate.id.to_string());
+    assert_eq!(body["estimates"][0]["file_count"], 2);
+    assert_eq!(body["estimates"][0]["bytes_saved"], 400_000_000);
+    assert_eq!(body["estimates"][0]["high_uncertainty_files"], 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_estimate_returns_detail_for_confirmation_dialog() {
+    let store = InMemoryStore::new();
+    let estimate = make_estimate_run();
+    let estimate_id = estimate.id;
+    store.insert_estimate_run(&estimate).unwrap();
+    let server = make_server(store);
+
+    let resp = server.get(&format!("/api/estimates/{estimate_id}")).await;
+    resp.assert_status_ok();
+    let body: serde_json::Value = resp.json();
+
+    assert_eq!(body["id"], estimate_id.to_string());
+    assert_eq!(body["wall_time_ms"], 60_000);
+    assert_eq!(body["compute_time_ms"], 120_000);
+    assert_eq!(body["net_loss_files"], 0);
+}
+
 // === Plugin API Tests ===
 
 #[tokio::test(flavor = "multi_thread")]
@@ -329,6 +384,16 @@ async fn test_policies_page() {
     let server = make_server(InMemoryStore::new());
     let resp = server.get("/policies").await;
     resp.assert_status_ok();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_estimates_page() {
+    let server = make_server(InMemoryStore::new());
+    let resp = server.get("/estimates").await;
+    resp.assert_status_ok();
+    let body = resp.text();
+    assert!(body.contains("Recent Estimates"));
+    assert!(body.contains("/api/estimates"));
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Summary

- Add `/api/estimates` and `/api/estimates/:id` for persisted pre-flight what-if records.
- Add an Estimates page with a review modal for aggregate savings, time, uncertainty, and net-loss counts.
- Add navigation, template registration, and focused API/page tests.

Refs #311

## Verification

- `cargo test -p voom-web-server -- --nocapture`
- `cargo clippy -p voom-web-server --all-targets --all-features -- -D warnings`
- Local server smoke: `curl -fsS http://127.0.0.1:4811/estimates` and `curl -fsS http://127.0.0.1:4811/api/estimates`

## Notes

This PR adds the Web review surface for persisted estimates. It does not add a Web policy-run launch flow; #313 tracks the remaining work needed to gate actual Web-started processing behind a required estimate confirmation.
