### PR TITLE
feat(backup): verify remote backup inventory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3497,6 +3497,7 @@ dependencies = [
  "chrono",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "tracing",
  "uuid",

--- a/crates/voom-cli/src/cli.rs
+++ b/crates/voom-cli/src/cli.rs
@@ -641,6 +641,15 @@ pub enum BackupCommands {
         #[arg(long)]
         yes: bool,
     },
+    /// Verify remote backup inventory against the destination
+    Verify {
+        /// Remote destination inventory to verify
+        #[arg(long)]
+        destination: String,
+        /// Output format
+        #[arg(short, long, default_value = "table")]
+        format: OutputFormat,
+    },
     /// Remove all backup files
     Cleanup {
         /// Directories to scan for backups
@@ -2201,6 +2210,40 @@ mod tests {
                 assert_eq!(output, Some(PathBuf::from("/restore/movie.mkv")));
             }
             _ => panic!("expected Backup Restore"),
+        }
+    }
+
+    #[test]
+    fn test_backup_verify_destination() {
+        let cli = parse(&["voom", "backup", "verify", "--destination", "offsite"]);
+        match cli.command {
+            Commands::Backup(BackupCommands::Verify {
+                destination,
+                format,
+            }) => {
+                assert_eq!(destination, "offsite");
+                assert!(matches!(format, OutputFormat::Table));
+            }
+            _ => panic!("expected Backup Verify"),
+        }
+    }
+
+    #[test]
+    fn test_backup_verify_destination_json() {
+        let cli = parse(&[
+            "voom",
+            "backup",
+            "verify",
+            "--destination",
+            "offsite",
+            "--format",
+            "json",
+        ]);
+        match cli.command {
+            Commands::Backup(BackupCommands::Verify { format, .. }) => {
+                assert!(matches!(format, OutputFormat::Json));
+            }
+            _ => panic!("expected Backup Verify"),
         }
     }
 

--- a/crates/voom-cli/src/commands/backup.rs
+++ b/crates/voom-cli/src/commands/backup.rs
@@ -1,7 +1,8 @@
 use std::path::{Path, PathBuf};
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use console::style;
+use serde::Serialize;
 use voom_backup_manager::inventory::{RemoteBackupInventory, RemoteBackupInventoryRecord};
 use voom_domain::utils::format;
 
@@ -34,6 +35,10 @@ pub fn run(cmd: BackupCommands, global_yes: bool) -> Result<()> {
             output.as_deref(),
             yes || global_yes,
         ),
+        BackupCommands::Verify {
+            destination,
+            format,
+        } => verify_remote_inventory(&destination, format),
         BackupCommands::Cleanup { paths, yes } => cleanup(&paths, yes || global_yes),
     }
 }
