### PR TITLE
Gate Web process runs on estimates

### DIFF
--- a/crates/voom-cli/src/commands/serve.rs
+++ b/crates/voom-cli/src/commands/serve.rs
@@ -5,9 +5,12 @@ use anyhow::{Context, Result};
 use console::style;
 use tokio_util::sync::CancellationToken;
 use voom_web_server::server::{start_server, ServerConfig};
-use voom_web_server::state::{SseEvent, SSE_CHANNEL_CAPACITY};
+use voom_web_server::state::{
+    ProcessRunLaunchRequest, ProcessRunLaunchResponse, ProcessRunLauncher, SseEvent,
+    SSE_CHANNEL_CAPACITY,
+};
 
-use crate::cli::ServeArgs;
+use crate::cli::{ErrorHandling, ProcessArgs, ServeArgs};
 
 /// Priority for the web-sse-bridge plugin. In the VOOM event bus, lower
 /// priority numbers dispatch first; 200 is the highest registered value
@@ -15,6 +18,58 @@ use crate::cli::ServeArgs;
 /// job-manager (20) and sqlite-store (100) have already logged and
 /// persisted them.
 const PRIORITY_WEB_SSE_BRIDGE: i32 = 200;
+
+struct CliProcessRunLauncher {
+    token: CancellationToken,
+}
+
+impl CliProcessRunLauncher {
+    fn new(token: CancellationToken) -> Self {
+        Self { token }
+    }
+}
+
+impl ProcessRunLauncher for CliProcessRunLauncher {
+    fn launch(&self, request: ProcessRunLaunchRequest) -> Result<ProcessRunLaunchResponse, String> {
+        let run_id = uuid::Uuid::new_v4().to_string();
+        let process_args = process_args_from_launch_request(request);
+        let token = self.token.child_token();
+        let run_id_for_task = run_id.clone();
+
+        tokio::spawn(async move {
+            if let Err(error) = crate::commands::process::run(process_args, true, token).await {
+                tracing::error!(
+                    run_id = %run_id_for_task,
+                    error = %error,
+                    "web-started process run failed"
+                );
+            }
+        });
+
+        Ok(ProcessRunLaunchResponse::new(run_id, "started"))
+    }
+}
+
+fn process_args_from_launch_request(request: ProcessRunLaunchRequest) -> ProcessArgs {
+    ProcessArgs {
+        paths: request.paths,
+        policy: request.policy,
+        policy_map: request.policy_map,
+        dry_run: false,
+        estimate: false,
+        estimate_only: false,
+        on_error: ErrorHandling::Fail,
+        workers: request.workers,
+        approve: false,
+        no_backup: false,
+        force_rescan: request.force_rescan,
+        flag_size_increase: false,
+        flag_duration_shrink: false,
+        plan_only: false,
+        confirm_savings: None,
+        priority_by_date: false,
+    }
+}
 
 pub async fn run(args: ServeArgs, token: CancellationToken) -> Result<()> {
     let config = crate::config::load_config()?;
@@ -156,6 +211,7 @@ pub async fn run(args: ServeArgs, token: CancellationToken) -> Result<()> {
     server_config.auth_token = config.auth_token;
     server_config.plugin_info = plugin_info;
     server_config.data_dir = Some(config.data_dir.clone());
+    server_config.process_runner = Some(Arc::new(CliProcessRunLauncher::new(token.clone())));
 
     let shutdown = async move { token.cancelled().await };
     start_server(server_config, store, shutdown).await?;
@@ -182,6 +238,33 @@ mod tests {
         assert_eq!(server_config.port, 8080);
         assert_eq!(server_config.host, "127.0.0.1");
         assert!(server_config.auth_token.is_none());
+    }
+
+    #[test]
+    fn process_args_from_web_launch_request_runs_existing_process_path() {
+        let request = voom_web_server::state::ProcessRunLaunchRequest::new(
+            vec![std::path::PathBuf::from("/media/movie.mkv")],
+            uuid::Uuid::new_v4(),
+        )
+        .with_policy(Some(std::path::PathBuf::from("/policies/archive.voom")))
+        .with_workers(2)
+        .with_force_rescan(true);
+
+        let args = process_args_from_launch_request(request);
+
+        assert_eq!(
+            args.paths,
+            vec![std::path::PathBuf::from("/media/movie.mkv")]
+        );
+        assert_eq!(
+            args.policy,
+            Some(std::path::PathBuf::from("/policies/archive.voom"))
+        );
+        assert_eq!(args.workers, 2);
+        assert!(args.force_rescan);
+        assert!(!args.estimate);
+        assert!(!args.dry_run);
+        assert!(!args.plan_only);
     }
 
     #[test]

--- a/docs/preflight-estimates.md
+++ b/docs/preflight-estimates.md
@@ -61,6 +61,17 @@ voom process /media/movies \
 Files below the threshold are skipped before `PlanCreated` is dispatched, so
 executor plugins do not run for those plans.
 
+## Web UI
+
+The Web UI exposes persisted estimate records at `/estimates`. Open a record
+with **Review**, enter the target media path and policy path, then choose
+**Confirm Run**. The UI reloads the persisted estimate and shows the final
+confirmation summary before dispatching any processing work.
+
+Use **Cancel** from either dialog to leave the estimate as a what-if record.
+No `PlanCreated` events are dispatched until the final **Start Run** action is
+confirmed.
+
 ## Confidence
 
 High uncertainty means the estimator had fewer than five matching samples or

--- a/plugins/web-server/src/api/mod.rs
+++ b/plugins/web-server/src/api/mod.rs
@@ -6,6 +6,7 @@ pub mod health;
 pub mod jobs;
 pub mod plugins;
 pub mod policy;
+pub mod process_runs;
 pub mod stats;
 pub mod tools;
 pub mod transitions;

--- a/plugins/web-server/src/api/process_runs.rs
+++ b/plugins/web-server/src/api/process_runs.rs
@@ -1,0 +1,118 @@
+//! Policy process-run API endpoints.
+
+use std::path::PathBuf;
+
+use axum::extract::State;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::errors::{spawn_store_op, WebError};
+use crate::state::{AppState, ProcessRunLaunchRequest, ProcessRunLaunchResponse};
+
+#[derive(Debug, Deserialize)]
+#[non_exhaustive]
+pub struct ProcessRunRequest {
+    pub paths: Vec<PathBuf>,
+    pub policy: Option<PathBuf>,
+    pub policy_map: Option<PathBuf>,
+    pub estimate_id: Uuid,
+    #[serde(default)]
+    pub confirmed: bool,
+    #[serde(default)]
+    pub workers: usize,
+    #[serde(default)]
+    pub force_rescan: bool,
+}
+
+#[derive(Debug, Serialize)]
+#[non_exhaustive]
+pub struct ProcessRunResponse {
+    pub requires_confirmation: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub estimate: Option<voom_domain::EstimateRun>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+/// POST /api/process-runs -- start a confirmed policy run.
+#[tracing::instrument(skip(state))]
+pub async fn create_process_run(
+    State(state): State<AppState>,
+    Json(request): Json<ProcessRunRequest>,
+) -> Result<Json<ProcessRunResponse>, WebError> {
+    validate_request(&request)?;
+
+    let store = state.store.clone();
+    let estimate_id = request.estimate_id;
+    let estimate = spawn_store_op(move || store.get_estimate_run(&estimate_id)).await?;
+    let estimate =
+        estimate.ok_or_else(|| WebError::NotFound(format!("Estimate {estimate_id} not found")))?;
+
+    if !request.confirmed {
+        return Ok(Json(ProcessRunResponse {
+            requires_confirmation: true,
+            estimate: Some(estimate),
+            run_id: None,
+            message: None,
+        }));
+    }
+
+    let runner = state
+        .process_runner
+        .as_ref()
+        .ok_or_else(|| WebError::Internal("process runner is not configured".to_string()))?;
+    let launch_request = ProcessRunLaunchRequest::new(request.paths, estimate_id)
+        .with_policy(request.policy)
+        .with_policy_map(request.policy_map)
+        .with_workers(request.workers)
+        .with_force_rescan(request.force_rescan);
+    let launched = runner.launch(launch_request).map_err(WebError::Internal)?;
+
+    Ok(Json(response_from_launch(launched)))
+}
+
+fn validate_request(request: &ProcessRunRequest) -> Result<(), WebError> {
+    if request.paths.is_empty() {
+        return Err(WebError::BadRequest(
+            "paths must include at least one media path".to_string(),
+        ));
+    }
+    if request.policy.is_some() && request.policy_map.is_some() {
+        return Err(WebError::BadRequest(
+            "policy and policy_map cannot both be set".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn response_from_launch(launched: ProcessRunLaunchResponse) -> ProcessRunResponse {
+    ProcessRunResponse {
+        requires_confirmation: false,
+        estimate: None,
+        run_id: Some(launched.run_id),
+        message: Some(launched.message),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn process_run_request_rejects_empty_paths() {
+        let request = ProcessRunRequest {
+            paths: Vec::new(),
+            policy: None,
+            policy_map: None,
+            estimate_id: Uuid::new_v4(),
+            confirmed: false,
+            workers: 0,
+            force_rescan: false,
+        };
+
+        assert!(validate_request(&request).is_err());
+    }
+}

--- a/plugins/web-server/src/router.rs
+++ b/plugins/web-server/src/router.rs
@@ -41,6 +41,7 @@ pub fn build_router(state: AppState) -> Router {
         .route("/stats", get(api::stats::get_stats))
         .route("/policy/validate", post(api::policy::validate_policy))
         .route("/policy/format", post(api::policy::format_policy))
+        .route("/process-runs", post(api::process_runs::create_process_run))
         .route("/tools", get(api::tools::list_tools))
         .route(
             "/executor-capabilities",

--- a/plugins/web-server/src/server.rs
+++ b/plugins/web-server/src/server.rs
@@ -13,7 +13,7 @@ use crate::state::{AppState, SseEvent};
 
 /// Configuration for the web server.
 #[non_exhaustive]
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct ServerConfig {
     pub host: String,
     pub port: u16,
@@ -25,6 +25,7 @@ pub struct ServerConfig {
     /// the caller's responsibility; the server uses this sender directly so
     /// that it shares the same channel as any kernel-side bridge plugin.
     pub sse_tx: broadcast::Sender<SseEvent>,
+    pub process_runner: Option<Arc<dyn crate::state::ProcessRunLauncher>>,
 }
 
 impl ServerConfig {
@@ -38,6 +39,7 @@ impl ServerConfig {
             plugin_info: Vec::new(),
             data_dir: None,
             sse_tx,
+            process_runner: None,
         }
     }
 }
@@ -76,6 +78,10 @@ pub async fn start_server(
         config.data_dir,
     )
     .with_plugin_info(config.plugin_info);
+    let state = match config.process_runner {
+        Some(runner) => state.with_process_runner(runner),
+        None => state,
+    };
     let router = build_router(state).layer(DefaultBodyLimit::max(2 * 1024 * 1024)); // 2 MiB
 
     let address = format!("{}:{}", config.host, config.port);
@@ -179,6 +185,7 @@ mod tests {
             plugin_info: vec![],
             data_dir: None,
             sse_tx,
+            process_runner: None,
         };
         assert_eq!(config.host, "127.0.0.1");
         assert_eq!(config.port, 8080);
@@ -197,6 +204,7 @@ mod tests {
             plugin_info: vec![],
             data_dir: None,
             sse_tx,
+            process_runner: None,
         };
         let cloned = config.clone();
         assert_eq!(cloned.host, "0.0.0.0");

--- a/plugins/web-server/src/state.rs
+++ b/plugins/web-server/src/state.rs
@@ -10,6 +10,84 @@ use voom_domain::storage::StorageTrait;
 /// job-progress events without lagging slow clients.
 pub const SSE_CHANNEL_CAPACITY: usize = 256;
 
+/// Request handed from the Web API to the application-level process launcher.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct ProcessRunLaunchRequest {
+    pub paths: Vec<std::path::PathBuf>,
+    pub policy: Option<std::path::PathBuf>,
+    pub policy_map: Option<std::path::PathBuf>,
+    pub workers: usize,
+    pub force_rescan: bool,
+    pub estimate_id: uuid::Uuid,
+}
+
+impl ProcessRunLaunchRequest {
+    #[must_use]
+    pub fn new(paths: Vec<std::path::PathBuf>, estimate_id: uuid::Uuid) -> Self {
+        Self {
+            paths,
+            policy: None,
+            policy_map: None,
+            workers: 0,
+            force_rescan: false,
+            estimate_id,
+        }
+    }
+
+    #[must_use]
+    pub fn with_policy(mut self, policy: Option<std::path::PathBuf>) -> Self {
+        self.policy = policy;
+        self
+    }
+
+    #[must_use]
+    pub fn with_policy_map(mut self, policy_map: Option<std::path::PathBuf>) -> Self {
+        self.policy_map = policy_map;
+        self
+    }
+
+    #[must_use]
+    pub fn with_workers(mut self, workers: usize) -> Self {
+        self.workers = workers;
+        self
+    }
+
+    #[must_use]
+    pub fn with_force_rescan(mut self, force_rescan: bool) -> Self {
+        self.force_rescan = force_rescan;
+        self
+    }
+}
+
+/// Response returned by the application-level process launcher.
+#[derive(Debug, Clone, serde::Serialize)]
+#[non_exhaustive]
+pub struct ProcessRunLaunchResponse {
+    pub run_id: String,
+    pub message: String,
+}
+
+impl ProcessRunLaunchResponse {
+    #[must_use]
+    pub fn new(run_id: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            run_id: run_id.into(),
+            message: message.into(),
+        }
+    }
+}
+
+/// Application-level process launcher injected by the CLI binary.
+pub trait ProcessRunLauncher: Send + Sync {
+    /// Launch a confirmed process run.
+    ///
+    /// # Errors
+    /// Returns a user-facing message when the launch request cannot be queued
+    /// or started.
+    fn launch(&self, request: ProcessRunLaunchRequest) -> Result<ProcessRunLaunchResponse, String>;
+}
+
 /// Events broadcast via SSE to connected clients.
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(tag = "type", content = "data")]
@@ -73,6 +151,7 @@ pub struct AppState {
     pub sse_client_count: Arc<AtomicU32>,
     pub plugin_info: Arc<Vec<crate::api::plugins::PluginInfoResponse>>,
     pub data_dir: Option<std::path::PathBuf>,
+    pub process_runner: Option<Arc<dyn ProcessRunLauncher>>,
 }
 
 impl AppState {
@@ -96,6 +175,7 @@ impl AppState {
             sse_client_count: Arc::new(AtomicU32::new(0)),
             plugin_info: Arc::new(Vec::new()),
             data_dir,
+            process_runner: None,
         }
     }
 
@@ -117,6 +197,13 @@ impl AppState {
     #[must_use]
     pub fn with_plugin_info(mut self, info: Vec<crate::api::plugins::PluginInfoResponse>) -> Self {
         self.plugin_info = Arc::new(info);
+        self
+    }
+
+    /// Set the process runner used by `/api/process-runs`.
+    #[must_use]
+    pub fn with_process_runner(mut self, runner: Arc<dyn ProcessRunLauncher>) -> Self {
+        self.process_runner = Some(runner);
         self
     }
 

--- a/plugins/web-server/templates/estimates.html
+++ b/plugins/web-server/templates/estimates.html
@@ -98,6 +98,81 @@
                             <tr><td>Compute Time</td><td x-text="formatDurationMs(detail.compute_time_ms)"></td></tr>
                         </tbody>
                     </table>
+
+                    <form class="mt-1" @submit.prevent="requestRunConfirmation()">
+                        <div class="form-row">
+                            <div class="form-group">
+                                <label for="estimate-run-path">Path</label>
+                                <input id="estimate-run-path" type="text" x-model="runForm.path" required>
+                            </div>
+                            <div class="form-group">
+                                <label for="estimate-run-policy">Policy</label>
+                                <input id="estimate-run-policy" type="text" x-model="runForm.policy">
+                            </div>
+                        </div>
+                        <div class="btn-group">
+                            <button class="btn btn-primary" type="submit">Confirm Run</button>
+                            <button class="btn btn-secondary" type="button" @click="detail = null">Cancel</button>
+                        </div>
+                    </form>
+                </div>
+            </template>
+        </section>
+    </div>
+
+    <div x-show="confirmation" x-cloak
+         style="position: fixed; inset: 0; z-index: 320; background: rgba(0,0,0,0.7); display: flex; align-items: center; justify-content: center; padding: 1rem;">
+        <section style="width: min(640px, 100%); background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem;">
+            <div class="card-header">
+                <h2>Confirm Run</h2>
+                <button class="btn btn-secondary btn-sm" type="button" @click="confirmation = null">Cancel</button>
+            </div>
+            <template x-if="confirmation">
+                <div>
+                    <div class="card-grid">
+                        <div class="stat-card success">
+                            <div class="stat-value" x-text="formatSignedSize(confirmation.bytes_saved)"></div>
+                            <div class="stat-label">Bytes Saved</div>
+                        </div>
+                        <div class="stat-card info">
+                            <div class="stat-value" x-text="formatDurationMs(confirmation.wall_time_ms)"></div>
+                            <div class="stat-label">Wall Time</div>
+                        </div>
+                        <div class="stat-card warning">
+                            <div class="stat-value" x-text="confirmation.high_uncertainty_files"></div>
+                            <div class="stat-label">Uncertain</div>
+                        </div>
+                        <div class="stat-card danger">
+                            <div class="stat-value" x-text="confirmation.net_loss_files"></div>
+                            <div class="stat-label">Net Loss</div>
+                        </div>
+                    </div>
+                    <table class="mb-1">
+                        <tbody>
+                            <tr><td>Bytes In</td><td x-text="formatSize(confirmation.bytes_in)"></td></tr>
+                            <tr><td>Bytes Out</td><td x-text="formatSize(confirmation.bytes_out)"></td></tr>
+                            <tr><td>Compute Time</td><td x-text="formatDurationMs(confirmation.compute_time_ms)"></td></tr>
+                        </tbody>
+                    </table>
+                    <h2>Phase Breakdown</h2>
+                    <table class="mb-1">
+                        <thead>
+                            <tr><th>Phase</th><th>Plans</th><th>Compute</th></tr>
+                        </thead>
+                        <tbody>
+                            <template x-for="phase in phaseBreakdown(confirmation)" :key="phase.name">
+                                <tr>
+                                    <td x-text="phase.name"></td>
+                                    <td x-text="phase.count"></td>
+                                    <td x-text="formatDurationMs(phase.compute_ms)"></td>
+                                </tr>
+                            </template>
+                        </tbody>
+                    </table>
+                    <div class="btn-group">
+                        <button class="btn btn-primary" type="button" @click="startConfirmedRun()">Start Run</button>
+                        <button class="btn btn-secondary" type="button" @click="confirmation = null">Cancel</button>
+                    </div>
                 </div>
             </template>
         </section>
@@ -109,6 +184,8 @@ function estimateRecords() {
     return {
         estimates: [],
         detail: null,
+        confirmation: null,
+        runForm: { path: '', policy: '' },
         error: null,
         refresh() {
             fetch('/api/estimates')
@@ -125,7 +202,42 @@ function estimateRecords() {
                     if (!r.ok) throw new Error('request failed');
                     return r.json();
                 })
-                .then(d => { this.detail = d; this.error = null; })
+                .then(d => { this.detail = d; this.confirmation = null; this.error = null; })
+                .catch(() => { this.error = 'unavailable'; });
+        },
+        processRunPayload(confirmed) {
+            const payload = {
+                paths: [this.runForm.path],
+                estimate_id: this.detail.id,
+                confirmed: confirmed
+            };
+            if (this.runForm.policy) payload.policy = this.runForm.policy;
+            return payload;
+        },
+        requestRunConfirmation() {
+            fetch('/api/process-runs', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(this.processRunPayload(false))
+            })
+                .then(r => {
+                    if (!r.ok) throw new Error('request failed');
+                    return r.json();
+                })
+                .then(d => { this.confirmation = d.estimate; this.error = null; })
+                .catch(() => { this.error = 'unavailable'; });
+        },
+        startConfirmedRun() {
+            fetch('/api/process-runs', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(this.processRunPayload(true))
+            })
+                .then(r => {
+                    if (!r.ok) throw new Error('request failed');
+                    return r.json();
+                })
+                .then(() => { this.confirmation = null; this.detail = null; this.error = null; })
                 .catch(() => { this.error = 'unavailable'; });
         }
     };
@@ -146,6 +258,18 @@ function formatSize(bytes) {
 function formatSignedSize(bytes) {
     if ((bytes || 0) < 0) return '-' + formatSize(bytes);
     return formatSize(bytes);
+}
+
+function phaseBreakdown(estimate) {
+    const phases = new Map();
+    (estimate?.files || []).forEach(file => {
+        const phase = file.phase_name || 'unknown';
+        const current = phases.get(phase) || { name: phase, count: 0, compute_ms: 0 };
+        current.count += 1;
+        current.compute_ms += file.compute_time_ms || 0;
+        phases.set(phase, current);
+    });
+    return Array.from(phases.values()).sort((a, b) => a.name.localeCompare(b.name));
 }
 </script>
 {% endblock %}

--- a/plugins/web-server/tests/api_tests.rs
+++ b/plugins/web-server/tests/api_tests.rs
@@ -1,5 +1,6 @@
 //! Integration tests for the web server REST API.
 
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use axum_test::TestServer;
@@ -80,6 +81,33 @@ fn make_server_with_auth(store: InMemoryStore, auth_token: Option<String>) -> Te
     let templates = voom_web_server::server::embedded_templates().unwrap();
     let state =
         voom_web_server::state::AppState::new_with_default_sse(store, templates, auth_token, None);
+    let router = voom_web_server::router::build_router(state);
+    TestServer::new(router).unwrap()
+}
+
+#[derive(Default)]
+struct CountingProcessRunner {
+    calls: AtomicUsize,
+}
+
+impl voom_web_server::state::ProcessRunLauncher for CountingProcessRunner {
+    fn launch(
+        &self,
+        _request: voom_web_server::state::ProcessRunLaunchRequest,
+    ) -> Result<voom_web_server::state::ProcessRunLaunchResponse, String> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Ok(voom_web_server::state::ProcessRunLaunchResponse::new(
+            "test-run", "started",
+        ))
+    }
+}
+
+fn make_server_with_runner(store: InMemoryStore, runner: Arc<CountingProcessRunner>) -> TestServer {
+    let store = Arc::new(store);
+    let templates = voom_web_server::server::embedded_templates().unwrap();
+    let state =
+        voom_web_server::state::AppState::new_with_default_sse(store, templates, None, None)
+            .with_process_runner(runner);
     let router = voom_web_server::router::build_router(state);
     TestServer::new(router).unwrap()
 }
@@ -247,6 +275,58 @@ async fn test_get_estimate_returns_detail_for_confirmation_dialog() {
     assert_eq!(body["net_loss_files"], 0);
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_unconfirmed_process_run_returns_estimate_without_dispatch() {
+    let store = InMemoryStore::new();
+    let estimate = make_estimate_run();
+    let estimate_id = estimate.id;
+    store.insert_estimate_run(&estimate).unwrap();
+    let runner = Arc::new(CountingProcessRunner::default());
+    let server = make_server_with_runner(store, runner.clone());
+
+    let resp = server
+        .post("/api/process-runs")
+        .json(&json!({
+            "paths": ["/media/movie.mkv"],
+            "policy": "/policies/archive.voom",
+            "estimate_id": estimate_id,
+            "confirmed": false
+        }))
+        .await;
+
+    resp.assert_status_ok();
+    let body: serde_json::Value = resp.json();
+    assert_eq!(body["requires_confirmation"], true);
+    assert_eq!(body["estimate"]["id"], estimate_id.to_string());
+    assert_eq!(runner.calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_confirmed_process_run_dispatches_after_estimate_confirmation() {
+    let store = InMemoryStore::new();
+    let estimate = make_estimate_run();
+    let estimate_id = estimate.id;
+    store.insert_estimate_run(&estimate).unwrap();
+    let runner = Arc::new(CountingProcessRunner::default());
+    let server = make_server_with_runner(store, runner.clone());
+
+    let resp = server
+        .post("/api/process-runs")
+        .json(&json!({
+            "paths": ["/media/movie.mkv"],
+            "policy": "/policies/archive.voom",
+            "estimate_id": estimate_id,
+            "confirmed": true
+        }))
+        .await;
+
+    resp.assert_status_ok();
+    let body: serde_json::Value = resp.json();
+    assert_eq!(body["requires_confirmation"], false);
+    assert_eq!(body["run_id"], "test-run");
+    assert_eq!(runner.calls.load(Ordering::SeqCst), 1);
+}
+
 // === Plugin API Tests ===
 
 #[tokio::test(flavor = "multi_thread")]
@@ -394,6 +474,10 @@ async fn test_estimates_page() {
     let body = resp.text();
     assert!(body.contains("Recent Estimates"));
     assert!(body.contains("/api/estimates"));
+    assert!(body.contains("/api/process-runs"));
+    assert!(body.contains("Confirm Run"));
+    assert!(body.contains("Phase Breakdown"));
+    assert!(body.contains("Cancel"));
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Summary

- Add `/api/process-runs` with an explicit estimate confirmation gate.
- Keep unconfirmed requests as what-if confirmation responses, without calling the process launcher.
- Inject a Web process-run launcher from the CLI `serve` command and wire confirmed runs to the existing `process::run` path.
- Extend the Estimates page with path/policy inputs, final confirmation, cancel actions, bytes/time/uncertainty/net-loss summary, and phase breakdown.
- Document the Web workflow.

Closes #313

## Verification

- `cargo test -p voom-web-server -- --nocapture`
- `cargo test -p voom-cli serve -- --nocapture`
- `cargo clippy -p voom-web-server --all-targets --all-features -- -D warnings`
- `cargo clippy -p voom-cli --all-targets --all-features -- -D warnings`
- `scripts/generate-test-corpus /tmp/voom-313-corpus --profile smoke --count 0 --seed 313 --duration 1`
- `XDG_CONFIG_HOME=/tmp/voom-313-config cargo run -p voom-cli -- --force estimate /tmp/voom-313-corpus --policy docs/examples/preflight-archive.voom --workers 2`
- Local server smoke against `/api/estimates` and unconfirmed `/api/process-runs` returned `requires_confirmation: true` with the persisted estimate id.

## Notes

The confirmed Web launch returns immediately after spawning the existing process orchestration path. Follow-up progress remains visible through the existing jobs/events surfaces.
