### PR TITLE
feat(backup): persist remote backup inventory

### DIFF
--- a/crates/voom-cli/src/cli.rs
+++ b/crates/voom-cli/src/cli.rs
@@ -618,8 +618,11 @@ pub enum BackupCommands {
     /// List backup files
     List {
         /// Directories to scan for backups
-        #[arg(required = true, num_args = 1..)]
+        #[arg(num_args = 0..)]
         paths: Vec<PathBuf>,
+        /// Remote destination inventory to list
+        #[arg(long)]
+        destination: Option<String>,
         /// Output format
         #[arg(short, long, default_value = "table")]
         format: OutputFormat,
@@ -2101,16 +2104,28 @@ mod tests {
     fn test_backup_list() {
         let cli = parse(&["voom", "backup", "list", "/media"]);
         match cli.command {
-            Commands::Backup(BackupCommands::List { paths, .. }) => {
+            Commands::Backup(BackupCommands::List {
+                paths, destination, ..
+            }) => {
                 assert_eq!(paths, vec![PathBuf::from("/media")]);
+                assert_eq!(destination, None);
             }
             _ => panic!("expected Backup List"),
         }
     }
 
     #[test]
-    fn test_backup_list_requires_path() {
-        assert!(try_parse(&["voom", "backup", "list"]).is_err());
+    fn test_backup_list_accepts_destination_without_path() {
+        let cli = parse(&["voom", "backup", "list", "--destination", "offsite"]);
+        match cli.command {
+            Commands::Backup(BackupCommands::List {
+                paths, destination, ..
+            }) => {
+                assert!(paths.is_empty());
+                assert_eq!(destination.as_deref(), Some("offsite"));
+            }
+            _ => panic!("expected Backup List"),
+        }
     }
 
     #[test]

--- a/crates/voom-cli/src/commands/backup.rs
+++ b/crates/voom-cli/src/commands/backup.rs
@@ -5,6 +5,7 @@ use console::style;
 use voom_domain::utils::format;
 
 use crate::cli::{BackupCommands, OutputFormat};
+use crate::config;
 use crate::output;
 
 /// A discovered `.vbak` file on disk.
@@ -16,13 +17,24 @@ struct VbakEntry {
 
 pub fn run(cmd: BackupCommands, global_yes: bool) -> Result<()> {
     match cmd {
-        BackupCommands::List { paths, format } => list(&paths, format),
+        BackupCommands::List {
+            paths,
+            destination,
+            format,
+        } => list(&paths, destination.as_deref(), format),
         BackupCommands::Restore { backup_path, yes } => restore(&backup_path, yes || global_yes),
         BackupCommands::Cleanup { paths, yes } => cleanup(&paths, yes || global_yes),
     }
 }
 
-fn list(roots: &[PathBuf], format: OutputFormat) -> Result<()> {
+fn list(roots: &[PathBuf], destination: Option<&str>, format: OutputFormat) -> Result<()> {
+    if let Some(destination) = destination {
+        return list_remote_inventory(destination, format);
+    }
+    if roots.is_empty() {
+        anyhow::bail!("backup list requires at least one path unless --destination is provided");
+    }
+
     let mut all_entries = Vec::new();
     for root in roots {
         let entries = scan_vbak_files(root)?;
@@ -80,6 +92,85 @@ fn list(roots: &[PathBuf], format: OutputFormat) -> Result<()> {
         OutputFormat::Plain | OutputFormat::Csv => {
             for entry in &entries {
                 println!("{}", entry.backup_path.display());
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn list_remote_inventory(destination: &str, format: OutputFormat) -> Result<()> {
+    let config = config::load_config()?;
+    let inventory = voom_backup_manager::inventory::RemoteBackupInventory::new(
+        voom_backup_manager::inventory::RemoteBackupInventory::default_path(&config.data_dir),
+    );
+    let entries = inventory
+        .list(Some(destination))
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    if entries.is_empty() {
+        if format.is_machine() {
+            if matches!(format, OutputFormat::Json) {
+                println!("[]");
+            }
+            return Ok(());
+        }
+        eprintln!(
+            "{}",
+            style(format!(
+                "No remote backups found for destination '{destination}'."
+            ))
+            .dim()
+        );
+        return Ok(());
+    }
+
+    match format {
+        OutputFormat::Json => {
+            let json: Vec<serde_json::Value> = entries
+                .iter()
+                .map(|e| {
+                    serde_json::json!({
+                        "backup_id": e.backup_id,
+                        "original_path": e.original_path.display().to_string(),
+                        "local_backup_path": e.local_backup_path.display().to_string(),
+                        "destination_name": e.destination_name,
+                        "remote_path": e.remote_path,
+                        "size": e.size,
+                        "uploaded_at": e.uploaded_at,
+                        "verified_at": e.verified_at,
+                        "status": e.status.as_str(),
+                    })
+                })
+                .collect();
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&json)
+                    .expect("serde_json::Value serialization cannot fail")
+            );
+        }
+        OutputFormat::Table => {
+            println!(
+                "{} remote backup(s) found for {}:\n",
+                style(entries.len()).bold(),
+                style(destination).bold()
+            );
+
+            let mut table = output::new_table();
+            table.set_header(vec!["Original", "Size", "Status", "Remote Path"]);
+            for entry in &entries {
+                table.add_row(vec![
+                    comfy_table::Cell::new(entry.original_path.display()),
+                    comfy_table::Cell::new(format::format_size(entry.size)),
+                    comfy_table::Cell::new(entry.status.as_str()),
+                    comfy_table::Cell::new(&entry.remote_path),
+                ]);
+            }
+            println!("{table}");
+        }
+        OutputFormat::Plain | OutputFormat::Csv => {
+            for entry in &entries {
+                println!("{}", entry.remote_path);
             }
         }
     }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -812,12 +812,13 @@ for rclone, S3, SFTP, and WebDAV examples.
 List backups (`.vbak` files) in one or more directories.
 
 ```
-voom backup list <PATH>... [OPTIONS]
+voom backup list [PATH]... [OPTIONS]
 ```
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `<PATH>...` | *required* | Directories to search for backups (one or more) |
+| `<PATH>...` | none | Directories to search for local `.vbak` files |
+| `--destination <DESTINATION>` | none | List persistent remote backup inventory for one destination |
 | `-f`, `--format <FORMAT>` | `table` | Output format: `table`, `json`, `plain`, or `csv` |
 
 #### `voom backup restore`
@@ -851,6 +852,7 @@ voom backup cleanup <PATH>... [OPTIONS]
 ```bash
 voom backup list /media/movies
 voom backup list /media/movies /media/tv --format json
+voom backup list --destination offsite
 voom backup restore /media/movies/film.mkv.vbak
 voom backup restore /media/movies/film.mkv.vbak --yes
 voom backup cleanup /media/movies --yes

--- a/docs/functional-test-plan-remote-backups.md
+++ b/docs/functional-test-plan-remote-backups.md
@@ -88,8 +88,24 @@ XDG_CONFIG_HOME=/tmp/voom-remote-config cargo run -p voom-cli -- process \
 ```
 
 Expected: processing succeeds, local `.vbak` files are retained because the
-policy sets `keep_backups: true`, and `/tmp/voom-remote-backup-target` contains
-remote backup copies under `fake_voom/<uuid>/`.
+policy sets `keep_backups: true`, `/tmp/voom-remote-backup-target` contains
+remote backup copies under `fake_voom/<uuid>/`, and the remote inventory file
+exists at:
+
+```text
+/tmp/voom-remote-config/voom/data/backup-manager/remote-backups.jsonl
+```
+
+List the remote inventory:
+
+```sh
+XDG_CONFIG_HOME=/tmp/voom-remote-config cargo run -p voom-cli -- backup list \
+  --destination fake-offsite \
+  --format json
+```
+
+Expected: JSON output contains at least one record with
+`"destination_name": "fake-offsite"` and `"status": "verified"`.
 
 ## Failure Blocks Destructive Work
 

--- a/docs/plans/issue-319-adversarial-review.md
+++ b/docs/plans/issue-319-adversarial-review.md
@@ -1,0 +1,40 @@
+# Issue 319 Remote Backup Inventory Adversarial Review
+
+## Scope Reviewed
+
+Implemented surface:
+
+- Remote backup records are persisted as JSONL under
+  `<data_dir>/backup-manager/remote-backups.jsonl`.
+- `backup-manager` appends one record per successful remote destination upload.
+- `voom backup list --destination <name>` reads the persistent inventory.
+- Existing local `.vbak` path listing still works.
+
+## Acceptance Criteria Review
+
+| Criterion | Status | Evidence / risk |
+|---|---|---|
+| Add persistent storage for remote backup records | Implemented | JSONL inventory survives process exit and is under VOOM `data_dir`. |
+| Add `voom backup list --destination <name>` | Implemented | CLI parser and command read inventory by destination. |
+| Preserve existing local `.vbak` listing behavior | Implemented | Existing path-based listing remains the default when `--destination` is absent. |
+| Tests for empty inventory, one destination, multiple destinations, and missing destination | Implemented | Inventory tests cover empty file, multiple records, destination filtering, and absent destination names. CLI parser tests cover destination usage. |
+| Update docs and CLI reference | Implemented | `docs/remote-backups.md`, `docs/cli-reference.md`, and the functional test plan were updated. |
+
+## Adversarial Findings
+
+1. JSONL is transparent and agent-friendly, but it is append-only. Cleanup and
+   restore issues must define how records become stale, restored, or deleted.
+
+2. `voom backup list --destination` filters inventory by destination name but
+   does not validate that the destination is still present in current config.
+   That preserves historical visibility but may surprise users after config
+   renames.
+
+3. There is no de-duplication if a process retries and uploads the same source
+   to the same destination more than once. That is acceptable because each
+   record has a unique backup UUID.
+
+4. The command-level behavior is covered mostly through parser and inventory
+   unit tests. A future integration test could run the CLI with isolated
+   `XDG_CONFIG_HOME` and a seeded inventory file, but the current behavior is
+   built on the tested inventory reader.

--- a/docs/remote-backups.md
+++ b/docs/remote-backups.md
@@ -49,6 +49,28 @@ Remote backup paths use this layout:
 The UUID prevents collisions when different source directories contain files
 with the same name.
 
+## Remote Inventory
+
+Every successful remote upload appends a JSONL record under the VOOM data
+directory:
+
+```text
+<data_dir>/backup-manager/remote-backups.jsonl
+```
+
+List records for one destination:
+
+```sh
+voom backup list --destination offsite
+voom backup list --destination offsite --format json
+```
+
+Local backup listing still scans `.vbak` files by path:
+
+```sh
+voom backup list /media/movies
+```
+
 ## S3, SFTP, And WebDAV
 
 Typed provider names document intent while keeping one execution model:
@@ -81,10 +103,8 @@ rclone lsd dav:
 
 ## Restore Status
 
-`voom backup list`, `voom backup restore`, and `voom backup cleanup` continue to
-operate on local `.vbak` files. Remote upload metadata is emitted in backup
-events during processing, but persistent remote listing and remote restore are
-not exposed as CLI commands yet.
+`voom backup restore` and `voom backup cleanup` continue to operate on local
+`.vbak` files. Remote restore is tracked separately in issue #320.
 
 ## Credential Safety
 

--- a/plugins/backup-manager/src/inventory.rs
+++ b/plugins/backup-manager/src/inventory.rs
@@ -19,6 +19,16 @@ pub enum RemoteBackupInventoryStatus {
     Verified,
 }
 
+impl RemoteBackupInventoryStatus {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Uploaded => "uploaded",
+            Self::Verified => "verified",
+        }
+    }
+}
+
 /// One persisted remote backup object.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RemoteBackupInventoryRecord {

--- a/plugins/backup-manager/src/inventory.rs
+++ b/plugins/backup-manager/src/inventory.rs
@@ -182,6 +182,20 @@ mod tests {
     }
 
     #[test]
+    fn list_missing_destination_returns_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let inventory = RemoteBackupInventory::new(dir.path().join("remote-backups.jsonl"));
+
+        inventory
+            .append(&record("offsite", "b2:voom/a.vbak"))
+            .unwrap();
+
+        let records = inventory.list(Some("missing")).unwrap();
+
+        assert!(records.is_empty());
+    }
+
+    #[test]
     fn missing_inventory_lists_empty() {
         let dir = tempfile::tempdir().unwrap();
         let inventory = RemoteBackupInventory::new(dir.path().join("missing.jsonl"));

--- a/plugins/backup-manager/src/inventory.rs
+++ b/plugins/backup-manager/src/inventory.rs
@@ -1,0 +1,183 @@
+//! Persistent remote backup inventory.
+
+use std::fs::{self, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use voom_domain::errors::Result;
+
+use crate::plugin_err;
+
+/// Persisted status for one remote backup object.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RemoteBackupInventoryStatus {
+    Uploaded,
+    Verified,
+}
+
+/// One persisted remote backup object.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RemoteBackupInventoryRecord {
+    pub backup_id: Uuid,
+    pub original_path: PathBuf,
+    pub local_backup_path: PathBuf,
+    pub destination_name: String,
+    pub remote_path: String,
+    pub size: u64,
+    pub uploaded_at: DateTime<Utc>,
+    pub verified_at: Option<DateTime<Utc>>,
+    pub status: RemoteBackupInventoryStatus,
+}
+
+/// JSONL inventory file for remote backup records.
+#[derive(Debug, Clone)]
+pub struct RemoteBackupInventory {
+    path: PathBuf,
+}
+
+impl RemoteBackupInventory {
+    #[must_use]
+    pub fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+
+    #[must_use]
+    pub fn default_path(data_dir: &Path) -> PathBuf {
+        data_dir.join("backup-manager").join("remote-backups.jsonl")
+    }
+
+    pub fn append(&self, record: &RemoteBackupInventoryRecord) -> Result<()> {
+        if let Some(parent) = self.path.parent() {
+            fs::create_dir_all(parent).map_err(|e| {
+                plugin_err(format!(
+                    "failed to create remote backup inventory directory {}: {e}",
+                    parent.display()
+                ))
+            })?;
+        }
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)
+            .map_err(|e| {
+                plugin_err(format!(
+                    "failed to open remote backup inventory {}: {e}",
+                    self.path.display()
+                ))
+            })?;
+        let json = serde_json::to_string(record)
+            .expect("RemoteBackupInventoryRecord serialization cannot fail");
+        writeln!(file, "{json}").map_err(|e| {
+            plugin_err(format!(
+                "failed to write remote backup inventory {}: {e}",
+                self.path.display()
+            ))
+        })?;
+        Ok(())
+    }
+
+    pub fn list(&self, destination: Option<&str>) -> Result<Vec<RemoteBackupInventoryRecord>> {
+        let file = match fs::File::open(&self.path) {
+            Ok(file) => file,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(e) => {
+                return Err(plugin_err(format!(
+                    "failed to open remote backup inventory {}: {e}",
+                    self.path.display()
+                )));
+            }
+        };
+
+        let mut records = Vec::new();
+        for line in BufReader::new(file).lines() {
+            let line = line.map_err(|e| {
+                plugin_err(format!(
+                    "failed to read remote backup inventory {}: {e}",
+                    self.path.display()
+                ))
+            })?;
+            let record: RemoteBackupInventoryRecord = serde_json::from_str(&line).map_err(|e| {
+                plugin_err(format!(
+                    "failed to parse remote backup inventory {}: {e}",
+                    self.path.display()
+                ))
+            })?;
+            if destination.is_none_or(|name| record.destination_name == name) {
+                records.push(record);
+            }
+        }
+        Ok(records)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use chrono::Utc;
+
+    use super::*;
+
+    fn record(destination_name: &str, remote_path: &str) -> RemoteBackupInventoryRecord {
+        RemoteBackupInventoryRecord {
+            backup_id: uuid::Uuid::new_v4(),
+            original_path: PathBuf::from("/media/movie.mkv"),
+            local_backup_path: PathBuf::from("/backups/movie.mkv.vbak"),
+            destination_name: destination_name.to_string(),
+            remote_path: remote_path.to_string(),
+            size: 42,
+            uploaded_at: Utc::now(),
+            verified_at: Some(Utc::now()),
+            status: RemoteBackupInventoryStatus::Verified,
+        }
+    }
+
+    #[test]
+    fn append_and_list_inventory_records() {
+        let dir = tempfile::tempdir().unwrap();
+        let inventory = RemoteBackupInventory::new(dir.path().join("remote-backups.jsonl"));
+
+        inventory
+            .append(&record("offsite", "b2:voom/a.vbak"))
+            .unwrap();
+        inventory
+            .append(&record("archive", "s3:voom/b.vbak"))
+            .unwrap();
+
+        let records = inventory.list(None).unwrap();
+
+        assert_eq!(records.len(), 2);
+    }
+
+    #[test]
+    fn list_filters_by_destination() {
+        let dir = tempfile::tempdir().unwrap();
+        let inventory = RemoteBackupInventory::new(dir.path().join("remote-backups.jsonl"));
+
+        inventory
+            .append(&record("offsite", "b2:voom/a.vbak"))
+            .unwrap();
+        inventory
+            .append(&record("archive", "s3:voom/b.vbak"))
+            .unwrap();
+
+        let records = inventory.list(Some("archive")).unwrap();
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].destination_name, "archive");
+    }
+
+    #[test]
+    fn missing_inventory_lists_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let inventory = RemoteBackupInventory::new(dir.path().join("missing.jsonl"));
+
+        let records = inventory.list(Some("offsite")).unwrap();
+
+        assert!(records.is_empty());
+    }
+}

--- a/plugins/backup-manager/src/lib.rs
+++ b/plugins/backup-manager/src/lib.rs
@@ -10,6 +10,7 @@
 
 pub mod backup;
 pub mod destination;
+pub mod inventory;
 pub mod space;
 
 use std::collections::HashMap;
@@ -25,6 +26,9 @@ use voom_domain::events::{Event, EventResult};
 use voom_kernel::Plugin;
 
 use crate::destination::{BackupDestinationConfig, BackupDestinationsConfig, RemoteBackupRecord};
+use crate::inventory::{
+    RemoteBackupInventory, RemoteBackupInventoryRecord, RemoteBackupInventoryStatus,
+};
 
 /// Create a `VoomError::Plugin` for the backup-manager plugin.
 pub(crate) fn plugin_err(message: impl Into<String>) -> VoomError {
@@ -124,6 +128,7 @@ pub struct BackupManagerPlugin {
     config: BackupConfig,
     /// Active backup records indexed by original path.
     records: Mutex<HashMap<PathBuf, BackupRecord>>,
+    inventory: Option<RemoteBackupInventory>,
 }
 
 impl BackupManagerPlugin {
@@ -133,6 +138,7 @@ impl BackupManagerPlugin {
             capabilities: vec![Capability::Backup],
             config: BackupConfig::default(),
             records: Mutex::new(HashMap::new()),
+            inventory: None,
         }
     }
 
@@ -142,7 +148,19 @@ impl BackupManagerPlugin {
             capabilities: vec![Capability::Backup],
             config,
             records: Mutex::new(HashMap::new()),
+            inventory: None,
         }
+    }
+
+    #[must_use]
+    pub fn with_inventory_path(mut self, path: PathBuf) -> Self {
+        self.inventory = Some(RemoteBackupInventory::new(path));
+        self
+    }
+
+    #[must_use]
+    pub fn remote_inventory(&self) -> Option<&RemoteBackupInventory> {
+        self.inventory.as_ref()
     }
 
     fn records(&self) -> Result<MutexGuard<'_, HashMap<PathBuf, BackupRecord>>> {
@@ -162,7 +180,34 @@ impl BackupManagerPlugin {
         let mut records = self.records()?;
         records.insert(path.to_path_buf(), record.clone());
 
+        self.persist_remote_inventory(&record)?;
+
         Ok(record)
+    }
+
+    fn persist_remote_inventory(&self, record: &BackupRecord) -> Result<()> {
+        let Some(inventory) = &self.inventory else {
+            return Ok(());
+        };
+        for remote in &record.remote_backups {
+            let now = Utc::now();
+            inventory.append(&RemoteBackupInventoryRecord {
+                backup_id: record.id,
+                original_path: record.original_path.clone(),
+                local_backup_path: record.backup_path.clone(),
+                destination_name: remote.destination_name.clone(),
+                remote_path: remote.remote_path.clone(),
+                size: record.size,
+                uploaded_at: now,
+                verified_at: remote.verified.then_some(now),
+                status: if remote.verified {
+                    RemoteBackupInventoryStatus::Verified
+                } else {
+                    RemoteBackupInventoryStatus::Uploaded
+                },
+            })?;
+        }
+        Ok(())
     }
 
     /// Restore a file from its backup.
@@ -276,6 +321,9 @@ impl Plugin for BackupManagerPlugin {
         let config: BackupConfig = ctx.parse_config()?;
         config.validate()?;
         self.config = config;
+        self.inventory = Some(RemoteBackupInventory::new(
+            RemoteBackupInventory::default_path(&ctx.data_dir),
+        ));
         Ok(Vec::new())
     }
 
@@ -385,6 +433,7 @@ mod tests {
     use super::*;
     use std::fs;
     use std::io::Write;
+    use std::os::unix::fs::PermissionsExt;
     use tempfile::TempDir;
 
     fn create_test_file(dir: &Path, name: &str, content: &[u8]) -> PathBuf {
@@ -392,6 +441,12 @@ mod tests {
         let mut f = fs::File::create(&path).unwrap();
         f.write_all(content).unwrap();
         path
+    }
+
+    fn make_executable(path: &Path) {
+        let mut permissions = fs::metadata(path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(path, permissions).unwrap();
     }
 
     #[test]
@@ -727,6 +782,69 @@ mod tests {
         let data = result.data.unwrap();
 
         assert_eq!(data["remote_backups"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn test_backup_file_persists_remote_inventory_records() {
+        let dir = TempDir::new().unwrap();
+        let file_path = create_test_file(dir.path(), "movie.mkv", b"movie data");
+        let rclone_path = dir.path().join("fake-rclone");
+        let target_dir = dir.path().join("remote");
+        fs::write(
+            &rclone_path,
+            format!(
+                "#!/usr/bin/env bash\n\
+                 set -euo pipefail\n\
+                 cmd=\"$1\"\n\
+                 shift\n\
+                 case \"$cmd\" in\n\
+                   copyto)\n\
+                     target=\"{}/$2\"\n\
+                     mkdir -p \"$(dirname \"$target\")\"\n\
+                     cp \"$1\" \"$target\"\n\
+                     ;;\n\
+                   size)\n\
+                     shift\n\
+                     target=\"{}/$1\"\n\
+                     bytes=\"$(wc -c < \"$target\" | tr -d ' ')\"\n\
+                     printf '{{\"bytes\":%s,\"count\":1}}\\n' \"$bytes\"\n\
+                     ;;\n\
+                 esac\n",
+                target_dir.display(),
+                target_dir.display(),
+            ),
+        )
+        .unwrap();
+        make_executable(&rclone_path);
+        let inventory_path = dir.path().join("inventory.jsonl");
+
+        let config = BackupConfig {
+            backup_dir: Some(dir.path().join("backups")),
+            use_global_dir: true,
+            min_free_space: 0,
+            rclone_path: rclone_path.display().to_string(),
+            destinations: vec![crate::destination::BackupDestinationConfig::rclone(
+                "offsite",
+                "fake:voom",
+            )],
+            ..BackupConfig::default()
+        };
+        let plugin = BackupManagerPlugin::from_config(config).with_inventory_path(inventory_path);
+
+        plugin.backup_file(&file_path).unwrap();
+
+        let records = plugin
+            .remote_inventory()
+            .unwrap()
+            .list(Some("offsite"))
+            .unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].original_path, file_path);
+        assert_eq!(records[0].destination_name, "offsite");
+        assert_eq!(
+            records[0].status,
+            crate::inventory::RemoteBackupInventoryStatus::Verified
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary\n- persist remote backup upload records as JSONL under the VOOM data directory\n- add `voom backup list --destination <name>` for remote inventory listing\n- update remote-backup docs, CLI reference, functional test plan, and adversarial review\n\n## Verification\n- cargo fmt --check\n- cargo test -p voom-backup-manager\n- cargo test -p voom-cli cli::tests::test_backup\n- cargo clippy -p voom-backup-manager -p voom-cli --all-targets -- -D warnings\n\nCloses #319