@@ -108,6 +113,247 @@ fn list(roots: &[PathBuf], destination: Option<&str>, format: OutputFormat) -> R
     }
 
     Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum RemoteBackupVerificationStatus {
+    Verified,
+    Missing,
+    SizeMismatch,
+    HashMismatch,
+    Error,
+}
+
+impl RemoteBackupVerificationStatus {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Verified => "verified",
+            Self::Missing => "missing",
+            Self::SizeMismatch => "size_mismatch",
+            Self::HashMismatch => "hash_mismatch",
+            Self::Error => "error",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct RemoteBackupVerificationResult {
+    backup_id: uuid::Uuid,
+    original_path: PathBuf,
+    remote_path: String,
+    expected_size: u64,
+    actual_size: Option<u64>,
+    expected_sha256: Option<String>,
+    actual_sha256: Option<String>,
+    status: RemoteBackupVerificationStatus,
+    message: Option<String>,
+}
+
+fn verify_remote_inventory(destination: &str, format: OutputFormat) -> Result<()> {
+    let app_config = config::load_config()?;
+    let backup_config = backup_config_from_app_config(&app_config)?;
+    ensure_backup_destination_configured(&backup_config, destination)?;
+
+    let inventory =
+        RemoteBackupInventory::new(RemoteBackupInventory::default_path(&app_config.data_dir));
+    let records = inventory
+        .list(Some(destination))
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    let results = verify_remote_records(&backup_config.rclone_path, &records);
+
+    print_remote_verification_results(destination, &results, format)?;
+    let problem_count = results
+        .iter()
+        .filter(|result| result.status != RemoteBackupVerificationStatus::Verified)
+        .count();
+    if problem_count > 0 {
+        bail!("remote backup verification found {problem_count} problem(s)");
+    }
+    Ok(())
+}
+
+fn ensure_backup_destination_configured(
+    config: &voom_backup_manager::BackupConfig,
+    destination: &str,
+) -> Result<()> {
+    if config
+        .destinations
+        .iter()
+        .any(|configured| configured.name == destination)
+    {
+        Ok(())
+    } else {
+        bail!("backup destination '{destination}' is not configured")
+    }
+}
+
+fn verify_remote_records(
+    rclone_path: &str,
+    records: &[RemoteBackupInventoryRecord],
+) -> Vec<RemoteBackupVerificationResult> {
+    records
+        .iter()
+        .map(|record| verify_remote_record(rclone_path, record))
+        .collect()
+}
+
+fn verify_remote_record(
+    rclone_path: &str,
+    record: &RemoteBackupInventoryRecord,
+) -> RemoteBackupVerificationResult {
+    match voom_backup_manager::destination::remote_size(rclone_path, &record.remote_path) {
+        Ok(actual_size) if actual_size != record.size => {
+            remote_verify_result(record, RemoteBackupVerificationStatus::SizeMismatch)
+                .with_actual_size(actual_size)
+        }
+        Ok(actual_size) => verify_remote_hash(rclone_path, record, actual_size),
+        Err(e) if is_missing_remote_error(&e.to_string()) => {
+            remote_verify_result(record, RemoteBackupVerificationStatus::Missing)
+                .with_message(e.to_string())
+        }
+        Err(e) => remote_verify_result(record, RemoteBackupVerificationStatus::Error)
+            .with_message(e.to_string()),
+    }
+}
+
+fn verify_remote_hash(
+    rclone_path: &str,
+    record: &RemoteBackupInventoryRecord,
+    actual_size: u64,
+) -> RemoteBackupVerificationResult {
+    let actual_sha256 =
+        voom_backup_manager::destination::remote_sha256(rclone_path, &record.remote_path)
+            .unwrap_or(None);
+    let status = match (&record.sha256, &actual_sha256) {
+        (Some(expected), Some(actual)) if expected.to_ascii_lowercase() != *actual => {
+            RemoteBackupVerificationStatus::HashMismatch
+        }
+        _ => RemoteBackupVerificationStatus::Verified,
+    };
+    remote_verify_result(record, status)
+        .with_actual_size(actual_size)
+        .with_actual_sha256(actual_sha256)
+}
+
+fn is_missing_remote_error(message: &str) -> bool {
+    let message = message.to_ascii_lowercase();
+    [
+        "not found",
+        "no such file",
+        "does not exist",
+        "doesn't exist",
+    ]
+    .iter()
+    .any(|needle| message.contains(needle))
+}
+
+fn remote_verify_result(
+    record: &RemoteBackupInventoryRecord,
+    status: RemoteBackupVerificationStatus,
+) -> RemoteBackupVerificationResult {
+    RemoteBackupVerificationResult {
+        backup_id: record.backup_id,
+        original_path: record.original_path.clone(),
+        remote_path: record.remote_path.clone(),
+        expected_size: record.size,
+        actual_size: None,
+        expected_sha256: record.sha256.clone(),
+        actual_sha256: None,
+        status,
+        message: None,
+    }
+}
+
+impl RemoteBackupVerificationResult {
+    fn with_actual_size(mut self, actual_size: u64) -> Self {
+        self.actual_size = Some(actual_size);
+        self
+    }
+
+    fn with_actual_sha256(mut self, actual_sha256: Option<String>) -> Self {
+        self.actual_sha256 = actual_sha256;
+        self
+    }
+
+    fn with_message(mut self, message: String) -> Self {
+        self.message = Some(message);
+        self
+    }
+}
+
+fn print_remote_verification_results(
+    destination: &str,
+    results: &[RemoteBackupVerificationResult],
+    format: OutputFormat,
+) -> Result<()> {
+    match format {
+        OutputFormat::Json => print_remote_verification_json(results),
+        OutputFormat::Table => print_remote_verification_table(destination, results),
+        OutputFormat::Plain | OutputFormat::Csv => {
+            for result in results {
+                println!("{}\t{}", result.status.as_str(), result.remote_path);
+            }
+            Ok(())
+        }
+    }
+}
+
+fn print_remote_verification_json(results: &[RemoteBackupVerificationResult]) -> Result<()> {
+    let json: Vec<serde_json::Value> = results
+        .iter()
+        .map(|result| {
+            serde_json::json!({
+                "backup_id": result.backup_id,
+                "original_path": result.original_path.display().to_string(),
+                "remote_path": result.remote_path,
+                "expected_size": result.expected_size,
+                "actual_size": result.actual_size,
+                "expected_sha256": result.expected_sha256,
+                "actual_sha256": result.actual_sha256,
+                "status": result.status,
+                "message": result.message,
+            })
+        })
+        .collect();
+    println!("{}", serde_json::to_string_pretty(&json)?);
+    Ok(())
+}
+
+fn print_remote_verification_table(
+    destination: &str,
+    results: &[RemoteBackupVerificationResult],
+) -> Result<()> {
+    println!(
+        "{} remote backup(s) verified for {}:\n",
+        style(results.len()).bold(),
+        style(destination).bold()
+    );
+    let mut table = output::new_table();
+    table.set_header(vec!["Status", "Expected", "Actual", "Hash", "Remote Path"]);
+    for result in results {
+        table.add_row(vec![
+            comfy_table::Cell::new(result.status.as_str()),
+            comfy_table::Cell::new(format::format_size(result.expected_size)),
+            comfy_table::Cell::new(
+                result
+                    .actual_size
+                    .map_or_else(|| "-".to_string(), format::format_size),
+            ),
+            comfy_table::Cell::new(hash_status(result)),
+            comfy_table::Cell::new(&result.remote_path),
+        ]);
+    }
+    println!("{table}");
+    Ok(())
+}
+
+fn hash_status(result: &RemoteBackupVerificationResult) -> &'static str {
+    match (&result.expected_sha256, &result.actual_sha256) {
+        (Some(_), Some(_)) => "checked",
+        (Some(_), None) => "unavailable",
+        (None, _) => "not_recorded",
+    }
 }
 
 fn list_remote_inventory(destination: &str, format: OutputFormat) -> Result<()> {
@@ -507,21 +753,81 @@ fn derive_original_path(backup_path: &Path, original_name: &str) -> PathBuf {
 mod tests {
     use super::*;
     use std::fs;
+    use std::os::unix::fs::PermissionsExt;
     use tempfile::TempDir;
+    use voom_backup_manager::destination::BackupDestinationConfig;
     use voom_backup_manager::inventory::RemoteBackupInventoryStatus;
 
     fn remote_record(original_path: &Path, destination: &str) -> RemoteBackupInventoryRecord {
+        remote_record_with_path(original_path, destination, "movie.vbak", 5, None)
+    }
+
+    fn remote_record_with_path(
+        original_path: &Path,
+        destination: &str,
+        path: &str,
+        size: u64,
+        sha256: Option<String>,
+    ) -> RemoteBackupInventoryRecord {
         RemoteBackupInventoryRecord {
             backup_id: uuid::Uuid::new_v4(),
             original_path: original_path.to_path_buf(),
             local_backup_path: PathBuf::from("/backups/movie.vbak"),
             destination_name: destination.to_string(),
-            remote_path: format!("{destination}:voom/movie.vbak"),
-            size: 5,
+            remote_path: format!("{destination}:voom/{path}"),
+            size,
+            sha256,
             uploaded_at: chrono::Utc::now(),
             verified_at: Some(chrono::Utc::now()),
             status: RemoteBackupInventoryStatus::Verified,
         }
+    }
+
+    fn make_executable(path: &Path) {
+        let mut permissions = std::fs::metadata(path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(path, permissions).unwrap();
+    }
+
+    fn fake_rclone(dir: &Path) -> PathBuf {
+        let rclone = dir.join("fake-rclone");
+        let remote_root = dir.join("remote");
+        std::fs::create_dir_all(&remote_root).unwrap();
+        std::fs::write(
+            &rclone,
+            format!(
+                "#!/usr/bin/env bash\n\
+                 set -euo pipefail\n\
+                 root=\"{}\"\n\
+                 cmd=\"$1\"\n\
+                 shift\n\
+                 case \"$cmd\" in\n\
+                   size)\n\
+                     shift\n\
+                     file=\"$root/$1\"\n\
+                     if [[ ! -f \"$file\" ]]; then\n\
+                       echo \"not found: $1\" >&2\n\
+                       exit 1\n\
+                     fi\n\
+                     bytes=\"$(wc -c < \"$file\" | tr -d ' ')\"\n\
+                     printf '{{\"bytes\":%s,\"count\":1}}\\n' \"$bytes\"\n\
+                     ;;\n\
+                   hashsum)\n\
+                     shift\n\
+                     case \"$1\" in\n\
+                       *hash-mismatch*) printf '{}  %s\\n' \"$1\" ;;\n\
+                       *) printf '{}  %s\\n' \"$1\" ;;\n\
+                     esac\n\
+                     ;;\n\
+                 esac\n",
+                remote_root.display(),
+                "b".repeat(64),
+                "a".repeat(64),
+            ),
+        )
+        .unwrap();
+        make_executable(&rclone);
+        rclone
     }
 
     #[test]
@@ -640,5 +946,97 @@ mod tests {
         let err = select_remote_restore_record(&records, original, "offsite").unwrap_err();
 
         assert!(err.to_string().contains("ambiguous"));
+    }
+
+    #[test]
+    fn verify_remote_records_reports_verified_backup() {
+        let dir = TempDir::new().unwrap();
+        let rclone = fake_rclone(dir.path());
+        let remote_file = dir.path().join("remote/offsite:voom/movie.vbak");
+        std::fs::create_dir_all(remote_file.parent().unwrap()).unwrap();
+        std::fs::write(remote_file, b"movie").unwrap();
+        let records = vec![remote_record_with_path(
+            Path::new("/media/movie.mkv"),
+            "offsite",
+            "movie.vbak",
+            5,
+            Some("a".repeat(64)),
+        )];
+
+        let results = verify_remote_records(&rclone.display().to_string(), &records);
+
+        assert_eq!(results[0].status, RemoteBackupVerificationStatus::Verified);
+        assert_eq!(results[0].actual_size, Some(5));
+        assert_eq!(results[0].actual_sha256, Some("a".repeat(64)));
+    }
+
+    #[test]
+    fn verify_remote_records_reports_missing_backup() {
+        let dir = TempDir::new().unwrap();
+        let rclone = fake_rclone(dir.path());
+        let records = vec![remote_record(Path::new("/media/movie.mkv"), "offsite")];
+
+        let results = verify_remote_records(&rclone.display().to_string(), &records);
+
+        assert_eq!(results[0].status, RemoteBackupVerificationStatus::Missing);
+        assert!(results[0].message.as_deref().unwrap().contains("not found"));
+    }
+
+    #[test]
+    fn verify_remote_records_reports_size_mismatch() {
+        let dir = TempDir::new().unwrap();
+        let rclone = fake_rclone(dir.path());
+        let remote_file = dir.path().join("remote/offsite:voom/size-mismatch.vbak");
+        std::fs::create_dir_all(remote_file.parent().unwrap()).unwrap();
+        std::fs::write(remote_file, b"too-large").unwrap();
+        let records = vec![remote_record_with_path(
+            Path::new("/media/movie.mkv"),
+            "offsite",
+            "size-mismatch.vbak",
+            5,
+            None,
+        )];
+
+        let results = verify_remote_records(&rclone.display().to_string(), &records);
+
+        assert_eq!(
+            results[0].status,
+            RemoteBackupVerificationStatus::SizeMismatch
+        );
+        assert_eq!(results[0].actual_size, Some(9));
+    }
+
+    #[test]
+    fn verify_remote_records_reports_hash_mismatch() {
+        let dir = TempDir::new().unwrap();
+        let rclone = fake_rclone(dir.path());
+        let remote_file = dir.path().join("remote/offsite:voom/hash-mismatch.vbak");
+        std::fs::create_dir_all(remote_file.parent().unwrap()).unwrap();
+        std::fs::write(remote_file, b"movie").unwrap();
+        let records = vec![remote_record_with_path(
+            Path::new("/media/movie.mkv"),
+            "offsite",
+            "hash-mismatch.vbak",
+            5,
+            Some("a".repeat(64)),
+        )];
+
+        let results = verify_remote_records(&rclone.display().to_string(), &records);
+
+        assert_eq!(
+            results[0].status,
+            RemoteBackupVerificationStatus::HashMismatch
+        );
+        assert_eq!(results[0].actual_sha256, Some("b".repeat(64)));
+    }
+
+    #[test]
+    fn ensure_backup_destination_configured_rejects_missing_destination() {
+        let mut config = voom_backup_manager::BackupConfig::default();
+        config.destinations = vec![BackupDestinationConfig::rclone("offsite", "b2:voom")];
+
+        let err = ensure_backup_destination_configured(&config, "archive").unwrap_err();
+
+        assert!(err.to_string().contains("not configured"));
     }
 }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -836,6 +836,23 @@ voom backup restore <BACKUP_PATH_OR_FILE_PATH> [OPTIONS]
 | `--output <PATH>` | none | Write remote restore to this path instead of replacing the original path |
 | `--yes` | `false` | Skip confirmation prompt |
 
+#### `voom backup verify`
+
+Verify remote backup inventory against a configured destination.
+
+```
+voom backup verify --destination <DESTINATION> [OPTIONS]
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--destination <DESTINATION>` | *required* | Remote backup destination to verify |
+| `-f`, `--format <FORMAT>` | `table` | Output format: `table`, `json`, `plain`, or `csv` |
+
+The command reports `verified`, `missing`, `size_mismatch`, `hash_mismatch`, or
+`error` for each inventory record and exits non-zero when any record is not
+verified.
+
 #### `voom backup cleanup`
 
 Remove all backup files from one or more directories.
@@ -859,6 +876,8 @@ voom backup restore /media/movies/film.mkv.vbak
 voom backup restore /media/movies/film.mkv.vbak --yes
 voom backup restore /media/movies/film.mkv --from offsite
 voom backup restore /media/movies/film.mkv --from offsite --output /tmp/film.mkv
+voom backup verify --destination offsite
+voom backup verify --destination offsite --format json
 voom backup cleanup /media/movies --yes
 ```
 

--- a/docs/functional-test-plan-remote-backups.md
+++ b/docs/functional-test-plan-remote-backups.md
@@ -43,6 +43,17 @@ case "$cmd" in
     bytes="$(wc -c < "$target" | tr -d ' ')"
     printf '{"bytes":%s,"count":1}\n' "$bytes"
     ;;
+  hashsum)
+    algorithm="$1"
+    remote="$2"
+    target="/tmp/voom-remote-backup-target/${remote//:/_}"
+    if [[ "$algorithm" != "SHA-256" ]]; then
+      echo "unsupported hash algorithm: $algorithm" >&2
+      exit 64
+    fi
+    hash="$(shasum -a 256 "$target" | awk '{print $1}')"
+    printf '%s  %s\n' "$hash" "$remote"
+    ;;
   *)
     echo "unsupported fake rclone command: $cmd" >&2
     exit 64
@@ -106,6 +117,18 @@ XDG_CONFIG_HOME=/tmp/voom-remote-config cargo run -p voom-cli -- backup list \
 
 Expected: JSON output contains at least one record with
 `"destination_name": "fake-offsite"` and `"status": "verified"`.
+
+Verify the remote inventory:
+
+```sh
+XDG_CONFIG_HOME=/tmp/voom-remote-config cargo run -p voom-cli -- backup verify \
+  --destination fake-offsite \
+  --format json
+```
+
+Expected: JSON output reports `verified` for each record, includes matching
+`expected_size` and `actual_size` values, and includes matching
+`expected_sha256` and `actual_sha256` values.
 
 Restore to an explicit output path:
 

--- a/docs/plans/issue-321-adversarial-review.md
+++ b/docs/plans/issue-321-adversarial-review.md
@@ -1,0 +1,33 @@
+# Issue 321 Adversarial Review: Remote Backup Verification
+
+Branch: `feat/issue-321-remote-verify`
+
+## Acceptance Criteria Mapping
+
+| Criterion | Status | Notes |
+|-----------|--------|-------|
+| Add `voom backup verify --destination <name>` | Implemented | New backup subcommand verifies one configured destination. |
+| Compare inventory against remote object size and optional hash metadata | Implemented | Size is checked with `rclone size --json`; SHA-256 is compared when both inventory and rclone provide it. |
+| Report missing, mismatched, and verified backups in table and JSON formats | Implemented | Results use `verified`, `missing`, `size_mismatch`, `hash_mismatch`, and `error`. |
+| Tests cover clean, missing object, size mismatch, and destination config errors | Implemented | CLI unit tests use a fake rclone and direct config validation. |
+| Document generated-corpus verification workflow | Implemented | `docs/functional-test-plan-remote-backups.md` includes `backup verify`. |
+
+## Risks And Mitigations
+
+1. Old inventory records do not have `sha256`.
+   - Mitigation: the field is optional and defaults during deserialization.
+     Verification still checks size for old rows and reports hash as
+     `not_recorded`.
+
+2. Not every rclone backend exposes SHA-256 metadata.
+   - Mitigation: `hashsum SHA-256` failure is treated as hash unavailable after
+     size succeeds. Missing objects are still detected by the mandatory size
+     check.
+
+3. The CLI exits non-zero after reporting any non-verified record.
+   - Mitigation: JSON/table output is written before the error, so automation can
+     parse the report and still use process status as a guardrail.
+
+4. Hash verification covers newly recorded uploads only.
+   - Mitigation: future uploads persist SHA-256. Existing rows remain usable for
+     size verification without migration.

--- a/docs/remote-backups.md
+++ b/docs/remote-backups.md
@@ -65,6 +65,19 @@ voom backup list --destination offsite
 voom backup list --destination offsite --format json
 ```
 
+Verify the recorded inventory against the remote destination:
+
+```sh
+voom backup verify --destination offsite
+voom backup verify --destination offsite --format json
+```
+
+Remote verification checks object size for every inventory record. New
+inventory records also include a SHA-256 of the backup content; when rclone can
+return SHA-256 metadata for the remote object, VOOM compares that hash as well.
+The command reports `verified`, `missing`, `size_mismatch`, `hash_mismatch`, or
+`error` for each record and exits non-zero when any record is not verified.
+
 Restore a remote backup from one destination:
 
 ```sh

--- a/plugins/backup-manager/Cargo.toml
+++ b/plugins/backup-manager/Cargo.toml
@@ -16,6 +16,7 @@ voom-domain = { workspace = true }
 voom-kernel = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+sha2 = { workspace = true }
 tracing = { workspace = true }
 chrono = { workspace = true }
 uuid = { workspace = true }

--- a/plugins/backup-manager/src/destination.rs
+++ b/plugins/backup-manager/src/destination.rs
@@ -194,6 +194,18 @@ impl RcloneCommand {
         }
     }
 
+    #[must_use]
+    pub fn hashsum(program: impl Into<String>, algorithm: &str, remote_path: &str) -> Self {
+        Self {
+            program: program.into(),
+            args: vec![
+                "hashsum".to_string(),
+                algorithm.to_string(),
+                remote_path.to_string(),
+            ],
+        }
+    }
+
     fn run(&self) -> Result<Vec<u8>> {
         let output = Command::new(&self.program)
             .args(&self.args)
@@ -292,6 +304,16 @@ pub fn download_with_rclone(
 }
 
 fn verify_remote_size(rclone_path: &str, remote_path: &str, expected_size: u64) -> Result<()> {
+    let actual_size = remote_size(rclone_path, remote_path)?;
+    if actual_size != expected_size {
+        return Err(plugin_err(format!(
+            "remote backup size mismatch for {remote_path}: expected {expected_size}, got {actual_size}",
+        )));
+    }
+    Ok(())
+}
+
+pub fn remote_size(rclone_path: &str, remote_path: &str) -> Result<u64> {
     let command = RcloneCommand::size(rclone_path, remote_path);
     let stdout = command.run()?;
     let size: RcloneSizeOutput = serde_json::from_slice(&stdout).map_err(|e| {
@@ -299,13 +321,24 @@ fn verify_remote_size(rclone_path: &str, remote_path: &str, expected_size: u64) 
             "failed to parse rclone size output for {remote_path}: {e}"
         ))
     })?;
-    if size.bytes != expected_size {
-        return Err(plugin_err(format!(
-            "remote backup size mismatch for {remote_path}: expected {expected_size}, got {}",
-            size.bytes
-        )));
+    Ok(size.bytes)
+}
+
+pub fn remote_sha256(rclone_path: &str, remote_path: &str) -> Result<Option<String>> {
+    let command = RcloneCommand::hashsum(rclone_path, "SHA-256", remote_path);
+    let stdout = match command.run() {
+        Ok(stdout) => stdout,
+        Err(_) => return Ok(None),
+    };
+    let text = String::from_utf8_lossy(&stdout);
+    let Some(hash) = text.split_whitespace().next() else {
+        return Ok(None);
+    };
+    if hash.len() == 64 && hash.chars().all(|c| c.is_ascii_hexdigit()) {
+        Ok(Some(hash.to_ascii_lowercase()))
+    } else {
+        Ok(None)
     }
-    Ok(())
 }
 
 #[cfg(test)]
@@ -396,6 +429,17 @@ mod tests {
         assert_eq!(command.args[1], "/tmp/movie.mkv");
         assert_eq!(command.args[2], "b2:voom/backup.vbak");
         assert!(command.args.contains(&"--bwlimit".to_string()));
+    }
+
+    #[test]
+    fn rclone_hashsum_uses_sha256_without_shell() {
+        let command = RcloneCommand::hashsum("rclone", "SHA-256", "b2:voom/backup.vbak");
+
+        assert_eq!(command.program, "rclone");
+        assert_eq!(
+            command.args,
+            vec!["hashsum", "SHA-256", "b2:voom/backup.vbak"]
+        );
     }
 
     #[test]

--- a/plugins/backup-manager/src/inventory.rs
+++ b/plugins/backup-manager/src/inventory.rs
@@ -38,6 +38,8 @@ pub struct RemoteBackupInventoryRecord {
     pub destination_name: String,
     pub remote_path: String,
     pub size: u64,
+    #[serde(default)]
+    pub sha256: Option<String>,
     pub uploaded_at: DateTime<Utc>,
     pub verified_at: Option<DateTime<Utc>>,
     pub status: RemoteBackupInventoryStatus,
@@ -140,6 +142,7 @@ mod tests {
             destination_name: destination_name.to_string(),
             remote_path: remote_path.to_string(),
             size: 42,
+            sha256: Some("a".repeat(64)),
             uploaded_at: Utc::now(),
             verified_at: Some(Utc::now()),
             status: RemoteBackupInventoryStatus::Verified,

--- a/plugins/backup-manager/src/lib.rs
+++ b/plugins/backup-manager/src/lib.rs
@@ -14,11 +14,13 @@ pub mod inventory;
 pub mod space;
 
 use std::collections::HashMap;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, MutexGuard};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use uuid::Uuid;
 use voom_domain::capabilities::Capability;
 use voom_domain::errors::{Result, VoomError};
@@ -198,6 +200,7 @@ impl BackupManagerPlugin {
                 destination_name: remote.destination_name.clone(),
                 remote_path: remote.remote_path.clone(),
                 size: record.size,
+                sha256: Some(compute_sha256(&record.backup_path)?),
                 uploaded_at: now,
                 verified_at: remote.verified.then_some(now),
                 status: if remote.verified {
@@ -278,6 +281,24 @@ impl BackupManagerPlugin {
 
         Ok(removed)
     }
+}
+
+fn compute_sha256(path: &Path) -> Result<String> {
+    let mut file = std::fs::File::open(path)
+        .map_err(|e| plugin_err(format!("failed to open backup {}: {e}", path.display())))?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0u8; 64 * 1024];
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .map_err(|e| plugin_err(format!("failed to read backup {}: {e}", path.display())))?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    let digest = hasher.finalize();
+    Ok(format!("{digest:x}"))
 }
 
 impl Default for BackupManagerPlugin {


### PR DESCRIPTION
## Summary
- add `voom backup verify --destination <name>` with table, JSON, plain, and CSV-compatible output
- verify each remote inventory record with rclone size checks and SHA-256 comparison when both sides provide hashes
- report verified, missing, size mismatch, hash mismatch, and generic error statuses
- document remote verification and generated-corpus fake-rclone workflow

## Verification
- cargo fmt --check
- cargo test -p voom-backup-manager
- cargo test -p voom-cli backup
- cargo clippy -p voom-backup-manager -p voom-cli --all-targets -- -D warnings

Closes #321