### PR TITLE
feat(backup): add rclone-backed remote destinations

### DIFF
--- a/crates/voom-dsl/tests/parser_snapshots.rs
+++ b/crates/voom-dsl/tests/parser_snapshots.rs
@@ -324,6 +324,15 @@ fn example_vmaf_guided_parses_and_validates() {
 }
 
 #[test]
+fn example_remote_backup_transcode_parses_and_validates() {
+    let input = include_str!("../../../docs/examples/remote-backup-transcode.voom");
+    let ast = parse_policy(input).unwrap();
+    assert_eq!(ast.name, "remote-backup-transcode");
+    assert_eq!(ast.phases.len(), 2);
+    voom_dsl::validate(&ast).unwrap();
+}
+
+#[test]
 fn example_metadata_enrichment_parses() {
     let input = include_str!("../../../docs/examples/metadata-enrichment.voom");
     let ast = parse_policy(input).unwrap();

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -803,6 +803,10 @@ voom history /media/movies/film.mkv --format json
 
 Backup management.
 
+Remote backup destinations are configured through `[plugin.backup-manager]` in
+`~/.config/voom/config.toml`. See [Remote Backup Destinations](remote-backups.md)
+for rclone, S3, SFTP, and WebDAV examples.
+
 #### `voom backup list`
 
 List backups (`.vbak` files) in one or more directories.

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -34,6 +34,13 @@ transcodes can be skipped before executor dispatch.
 
 **Plugins used:** policy-evaluator, ffmpeg-executor
 
+### [remote-backup-transcode.voom](remote-backup-transcode.voom)
+Destructive transcode policy intended for remote-backup testing. Pair with
+`remote-backup-rclone.toml` or `remote-backup-s3.toml` in `~/.config/voom/config.toml`
+to upload and verify backups before mutation.
+
+**Plugins used:** policy-evaluator, ffmpeg-executor, backup-manager
+
 ### [hdr-archival.voom](hdr-archival.voom)
 HDR archival transcode policy. Preserves detected HDR10 metadata while encoding HEVC output and demonstrates optional hardware acceleration.
 

--- a/docs/examples/remote-backup-rclone.toml
+++ b/docs/examples/remote-backup-rclone.toml
@@ -1,0 +1,12 @@
+[plugin.backup-manager]
+use_global_dir = true
+backup_dir = "/var/backups/voom"
+verify_after_upload = true
+block_on_remote_failure = true
+rclone_path = "rclone"
+
+[[plugin.backup-manager.destinations]]
+name = "offsite"
+kind = "rclone"
+remote = "b2:voom-backups"
+bandwidth_limit = "10M"

--- a/docs/examples/remote-backup-s3.toml
+++ b/docs/examples/remote-backup-s3.toml
@@ -1,0 +1,11 @@
+[plugin.backup-manager]
+use_global_dir = true
+backup_dir = "/var/backups/voom"
+verify_after_upload = true
+block_on_remote_failure = true
+rclone_path = "rclone"
+
+[[plugin.backup-manager.destinations]]
+name = "archive-s3"
+kind = "s3"
+remote = "aws-archive:voom-backups"

--- a/docs/examples/remote-backup-transcode.voom
+++ b/docs/examples/remote-backup-transcode.voom
@@ -1,0 +1,28 @@
+// Remote backup transcode policy.
+//
+// Pair this policy with one of the remote-backup-*.toml examples by copying
+// the TOML into ~/.config/voom/config.toml. The policy keeps local backups so
+// remote upload failures and local restore paths can be inspected after a run.
+
+policy "remote-backup-transcode" {
+  config {
+    languages audio: [eng, und]
+    languages subtitle: [eng, und]
+    keep_backups: true
+    on_error: abort
+  }
+
+  phase normalize-container {
+    container mkv
+  }
+
+  phase transcode-video {
+    depends_on: [normalize-container]
+    skip when video.codec in [hevc, h265]
+
+    transcode video to hevc {
+      preset: medium
+      crf: 26
+    }
+  }
+}

--- a/docs/functional-test-plan-remote-backups.md
+++ b/docs/functional-test-plan-remote-backups.md
@@ -1,0 +1,112 @@
+# Remote Backups Functional Test Plan
+
+This plan verifies issue 207 behavior without cloud credentials by using
+`scripts/generate-test-corpus` and a fake `rclone` executable that copies remote
+objects into a local directory.
+
+## Generate Corpus
+
+```sh
+rm -rf /tmp/voom-remote-backup-corpus
+scripts/generate-test-corpus /tmp/voom-remote-backup-corpus \
+  --profile smoke \
+  --duration 1
+```
+
+Expected: `manifest.json` exists and at least one generated media file is
+available for processing.
+
+## Create Fake Rclone
+
+```sh
+rm -rf /tmp/voom-remote-backup-bin /tmp/voom-remote-backup-target
+mkdir -p /tmp/voom-remote-backup-bin /tmp/voom-remote-backup-target
+cat > /tmp/voom-remote-backup-bin/rclone <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+cmd="$1"
+shift
+
+case "$cmd" in
+  copyto)
+    source="$1"
+    remote="$2"
+    target="/tmp/voom-remote-backup-target/${remote//:/_}"
+    mkdir -p "$(dirname "$target")"
+    cp "$source" "$target"
+    ;;
+  size)
+    shift
+    remote="$1"
+    target="/tmp/voom-remote-backup-target/${remote//:/_}"
+    bytes="$(wc -c < "$target" | tr -d ' ')"
+    printf '{"bytes":%s,"count":1}\n' "$bytes"
+    ;;
+  *)
+    echo "unsupported fake rclone command: $cmd" >&2
+    exit 64
+    ;;
+esac
+SH
+chmod +x /tmp/voom-remote-backup-bin/rclone
+```
+
+Expected: `/tmp/voom-remote-backup-bin/rclone` is executable.
+
+## Configure VOOM
+
+```sh
+rm -rf /tmp/voom-remote-config
+mkdir -p /tmp/voom-remote-config/voom
+cat > /tmp/voom-remote-config/voom/config.toml <<'TOML'
+data_dir = "/tmp/voom-remote-config/voom/data"
+
+[plugin.backup-manager]
+use_global_dir = true
+backup_dir = "/tmp/voom-remote-config/voom/local-backups"
+verify_after_upload = true
+block_on_remote_failure = true
+rclone_path = "/tmp/voom-remote-backup-bin/rclone"
+
+[[plugin.backup-manager.destinations]]
+name = "fake-offsite"
+kind = "rclone"
+remote = "fake:voom"
+TOML
+```
+
+Expected: config contains one rclone-backed destination.
+
+## Process Corpus
+
+```sh
+XDG_CONFIG_HOME=/tmp/voom-remote-config cargo run -p voom-cli -- process \
+  /tmp/voom-remote-backup-corpus \
+  --policy docs/examples/remote-backup-transcode.voom \
+  --yes
+```
+
+Expected: processing succeeds, local `.vbak` files are retained because the
+policy sets `keep_backups: true`, and `/tmp/voom-remote-backup-target` contains
+remote backup copies under `fake_voom/<uuid>/`.
+
+## Failure Blocks Destructive Work
+
+```sh
+cat > /tmp/voom-remote-backup-bin/rclone <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "simulated remote failure" >&2
+exit 50
+SH
+chmod +x /tmp/voom-remote-backup-bin/rclone
+
+XDG_CONFIG_HOME=/tmp/voom-remote-config cargo run -p voom-cli -- process \
+  /tmp/voom-remote-backup-corpus \
+  --policy docs/examples/remote-backup-transcode.voom \
+  --yes
+```
+
+Expected: processing exits non-zero with a backup-manager error before executor
+plugins modify files.

--- a/docs/plans/issue-207-adversarial-review.md
+++ b/docs/plans/issue-207-adversarial-review.md
@@ -62,10 +62,10 @@ Implemented surface:
 
 The following work is still needed for the full issue 207 acceptance list:
 
-- Remote backup inventory and `voom backup list --destination`.
-- Remote restore through `voom backup restore <file-path> --from <destination>`.
-- Standalone remote verification through `voom backup verify --destination`.
-- `voom health check` coverage for backup destinations.
-- Cost-aware retention guards for providers with minimum storage durations.
-- Optional native S3 backend if direct AWS SDK support remains desired after
-  rclone-backed S3 is available.
+- #319: Remote backup inventory and `voom backup list --destination`.
+- #320: Remote restore through `voom backup restore <file-path> --from <destination>`.
+- #321: Standalone remote verification through `voom backup verify --destination`.
+- #322: `voom health check` coverage for backup destinations.
+- #323: Cost-aware retention guards for providers with minimum storage durations.
+- #324: Optional native S3 backend if direct AWS SDK support remains desired
+  after rclone-backed S3 is available.

--- a/docs/plans/issue-207-adversarial-review.md
+++ b/docs/plans/issue-207-adversarial-review.md
@@ -1,0 +1,71 @@
+# Issue 207 Remote Backups Adversarial Review
+
+## Scope Reviewed
+
+Branch: `feat/issue-207-remote-backups`
+
+Implemented surface:
+
+- `backup-manager` loads remote destinations from `[plugin.backup-manager]`.
+- `rclone`, `s3`, `sftp`, and `webdav` destination kinds are accepted.
+- All remote destination kinds are rclone-backed.
+- Local `.vbak` creation remains the staging and restore path.
+- Remote uploads run before `PlanExecuting` returns success.
+- Remote failures block destructive processing by default.
+- Remote object size verification runs through `rclone size --json`.
+- Backup event results include local and remote backup metadata.
+- User docs, example policy/config files, and a generated-corpus functional test
+  plan document the feature.
+
+## Acceptance Criteria Review
+
+| Issue 207 criterion | Status | Evidence / risk |
+|---|---|---|
+| S3-compatible destinations work end-to-end | Partial | `kind = "s3"` is supported through rclone remotes. Native S3 SDK upload/list/restore/delete is not implemented. |
+| Rclone destinations work | Implemented for upload and size verification | `BackupDestinationConfig::rclone`, `RcloneCommand::copyto`, `upload_with_rclone`, and backup unit tests cover command construction and blocking behavior. |
+| SFTP and WebDAV work | Partial | `kind = "sftp"` and `kind = "webdav"` are accepted as rclone-backed aliases. Real provider integration depends on rclone config. |
+| Pre-modification upload-and-verify is enforced | Implemented | `backup-manager` runs on `PlanExecuting` before executor dispatch; upload errors return from `backup_file`. |
+| Failed uploads block destructive ops by default | Implemented | `block_on_remote_failure` defaults to true and `remote_upload_failure_blocks_backup` covers it. |
+| Bandwidth limits respected | Implemented for rclone | `RcloneCommand::copyto` passes `--bwlimit` as argv, not through a shell. |
+| `voom backup restore --from <dest>` works | Not implemented | Existing restore remains local `.vbak` only. |
+| `voom backup verify --destination` detects bit-rot | Not implemented | Upload-time size verification exists; standalone remote verify CLI does not. |
+| Retention policy honors cost-aware minimums | Not implemented | No cloud retention implementation or schema exists in this branch. |
+| Health check covers all configured destinations | Not implemented | Config validation exists; `voom health check` integration is absent. |
+| Credentials never logged in plaintext | Implemented by design constraint | VOOM does not accept inline remote credentials. Error paths log destination names and remote paths only. |
+
+## Adversarial Findings
+
+1. The branch is honest rclone-backed support, not native cloud protocol support.
+   The docs must keep saying S3/SFTP/WebDAV require rclone remotes. Marketing
+   this as native S3 would be misleading.
+
+2. Remote restore is the biggest user-facing gap. Upload safety is useful, but
+   users cannot yet ask VOOM to pull a specific remote backup back down.
+
+3. Backup status is still process-local. `BackupRecord.remote_backups` and event
+   JSON expose remote metadata during a run, but there is no persistent backup
+   inventory table yet.
+
+4. `rclone size --json <remote-object>` assumes rclone returns a JSON object
+   with `bytes`. This should be validated against at least one real rclone
+   remote before broad release notes claim provider-level coverage.
+
+5. `block_on_remote_failure = false` can create a false sense of offsite safety.
+   The docs call it out, but CLI output could be more visible in a future
+   change.
+
+6. The fake-rclone functional test plan verifies dispatch and local subprocess
+   behavior, not cloud authentication, provider permissions, lifecycle rules, or
+   minimum-storage billing behavior.
+
+## Recommended Follow-Up Issues
+
+The following work is still needed for the full issue 207 acceptance list:
+
+- Remote backup inventory and `voom backup list --destination`.
+- Remote restore through `voom backup restore <file-path> --from <destination>`.
+- Standalone remote verification through `voom backup verify --destination`.
+- `voom health check` coverage for backup destinations.
+- Cost-aware retention guards for providers with minimum storage durations.
+- Optional native S3 backend if direct AWS SDK support remains desired after
+  rclone-backed S3 is available.

--- a/docs/remote-backups.md
+++ b/docs/remote-backups.md
@@ -1,0 +1,93 @@
+# Remote Backup Destinations
+
+VOOM can upload backups to rclone-backed remote destinations before destructive
+processing starts. The local `.vbak` backup is still created first; remote
+uploads are an additional safety check before executor plugins can modify the
+source file.
+
+Remote backup configuration lives in `~/.config/voom/config.toml`:
+
+```toml
+[plugin.backup-manager]
+use_global_dir = true
+backup_dir = "/var/backups/voom"
+verify_after_upload = true
+block_on_remote_failure = true
+rclone_path = "rclone"
+
+[[plugin.backup-manager.destinations]]
+name = "offsite"
+kind = "rclone"
+remote = "b2:voom-backups"
+bandwidth_limit = "10M"
+```
+
+`kind` may be `rclone`, `s3`, `sftp`, or `webdav`. All remote kinds are backed
+by rclone in this implementation; configure credentials and provider details in
+rclone, then reference the remote from VOOM. VOOM does not accept inline access
+keys or passwords for backup destinations.
+
+## Behavior
+
+For every destructive plan, `backup-manager`:
+
+1. Creates the normal local `.vbak` backup.
+2. Uploads the original source file to each remote destination.
+3. Verifies the remote object size when `verify_after_upload = true`.
+4. Blocks the destructive operation if a required upload or verification fails.
+
+`block_on_remote_failure` defaults to `true`. Set it to `false` only when local
+backups are acceptable for that run and remote upload failures should be logged
+without blocking processing.
+
+Remote backup paths use this layout:
+
+```text
+<remote>/<backup-uuid>/<original-file-name>.vbak
+```
+
+The UUID prevents collisions when different source directories contain files
+with the same name.
+
+## S3, SFTP, And WebDAV
+
+Typed provider names document intent while keeping one execution model:
+
+```toml
+[[plugin.backup-manager.destinations]]
+name = "archive-s3"
+kind = "s3"
+remote = "aws-archive:voom"
+
+[[plugin.backup-manager.destinations]]
+name = "nas-sftp"
+kind = "sftp"
+remote = "vps:/srv/voom"
+
+[[plugin.backup-manager.destinations]]
+name = "library-webdav"
+kind = "webdav"
+remote = "dav:voom"
+```
+
+Create and test those remotes with rclone first:
+
+```sh
+rclone config
+rclone lsd aws-archive:
+rclone lsd vps:
+rclone lsd dav:
+```
+
+## Restore Status
+
+`voom backup list`, `voom backup restore`, and `voom backup cleanup` continue to
+operate on local `.vbak` files. Remote upload metadata is emitted in backup
+events during processing, but persistent remote listing and remote restore are
+not exposed as CLI commands yet.
+
+## Credential Safety
+
+Keep credentials in rclone config, provider environment variables, or the
+provider's native credential store. VOOM logs destination names and remote
+object paths, not secrets.

--- a/docs/superpowers/plans/2026-05-10-issue-207-remote-backups.md
+++ b/docs/superpowers/plans/2026-05-10-issue-207-remote-backups.md
@@ -290,10 +290,10 @@ It must configure fake rclone to copy into `/tmp/voom-remote-backup-target`.
 Run:
 
 ```sh
-cargo test -p voom-dsl --test examples
+cargo test -p voom-dsl --test parser_snapshots example_remote_backup_transcode_parses_and_validates
 ```
 
-Expected: all example parser tests pass.
+Expected: the remote backup example parses and validates.
 
 - [ ] **Step 4: Commit**
 
@@ -320,7 +320,7 @@ Run:
 ```sh
 cargo fmt --check
 cargo test -p voom-backup-manager
-cargo test -p voom-dsl --test examples
+cargo test -p voom-dsl --test parser_snapshots
 cargo clippy -p voom-backup-manager --all-targets -- -D warnings
 ```
 

--- a/docs/superpowers/plans/2026-05-10-issue-207-remote-backups.md
+++ b/docs/superpowers/plans/2026-05-10-issue-207-remote-backups.md
@@ -1,0 +1,362 @@
+# Issue 207 Remote Backups Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add rclone-backed remote backup destinations that upload and verify originals before destructive processing.
+
+**Architecture:** Extend `voom-backup-manager` with typed destination config and a small destination runner abstraction. Keep the existing local `.vbak` backup as the staging and restore path, then upload the source bytes to each configured remote before returning from `PlanExecuting`.
+
+**Tech Stack:** Rust 2021, native VOOM plugin config through `PluginContext::parse_config`, `std::process::Command` subprocess execution, existing CLI/docs/example policy infrastructure.
+
+---
+
+## File Map
+
+- Modify: `plugins/backup-manager/src/lib.rs` for config parsing, record metadata, and event output.
+- Modify: `plugins/backup-manager/src/backup.rs` for destination upload orchestration.
+- Create: `plugins/backup-manager/src/destination.rs` for destination config, validation, path layout, and rclone command runner.
+- Modify: `plugins/backup-manager/Cargo.toml` only if serde derive support is missing.
+- Modify: `crates/voom-cli/src/app.rs` only if plugin init needs a constructed config.
+- Modify: `docs/remote-backups.md` for user documentation.
+- Modify: `docs/cli-reference.md` to link backup remote configuration.
+- Create: `docs/examples/remote-backup-transcode.voom`.
+- Create: `docs/examples/remote-backup-rclone.toml`.
+- Create: `docs/examples/remote-backup-s3.toml`.
+- Modify: `docs/examples/README.md` to list the new example.
+- Create: `docs/functional-test-plan-remote-backups.md`.
+- Create: `docs/plans/issue-207-adversarial-review.md`.
+
+### Task 1: Destination Config And Validation
+
+**Files:**
+- Create: `plugins/backup-manager/src/destination.rs`
+- Modify: `plugins/backup-manager/src/lib.rs`
+
+- [ ] **Step 1: Write failing config tests**
+
+Add tests in `plugins/backup-manager/src/destination.rs`:
+
+```rust
+#[test]
+fn rejects_duplicate_destination_names() {
+    let config = BackupDestinationsConfig {
+        destinations: vec![
+            BackupDestinationConfig::rclone("offsite", "b2:voom"),
+            BackupDestinationConfig::rclone("offsite", "s3:voom"),
+        ],
+        ..BackupDestinationsConfig::default()
+    };
+
+    let err = config.validate().unwrap_err();
+
+    assert!(err.to_string().contains("duplicate backup destination"));
+}
+
+#[test]
+fn rejects_rclone_destination_without_remote() {
+    let config = BackupDestinationsConfig {
+        destinations: vec![BackupDestinationConfig {
+            name: "offsite".to_string(),
+            kind: DestinationKind::Rclone,
+            remote: None,
+            bandwidth_limit: None,
+        }],
+        ..BackupDestinationsConfig::default()
+    };
+
+    let err = config.validate().unwrap_err();
+
+    assert!(err.to_string().contains("requires remote"));
+}
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```sh
+cargo test -p voom-backup-manager destination::tests::rejects_
+```
+
+Expected: fail because `destination` module and types do not exist.
+
+- [ ] **Step 3: Implement destination config**
+
+Create `destination.rs` with `DestinationKind`, `BackupDestinationConfig`,
+`BackupDestinationsConfig`, validation, and helper constructors for tests.
+Expose it from `lib.rs` with `pub mod destination;`.
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run:
+
+```sh
+cargo test -p voom-backup-manager destination::tests
+```
+
+Expected: all destination config tests pass.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add plugins/backup-manager/src/lib.rs plugins/backup-manager/src/destination.rs
+git commit -m "feat(backup): add remote destination config"
+```
+
+### Task 2: Upload Orchestration And Rclone Runner
+
+**Files:**
+- Modify: `plugins/backup-manager/src/backup.rs`
+- Modify: `plugins/backup-manager/src/destination.rs`
+- Modify: `plugins/backup-manager/src/lib.rs`
+
+- [ ] **Step 1: Write failing upload tests**
+
+Add tests that construct fake destination runners:
+
+```rust
+#[test]
+fn backup_file_uploads_to_all_remote_destinations() {
+    let dir = tempfile::tempdir().unwrap();
+    let source = dir.path().join("movie.mkv");
+    fs::write(&source, b"movie").unwrap();
+    let mut uploads = Vec::new();
+    let config = remote_test_config(dir.path());
+
+    let record = backup_file_with_destinations(
+        &config,
+        &source,
+        |_backup, _source| Ok(()),
+        |request| {
+            uploads.push((request.destination_name.to_string(), request.remote_path.clone()));
+            Ok(RemoteUploadReceipt { verified: true })
+        },
+    )
+    .unwrap();
+
+    assert_eq!(record.remote_backups.len(), 2);
+    assert_eq!(uploads.len(), 2);
+}
+
+#[test]
+fn remote_upload_failure_blocks_backup() {
+    let dir = tempfile::tempdir().unwrap();
+    let source = dir.path().join("movie.mkv");
+    fs::write(&source, b"movie").unwrap();
+    let config = remote_test_config(dir.path());
+
+    let err = backup_file_with_destinations(
+        &config,
+        &source,
+        |_backup, _source| Ok(()),
+        |_request| Err(plugin_err("offsite upload failed")),
+    )
+    .unwrap_err();
+
+    assert!(err.to_string().contains("offsite upload failed"));
+}
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```sh
+cargo test -p voom-backup-manager backup::tests::backup_file_uploads_to_all_remote_destinations backup::tests::remote_upload_failure_blocks_backup
+```
+
+Expected: fail because upload helpers do not exist.
+
+- [ ] **Step 3: Implement upload orchestration**
+
+Add `RemoteBackupRecord`, `RemoteUploadRequest`, `RemoteUploadReceipt`, and
+`backup_file_with_destinations`. Keep `backup_file` as a wrapper that passes
+the real rclone runner.
+
+- [ ] **Step 4: Add rclone command tests**
+
+Add tests in `destination.rs` for argv generation:
+
+```rust
+#[test]
+fn rclone_copyto_uses_argv_without_shell() {
+    let command = RcloneCommand::copyto(
+        "rclone",
+        Path::new("/tmp/movie.mkv"),
+        "b2:voom/backup.vbak",
+        Some("10M"),
+    );
+
+    assert_eq!(command.program, "rclone");
+    assert_eq!(command.args[0], "copyto");
+    assert!(command.args.contains(&"--bwlimit".to_string()));
+}
+```
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```sh
+cargo test -p voom-backup-manager
+```
+
+Expected: all backup-manager tests pass.
+
+- [ ] **Step 6: Commit**
+
+```sh
+git add plugins/backup-manager/src/lib.rs plugins/backup-manager/src/backup.rs plugins/backup-manager/src/destination.rs
+git commit -m "feat(backup): upload backups to rclone destinations"
+```
+
+### Task 3: Plugin Init And Event Metadata
+
+**Files:**
+- Modify: `plugins/backup-manager/src/lib.rs`
+
+- [ ] **Step 1: Write failing init tests**
+
+Add tests that initialize `BackupManagerPlugin` with JSON config containing
+destinations and verify `backup_file` uses the parsed config.
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```sh
+cargo test -p voom-backup-manager tests::test_init_parses_remote_destinations
+```
+
+Expected: fail because `init` does not parse config.
+
+- [ ] **Step 3: Implement init parsing**
+
+Derive `Deserialize` for backup config types, implement `Plugin::init`, validate
+destinations, and store parsed config on the plugin before registration.
+
+- [ ] **Step 4: Include remote metadata in event result**
+
+Update `PlanExecuting` result JSON to include destination names and paths, with
+no credential values.
+
+- [ ] **Step 5: Run tests**
+
+Run:
+
+```sh
+cargo test -p voom-backup-manager
+```
+
+Expected: all backup-manager tests pass.
+
+- [ ] **Step 6: Commit**
+
+```sh
+git add plugins/backup-manager/src/lib.rs plugins/backup-manager/src/destination.rs
+git commit -m "feat(backup): load remote destinations from config"
+```
+
+### Task 4: Docs, Examples, And Functional Test Plan
+
+**Files:**
+- Create: `docs/remote-backups.md`
+- Modify: `docs/cli-reference.md`
+- Create: `docs/examples/remote-backup-transcode.voom`
+- Create: `docs/examples/remote-backup-rclone.toml`
+- Create: `docs/examples/remote-backup-s3.toml`
+- Modify: `docs/examples/README.md`
+- Create: `docs/functional-test-plan-remote-backups.md`
+
+- [ ] **Step 1: Write docs and examples**
+
+Document config keys, rclone prerequisites, fake-rclone testing, failure
+behavior, credential handling, and current restore limitations.
+
+- [ ] **Step 2: Include generated-corpus functional plan**
+
+The test plan must use:
+
+```sh
+scripts/generate-test-corpus /tmp/voom-remote-backup-corpus --profile smoke --duration 1
+VOOM_CONFIG_HOME=/tmp/voom-remote-config cargo run -p voom-cli -- process \
+  /tmp/voom-remote-backup-corpus --policy docs/examples/remote-backup-transcode.voom --yes
+```
+
+It must configure fake rclone to copy into `/tmp/voom-remote-backup-target`.
+
+- [ ] **Step 3: Verify examples parse**
+
+Run:
+
+```sh
+cargo test -p voom-dsl --test examples
+```
+
+Expected: all example parser tests pass.
+
+- [ ] **Step 4: Commit**
+
+```sh
+git add docs/remote-backups.md docs/cli-reference.md docs/examples/remote-backup-transcode.voom docs/examples/remote-backup-rclone.toml docs/examples/remote-backup-s3.toml docs/examples/README.md docs/functional-test-plan-remote-backups.md
+git commit -m "docs(backup): document remote backup destinations"
+```
+
+### Task 5: Adversarial Review And Final Verification
+
+**Files:**
+- Create: `docs/plans/issue-207-adversarial-review.md`
+
+- [ ] **Step 1: Write adversarial review**
+
+Review the plan and resulting code against issue 207 acceptance criteria, with
+explicit notes for what is rclone-backed, what is not native protocol support,
+credential safety, failure blocking, and restore limitations.
+
+- [ ] **Step 2: Run final verification**
+
+Run:
+
+```sh
+cargo fmt --check
+cargo test -p voom-backup-manager
+cargo test -p voom-dsl --test examples
+cargo clippy -p voom-backup-manager --all-targets -- -D warnings
+```
+
+Expected: every command exits 0 with no warnings.
+
+- [ ] **Step 3: Commit review artifact**
+
+```sh
+git add docs/plans/issue-207-adversarial-review.md
+git commit -m "docs(backup): review remote backup implementation risks"
+```
+
+### Task 6: PR Process
+
+- [ ] Push branch:
+
+```sh
+git push -u origin feat/issue-207-remote-backups
+```
+
+- [ ] Open PR:
+
+```sh
+gh pr create --fill --base main --head feat/issue-207-remote-backups
+```
+
+- [ ] Watch checks:
+
+```sh
+gh pr checks --watch
+```
+
+- [ ] Address review feedback with additional small conventional commits.
+
+- [ ] Merge after approval and green checks:
+
+```sh
+gh pr merge --squash --delete-branch
+```

--- a/docs/superpowers/specs/2026-05-10-issue-207-remote-backups-design.md
+++ b/docs/superpowers/specs/2026-05-10-issue-207-remote-backups-design.md
@@ -1,0 +1,156 @@
+# Issue 207 Remote Backups Design
+
+**Goal:** Add remote backup destinations so destructive processing is blocked until
+configured offsite backups are uploaded and verified.
+
+**Issue:** https://github.com/randomparity/voom/issues/207
+
+## Scope
+
+This implementation ships rclone-backed remote destinations through the existing
+native `backup-manager` plugin. The existing local sibling/global backup remains
+the hot path and mandatory staging object. Remote destinations receive a copy of
+the original source file before executor plugins can mutate it.
+
+The feature supports these configured destination kinds:
+
+- `local`: existing filesystem backup behavior.
+- `rclone`: any rclone remote or local test target accepted by `rclone copyto`.
+- `s3`, `sftp`, `webdav`: typed aliases that use rclone remotes. Users configure
+  the provider in rclone and reference it from VOOM.
+
+Direct AWS SDK S3, native SFTP, native WebDAV, restic, persistent DB tracking,
+and cloud-cost retention rules are intentionally not part of this first
+implementation because they multiply credentials, protocol behavior, dependency
+surface, and schema work. The rclone path still covers the requested providers
+end-to-end while keeping one execution and verification model.
+
+## User Configuration
+
+Remote destinations live in `~/.config/voom/config.toml` under
+`[plugin.backup-manager]`:
+
+```toml
+[plugin.backup-manager]
+use_global_dir = true
+backup_dir = "/var/backups/voom"
+verify_after_upload = true
+block_on_remote_failure = true
+
+[[plugin.backup-manager.destinations]]
+name = "offsite"
+kind = "rclone"
+remote = "b2:voom-backups"
+bandwidth_limit = "10M"
+
+[[plugin.backup-manager.destinations]]
+name = "archive-s3"
+kind = "s3"
+remote = "aws-archive:voom-backups"
+```
+
+`block_on_remote_failure` defaults to `true`. When true, any failed upload or
+verification returns an error from `PlanExecuting`, so destructive executors do
+not receive `PlanCreated`. Credentials stay in rclone or environment-specific
+provider configuration; VOOM only logs destination names and remote paths.
+
+Policy files continue to opt into retained backups with:
+
+```voom
+config {
+  keep_backups: true
+}
+```
+
+The policy examples demonstrate destructive policies that rely on remote backup
+configuration but do not embed credentials or remote endpoints in `.voom` files.
+
+## Remote Path Layout
+
+For each backup record, `backup-manager` computes one backup UUID and local
+backup path. Remote destinations use deterministic object names:
+
+```text
+<remote>/<uuid>/<original-file-name>.vbak
+```
+
+The UUID avoids collisions across files with the same name. The sanitized file
+name keeps restore/list output understandable.
+
+## Upload And Verify Flow
+
+1. Reject symlink source files.
+2. Read source metadata and allocate one backup UUID.
+3. Create and verify the local `.vbak` staging backup.
+4. For each configured remote destination, upload the original source file to
+   the destination path before mutation.
+5. If `verify_after_upload` is true, verify uploaded byte size matches the
+   source size.
+6. Return the backup record only after all required destinations succeed.
+
+The rclone backend runs:
+
+```sh
+rclone copyto <source> <remote-path> --bwlimit <limit>
+rclone lsf --format s <remote-parent>
+```
+
+Verification fails if the expected object size is absent or differs from the
+source size. Tests use fake command runners instead of invoking real rclone.
+
+## Restore And Listing
+
+The existing `voom backup list`, `restore`, and `cleanup` commands keep their
+local `.vbak` behavior. The initial remote implementation adds metadata to the
+backup record and event results so future persistent listing can be built on the
+same model. Remote restore from persistent history is not exposed until backup
+records survive process exit.
+
+## Health Checks
+
+The plugin validates remote destination configuration during `init()`:
+
+- destination names are non-empty and unique,
+- destination kind is supported,
+- rclone-backed destinations include a remote,
+- bandwidth limits contain no shell metacharacter-sensitive behavior because
+  subprocess execution passes argv directly.
+
+Runtime connectivity is verified during upload. A later health-check extension
+can publish `HealthStatus` events without changing the destination model.
+
+## Test Strategy
+
+Unit tests cover configuration parsing, destination validation, local backup
+compatibility, rclone argument construction, upload failure blocking, size
+verification failure, multiple destinations, and credential redaction in error
+paths.
+
+Functional tests generate disposable media through `scripts/generate-test-corpus`
+and configure a fake rclone executable that copies to a local directory. This
+exercises real `voom process` backup dispatch without relying on cloud services.
+
+## Documentation And Examples
+
+User-facing docs go in `docs/remote-backups.md`, with `docs/cli-reference.md`
+linking from `voom backup`. Example policy and TOML files go under
+`docs/examples/`:
+
+- `remote-backup-transcode.voom`
+- `remote-backup-rclone.toml`
+- `remote-backup-s3.toml`
+
+## Adversarial Review Notes
+
+The riskiest failure mode is claiming S3/SFTP/WebDAV support without testing
+real cloud services. The implementation avoids protocol-specific promises by
+documenting them as rclone-backed providers and testing command construction,
+blocking behavior, and local fake-rclone end-to-end behavior.
+
+The second risk is leaking secrets. VOOM does not accept inline credential
+values for remote destinations in this implementation, and all errors mention
+only destination names plus sanitized remote paths.
+
+The third risk is false safety if remote uploads fail but local backups succeed.
+`block_on_remote_failure = true` is the default and is covered by tests that
+prove the backup operation returns an error before executor dispatch can happen.

--- a/plugins/backup-manager/src/backup.rs
+++ b/plugins/backup-manager/src/backup.rs
@@ -10,6 +10,10 @@ use chrono::Utc;
 use uuid::Uuid;
 use voom_domain::errors::Result;
 
+use crate::destination::{
+    remote_path_for, upload_with_rclone, RemoteBackupRecord, RemoteUploadReceipt,
+    RemoteUploadRequest,
+};
 use crate::{plugin_err, BackupConfig, BackupRecord};
 
 /// Create a backup of the given file.
@@ -20,6 +24,19 @@ pub fn backup_file(
     config: &BackupConfig,
     path: &Path,
     validate_space: impl FnOnce(&Path, &Path) -> Result<()>,
+) -> Result<BackupRecord> {
+    backup_file_with_destinations(config, path, validate_space, upload_with_rclone)
+}
+
+/// Create a backup and upload it to configured remote destinations.
+///
+/// The upload runner is injected so unit tests can verify behavior without
+/// invoking rclone.
+pub fn backup_file_with_destinations(
+    config: &BackupConfig,
+    path: &Path,
+    validate_space: impl FnOnce(&Path, &Path) -> Result<()>,
+    mut upload_remote: impl FnMut(RemoteUploadRequest<'_>) -> Result<RemoteUploadReceipt>,
 ) -> Result<BackupRecord> {
     // Reject symlinks to prevent following links to unintended targets
     let symlink_meta = fs::symlink_metadata(path)
@@ -52,12 +69,42 @@ pub fn backup_file(
         ))
     })?;
 
+    let mut remote_backups = Vec::new();
+    for destination in &config.destinations {
+        if !destination.kind.is_rclone_backed() {
+            continue;
+        }
+        let remote_path = remote_path_for(destination, backup_id, path)?;
+        let request = RemoteUploadRequest {
+            destination,
+            source_path: path,
+            remote_path: remote_path.clone(),
+            expected_size: metadata.len(),
+            rclone_path: &config.rclone_path,
+            verify_after_upload: config.verify_after_upload,
+        };
+        match upload_remote(request) {
+            Ok(receipt) => remote_backups.push(RemoteBackupRecord {
+                destination_name: destination.name.clone(),
+                remote_path,
+                verified: receipt.verified,
+            }),
+            Err(e) if config.block_on_remote_failure => return Err(e),
+            Err(e) => tracing::warn!(
+                destination = %destination.name,
+                error = %e,
+                "remote backup upload failed; continuing because block_on_remote_failure=false"
+            ),
+        }
+    }
+
     let record = BackupRecord {
         id: backup_id,
         original_path: path.to_path_buf(),
         backup_path,
         size: metadata.len(),
         created_at: Utc::now(),
+        remote_backups,
         retained: false,
     };
 
@@ -211,6 +258,8 @@ pub fn backup_path_for(config: &BackupConfig, path: &Path, unique_id: Uuid) -> P
 mod tests {
     use std::cell::RefCell;
 
+    use crate::destination::{BackupDestinationConfig, DestinationKind};
+
     use super::*;
 
     fn global_config(dir: &Path) -> BackupConfig {
@@ -218,6 +267,25 @@ mod tests {
             backup_dir: Some(dir.to_path_buf()),
             use_global_dir: true,
             min_free_space: 0,
+            verify_after_upload: true,
+            block_on_remote_failure: true,
+            rclone_path: "rclone".to_string(),
+            destinations: Vec::new(),
+        }
+    }
+
+    fn remote_test_config(dir: &Path) -> BackupConfig {
+        BackupConfig {
+            destinations: vec![
+                BackupDestinationConfig::rclone("offsite", "b2:voom"),
+                BackupDestinationConfig {
+                    name: "archive-s3".to_string(),
+                    kind: DestinationKind::S3,
+                    remote: Some("aws:voom".to_string()),
+                    bandwidth_limit: Some("10M".to_string()),
+                },
+            ],
+            ..global_config(dir)
         }
     }
 
@@ -261,6 +329,59 @@ mod tests {
 
         assert!(err.to_string().contains("no space"));
         assert!(fs::read_dir(backup_dir.path()).unwrap().next().is_none());
+    }
+
+    #[test]
+    fn backup_file_uploads_to_all_remote_destinations() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("movie.mkv");
+        fs::write(&source, b"movie").unwrap();
+        let config = remote_test_config(dir.path());
+        let uploads = RefCell::new(Vec::new());
+
+        let record = backup_file_with_destinations(
+            &config,
+            &source,
+            |_backup, _source| Ok(()),
+            |request| {
+                uploads.borrow_mut().push((
+                    request.destination.name.clone(),
+                    request.remote_path.clone(),
+                    request.source_path.to_path_buf(),
+                ));
+                Ok(RemoteUploadReceipt { verified: true })
+            },
+        )
+        .unwrap();
+
+        assert_eq!(record.remote_backups.len(), 2);
+        assert_eq!(uploads.borrow().len(), 2);
+        assert!(record
+            .remote_backups
+            .iter()
+            .any(|backup| backup.destination_name == "offsite"));
+        assert!(record
+            .remote_backups
+            .iter()
+            .any(|backup| backup.destination_name == "archive-s3"));
+    }
+
+    #[test]
+    fn remote_upload_failure_blocks_backup() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("movie.mkv");
+        fs::write(&source, b"movie").unwrap();
+        let config = remote_test_config(dir.path());
+
+        let err = backup_file_with_destinations(
+            &config,
+            &source,
+            |_backup, _source| Ok(()),
+            |_request| Err(plugin_err("offsite upload failed")),
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("offsite upload failed"));
     }
 
     #[test]

--- a/plugins/backup-manager/src/destination.rs
+++ b/plugins/backup-manager/src/destination.rs
@@ -1,8 +1,11 @@
 //! Remote backup destination configuration and command helpers.
 
 use std::collections::HashSet;
+use std::path::Path;
+use std::process::Command;
 
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 use voom_domain::errors::Result;
 
 use crate::plugin_err;
@@ -124,8 +127,160 @@ fn default_rclone_path() -> String {
     "rclone".to_string()
 }
 
+/// A remote backup location that received a copy of the source file.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RemoteBackupRecord {
+    pub destination_name: String,
+    pub remote_path: String,
+    pub verified: bool,
+}
+
+/// Input passed to a remote upload runner.
+#[derive(Debug, Clone)]
+pub struct RemoteUploadRequest<'a> {
+    pub destination: &'a BackupDestinationConfig,
+    pub source_path: &'a Path,
+    pub remote_path: String,
+    pub expected_size: u64,
+    pub rclone_path: &'a str,
+    pub verify_after_upload: bool,
+}
+
+/// Result returned by a remote upload runner.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RemoteUploadReceipt {
+    pub verified: bool,
+}
+
+/// Command description used for testable rclone argv construction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RcloneCommand {
+    pub program: String,
+    pub args: Vec<String>,
+}
+
+impl RcloneCommand {
+    #[must_use]
+    pub fn copyto(
+        program: impl Into<String>,
+        source: &Path,
+        remote_path: &str,
+        bandwidth_limit: Option<&str>,
+    ) -> Self {
+        let mut args = vec![
+            "copyto".to_string(),
+            source.display().to_string(),
+            remote_path.to_string(),
+        ];
+        if let Some(limit) = bandwidth_limit {
+            args.push("--bwlimit".to_string());
+            args.push(limit.to_string());
+        }
+        Self {
+            program: program.into(),
+            args,
+        }
+    }
+
+    #[must_use]
+    pub fn size(program: impl Into<String>, remote_path: &str) -> Self {
+        Self {
+            program: program.into(),
+            args: vec![
+                "size".to_string(),
+                "--json".to_string(),
+                remote_path.to_string(),
+            ],
+        }
+    }
+
+    fn run(&self) -> Result<Vec<u8>> {
+        let output = Command::new(&self.program)
+            .args(&self.args)
+            .output()
+            .map_err(|e| plugin_err(format!("failed to run {}: {e}", self.program)))?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(plugin_err(format!(
+                "{} failed with status {}: {}",
+                self.program,
+                output.status,
+                stderr.trim()
+            )));
+        }
+        Ok(output.stdout)
+    }
+}
+
+#[derive(Deserialize)]
+struct RcloneSizeOutput {
+    bytes: u64,
+}
+
+pub fn remote_path_for(
+    destination: &BackupDestinationConfig,
+    id: Uuid,
+    source: &Path,
+) -> Result<String> {
+    let remote = destination.remote.as_ref().ok_or_else(|| {
+        plugin_err(format!(
+            "backup destination '{}' requires remote",
+            destination.name
+        ))
+    })?;
+    let file_name = source.file_name().map_or_else(
+        || "unknown".to_string(),
+        |name| name.to_string_lossy().replace(['/', '\\', '\0'], "_"),
+    );
+    Ok(format!(
+        "{}/{id}/{file_name}.vbak",
+        remote.trim_end_matches('/')
+    ))
+}
+
+pub fn upload_with_rclone(request: RemoteUploadRequest<'_>) -> Result<RemoteUploadReceipt> {
+    let copy = RcloneCommand::copyto(
+        request.rclone_path,
+        request.source_path,
+        &request.remote_path,
+        request.destination.bandwidth_limit.as_deref(),
+    );
+    copy.run()?;
+
+    if request.verify_after_upload {
+        verify_remote_size(
+            request.rclone_path,
+            &request.remote_path,
+            request.expected_size,
+        )?;
+    }
+
+    Ok(RemoteUploadReceipt {
+        verified: request.verify_after_upload,
+    })
+}
+
+fn verify_remote_size(rclone_path: &str, remote_path: &str, expected_size: u64) -> Result<()> {
+    let command = RcloneCommand::size(rclone_path, remote_path);
+    let stdout = command.run()?;
+    let size: RcloneSizeOutput = serde_json::from_slice(&stdout).map_err(|e| {
+        plugin_err(format!(
+            "failed to parse rclone size output for {remote_path}: {e}"
+        ))
+    })?;
+    if size.bytes != expected_size {
+        return Err(plugin_err(format!(
+            "remote backup size mismatch for {remote_path}: expected {expected_size}, got {}",
+            size.bytes
+        )));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use super::*;
 
     #[test]
@@ -187,5 +342,34 @@ mod tests {
         };
 
         config.validate().unwrap();
+    }
+
+    #[test]
+    fn rclone_copyto_uses_argv_without_shell() {
+        let command = RcloneCommand::copyto(
+            "rclone",
+            Path::new("/tmp/movie.mkv"),
+            "b2:voom/backup.vbak",
+            Some("10M"),
+        );
+
+        assert_eq!(command.program, "rclone");
+        assert_eq!(command.args[0], "copyto");
+        assert_eq!(command.args[1], "/tmp/movie.mkv");
+        assert_eq!(command.args[2], "b2:voom/backup.vbak");
+        assert!(command.args.contains(&"--bwlimit".to_string()));
+    }
+
+    #[test]
+    fn remote_path_uses_uuid_and_sanitized_file_name() {
+        let destination = BackupDestinationConfig::rclone("offsite", "b2:voom/");
+        let id = Uuid::parse_str("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa").unwrap();
+
+        let path = remote_path_for(&destination, id, &PathBuf::from("Movie.mkv")).unwrap();
+
+        assert_eq!(
+            path,
+            "b2:voom/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/Movie.mkv.vbak"
+        );
     }
 }

--- a/plugins/backup-manager/src/destination.rs
+++ b/plugins/backup-manager/src/destination.rs
@@ -1,0 +1,191 @@
+//! Remote backup destination configuration and command helpers.
+
+use std::collections::HashSet;
+
+use serde::{Deserialize, Serialize};
+use voom_domain::errors::Result;
+
+use crate::plugin_err;
+
+/// Backup destination kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DestinationKind {
+    Local,
+    Rclone,
+    S3,
+    Sftp,
+    Webdav,
+}
+
+impl DestinationKind {
+    #[must_use]
+    pub fn is_rclone_backed(self) -> bool {
+        match self {
+            Self::Local => false,
+            Self::Rclone | Self::S3 | Self::Sftp | Self::Webdav => true,
+        }
+    }
+}
+
+/// One configured backup destination.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BackupDestinationConfig {
+    pub name: String,
+    #[serde(default = "default_destination_kind")]
+    pub kind: DestinationKind,
+    pub remote: Option<String>,
+    pub bandwidth_limit: Option<String>,
+}
+
+fn default_destination_kind() -> DestinationKind {
+    DestinationKind::Local
+}
+
+impl BackupDestinationConfig {
+    #[must_use]
+    pub fn rclone(name: impl Into<String>, remote: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            kind: DestinationKind::Rclone,
+            remote: Some(remote.into()),
+            bandwidth_limit: None,
+        }
+    }
+
+    fn validate(&self) -> Result<()> {
+        if self.name.trim().is_empty() {
+            return Err(plugin_err("backup destination name cannot be empty"));
+        }
+        if self.kind.is_rclone_backed()
+            && self
+                .remote
+                .as_ref()
+                .is_none_or(|remote| remote.trim().is_empty())
+        {
+            return Err(plugin_err(format!(
+                "backup destination '{}' requires remote",
+                self.name
+            )));
+        }
+        Ok(())
+    }
+}
+
+/// Shared backup destination options.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BackupDestinationsConfig {
+    #[serde(default = "default_verify_after_upload")]
+    pub verify_after_upload: bool,
+    #[serde(default = "default_block_on_remote_failure")]
+    pub block_on_remote_failure: bool,
+    #[serde(default = "default_rclone_path")]
+    pub rclone_path: String,
+    #[serde(default)]
+    pub destinations: Vec<BackupDestinationConfig>,
+}
+
+impl BackupDestinationsConfig {
+    pub fn validate(&self) -> Result<()> {
+        let mut names = HashSet::new();
+        for destination in &self.destinations {
+            destination.validate()?;
+            if !names.insert(destination.name.clone()) {
+                return Err(plugin_err(format!(
+                    "duplicate backup destination '{}'",
+                    destination.name
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Default for BackupDestinationsConfig {
+    fn default() -> Self {
+        Self {
+            verify_after_upload: default_verify_after_upload(),
+            block_on_remote_failure: default_block_on_remote_failure(),
+            rclone_path: default_rclone_path(),
+            destinations: Vec::new(),
+        }
+    }
+}
+
+fn default_verify_after_upload() -> bool {
+    true
+}
+
+fn default_block_on_remote_failure() -> bool {
+    true
+}
+
+fn default_rclone_path() -> String {
+    "rclone".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_duplicate_destination_names() {
+        let config = BackupDestinationsConfig {
+            destinations: vec![
+                BackupDestinationConfig::rclone("offsite", "b2:voom"),
+                BackupDestinationConfig::rclone("offsite", "s3:voom"),
+            ],
+            ..BackupDestinationsConfig::default()
+        };
+
+        let err = config.validate().unwrap_err();
+
+        assert!(err.to_string().contains("duplicate backup destination"));
+    }
+
+    #[test]
+    fn rejects_rclone_destination_without_remote() {
+        let config = BackupDestinationsConfig {
+            destinations: vec![BackupDestinationConfig {
+                name: "offsite".to_string(),
+                kind: DestinationKind::Rclone,
+                remote: None,
+                bandwidth_limit: None,
+            }],
+            ..BackupDestinationsConfig::default()
+        };
+
+        let err = config.validate().unwrap_err();
+
+        assert!(err.to_string().contains("requires remote"));
+    }
+
+    #[test]
+    fn accepts_typed_rclone_backed_destinations() {
+        let config = BackupDestinationsConfig {
+            destinations: vec![
+                BackupDestinationConfig {
+                    name: "archive-s3".to_string(),
+                    kind: DestinationKind::S3,
+                    remote: Some("aws:voom".to_string()),
+                    bandwidth_limit: None,
+                },
+                BackupDestinationConfig {
+                    name: "nas-sftp".to_string(),
+                    kind: DestinationKind::Sftp,
+                    remote: Some("vps:/srv/voom".to_string()),
+                    bandwidth_limit: Some("10M".to_string()),
+                },
+                BackupDestinationConfig {
+                    name: "webdav".to_string(),
+                    kind: DestinationKind::Webdav,
+                    remote: Some("dav:voom".to_string()),
+                    bandwidth_limit: None,
+                },
+            ],
+            ..BackupDestinationsConfig::default()
+        };
+
+        config.validate().unwrap();
+    }
+}

--- a/plugins/backup-manager/src/lib.rs
+++ b/plugins/backup-manager/src/lib.rs
@@ -24,7 +24,7 @@ use voom_domain::errors::{Result, VoomError};
 use voom_domain::events::{Event, EventResult};
 use voom_kernel::Plugin;
 
-use crate::destination::{BackupDestinationConfig, RemoteBackupRecord};
+use crate::destination::{BackupDestinationConfig, BackupDestinationsConfig, RemoteBackupRecord};
 
 /// Create a `VoomError::Plugin` for the backup-manager plugin.
 pub(crate) fn plugin_err(message: impl Into<String>) -> VoomError {
@@ -49,12 +49,14 @@ pub struct BackupRecord {
 /// Configuration for backup operations.
 #[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct BackupConfig {
     /// Directory to store backups. Used when `use_global_dir` is true.
     pub backup_dir: Option<PathBuf>,
     /// Whether to use a global backup directory or per-file sibling directory.
     pub use_global_dir: bool,
     /// Minimum free space (bytes) required before allowing execution.
+    #[serde(default = "default_min_free_space")]
     pub min_free_space: u64,
     /// Verify remote object size after upload.
     #[serde(default = "default_verify_after_upload")]
@@ -75,13 +77,29 @@ impl Default for BackupConfig {
         Self {
             backup_dir: None,
             use_global_dir: false,
-            min_free_space: 1024 * 1024 * 100, // 100 MB
+            min_free_space: default_min_free_space(),
             verify_after_upload: default_verify_after_upload(),
             block_on_remote_failure: default_block_on_remote_failure(),
             rclone_path: default_rclone_path(),
             destinations: Vec::new(),
         }
     }
+}
+
+impl BackupConfig {
+    pub fn validate(&self) -> Result<()> {
+        BackupDestinationsConfig {
+            verify_after_upload: self.verify_after_upload,
+            block_on_remote_failure: self.block_on_remote_failure,
+            rclone_path: self.rclone_path.clone(),
+            destinations: self.destinations.clone(),
+        }
+        .validate()
+    }
+}
+
+fn default_min_free_space() -> u64 {
+    1024 * 1024 * 100 // 100 MB
 }
 
 fn default_verify_after_upload() -> bool {
@@ -231,10 +249,6 @@ fn backup_result(data: serde_json::Value) -> EventResult {
 }
 
 impl Plugin for BackupManagerPlugin {
-    // NOTE: When config options are added to the plugin context for backup-manager,
-    // `ctx.parse_config::<BackupConfig>()` can be used in `init()` to ergonomically
-    // deserialize them (add Deserialize derive to BackupConfig first).
-
     fn name(&self) -> &'static str {
         "backup-manager"
     }
@@ -256,6 +270,13 @@ impl Plugin for BackupManagerPlugin {
             event_type,
             Event::PLAN_EXECUTING | Event::PLAN_COMPLETED | Event::PLAN_FAILED
         )
+    }
+
+    fn init(&mut self, ctx: &voom_kernel::PluginContext) -> Result<Vec<Event>> {
+        let config: BackupConfig = ctx.parse_config()?;
+        config.validate()?;
+        self.config = config;
+        Ok(Vec::new())
     }
 
     fn shutdown(&self) -> Result<()> {
@@ -292,12 +313,14 @@ impl Plugin for BackupManagerPlugin {
                     "Backing up file before plan execution"
                 );
 
-                self.backup_file(&evt.path)?;
+                let record = self.backup_file(&evt.path)?;
 
                 Ok(Some(backup_result(serde_json::json!({
                     "backed_up": true,
                     "path": evt.path,
                     "phase": evt.phase_name,
+                    "backup_path": record.backup_path,
+                    "remote_backups": record.remote_backups,
                 }))))
             }
             Event::PlanCompleted(evt) => {
@@ -387,6 +410,51 @@ mod tests {
         assert!(plugin.handles(Event::PLAN_FAILED));
         assert!(!plugin.handles(Event::FILE_DISCOVERED));
         assert!(!plugin.handles(Event::PLAN_CREATED));
+    }
+
+    #[test]
+    fn test_init_parses_remote_destinations() {
+        let mut plugin = BackupManagerPlugin::new();
+        let ctx = voom_kernel::PluginContext::new(
+            serde_json::json!({
+                "use_global_dir": true,
+                "backup_dir": "/tmp/voom-backups",
+                "min_free_space": 0,
+                "rclone_path": "fake-rclone",
+                "destinations": [
+                    {
+                        "name": "offsite",
+                        "kind": "rclone",
+                        "remote": "b2:voom",
+                        "bandwidth_limit": "10M"
+                    }
+                ]
+            }),
+            PathBuf::from("/tmp"),
+        );
+
+        plugin.init(&ctx).unwrap();
+
+        assert_eq!(plugin.config.rclone_path, "fake-rclone");
+        assert_eq!(plugin.config.destinations.len(), 1);
+        assert_eq!(plugin.config.destinations[0].name, "offsite");
+    }
+
+    #[test]
+    fn test_init_rejects_invalid_remote_destinations() {
+        let mut plugin = BackupManagerPlugin::new();
+        let ctx = voom_kernel::PluginContext::new(
+            serde_json::json!({
+                "destinations": [
+                    { "name": "offsite", "kind": "rclone" }
+                ]
+            }),
+            PathBuf::from("/tmp"),
+        );
+
+        let err = plugin.init(&ctx).unwrap_err();
+
+        assert!(err.to_string().contains("requires remote"));
     }
 
     #[test]
@@ -632,6 +700,33 @@ mod tests {
         assert_eq!(result.plugin_name, "backup-manager");
         assert!(!plugin.has_backup(&file_path).unwrap());
         assert!(!record.backup_path.exists());
+    }
+
+    #[test]
+    fn test_on_event_plan_executing_reports_remote_backup_metadata() {
+        use voom_domain::events::PlanExecutingEvent;
+
+        let dir = TempDir::new().unwrap();
+        let file_path = create_test_file(dir.path(), "movie.mkv", b"movie data");
+
+        let config = BackupConfig {
+            backup_dir: Some(dir.path().join("backups")),
+            use_global_dir: true,
+            min_free_space: 0,
+            ..BackupConfig::default()
+        };
+        let plugin = BackupManagerPlugin::from_config(config);
+        let event = Event::PlanExecuting(PlanExecutingEvent::new(
+            uuid::Uuid::new_v4(),
+            file_path,
+            "normalize",
+            1,
+        ));
+
+        let result = plugin.on_event(&event).unwrap().unwrap();
+        let data = result.data.unwrap();
+
+        assert_eq!(data["remote_backups"], serde_json::json!([]));
     }
 
     #[test]

--- a/plugins/backup-manager/src/lib.rs
+++ b/plugins/backup-manager/src/lib.rs
@@ -9,6 +9,7 @@
 //! - [`space`] — disk space validation via `statvfs`
 
 pub mod backup;
+pub mod destination;
 pub mod space;
 
 use std::collections::HashMap;

--- a/plugins/backup-manager/src/lib.rs
+++ b/plugins/backup-manager/src/lib.rs
@@ -17,11 +17,14 @@ use std::path::{Path, PathBuf};
 use std::sync::{Mutex, MutexGuard};
 
 use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 use voom_domain::capabilities::Capability;
 use voom_domain::errors::{Result, VoomError};
 use voom_domain::events::{Event, EventResult};
 use voom_kernel::Plugin;
+
+use crate::destination::{BackupDestinationConfig, RemoteBackupRecord};
 
 /// Create a `VoomError::Plugin` for the backup-manager plugin.
 pub(crate) fn plugin_err(message: impl Into<String>) -> VoomError {
@@ -37,6 +40,7 @@ pub struct BackupRecord {
     pub backup_path: PathBuf,
     pub size: u64,
     pub created_at: DateTime<Utc>,
+    pub remote_backups: Vec<RemoteBackupRecord>,
     /// Whether the backup was intentionally retained via `keep_backups`.
     /// Retained backups are not warned about at shutdown.
     pub retained: bool,
@@ -44,7 +48,7 @@ pub struct BackupRecord {
 
 /// Configuration for backup operations.
 #[non_exhaustive]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BackupConfig {
     /// Directory to store backups. Used when `use_global_dir` is true.
     pub backup_dir: Option<PathBuf>,
@@ -52,6 +56,18 @@ pub struct BackupConfig {
     pub use_global_dir: bool,
     /// Minimum free space (bytes) required before allowing execution.
     pub min_free_space: u64,
+    /// Verify remote object size after upload.
+    #[serde(default = "default_verify_after_upload")]
+    pub verify_after_upload: bool,
+    /// Whether remote upload failures block destructive operations.
+    #[serde(default = "default_block_on_remote_failure")]
+    pub block_on_remote_failure: bool,
+    /// Path to the rclone executable.
+    #[serde(default = "default_rclone_path")]
+    pub rclone_path: String,
+    /// Additional remote destinations.
+    #[serde(default)]
+    pub destinations: Vec<BackupDestinationConfig>,
 }
 
 impl Default for BackupConfig {
@@ -60,8 +76,24 @@ impl Default for BackupConfig {
             backup_dir: None,
             use_global_dir: false,
             min_free_space: 1024 * 1024 * 100, // 100 MB
+            verify_after_upload: default_verify_after_upload(),
+            block_on_remote_failure: default_block_on_remote_failure(),
+            rclone_path: default_rclone_path(),
+            destinations: Vec::new(),
         }
     }
+}
+
+fn default_verify_after_upload() -> bool {
+    true
+}
+
+fn default_block_on_remote_failure() -> bool {
+    true
+}
+
+fn default_rclone_path() -> String {
+    "rclone".to_string()
 }
 
 /// Plugin that manages file backups before plan execution.
@@ -375,6 +407,7 @@ mod tests {
             backup_dir: Some(PathBuf::from("/tmp/voom-backups")),
             use_global_dir: true,
             min_free_space: 0,
+            ..BackupConfig::default()
         };
         let plugin = BackupManagerPlugin::from_config(config);
         let path = Path::new("/media/movies/Movie.mkv");
@@ -394,6 +427,7 @@ mod tests {
             backup_dir: Some(dir.path().join("backups")),
             use_global_dir: true,
             min_free_space: 0,
+            ..BackupConfig::default()
         };
         let plugin = BackupManagerPlugin::from_config(config);
 
@@ -424,6 +458,7 @@ mod tests {
             backup_dir: Some(dir.path().join("backups")),
             use_global_dir: true,
             min_free_space: 0,
+            ..BackupConfig::default()
         };
         let plugin = BackupManagerPlugin::from_config(config);
 
@@ -446,6 +481,7 @@ mod tests {
             backup_dir: Some(dir.path().join("backups")),
             use_global_dir: true,
             min_free_space: 0,
+            ..BackupConfig::default()
         };
         let plugin = BackupManagerPlugin::from_config(config);
 
@@ -464,6 +500,7 @@ mod tests {
             backup_dir: Some(dir.path().join("backups")),
             use_global_dir: true,
             min_free_space: 0,
+            ..BackupConfig::default()
         };
         let plugin = BackupManagerPlugin::from_config(config);
 
@@ -484,6 +521,7 @@ mod tests {
             backup_dir: Some(dir.path().join("backups")),
             use_global_dir: true,
             min_free_space: 0,
+            ..BackupConfig::default()
         };
         let plugin = BackupManagerPlugin::from_config(config);
 
@@ -510,6 +548,7 @@ mod tests {
             backup_dir: Some(dir.path().join("backups")),
             use_global_dir: true,
             min_free_space: 0,
+            ..BackupConfig::default()
         };
         let plugin = BackupManagerPlugin::from_config(config);
 
@@ -569,6 +608,7 @@ mod tests {
             backup_dir: Some(dir.path().join("backups")),
             use_global_dir: true,
             min_free_space: 0,
+            ..BackupConfig::default()
         };
         let plugin = BackupManagerPlugin::from_config(config);
 
@@ -605,6 +645,7 @@ mod tests {
             backup_dir: Some(dir.path().join("backups")),
             use_global_dir: true,
             min_free_space: 0,
+            ..BackupConfig::default()
         };
         let plugin = BackupManagerPlugin::from_config(config);
 
@@ -642,6 +683,7 @@ mod tests {
             backup_dir: Some(dir.path().join("backups")),
             use_global_dir: true,
             min_free_space: 0,
+            ..BackupConfig::default()
         };
         let plugin = BackupManagerPlugin::from_config(config);
 
@@ -676,6 +718,7 @@ mod tests {
             backup_dir: Some(PathBuf::from("/tmp/voom-backups")),
             use_global_dir: true,
             min_free_space: 0,
+            ..BackupConfig::default()
         };
         let plugin = BackupManagerPlugin::from_config(config);
 


### PR DESCRIPTION
## Summary\n- add backup-manager destination config for rclone-backed remote backups\n- upload and size-verify remote backups before destructive executor dispatch\n- document remote backup setup with generated-corpus functional testing and example configs\n\n## Scope\nThis implements rclone-backed upload support for issue #207. S3, SFTP, and WebDAV are supported as typed rclone-backed destinations. The remaining issue #207 acceptance criteria are filed as follow-ups: #319, #320, #321, #322, #323, #324.\n\n## Verification\n- cargo fmt --check\n- cargo test -p voom-backup-manager\n- cargo test -p voom-dsl --test parser_snapshots\n- cargo clippy -p voom-backup-manager --all-targets -- -D warnings\n\nRefs #207