### PR TITLE
feat(backup): guard remote cleanup by retention

### DIFF
--- a/crates/voom-cli/src/cli.rs
+++ b/crates/voom-cli/src/cli.rs
@@ -653,8 +653,11 @@ pub enum BackupCommands {
     /// Remove all backup files
     Cleanup {
         /// Directories to scan for backups
-        #[arg(required = true, num_args = 1..)]
+        #[arg(num_args = 0..)]
         paths: Vec<PathBuf>,
+        /// Remote destination inventory to clean up
+        #[arg(long)]
+        destination: Option<String>,
         /// Skip confirmation prompt
         #[arg(long)]
         yes: bool,
@@ -2251,8 +2254,13 @@ mod tests {
     fn test_backup_cleanup() {
         let cli = parse(&["voom", "backup", "cleanup", "/media", "--yes"]);
         match cli.command {
-            Commands::Backup(BackupCommands::Cleanup { paths, yes }) => {
+            Commands::Backup(BackupCommands::Cleanup {
+                paths,
+                destination,
+                yes,
+            }) => {
                 assert_eq!(paths, vec![PathBuf::from("/media")]);
+                assert_eq!(destination, None);
                 assert!(yes);
             }
             _ => panic!("expected Backup Cleanup"),
@@ -2260,8 +2268,17 @@ mod tests {
     }
 
     #[test]
-    fn test_backup_cleanup_requires_path() {
-        assert!(try_parse(&["voom", "backup", "cleanup"]).is_err());
+    fn test_backup_cleanup_accepts_destination_without_path() {
+        let cli = parse(&["voom", "backup", "cleanup", "--destination", "offsite"]);
+        match cli.command {
+            Commands::Backup(BackupCommands::Cleanup {
+                paths, destination, ..
+            }) => {
+                assert!(paths.is_empty());
+                assert_eq!(destination.as_deref(), Some("offsite"));
+            }
+            _ => panic!("expected Backup Cleanup"),
+        }
     }
 
     #[test]
@@ -2339,7 +2356,7 @@ mod tests {
     fn test_backup_cleanup_multiple_paths() {
         let cli = parse(&["voom", "backup", "cleanup", "/movies", "/series", "--yes"]);
         match cli.command {
-            Commands::Backup(BackupCommands::Cleanup { paths, yes }) => {
+            Commands::Backup(BackupCommands::Cleanup { paths, yes, .. }) => {
                 assert_eq!(
                     paths,
                     vec![PathBuf::from("/movies"), PathBuf::from("/series")]

--- a/crates/voom-cli/src/commands/backup.rs
+++ b/crates/voom-cli/src/commands/backup.rs
@@ -1,8 +1,11 @@
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Result};
-use console::style;
+use chrono::{DateTime, Utc};
+use console::{style, StyledObject};
 use serde::Serialize;
+use voom_backup_manager::destination::BackupDestinationConfig;
 use voom_backup_manager::inventory::{RemoteBackupInventory, RemoteBackupInventoryRecord};
 use voom_domain::utils::format;
 
@@ -39,7 +42,11 @@ pub fn run(cmd: BackupCommands, global_yes: bool) -> Result<()> {
             destination,
             format,
         } => verify_remote_inventory(&destination, format),
-        BackupCommands::Cleanup { paths, yes } => cleanup(&paths, yes || global_yes),
+        BackupCommands::Cleanup {
+            paths,
+            destination,
+            yes,
+        } => cleanup(&paths, destination.as_deref(), yes || global_yes),
     }
 }
 
@@ -585,7 +592,26 @@ fn select_remote_restore_record<'a>(
     }
 }
 
-fn cleanup(roots: &[PathBuf], yes: bool) -> Result<()> {
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RemoteCleanupPlan {
+    delete: Vec<RemoteBackupInventoryRecord>,
+    skip: Vec<RemoteCleanupSkip>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RemoteCleanupSkip {
+    record: RemoteBackupInventoryRecord,
+    age_days: i64,
+    minimum_storage_days: u32,
+}
+
+fn cleanup(roots: &[PathBuf], destination: Option<&str>, yes: bool) -> Result<()> {
+    if let Some(destination) = destination {
+        return cleanup_remote(destination, yes);
+    }
+    if roots.is_empty() {
+        anyhow::bail!("backup cleanup requires at least one path unless --destination is provided");
+    }
     let mut all_entries = Vec::new();
     for root in roots {
         let entries = scan_vbak_files(root)?;
@@ -641,6 +667,116 @@ fn cleanup(roots: &[PathBuf], yes: bool) -> Result<()> {
     );
 
     Ok(())
+}
+
+fn cleanup_remote(destination: &str, yes: bool) -> Result<()> {
+    let app_config = config::load_config()?;
+    let backup_config = backup_config_from_app_config(&app_config)?;
+    let destination_config = backup_config
+        .destinations
+        .iter()
+        .find(|configured| configured.name == destination)
+        .ok_or_else(|| anyhow::anyhow!("backup destination '{destination}' is not configured"))?;
+    let inventory =
+        RemoteBackupInventory::new(RemoteBackupInventory::default_path(&app_config.data_dir));
+    let all_records = inventory.list(None).map_err(|e| anyhow::anyhow!("{e}"))?;
+    let plan = plan_remote_cleanup(
+        destination_config,
+        all_records
+            .iter()
+            .filter(|record| record.destination_name == destination),
+        Utc::now(),
+    );
+    print_remote_cleanup_plan(destination, &plan);
+    if plan.delete.is_empty() {
+        return Ok(());
+    }
+    if !output::confirm("Confirm remote deletion?", yes)? {
+        println!("{}", style("Aborted.").dim());
+        return Ok(());
+    }
+
+    let mut deleted_ids = HashSet::new();
+    let mut errors = 0u64;
+    for record in &plan.delete {
+        match voom_backup_manager::destination::delete_with_rclone(
+            &backup_config.rclone_path,
+            &record.remote_path,
+        ) {
+            Ok(()) => {
+                deleted_ids.insert(record.backup_id);
+            }
+            Err(e) => {
+                errors += 1;
+                eprintln!("{} {}: {e}", style("ERROR").red(), record.remote_path);
+            }
+        }
+    }
+    let remaining: Vec<RemoteBackupInventoryRecord> = all_records
+        .into_iter()
+        .filter(|record| {
+            record.destination_name != destination || !deleted_ids.contains(&record.backup_id)
+        })
+        .collect();
+    inventory
+        .replace_all(&remaining)
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    println!(
+        "{} Removed {} remote backup(s){}",
+        style("OK").bold().green(),
+        deleted_ids.len(),
+        if errors > 0 {
+            format!(", {errors} error(s)")
+        } else {
+            String::new()
+        }
+    );
+    Ok(())
+}
+
+fn plan_remote_cleanup<'a>(
+    destination: &BackupDestinationConfig,
+    records: impl Iterator<Item = &'a RemoteBackupInventoryRecord>,
+    now: DateTime<Utc>,
+) -> RemoteCleanupPlan {
+    let minimum_storage_days = destination.minimum_storage_days.unwrap_or(0);
+    let mut delete = Vec::new();
+    let mut skip = Vec::new();
+    for record in records {
+        let age_days = now.signed_duration_since(record.uploaded_at).num_days();
+        if age_days < i64::from(minimum_storage_days) {
+            skip.push(RemoteCleanupSkip {
+                record: record.clone(),
+                age_days,
+                minimum_storage_days,
+            });
+        } else {
+            delete.push(record.clone());
+        }
+    }
+    RemoteCleanupPlan { delete, skip }
+}
+
+fn print_remote_cleanup_plan(destination: &str, plan: &RemoteCleanupPlan) {
+    println!(
+        "Found {} remote backup(s) eligible for deletion on {}.",
+        style(plan.delete.len()).bold(),
+        style(destination).bold()
+    );
+    for skip in &plan.skip {
+        println!(
+            "{} Skipping {} on {}: age {} day(s), minimum {} day(s)",
+            styled_warn(),
+            skip.record.remote_path,
+            skip.record.destination_name,
+            skip.age_days,
+            skip.minimum_storage_days
+        );
+    }
+}
+
+fn styled_warn() -> StyledObject<&'static str> {
+    style("SKIP").yellow()
 }
 
 /// Scan for `.vbak` files under a directory.
@@ -752,6 +888,7 @@ fn derive_original_path(backup_path: &Path, original_name: &str) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::Duration;
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
     use tempfile::TempDir;
@@ -777,7 +914,7 @@ mod tests {
             remote_path: format!("{destination}:voom/{path}"),
             size,
             sha256,
-            uploaded_at: chrono::Utc::now(),
+            uploaded_at: chrono::Utc::now() - Duration::days(10),
             verified_at: Some(chrono::Utc::now()),
             status: RemoteBackupInventoryStatus::Verified,
         }
@@ -946,6 +1083,63 @@ mod tests {
         let err = select_remote_restore_record(&records, original, "offsite").unwrap_err();
 
         assert!(err.to_string().contains("ambiguous"));
+    }
+
+    #[test]
+    fn cleanup_local_backups_still_removes_vbak_files() {
+        let dir = TempDir::new().unwrap();
+        let backup_dir = dir.path().join("movies").join(".voom-backup");
+        fs::create_dir_all(&backup_dir).unwrap();
+        let backup_path = backup_dir.join("movie.mkv.20260329120000.vbak");
+        fs::write(&backup_path, b"backup").unwrap();
+
+        cleanup(&[dir.path().to_path_buf()], None, true).unwrap();
+
+        assert!(!backup_path.exists());
+    }
+
+    #[test]
+    fn cleanup_without_path_or_destination_fails() {
+        let err = cleanup(&[], None, true).unwrap_err();
+
+        assert!(err.to_string().contains("requires at least one path"));
+    }
+
+    #[test]
+    fn plan_remote_cleanup_skips_records_younger_than_minimum() {
+        let mut destination = BackupDestinationConfig::rclone("offsite", "b2:voom");
+        destination.minimum_storage_days = Some(30);
+        let mut record = remote_record(Path::new("/media/movie.mkv"), "offsite");
+        record.uploaded_at = chrono::Utc::now() - Duration::days(7);
+
+        let plan = plan_remote_cleanup(&destination, std::iter::once(&record), chrono::Utc::now());
+
+        assert!(plan.delete.is_empty());
+        assert_eq!(plan.skip.len(), 1);
+        assert_eq!(plan.skip[0].minimum_storage_days, 30);
+    }
+
+    #[test]
+    fn plan_remote_cleanup_mixes_eligible_and_retained_records() {
+        let mut destination = BackupDestinationConfig::rclone("offsite", "b2:voom");
+        destination.minimum_storage_days = Some(30);
+        let mut old =
+            remote_record_with_path(Path::new("/media/old.mkv"), "offsite", "old.vbak", 5, None);
+        old.uploaded_at = chrono::Utc::now() - Duration::days(45);
+        let mut young = remote_record_with_path(
+            Path::new("/media/young.mkv"),
+            "offsite",
+            "young.vbak",
+            5,
+            None,
+        );
+        young.uploaded_at = chrono::Utc::now() - Duration::days(3);
+
+        let records = [old.clone(), young.clone()];
+        let plan = plan_remote_cleanup(&destination, records.iter(), chrono::Utc::now());
+
+        assert_eq!(plan.delete, vec![old]);
+        assert_eq!(plan.skip[0].record, young);
     }
 
     #[test]

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -862,16 +862,21 @@ verified.
 
 #### `voom backup cleanup`
 
-Remove all backup files from one or more directories.
+Remove local backup files from one or more directories, or remove remote backup
+inventory for one destination.
 
 ```
-voom backup cleanup <PATH>... [OPTIONS]
+voom backup cleanup [PATH]... [OPTIONS]
 ```
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `<PATH>...` | *required* | Directories to remove backups from (one or more) |
+| `<PATH>...` | none | Directories to remove local `.vbak` backups from |
+| `--destination <DESTINATION>` | none | Delete eligible remote backups for one destination |
 | `--yes` | `false` | Skip confirmation prompt |
+
+Remote cleanup honors each destination's `minimum_storage_days` setting and
+reports skipped records with destination and age.
 
 **Examples:**
 
@@ -885,6 +890,7 @@ voom backup restore /media/movies/film.mkv --from offsite
 voom backup restore /media/movies/film.mkv --from offsite --output /tmp/film.mkv
 voom backup verify --destination offsite
 voom backup verify --destination offsite --format json
+voom backup cleanup --destination offsite --yes
 voom backup cleanup /media/movies --yes
 ```
 

--- a/docs/functional-test-plan-remote-backups.md
+++ b/docs/functional-test-plan-remote-backups.md
@@ -98,6 +98,7 @@ rclone_path = "/tmp/voom-remote-backup-bin/rclone"
 name = "fake-offsite"
 kind = "rclone"
 remote = "fake:voom"
+minimum_storage_days = 1
 TOML
 ```
 
@@ -153,6 +154,17 @@ XDG_CONFIG_HOME=/tmp/voom-remote-config cargo run -p voom-cli -- env check
 Expected: output includes a `Backup destinations` section with
 `fake-offsite (rclone) ... OK`. The persisted health history includes a
 `backup_destination:fake-offsite` record.
+
+Run remote cleanup before the minimum storage window expires:
+
+```sh
+XDG_CONFIG_HOME=/tmp/voom-remote-config cargo run -p voom-cli -- backup cleanup \
+  --destination fake-offsite \
+  --yes
+```
+
+Expected: output reports skipped records for `fake-offsite` with age below
+`minimum_storage_days`; remote backup objects and inventory records remain.
 
 Restore to an explicit output path:
 

--- a/docs/plans/issue-323-adversarial-review.md
+++ b/docs/plans/issue-323-adversarial-review.md
@@ -1,0 +1,27 @@
+# Issue 323 Adversarial Review: Remote Backup Retention
+
+Branch: `feat/issue-323-remote-retention`
+
+## Acceptance Criteria Mapping
+
+| Criterion | Status | Notes |
+|-----------|--------|-------|
+| Add destination retention config for minimum storage days | Implemented | `minimum_storage_days` is optional per destination. |
+| Prevent cleanup from deleting remote backups younger than the configured minimum | Implemented | `voom backup cleanup --destination <name>` skips young inventory records. |
+| Report skipped deletions with destination and age | Implemented | Cleanup prints destination, age, and configured minimum for each skip. |
+| Tests cover local retention, remote minimum-age retention, and mixed destinations | Implemented | Unit tests cover local cleanup, young remote skips, and mixed eligible/skipped records. |
+| Document provider examples such as Glacier Deep Archive | Implemented | Remote backup docs include an S3/Glacier-style minimum-age example. |
+
+## Risks And Mitigations
+
+1. Remote cleanup now mutates local inventory after successful deletion.
+   - Mitigation: only successfully deleted records are removed; skipped and
+     failed records remain for later verification or cleanup.
+
+2. Inventory uses backup IDs to track successful deletes.
+   - Mitigation: filtering is scoped to the selected destination, so records for
+     other destinations remain untouched.
+
+3. Providers can have lifecycle policies outside VOOM.
+   - Mitigation: VOOM reports local decisions and relies on rclone delete
+     success/failure for provider-side enforcement.

--- a/docs/remote-backups.md
+++ b/docs/remote-backups.md
@@ -20,6 +20,7 @@ name = "offsite"
 kind = "rclone"
 remote = "b2:voom-backups"
 bandwidth_limit = "10M"
+minimum_storage_days = 30
 ```
 
 `kind` may be `rclone`, `s3`, `sftp`, or `webdav`. All remote kinds are backed
@@ -101,6 +102,20 @@ Local backup listing still scans `.vbak` files by path:
 voom backup list /media/movies
 ```
 
+Remote cleanup deletes inventory records from one configured destination:
+
+```sh
+voom backup cleanup --destination offsite
+voom backup cleanup --destination offsite --yes
+```
+
+`minimum_storage_days` protects young remote objects from cleanup. Skipped
+deletions are reported with the destination and object age. Set this for
+providers with minimum billable storage windows, such as Amazon S3 Glacier Deep
+Archive, where early deletion can incur charges. Objects deleted successfully
+are removed from the local remote-backup inventory; skipped and failed records
+remain.
+
 ## S3, SFTP, And WebDAV
 
 Typed provider names document intent while keeping one execution model:
@@ -110,6 +125,7 @@ Typed provider names document intent while keeping one execution model:
 name = "archive-s3"
 kind = "s3"
 remote = "aws-archive:voom"
+minimum_storage_days = 180
 
 [[plugin.backup-manager.destinations]]
 name = "nas-sftp"
@@ -153,11 +169,6 @@ Failures are reported as:
 
 Health output names the destination and kind only. It does not print remote URLs
 or credential-bearing configuration values.
-
-## Restore Status
-
-`voom backup cleanup` continues to operate on local `.vbak` files. Remote
-cleanup is tracked separately by retention work.
 
 ## Credential Safety
 

--- a/plugins/backup-manager/src/backup.rs
+++ b/plugins/backup-manager/src/backup.rs
@@ -283,6 +283,7 @@ mod tests {
                     kind: DestinationKind::S3,
                     remote: Some("aws:voom".to_string()),
                     bandwidth_limit: Some("10M".to_string()),
+                    minimum_storage_days: None,
                 },
             ],
             ..global_config(dir)

--- a/plugins/backup-manager/src/destination.rs
+++ b/plugins/backup-manager/src/destination.rs
@@ -50,6 +50,8 @@ pub struct BackupDestinationConfig {
     pub kind: DestinationKind,
     pub remote: Option<String>,
     pub bandwidth_limit: Option<String>,
+    #[serde(default)]
+    pub minimum_storage_days: Option<u32>,
 }
 
 fn default_destination_kind() -> DestinationKind {
@@ -64,6 +66,7 @@ impl BackupDestinationConfig {
             kind: DestinationKind::Rclone,
             remote: Some(remote.into()),
             bandwidth_limit: None,
+            minimum_storage_days: None,
         }
     }
 
@@ -217,6 +220,14 @@ impl RcloneCommand {
         }
     }
 
+    #[must_use]
+    pub fn deletefile(program: impl Into<String>, remote_path: &str) -> Self {
+        Self {
+            program: program.into(),
+            args: vec!["deletefile".to_string(), remote_path.to_string()],
+        }
+    }
+
     fn run(&self) -> Result<Vec<u8>> {
         let output = Command::new(&self.program)
             .args(&self.args)
@@ -352,6 +363,11 @@ pub fn remote_sha256(rclone_path: &str, remote_path: &str) -> Result<Option<Stri
     }
 }
 
+pub fn delete_with_rclone(rclone_path: &str, remote_path: &str) -> Result<()> {
+    RcloneCommand::deletefile(rclone_path, remote_path).run()?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use std::os::unix::fs::PermissionsExt;
@@ -388,6 +404,7 @@ mod tests {
                 kind: DestinationKind::Rclone,
                 remote: None,
                 bandwidth_limit: None,
+                minimum_storage_days: None,
             }],
             ..BackupDestinationsConfig::default()
         };
@@ -406,18 +423,21 @@ mod tests {
                     kind: DestinationKind::S3,
                     remote: Some("aws:voom".to_string()),
                     bandwidth_limit: None,
+                    minimum_storage_days: Some(180),
                 },
                 BackupDestinationConfig {
                     name: "nas-sftp".to_string(),
                     kind: DestinationKind::Sftp,
                     remote: Some("vps:/srv/voom".to_string()),
                     bandwidth_limit: Some("10M".to_string()),
+                    minimum_storage_days: None,
                 },
                 BackupDestinationConfig {
                     name: "webdav".to_string(),
                     kind: DestinationKind::Webdav,
                     remote: Some("dav:voom".to_string()),
                     bandwidth_limit: None,
+                    minimum_storage_days: None,
                 },
             ],
             ..BackupDestinationsConfig::default()
@@ -451,6 +471,14 @@ mod tests {
             command.args,
             vec!["hashsum", "SHA-256", "b2:voom/backup.vbak"]
         );
+    }
+
+    #[test]
+    fn rclone_deletefile_uses_argv_without_shell() {
+        let command = RcloneCommand::deletefile("rclone", "b2:voom/backup.vbak");
+
+        assert_eq!(command.program, "rclone");
+        assert_eq!(command.args, vec!["deletefile", "b2:voom/backup.vbak"]);
     }
 
     #[test]

--- a/plugins/backup-manager/src/inventory.rs
+++ b/plugins/backup-manager/src/inventory.rs
@@ -124,6 +124,43 @@ impl RemoteBackupInventory {
         }
         Ok(records)
     }
+
+    pub fn replace_all(&self, records: &[RemoteBackupInventoryRecord]) -> Result<()> {
+        if let Some(parent) = self.path.parent() {
+            fs::create_dir_all(parent).map_err(|e| {
+                plugin_err(format!(
+                    "failed to create remote backup inventory directory {}: {e}",
+                    parent.display()
+                ))
+            })?;
+        }
+        let temp_path = self.path.with_extension("jsonl.tmp");
+        {
+            let mut file = fs::File::create(&temp_path).map_err(|e| {
+                plugin_err(format!(
+                    "failed to create remote backup inventory {}: {e}",
+                    temp_path.display()
+                ))
+            })?;
+            for record in records {
+                let json = serde_json::to_string(record)
+                    .expect("RemoteBackupInventoryRecord serialization cannot fail");
+                writeln!(file, "{json}").map_err(|e| {
+                    plugin_err(format!(
+                        "failed to write remote backup inventory {}: {e}",
+                        temp_path.display()
+                    ))
+                })?;
+            }
+        }
+        fs::rename(&temp_path, &self.path).map_err(|e| {
+            plugin_err(format!(
+                "failed to replace remote backup inventory {}: {e}",
+                self.path.display()
+            ))
+        })?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -206,5 +243,21 @@ mod tests {
         let records = inventory.list(Some("offsite")).unwrap();
 
         assert!(records.is_empty());
+    }
+
+    #[test]
+    fn replace_all_rewrites_inventory_records() {
+        let dir = tempfile::tempdir().unwrap();
+        let inventory = RemoteBackupInventory::new(dir.path().join("remote-backups.jsonl"));
+        inventory
+            .append(&record("offsite", "b2:voom/a.vbak"))
+            .unwrap();
+        let remaining = record("archive", "s3:voom/b.vbak");
+
+        inventory
+            .replace_all(std::slice::from_ref(&remaining))
+            .unwrap();
+
+        assert_eq!(inventory.list(None).unwrap(), vec![remaining]);
     }
 }


### PR DESCRIPTION
## Summary
- add per-destination `minimum_storage_days` for remote backup retention
- add `voom backup cleanup --destination <name>` for remote inventory cleanup
- skip young remote backups with destination and age reporting
- delete eligible remote objects through rclone and remove only successful deletes from inventory
- document cost-aware retention and Glacier-style minimum storage examples

## Verification
- cargo fmt --check
- cargo test -p voom-backup-manager
- cargo test -p voom-cli cleanup_
- cargo test -p voom-cli test_backup
- cargo clippy -p voom-backup-manager -p voom-cli --all-targets -- -D warnings

Closes #323