### PR TITLE
feat(backup): restore from remote destinations

### DIFF
--- a/crates/voom-cli/src/cli.rs
+++ b/crates/voom-cli/src/cli.rs
@@ -631,6 +631,12 @@ pub enum BackupCommands {
     Restore {
         /// Path to the .vbak backup file
         backup_path: PathBuf,
+        /// Restore from a remote destination inventory instead of a local .vbak
+        #[arg(long = "from")]
+        from: Option<String>,
+        /// Write restored content to this path instead of replacing the source path
+        #[arg(long)]
+        output: Option<PathBuf>,
         /// Skip confirmation prompt
         #[arg(long)]
         yes: bool,
@@ -2132,7 +2138,9 @@ mod tests {
     fn test_backup_restore() {
         let cli = parse(&["voom", "backup", "restore", "/path/to/file.vbak"]);
         match cli.command {
-            Commands::Backup(BackupCommands::Restore { backup_path, yes }) => {
+            Commands::Backup(BackupCommands::Restore {
+                backup_path, yes, ..
+            }) => {
                 assert_eq!(backup_path, PathBuf::from("/path/to/file.vbak"));
                 assert!(!yes);
             }
@@ -2146,6 +2154,51 @@ mod tests {
         match cli.command {
             Commands::Backup(BackupCommands::Restore { yes, .. }) => {
                 assert!(yes);
+            }
+            _ => panic!("expected Backup Restore"),
+        }
+    }
+
+    #[test]
+    fn test_backup_restore_from_destination() {
+        let cli = parse(&[
+            "voom",
+            "backup",
+            "restore",
+            "/media/movie.mkv",
+            "--from",
+            "offsite",
+        ]);
+        match cli.command {
+            Commands::Backup(BackupCommands::Restore {
+                backup_path,
+                from,
+                output,
+                ..
+            }) => {
+                assert_eq!(backup_path, PathBuf::from("/media/movie.mkv"));
+                assert_eq!(from.as_deref(), Some("offsite"));
+                assert_eq!(output, None);
+            }
+            _ => panic!("expected Backup Restore"),
+        }
+    }
+
+    #[test]
+    fn test_backup_restore_from_destination_with_output() {
+        let cli = parse(&[
+            "voom",
+            "backup",
+            "restore",
+            "/media/movie.mkv",
+            "--from",
+            "offsite",
+            "--output",
+            "/restore/movie.mkv",
+        ]);
+        match cli.command {
+            Commands::Backup(BackupCommands::Restore { output, .. }) => {
+                assert_eq!(output, Some(PathBuf::from("/restore/movie.mkv")));
             }
             _ => panic!("expected Backup Restore"),
         }

--- a/crates/voom-cli/src/commands/backup.rs
+++ b/crates/voom-cli/src/commands/backup.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use console::style;
+use voom_backup_manager::inventory::{RemoteBackupInventory, RemoteBackupInventoryRecord};
 use voom_domain::utils::format;
 
 use crate::cli::{BackupCommands, OutputFormat};
@@ -22,7 +23,17 @@ pub fn run(cmd: BackupCommands, global_yes: bool) -> Result<()> {
             destination,
             format,
         } => list(&paths, destination.as_deref(), format),
-        BackupCommands::Restore { backup_path, yes } => restore(&backup_path, yes || global_yes),
+        BackupCommands::Restore {
+            backup_path,
+            from,
+            output,
+            yes,
+        } => restore(
+            &backup_path,
+            from.as_deref(),
+            output.as_deref(),
+            yes || global_yes,
+        ),
         BackupCommands::Cleanup { paths, yes } => cleanup(&paths, yes || global_yes),
     }
 }
@@ -178,7 +189,14 @@ fn list_remote_inventory(destination: &str, format: OutputFormat) -> Result<()> 
     Ok(())
 }
 
-fn restore(backup_path: &Path, yes: bool) -> Result<()> {
+fn restore(backup_path: &Path, from: Option<&str>, output: Option<&Path>, yes: bool) -> Result<()> {
+    if let Some(destination) = from {
+        return restore_remote(backup_path, destination, output, yes);
+    }
+    if output.is_some() {
+        anyhow::bail!("--output requires --from for remote restore");
+    }
+
     let original_name = derive_original_name(backup_path).ok_or_else(|| {
         anyhow::anyhow!(
             "Cannot derive original filename from: {}. \
@@ -211,6 +229,114 @@ fn restore(backup_path: &Path, yes: bool) -> Result<()> {
     );
 
     Ok(())
+}
+
+fn restore_remote(
+    original_path: &Path,
+    destination: &str,
+    output: Option<&Path>,
+    yes: bool,
+) -> Result<()> {
+    let app_config = config::load_config()?;
+    let backup_config = backup_config_from_app_config(&app_config)?;
+    if !backup_config
+        .destinations
+        .iter()
+        .any(|configured| configured.name == destination)
+    {
+        anyhow::bail!("backup destination '{destination}' is not configured");
+    }
+
+    let inventory =
+        RemoteBackupInventory::new(RemoteBackupInventory::default_path(&app_config.data_dir));
+    let records = inventory
+        .list(Some(destination))
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    let record = select_remote_restore_record(&records, original_path, destination)?;
+    let output_path = output.unwrap_or(original_path);
+
+    let prompt = format!(
+        "Restore remote backup {} to {}?",
+        style(&record.remote_path).cyan(),
+        style(output_path.display()).cyan()
+    );
+    if !output::confirm(&prompt, yes)? {
+        println!("{}", style("Aborted.").dim());
+        return Ok(());
+    }
+
+    let temp_path = temporary_restore_path(output_path)?;
+    voom_backup_manager::destination::download_with_rclone(
+        &backup_config.rclone_path,
+        &record.remote_path,
+        &temp_path,
+        record.size,
+    )
+    .map_err(|e| anyhow::anyhow!("{e}"))?;
+    std::fs::rename(&temp_path, output_path).map_err(|e| {
+        anyhow::anyhow!(
+            "failed to move restored backup {} to {}: {e}",
+            temp_path.display(),
+            output_path.display()
+        )
+    })?;
+
+    println!(
+        "{} Restored remote backup to {}",
+        style("OK").bold().green(),
+        style(output_path.display()).cyan()
+    );
+
+    Ok(())
+}
+
+fn backup_config_from_app_config(
+    config: &config::AppConfig,
+) -> Result<voom_backup_manager::BackupConfig> {
+    let value = config.plugin.get("backup-manager").map_or_else(
+        || serde_json::json!({}),
+        |table| serde_json::to_value(table).unwrap_or_else(|_| serde_json::json!({})),
+    );
+    let backup_config: voom_backup_manager::BackupConfig = serde_json::from_value(value)?;
+    backup_config
+        .validate()
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    Ok(backup_config)
+}
+
+fn temporary_restore_path(output_path: &Path) -> Result<PathBuf> {
+    let parent = output_path.parent().unwrap_or(Path::new("."));
+    let file_name = output_path
+        .file_name()
+        .ok_or_else(|| anyhow::anyhow!("restore output path has no file name"))?
+        .to_string_lossy();
+    Ok(parent.join(format!(".{file_name}.voom-restore.tmp")))
+}
+
+fn select_remote_restore_record<'a>(
+    records: &'a [RemoteBackupInventoryRecord],
+    original_path: &Path,
+    destination: &str,
+) -> Result<&'a RemoteBackupInventoryRecord> {
+    let matches: Vec<&RemoteBackupInventoryRecord> = records
+        .iter()
+        .filter(|record| {
+            record.destination_name == destination && record.original_path == original_path
+        })
+        .collect();
+    match matches.as_slice() {
+        [record] => Ok(*record),
+        [] => anyhow::bail!(
+            "no remote backup found for {} on destination '{}'",
+            original_path.display(),
+            destination
+        ),
+        _ => anyhow::bail!(
+            "multiple remote backups found for {} on destination '{}'; restore is ambiguous",
+            original_path.display(),
+            destination
+        ),
+    }
 }
 
 fn cleanup(roots: &[PathBuf], yes: bool) -> Result<()> {
@@ -382,6 +508,21 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::TempDir;
+    use voom_backup_manager::inventory::RemoteBackupInventoryStatus;
+
+    fn remote_record(original_path: &Path, destination: &str) -> RemoteBackupInventoryRecord {
+        RemoteBackupInventoryRecord {
+            backup_id: uuid::Uuid::new_v4(),
+            original_path: original_path.to_path_buf(),
+            local_backup_path: PathBuf::from("/backups/movie.vbak"),
+            destination_name: destination.to_string(),
+            remote_path: format!("{destination}:voom/movie.vbak"),
+            size: 5,
+            uploaded_at: chrono::Utc::now(),
+            verified_at: Some(chrono::Utc::now()),
+            status: RemoteBackupInventoryStatus::Verified,
+        }
+    }
 
     #[test]
     fn test_derive_original_name_valid() {
@@ -462,5 +603,42 @@ mod tests {
 
         let entries = scan_vbak_files(dir.path()).unwrap();
         assert_eq!(entries.len(), 2);
+    }
+
+    #[test]
+    fn select_remote_restore_record_finds_unique_match() {
+        let original = Path::new("/media/movie.mkv");
+        let records = vec![
+            remote_record(original, "offsite"),
+            remote_record(Path::new("/media/other.mkv"), "offsite"),
+        ];
+
+        let selected = select_remote_restore_record(&records, original, "offsite").unwrap();
+
+        assert_eq!(selected.original_path, original);
+        assert_eq!(selected.destination_name, "offsite");
+    }
+
+    #[test]
+    fn select_remote_restore_record_rejects_missing_match() {
+        let original = Path::new("/media/movie.mkv");
+        let records = vec![remote_record(original, "offsite")];
+
+        let err = select_remote_restore_record(&records, original, "archive").unwrap_err();
+
+        assert!(err.to_string().contains("no remote backup found"));
+    }
+
+    #[test]
+    fn select_remote_restore_record_rejects_ambiguous_match() {
+        let original = Path::new("/media/movie.mkv");
+        let records = vec![
+            remote_record(original, "offsite"),
+            remote_record(original, "offsite"),
+        ];
+
+        let err = select_remote_restore_record(&records, original, "offsite").unwrap_err();
+
+        assert!(err.to_string().contains("ambiguous"));
     }
 }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -826,12 +826,14 @@ voom backup list [PATH]... [OPTIONS]
 Restore a file from a `.vbak` backup.
 
 ```
-voom backup restore <BACKUP_PATH> [OPTIONS]
+voom backup restore <BACKUP_PATH_OR_FILE_PATH> [OPTIONS]
 ```
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `<BACKUP_PATH>` | *required* | Path to the `.vbak` file to restore |
+| `<BACKUP_PATH_OR_FILE_PATH>` | *required* | Local `.vbak` path, or original file path when `--from` is provided |
+| `--from <DESTINATION>` | none | Restore from remote backup inventory for the named destination |
+| `--output <PATH>` | none | Write remote restore to this path instead of replacing the original path |
 | `--yes` | `false` | Skip confirmation prompt |
 
 #### `voom backup cleanup`
@@ -855,6 +857,8 @@ voom backup list /media/movies /media/tv --format json
 voom backup list --destination offsite
 voom backup restore /media/movies/film.mkv.vbak
 voom backup restore /media/movies/film.mkv.vbak --yes
+voom backup restore /media/movies/film.mkv --from offsite
+voom backup restore /media/movies/film.mkv --from offsite --output /tmp/film.mkv
 voom backup cleanup /media/movies --yes
 ```
 

--- a/docs/functional-test-plan-remote-backups.md
+++ b/docs/functional-test-plan-remote-backups.md
@@ -107,6 +107,20 @@ XDG_CONFIG_HOME=/tmp/voom-remote-config cargo run -p voom-cli -- backup list \
 Expected: JSON output contains at least one record with
 `"destination_name": "fake-offsite"` and `"status": "verified"`.
 
+Restore to an explicit output path:
+
+```sh
+first_file="/tmp/voom-remote-backup-corpus/$(jq -r '.generated[0].filename' /tmp/voom-remote-backup-corpus/manifest.json)"
+XDG_CONFIG_HOME=/tmp/voom-remote-config cargo run -p voom-cli -- backup restore \
+  "$first_file" \
+  --from fake-offsite \
+  --output /tmp/voom-remote-restored.mkv \
+  --yes
+```
+
+Expected: `/tmp/voom-remote-restored.mkv` exists and has the same byte size as
+the inventory record selected for `fake-offsite`.
+
 ## Failure Blocks Destructive Work
 
 ```sh

--- a/docs/plans/issue-320-adversarial-review.md
+++ b/docs/plans/issue-320-adversarial-review.md
@@ -1,0 +1,43 @@
+# Issue 320 Remote Restore Adversarial Review
+
+## Scope Reviewed
+
+Implemented surface:
+
+- `voom backup restore <file-path> --from <destination>` restores from remote
+  inventory.
+- `--output <path>` downloads to a separate path instead of replacing the
+  original path.
+- Restore checks current backup destination config, selects exactly one
+  inventory record, verifies remote size through rclone, downloads to a
+  same-directory temporary path, verifies local size, then renames into place.
+- Ambiguous and missing inventory matches return clear errors.
+
+## Acceptance Criteria Review
+
+| Criterion | Status | Evidence / risk |
+|---|---|---|
+| Add `voom backup restore <file-path> --from <destination>` | Implemented | CLI parser tests and restore command branch. |
+| Download to original path or explicit output path | Implemented | `--output` parser test and restore path handling. |
+| Verify downloaded size before replacing content | Implemented | `download_with_rclone` checks remote size and downloaded local size before rename. |
+| Refuse ambiguous restore requests | Implemented | `select_remote_restore_record_rejects_ambiguous_match`. |
+| Test with fake rclone and generated corpus fixtures | Partial | Fake-rclone unit test covers download behavior. The generated-corpus workflow is documented for functional execution. |
+| Document remote restore usage | Implemented | `docs/remote-backups.md`, CLI reference, and functional test plan updated. |
+
+## Adversarial Findings
+
+1. Restore selection intentionally fails when more than one inventory record
+   matches an original path and destination. This prevents silent recovery of
+   the wrong generation, but users need future tooling to choose a specific
+   backup ID.
+
+2. The implementation verifies byte size, not cryptographic hash. Issue #321
+   covers deeper remote verification.
+
+3. The temporary restore path lives beside the output path. That keeps rename
+   atomic on the same filesystem, but it requires write permission in the target
+   directory before restore can proceed.
+
+4. Remote restore depends on the destination still being present in current
+   config. Historical inventory alone is not enough to restore from a removed
+   destination.

--- a/docs/remote-backups.md
+++ b/docs/remote-backups.md
@@ -65,6 +65,23 @@ voom backup list --destination offsite
 voom backup list --destination offsite --format json
 ```
 
+Restore a remote backup from one destination:
+
+```sh
+voom backup restore /media/movies/film.mkv --from offsite
+```
+
+Download without replacing the original:
+
+```sh
+voom backup restore /media/movies/film.mkv --from offsite --output /tmp/film-restored.mkv
+```
+
+Remote restore refuses ambiguous requests when more than one inventory record
+matches the same original path and destination. Use a local `.vbak` restore or
+prune/adjust the inventory when you need to recover a specific historical
+version.
+
 Local backup listing still scans `.vbak` files by path:
 
 ```sh
@@ -103,8 +120,8 @@ rclone lsd dav:
 
 ## Restore Status
 
-`voom backup restore` and `voom backup cleanup` continue to operate on local
-`.vbak` files. Remote restore is tracked separately in issue #320.
+`voom backup cleanup` continues to operate on local `.vbak` files. Remote
+cleanup is tracked separately by retention work.
 
 ## Credential Safety
 

--- a/plugins/backup-manager/src/destination.rs
+++ b/plugins/backup-manager/src/destination.rs
@@ -260,6 +260,37 @@ pub fn upload_with_rclone(request: RemoteUploadRequest<'_>) -> Result<RemoteUplo
     })
 }
 
+pub fn download_with_rclone(
+    rclone_path: &str,
+    remote_path: &str,
+    output_path: &Path,
+    expected_size: u64,
+) -> Result<()> {
+    verify_remote_size(rclone_path, remote_path, expected_size)?;
+    let copy = RcloneCommand::copyto(
+        rclone_path,
+        Path::new(remote_path),
+        &output_path.display().to_string(),
+        None,
+    );
+    copy.run()?;
+    let downloaded = std::fs::metadata(output_path)
+        .map_err(|e| {
+            plugin_err(format!(
+                "failed to read restored backup {}: {e}",
+                output_path.display()
+            ))
+        })?
+        .len();
+    if downloaded != expected_size {
+        return Err(plugin_err(format!(
+            "restored backup size mismatch for {}: expected {expected_size}, got {downloaded}",
+            output_path.display()
+        )));
+    }
+    Ok(())
+}
+
 fn verify_remote_size(rclone_path: &str, remote_path: &str, expected_size: u64) -> Result<()> {
     let command = RcloneCommand::size(rclone_path, remote_path);
     let stdout = command.run()?;
@@ -279,9 +310,16 @@ fn verify_remote_size(rclone_path: &str, remote_path: &str, expected_size: u64) 
 
 #[cfg(test)]
 mod tests {
+    use std::os::unix::fs::PermissionsExt;
     use std::path::PathBuf;
 
     use super::*;
+
+    fn make_executable(path: &Path) {
+        let mut permissions = std::fs::metadata(path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(path, permissions).unwrap();
+    }
 
     #[test]
     fn rejects_duplicate_destination_names() {
@@ -371,5 +409,49 @@ mod tests {
             path,
             "b2:voom/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/Movie.mkv.vbak"
         );
+    }
+
+    #[test]
+    fn download_with_rclone_verifies_size_and_writes_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let rclone = dir.path().join("fake-rclone");
+        let remote_root = dir.path().join("remote");
+        let output = dir.path().join("restored.mkv");
+        let remote_file = remote_root.join("fake:voom/movie.vbak");
+        std::fs::create_dir_all(remote_file.parent().unwrap()).unwrap();
+        std::fs::write(&remote_file, b"movie").unwrap();
+        std::fs::write(
+            &rclone,
+            format!(
+                "#!/usr/bin/env bash\n\
+                 set -euo pipefail\n\
+                 cmd=\"$1\"\n\
+                 shift\n\
+                 case \"$cmd\" in\n\
+                   size)\n\
+                     shift\n\
+                     bytes=\"$(wc -c < \"{}/$1\" | tr -d ' ')\"\n\
+                     printf '{{\"bytes\":%s,\"count\":1}}\\n' \"$bytes\"\n\
+                     ;;\n\
+                   copyto)\n\
+                     cp \"{}/$1\" \"$2\"\n\
+                     ;;\n\
+                 esac\n",
+                remote_root.display(),
+                remote_root.display(),
+            ),
+        )
+        .unwrap();
+        make_executable(&rclone);
+
+        download_with_rclone(
+            &rclone.display().to_string(),
+            "fake:voom/movie.vbak",
+            &output,
+            5,
+        )
+        .unwrap();
+
+        assert_eq!(std::fs::read(output).unwrap(), b"movie");
     }
 }


### PR DESCRIPTION
## Summary
- add `voom backup restore <file-path> --from <destination>` for remote inventory restores
- download through rclone with remote and local size checks before replacing output
- reject missing or ambiguous inventory matches with clear errors
- document remote restore usage and generated-corpus functional workflow

## Verification
- cargo fmt --check
- cargo test -p voom-backup-manager
- cargo test -p voom-cli test_backup_restore_from_destination
- cargo test -p voom-cli select_remote_restore_record
- cargo clippy -p voom-backup-manager -p voom-cli --all-targets -- -D warnings

Closes #320