### PR TITLE
feat(e2e): add repro artifacts and failure summaries

### DIFF
--- a/scripts/e2e-policy-audit/README.md
+++ b/scripts/e2e-policy-audit/README.md
@@ -32,6 +32,15 @@ All flags have defaults (see `run.sh --help`):
 | `--no-web` | (off) | Skip the `voom serve` smoke-test |
 | `--no-probe` | (off) | Skip the independent `ffprobe` sweep (DB-only diffs) |
 
+After a failed run, inspect `diffs/failure-clusters.md` first. To materialize a
+small library containing representative problem files:
+
+```bash
+~/voom-e2e-runs/<run>/repro/copy-repro-set.sh /tmp/voom-repro-library
+```
+
+Then rerun the harness against `/tmp/voom-repro-library` with the same policy.
+
 ## Pre-conditions
 
 - `~/.config/voom/voom.db` must NOT exist.
@@ -48,14 +57,18 @@ All flags have defaults (see `run.sh --help`):
 ├── manifest.json                 run metadata + per-stage timings
 ├── pre/, post/                   library snapshots (find manifest + ffprobe NDJSON + DB NDJSON)
 │   └── voom-db-tables/           raw SQLite export (per-table TSV) post-scan / post-process
+├── env/                          tool versions, GPU state, policy copy, redacted config
 ├── logs/                         one file per CLI invocation, plus *.rc exit-code sidecars
 ├── db-export/                    raw SQLite tables (post-process; consumed by build-summary)
 ├── reports/                      voom report --all, files, plans, jobs, events.json
+├── repro/                        problem-file lists + copy-repro-set.sh
 ├── web-smoke/                    curl statuses + body samples
 ├── diffs/
 │   ├── files-summary.md          path-level (size/mtime/disappeared/new/common)
 │   ├── codec-pivot.md            video-codec × container counts: pre vs post
 │   ├── tracks-pivot.md           audio + subtitle pivots
+│   ├── failure-clusters.tsv/.md   failed plans grouped by signature/source shape
+│   ├── *-summary.tsv/.md          high-level diff class counts
 │   ├── db-vs-ffprobe-pre.tsv     VOOM introspection accuracy at scan time
 │   ├── db-vs-ffprobe-post.tsv    VOOM re-introspection accuracy after process
 │   ├── voom-db-pre-vs-post.tsv   what VOOM thinks changed
@@ -74,6 +87,18 @@ The harness does **not** judge whether your policy did the *right thing*. To
 do that, read `diffs/codec-pivot.md`, `diffs/tracks-pivot.md`, and the four
 `*.tsv` ndjson diffs — they describe what changed without prescribing what
 *should* have changed.
+
+For large runs, start with the aggregate views:
+
+- `diffs/failure-clusters.md` groups failed plans by phase, error signature,
+  exit code, source container, and source video codec.
+- `diffs/db-vs-ffprobe-post-summary.md` groups post-run introspection
+  divergences by stable signatures such as subtitle default drift or attachment
+  promotion.
+- `diffs/ffprobe-pre-vs-post-summary.md` groups actual on-disk metadata changes
+  independently of VOOM's DB view.
+- `repro/minimal-covering-set.tsv` picks a capped set of representative files
+  per failure/diff signature for faster follow-up runs.
 
 ## Canonical metadata comparison
 

--- a/scripts/e2e-policy-audit/lib/build-repro-set.py
+++ b/scripts/e2e-policy-audit/lib/build-repro-set.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Build small file lists for reproducing e2e failures."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import re
+from collections import defaultdict
+from pathlib import Path
+
+
+def manifest_library(run_dir: Path) -> str:
+    manifest = run_dir / "manifest.json"
+    if not manifest.exists():
+        return ""
+    with manifest.open() as f:
+        return str(json.load(f).get("library") or "")
+
+
+def diff_signature(change_class: str, details: str) -> str:
+    if change_class == "video" and re.search(r"\+#\d+\(png\)", details):
+        return "attachment-promoted-to-png-video"
+    if change_class == "attachment" and re.search(r"-#\d+\(png\)", details):
+        return "png-attachment-removed"
+    if change_class == "subtitle" and ".is_default:False→True" in details:
+        return "subtitle-default-enabled"
+    if change_class == "subtitle" and ".is_default:True→False" in details:
+        return "subtitle-default-disabled"
+    if ".language:und→" in details:
+        return "language-detected-from-und"
+    if re.search(r"\.language:[^→]+→und", details):
+        return "language-lost-to-und"
+    if re.search(r"\+#\d+", details):
+        return f"{change_class}-stream-added"
+    if re.search(r"-#\d+", details):
+        return f"{change_class}-stream-removed"
+    if change_class in {"video", "audio", "subtitle", "attachment"}:
+        fields = sorted(set(re.findall(r"#\d+\.([A-Za-z0-9_]+):", details)))
+        if fields:
+            return f"{change_class}-field-change:" + ",".join(fields[:4])
+    return change_class or "unknown"
+
+
+def add_failed_plan_rows(run_dir: Path, rows: list[dict[str, str]]) -> None:
+    path = run_dir / "repro" / "failed-plan-files.tsv"
+    if not path.exists():
+        return
+    with path.open(newline="") as f:
+        reader = csv.DictReader(f, delimiter="\t")
+        for row in reader:
+            if not row.get("path"):
+                continue
+            rows.append(
+                {
+                    "path": row["path"],
+                    "source": "failed-plan",
+                    "signature": row.get("signature", "unknown"),
+                    "phase": row.get("phase", ""),
+                    "detail": row.get("plan_id", ""),
+                }
+            )
+
+
+def add_diff_rows(run_dir: Path, diff_name: str, rows: list[dict[str, str]]) -> None:
+    path = run_dir / "diffs" / f"{diff_name}.tsv"
+    if not path.exists():
+        return
+    with path.open(newline="") as f:
+        reader = csv.DictReader(f, delimiter="\t")
+        for row in reader:
+            if row.get("side") != "both":
+                continue
+            change_class = row.get("change-class", "")
+            details = row.get("details", "")
+            signature = diff_signature(change_class, details)
+            if signature in {"bitrate", "size", "content_hash"}:
+                continue
+            rows.append(
+                {
+                    "path": row["path"],
+                    "source": diff_name,
+                    "signature": signature,
+                    "phase": "",
+                    "detail": details[:500],
+                }
+            )
+
+
+def unique_rows(rows: list[dict[str, str]]) -> list[dict[str, str]]:
+    seen: set[tuple[str, str, str]] = set()
+    out: list[dict[str, str]] = []
+    for row in rows:
+        key = (row["path"], row["source"], row["signature"])
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(row)
+    return out
+
+
+def relative_to_library(path: str, library: str) -> str:
+    if not library:
+        return ""
+    try:
+        rel = os.path.relpath(path, library)
+    except ValueError:
+        return ""
+    if rel == "." or rel.startswith(".."):
+        return ""
+    return rel
+
+
+def write_tsv(path: Path, rows: list[dict[str, str]], *, library: str) -> None:
+    with path.open("w", newline="") as f:
+        fieldnames = ["path", "relative_path", "source", "signature", "phase", "detail"]
+        writer = csv.DictWriter(f, fieldnames=fieldnames, delimiter="\t", lineterminator="\n")
+        writer.writeheader()
+        for row in rows:
+            out = dict(row)
+            out["relative_path"] = relative_to_library(row["path"], library)
+            writer.writerow(out)
+
+
+def write_copy_script(run_dir: Path, library: str) -> None:
+    script = run_dir / "repro" / "copy-repro-set.sh"
+    script.write_text(
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+
+dest="${{1:?usage: $0 <dest-dir>}}"
+library="${{VOOM_REPRO_LIBRARY:-{library}}}"
+list_dir="$(cd "$(dirname "${{BASH_SOURCE[0]}}")" && pwd)"
+paths="${{list_dir}}/minimal-covering-set.relative-paths"
+
+if [[ ! -d "${{library}}" ]]; then
+  echo "library root not found: ${{library}}" >&2
+  exit 1
+fi
+
+mkdir -p "${{dest}}"
+rsync -a --files-from="${{paths}}" "${{library%/}}/" "${{dest%/}}/"
+echo "Copied repro set to ${{dest}}"
+"""
+    )
+    script.chmod(0o755)
+
+
+def build(run_dir: Path, cap: int) -> None:
+    repro_dir = run_dir / "repro"
+    repro_dir.mkdir(parents=True, exist_ok=True)
+    library = manifest_library(run_dir)
+
+    rows: list[dict[str, str]] = []
+    add_failed_plan_rows(run_dir, rows)
+    add_diff_rows(run_dir, "db-vs-ffprobe-post", rows)
+    add_diff_rows(run_dir, "ffprobe-pre-vs-post", rows)
+    rows = unique_rows(rows)
+
+    write_tsv(repro_dir / "all-problem-files.tsv", rows, library=library)
+
+    selected: list[dict[str, str]] = []
+    counts: defaultdict[tuple[str, str], int] = defaultdict(int)
+    for row in rows:
+        key = (row["source"], row["signature"])
+        if counts[key] >= cap:
+            continue
+        selected.append(row)
+        counts[key] += 1
+
+    write_tsv(repro_dir / "minimal-covering-set.tsv", selected, library=library)
+
+    absolute_paths = sorted({row["path"] for row in selected if row["path"]})
+    (repro_dir / "minimal-covering-set.paths").write_text(
+        "".join(f"{path}\n" for path in absolute_paths)
+    )
+
+    relative_paths = sorted(
+        {
+            relative_to_library(row["path"], library)
+            for row in selected
+            if relative_to_library(row["path"], library)
+        }
+    )
+    (repro_dir / "minimal-covering-set.relative-paths").write_text(
+        "".join(f"{path}\n" for path in relative_paths)
+    )
+
+    attachment_rows = [
+        row
+        for row in rows
+        if "attachment" in row["signature"] or "png-video" in row["signature"]
+    ]
+    write_tsv(repro_dir / "attachment-regression-files.tsv", attachment_rows, library=library)
+
+    metadata_rows = [
+        row
+        for row in rows
+        if row["source"] != "failed-plan"
+        and (
+            "language" in row["signature"]
+            or "default" in row["signature"]
+            or "field-change" in row["signature"]
+            or "stream-" in row["signature"]
+        )
+    ]
+    write_tsv(repro_dir / "metadata-drift-files.tsv", metadata_rows, library=library)
+    write_copy_script(run_dir, library)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("run_dir")
+    parser.add_argument("--cap-per-signature", type=int, default=3)
+    args = parser.parse_args()
+    build(Path(args.run_dir), args.cap_per_signature)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/e2e-policy-audit/lib/build-summary.sh
+++ b/scripts/e2e-policy-audit/lib/build-summary.sh
@@ -79,6 +79,7 @@ failed_plans="${run}/diffs/failed-plans.tsv"
 failure_clusters="${run}/diffs/failure-clusters.tsv"
 failure_clusters_md="${run}/diffs/failure-clusters.md"
 plans_tsv="${run}/db-export/plans.tsv"
+total_failed_plans=0
 if [[ -f "${plans_tsv}" ]]; then
   "${script_dir}/plan-phase-summary.py" "${plans_tsv}" "${phase_summary}" "${failed_plans}"
   if [[ -s "${failed_plans}" ]] && [[ $(awk 'END {print NR}' "${failed_plans}") -gt 1 ]]; then
@@ -90,10 +91,23 @@ if [[ -f "${plans_tsv}" ]]; then
 
   while IFS=$'\t' read -r phase total _completed _skipped failed; do
     [[ "${phase}" == "phase" ]] && continue
+    total_failed_plans=$((total_failed_plans + failed))
     if ((failed > 0)); then
       note_fail "phase ${phase}: ${failed}/${total} plans failed"
     fi
   done <"${phase_summary}"
+fi
+
+if ((total_failed_plans > 0)); then
+  process_rc_file="${run}/logs/process.log.rc"
+  if [[ -f "${process_rc_file}" ]] && [[ "$(cat "${process_rc_file}")" == "0" ]]; then
+    note_warn "process exited 0 despite ${total_failed_plans} failed plan(s)"
+  fi
+  if [[ -f "${jobs_report}" ]] &&
+    grep -qE 'completed:[[:space:]]+[1-9][0-9]*' "${jobs_report}" &&
+    ! grep -qE 'failed:[[:space:]]+[1-9][0-9]*' "${jobs_report}"; then
+    note_warn "jobs report has completed jobs but no failed jobs despite ${total_failed_plans} failed plan(s)"
+  fi
 fi
 
 "${script_dir}/build-repro-set.py" "${run}" ||

--- a/scripts/e2e-policy-audit/lib/build-summary.sh
+++ b/scripts/e2e-policy-audit/lib/build-summary.sh
@@ -76,9 +76,17 @@ fi
 # Per-phase plan summary from db-export/plans.tsv.
 phase_summary="${run}/diffs/phase-summary.tsv"
 failed_plans="${run}/diffs/failed-plans.tsv"
+failure_clusters="${run}/diffs/failure-clusters.tsv"
+failure_clusters_md="${run}/diffs/failure-clusters.md"
 plans_tsv="${run}/db-export/plans.tsv"
 if [[ -f "${plans_tsv}" ]]; then
   "${script_dir}/plan-phase-summary.py" "${plans_tsv}" "${phase_summary}" "${failed_plans}"
+  if [[ -s "${failed_plans}" ]] && [[ $(awk 'END {print NR}' "${failed_plans}") -gt 1 ]]; then
+    "${script_dir}/failure-clusters.py" \
+      "${failed_plans}" "${failure_clusters}" "${failure_clusters_md}" \
+      --files-tsv "${run}/db-export/files.tsv" \
+      --pre-ffprobe "${run}/pre/ffprobe.ndjson"
+  fi
 
   while IFS=$'\t' read -r phase total _completed _skipped failed; do
     [[ "${phase}" == "phase" ]] && continue
@@ -129,10 +137,19 @@ fi
   echo
   echo "## Anomaly section"
   echo
-  echo "### Failed plans (first 50)"
+  echo "### Failure clusters"
+  if [[ -s "${failure_clusters}" ]]; then
+    echo '```'
+    head -21 "${failure_clusters}"
+    echo '```'
+  else
+    echo "(none)"
+  fi
+  echo
+  echo "### Failed plans (first 20)"
   echo '```'
   if [[ -f "${failed_plans}" ]] && [[ $(awk 'END {print NR}' "${failed_plans}") -gt 1 ]]; then
-    head -51 "${failed_plans}"
+    head -21 "${failed_plans}"
   else
     echo "(none)"
   fi

--- a/scripts/e2e-policy-audit/lib/build-summary.sh
+++ b/scripts/e2e-policy-audit/lib/build-summary.sh
@@ -173,6 +173,24 @@ fi
     echo '```'
   fi
   echo
+  echo "### Top db-vs-ffprobe-post diff classes"
+  if [[ -f "${run}/diffs/db-vs-ffprobe-post-summary.tsv" ]]; then
+    echo '```'
+    head -21 "${run}/diffs/db-vs-ffprobe-post-summary.tsv"
+    echo '```'
+  else
+    echo "(not generated)"
+  fi
+  echo
+  echo "### Top ffprobe pre-vs-post diff classes"
+  if [[ -f "${run}/diffs/ffprobe-pre-vs-post-summary.tsv" ]]; then
+    echo '```'
+    head -21 "${run}/diffs/ffprobe-pre-vs-post-summary.tsv"
+    echo '```'
+  else
+    echo "(not generated)"
+  fi
+  echo
   echo "## Linked artifacts"
   echo
   echo "- [diffs/](diffs/)"

--- a/scripts/e2e-policy-audit/lib/build-summary.sh
+++ b/scripts/e2e-policy-audit/lib/build-summary.sh
@@ -96,6 +96,9 @@ if [[ -f "${plans_tsv}" ]]; then
   done <"${phase_summary}"
 fi
 
+"${script_dir}/build-repro-set.py" "${run}" ||
+  note_warn "failed to build repro file set"
+
 # Render
 {
   echo "# E2E Run Summary — ${verdict}"
@@ -197,6 +200,7 @@ fi
   echo "- [logs/](logs/)"
   echo "- [reports/](reports/)"
   echo "- [db-export/](db-export/)"
+  echo "- [repro/](repro/)"
   echo "- [web-smoke/](web-smoke/)"
 } >"${run}/summary.md"
 

--- a/scripts/e2e-policy-audit/lib/diff-class-summary.py
+++ b/scripts/e2e-policy-audit/lib/diff-class-summary.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Summarize canonical diff TSV rows by stable change signatures."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+from collections import Counter, defaultdict
+from pathlib import Path
+
+
+def classify(change_class: str, details: str) -> str:
+    if change_class == "video" and re.search(r"\+#\d+\(png\)", details):
+        return "attachment-promoted-to-png-video"
+    if change_class == "attachment" and re.search(r"-#\d+\(png\)", details):
+        return "png-attachment-removed"
+    if change_class == "subtitle" and ".is_default:False→True" in details:
+        return "subtitle-default-enabled"
+    if change_class == "subtitle" and ".is_default:True→False" in details:
+        return "subtitle-default-disabled"
+    if ".language:und→" in details:
+        return "language-detected-from-und"
+    if re.search(r"\.language:[^→]+→und", details):
+        return "language-lost-to-und"
+    if re.search(r"\+#\d+", details):
+        return f"{change_class}-stream-added"
+    if re.search(r"-#\d+", details):
+        return f"{change_class}-stream-removed"
+    if change_class in {"bitrate", "size", "container", "duration", "content_hash", "mtime"}:
+        return change_class
+    if change_class in {"video", "audio", "subtitle", "attachment"}:
+        fields = sorted(set(re.findall(r"#\d+\.([A-Za-z0-9_]+):", details)))
+        if fields:
+            return f"{change_class}-field-change:" + ",".join(fields[:4])
+    if change_class == "-":
+        return "path-presence"
+    return change_class or "unknown"
+
+
+def summarize(diff_tsv: Path, out_tsv: Path, out_md: Path) -> None:
+    counts: Counter[tuple[str, str]] = Counter()
+    samples: dict[tuple[str, str], str] = {}
+    paths_by_key: defaultdict[tuple[str, str], set[str]] = defaultdict(set)
+
+    with diff_tsv.open(newline="") as f:
+        reader = csv.DictReader(f, delimiter="\t")
+        if reader.fieldnames is None or not {"path", "change-class", "details"}.issubset(
+            reader.fieldnames
+        ):
+            raise SystemExit(f"{diff_tsv}: missing required diff columns")
+        for row in reader:
+            change_class = row["change-class"]
+            signature = classify(change_class, row["details"])
+            key = (change_class, signature)
+            counts[key] += 1
+            paths_by_key[key].add(row["path"])
+            samples.setdefault(key, row["path"])
+
+    out_tsv.parent.mkdir(parents=True, exist_ok=True)
+    with out_tsv.open("w", newline="") as f:
+        writer = csv.writer(f, delimiter="\t", lineterminator="\n")
+        writer.writerow(["change-class", "signature", "rows", "files", "sample_path"])
+        for (change_class, signature), rows in sorted(
+            counts.items(), key=lambda item: (-item[1], item[0])
+        ):
+            writer.writerow(
+                [
+                    change_class,
+                    signature,
+                    rows,
+                    len(paths_by_key[(change_class, signature)]),
+                    samples[(change_class, signature)],
+                ]
+            )
+
+    with out_md.open("w") as f:
+        f.write(f"# Diff Class Summary: {diff_tsv.name}\n\n")
+        if not counts:
+            f.write("(none)\n")
+            return
+        f.write("| Rows | Files | Class | Signature | Sample |\n")
+        f.write("|---:|---:|---|---|---|\n")
+        for (change_class, signature), rows in sorted(
+            counts.items(), key=lambda item: (-item[1], item[0])
+        ):
+            sample = samples[(change_class, signature)].replace("|", "\\|")
+            f.write(
+                f"| {rows} | {len(paths_by_key[(change_class, signature)])} | "
+                f"{change_class} | {signature} | `{sample}` |\n"
+            )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("diff_tsv")
+    parser.add_argument("out_tsv")
+    parser.add_argument("out_md")
+    args = parser.parse_args()
+    summarize(Path(args.diff_tsv), Path(args.out_tsv), Path(args.out_md))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/e2e-policy-audit/lib/failure-clusters.py
+++ b/scripts/e2e-policy-audit/lib/failure-clusters.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Cluster failed plan rows into reviewable failure signatures."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+
+def load_files(files_tsv: Path | None) -> dict[str, str]:
+    if files_tsv is None or not files_tsv.exists():
+        return {}
+    with files_tsv.open(newline="") as f:
+        reader = csv.DictReader(f, delimiter="\t")
+        if reader.fieldnames is None or not {"id", "path"}.issubset(reader.fieldnames):
+            return {}
+        return {row["id"]: row["path"] for row in reader}
+
+
+def load_ffprobe(path: Path | None) -> dict[str, dict[str, Any]]:
+    if path is None or not path.exists():
+        return {}
+    records: dict[str, dict[str, Any]] = {}
+    with path.open() as f:
+        for line in f:
+            if not line.strip():
+                continue
+            record = json.loads(line)
+            records[record["path"]] = record
+    return records
+
+
+def text_for_result(raw: str) -> tuple[dict[str, Any], str]:
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}, raw
+    if not isinstance(parsed, dict):
+        return {}, raw
+    detail = parsed.get("detail") or {}
+    parts = [
+        str(parsed.get("error") or ""),
+        str(detail.get("stderr_tail") or ""),
+        str(detail.get("command") or ""),
+    ]
+    return parsed, "\n".join(parts)
+
+
+def classify(text: str) -> str:
+    checks = [
+        ("storage-fk-transcode-outcome", "failed to insert transcode outcome: FOREIGN KEY"),
+        ("cuda-context-oom", "CUDA_ERROR_OUT_OF_MEMORY"),
+        ("cuda-context-unknown", "CUDA_ERROR_UNKNOWN"),
+        ("nvenc-initialize-oom", "InitializeEncoder failed: out of memory"),
+        ("cuda-decoder-packet-oom", "Error submitting packet to decoder: Cannot allocate memory"),
+        ("filter-format-conversion", "Impossible to convert between the formats"),
+        ("no-hw-decoder-device", "No device available for decoder"),
+        ("no-output-written", "Nothing was written into output file"),
+        ("ffmpeg-conversion-failed", "Conversion failed"),
+    ]
+    for signature, needle in checks:
+        if needle in text:
+            return signature
+    if "ffmpeg exited with exit status" in text:
+        return "ffmpeg-nonzero"
+    return "unknown"
+
+
+def exit_code(parsed: dict[str, Any]) -> str:
+    detail = parsed.get("detail") or {}
+    value = detail.get("exit_code")
+    return "" if value is None else str(value)
+
+
+def command(parsed: dict[str, Any]) -> str:
+    detail = parsed.get("detail") or {}
+    return str(detail.get("command") or "")
+
+
+def video_shape(record: dict[str, Any] | None) -> tuple[str, str, str, str]:
+    if not record:
+        return "", "", "", ""
+    videos = record.get("video") or []
+    first = videos[0] if videos else {}
+    codec = str(first.get("codec") or "")
+    width = first.get("width")
+    height = first.get("height")
+    resolution = f"{width}x{height}" if width and height else ""
+    container = str(record.get("container") or "")
+    return container, codec, resolution, str(len(record.get("audio") or []))
+
+
+def sample_error(text: str) -> str:
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    interesting = [
+        line
+        for line in lines
+        if any(
+            needle in line
+            for needle in [
+                "CUDA_ERROR",
+                "InitializeEncoder",
+                "FOREIGN KEY",
+                "No device available",
+                "Impossible to convert",
+                "Nothing was written",
+                "Conversion failed",
+                "ffmpeg exited",
+            ]
+        )
+    ]
+    chosen = interesting[:3] or lines[:3]
+    return " | ".join(chosen)[:500]
+
+
+def write_outputs(
+    failed_plans: Path,
+    files_tsv: Path | None,
+    pre_ffprobe: Path | None,
+    out_tsv: Path,
+    out_md: Path,
+) -> None:
+    file_paths = load_files(files_tsv)
+    ffprobe = load_ffprobe(pre_ffprobe)
+    clusters: dict[tuple[str, str, str, str, str], dict[str, Any]] = {}
+    per_file_rows: list[dict[str, str]] = []
+
+    with failed_plans.open(newline="") as f:
+        reader = csv.DictReader(f, delimiter="\t")
+        if reader.fieldnames is None or not {"plan_id", "file_id", "phase", "result"}.issubset(
+            reader.fieldnames
+        ):
+            raise SystemExit(f"{failed_plans}: missing required failed-plan columns")
+
+        for row in reader:
+            parsed, text = text_for_result(row["result"])
+            path = file_paths.get(row["file_id"]) or extract_path(command(parsed)) or ""
+            container, codec, resolution, audio_count = video_shape(ffprobe.get(path))
+            signature = classify(text)
+            code = exit_code(parsed)
+            phase = row["phase"]
+            key = (phase, signature, code, container, codec)
+            cluster = clusters.setdefault(
+                key,
+                {
+                    "count": 0,
+                    "sample_path": path,
+                    "sample_plan_id": row["plan_id"],
+                    "sample_error": sample_error(text),
+                    "resolutions": Counter(),
+                    "audio_counts": Counter(),
+                },
+            )
+            cluster["count"] += 1
+            if resolution:
+                cluster["resolutions"][resolution] += 1
+            if audio_count:
+                cluster["audio_counts"][audio_count] += 1
+            per_file_rows.append(
+                {
+                    "path": path,
+                    "phase": phase,
+                    "signature": signature,
+                    "exit_code": code,
+                    "container": container,
+                    "video_codec": codec,
+                    "resolution": resolution,
+                    "plan_id": row["plan_id"],
+                    "file_id": row["file_id"],
+                }
+            )
+
+    out_tsv.parent.mkdir(parents=True, exist_ok=True)
+    with out_tsv.open("w", newline="") as f:
+        writer = csv.writer(f, delimiter="\t", lineterminator="\n")
+        writer.writerow(
+            [
+                "phase",
+                "signature",
+                "exit_code",
+                "container",
+                "video_codec",
+                "count",
+                "top_resolution",
+                "sample_path",
+                "sample_plan_id",
+                "sample_error",
+            ]
+        )
+        for key, value in sorted(clusters.items(), key=lambda item: (-item[1]["count"], item[0])):
+            phase, signature, code, container, codec = key
+            top_resolution = ""
+            if value["resolutions"]:
+                top_resolution = value["resolutions"].most_common(1)[0][0]
+            writer.writerow(
+                [
+                    phase,
+                    signature,
+                    code,
+                    container,
+                    codec,
+                    value["count"],
+                    top_resolution,
+                    value["sample_path"],
+                    value["sample_plan_id"],
+                    value["sample_error"],
+                ]
+            )
+
+    with out_md.open("w") as f:
+        f.write("# Failure Clusters\n\n")
+        if not clusters:
+            f.write("(none)\n")
+            return
+        f.write("| Count | Phase | Signature | Exit | Source | Top Resolution | Sample |\n")
+        f.write("|---:|---|---|---|---|---|---|\n")
+        for key, value in sorted(clusters.items(), key=lambda item: (-item[1]["count"], item[0])):
+            phase, signature, code, container, codec = key
+            source = "/".join(part for part in [container, codec] if part)
+            top_resolution = ""
+            if value["resolutions"]:
+                top_resolution = value["resolutions"].most_common(1)[0][0]
+            sample = value["sample_path"].replace("|", "\\|")
+            f.write(
+                f"| {value['count']} | {phase} | {signature} | {code} | "
+                f"{source} | {top_resolution} | `{sample}` |\n"
+            )
+
+    run_root = out_tsv.parent.parent if out_tsv.parent.name == "diffs" else out_tsv.parent
+    repro_tsv = run_root / "repro" / "failed-plan-files.tsv"
+    repro_tsv.parent.mkdir(parents=True, exist_ok=True)
+    with repro_tsv.open("w", newline="") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=[
+                "path",
+                "phase",
+                "signature",
+                "exit_code",
+                "container",
+                "video_codec",
+                "resolution",
+                "plan_id",
+                "file_id",
+            ],
+            delimiter="\t",
+            lineterminator="\n",
+        )
+        writer.writeheader()
+        writer.writerows(per_file_rows)
+
+
+def extract_path(command_text: str) -> str:
+    match = re.search(r" -i '([^']+)' ", command_text)
+    if match:
+        return match.group(1)
+    match = re.search(r' -i "([^"]+)" ', command_text)
+    if match:
+        return match.group(1)
+    return ""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("failed_plans")
+    parser.add_argument("out_tsv")
+    parser.add_argument("out_md")
+    parser.add_argument("--files-tsv")
+    parser.add_argument("--pre-ffprobe")
+    args = parser.parse_args()
+
+    write_outputs(
+        Path(args.failed_plans),
+        Path(args.files_tsv) if args.files_tsv else None,
+        Path(args.pre_ffprobe) if args.pre_ffprobe else None,
+        Path(args.out_tsv),
+        Path(args.out_md),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/e2e-policy-audit/lib/preflight.sh
+++ b/scripts/e2e-policy-audit/lib/preflight.sh
@@ -50,6 +50,43 @@ kernel=$(uname -sr)
 cpu=$(awk -F': ' '/^model name/ {print $2; exit}' /proc/cpuinfo 2>/dev/null || echo "unknown")
 gpu=$(command -v nvidia-smi >/dev/null && nvidia-smi --query-gpu=name --format=csv,noheader,nounits 2>/dev/null | head -1 || echo "none")
 
+env_dir="${run_dir}/env"
+mkdir -p "${env_dir}"
+
+capture_env_command() {
+    local out="$1"
+    shift
+    {
+        printf '$'
+        printf ' %q' "$@"
+        printf '\n\n'
+        "$@"
+    } >"${env_dir}/${out}" 2>&1 || true
+}
+
+capture_env_command ffmpeg-version.txt ffmpeg -hide_banner -version
+capture_env_command ffmpeg-hwaccels.txt ffmpeg -hide_banner -hwaccels
+capture_env_command ffmpeg-encoders.txt ffmpeg -hide_banner -encoders
+capture_env_command ffprobe-version.txt ffprobe -hide_banner -version
+capture_env_command mkvmerge-version.txt mkvmerge --version
+
+if command -v nvidia-smi >/dev/null 2>&1; then
+    capture_env_command nvidia-smi.txt nvidia-smi
+    capture_env_command nvidia-smi-query.csv nvidia-smi \
+        --query-gpu=index,name,driver_version,cuda_version,memory.total,memory.used,memory.free,utilization.gpu,utilization.memory \
+        --format=csv
+fi
+
+git -C "$(git rev-parse --show-toplevel 2>/dev/null || pwd)" status --short --branch \
+    >"${env_dir}/git-status.txt" 2>&1 || true
+cp "${policy_path}" "${env_dir}/policy.voom" 2>/dev/null || true
+
+config_file="${config_dir}/config.toml"
+if [[ -r "${config_file}" ]]; then
+    sed -E 's/(password|token|secret|key|credential)([[:space:]]*=[[:space:]]*).*/\1\2"<redacted>"/I' \
+        "${config_file}" >"${env_dir}/voom-config.redacted.toml" || true
+fi
+
 jq -n \
     --arg started_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
     --arg voom_version "${voom_version}" \
@@ -68,6 +105,7 @@ jq -n \
         policy: { path: $policy_path, sha256: $policy_sha256 },
         library: $library,
         host: { kernel: $kernel, cpu: $cpu, gpu: $gpu },
+        env_dir: "env",
         stages: {}
     }' >"${run_dir}/manifest.json"
 

--- a/scripts/e2e-policy-audit/run.sh
+++ b/scripts/e2e-policy-audit/run.sh
@@ -237,6 +237,17 @@ if ((do_probe)); then
             echo "diff/pivot pid ${pid} failed (continuing)" >&2
         fi
     done
+
+    for diff_name in db-vs-ffprobe-post ffprobe-pre-vs-post; do
+        diff_tsv="${run_dir}/diffs/${diff_name}.tsv"
+        if [[ -r "${diff_tsv}" ]]; then
+            "${lib_dir}/diff-class-summary.py" \
+                "${diff_tsv}" \
+                "${run_dir}/diffs/${diff_name}-summary.tsv" \
+                "${run_dir}/diffs/${diff_name}-summary.md" ||
+                echo "diff class summary failed for ${diff_name} (continuing)" >&2
+        fi
+    done
 fi
 stage_end diff "$t"
 

--- a/scripts/e2e-policy-audit/tests/expected/summary-failed-phase/summary.md
+++ b/scripts/e2e-policy-audit/tests/expected/summary-failed-phase/summary.md
@@ -58,4 +58,5 @@ plan-4	file-4	transcode-video	{"error":"encoder failed"}
 - [logs/](logs/)
 - [reports/](reports/)
 - [db-export/](db-export/)
+- [repro/](repro/)
 - [web-smoke/](web-smoke/)

--- a/scripts/e2e-policy-audit/tests/expected/summary-failed-phase/summary.md
+++ b/scripts/e2e-policy-audit/tests/expected/summary-failed-phase/summary.md
@@ -26,7 +26,13 @@ transcode-video	3	1	1	1
 
 ## Anomaly section
 
-### Failed plans (first 50)
+### Failure clusters
+```
+phase	signature	exit_code	container	video_codec	count	top_resolution	sample_path	sample_plan_id	sample_error
+transcode-video	unknown				1			plan-4	encoder failed
+```
+
+### Failed plans (first 20)
 ```
 plan_id	file_id	phase	result
 plan-4	file-4	transcode-video	{"error":"encoder failed"}

--- a/scripts/e2e-policy-audit/tests/expected/summary-failed-phase/summary.md
+++ b/scripts/e2e-policy-audit/tests/expected/summary-failed-phase/summary.md
@@ -46,6 +46,12 @@ plan-4	file-4	transcode-video	{"error":"encoder failed"}
 
 ### First 50 db-vs-ffprobe-post divergences (introspection bugs)
 
+### Top db-vs-ffprobe-post diff classes
+(not generated)
+
+### Top ffprobe pre-vs-post diff classes
+(not generated)
+
 ## Linked artifacts
 
 - [diffs/](diffs/)

--- a/scripts/e2e-policy-audit/tests/test.sh
+++ b/scripts/e2e-policy-audit/tests/test.sh
@@ -78,6 +78,49 @@ EOF
 
 run_summary_failed_phase_test
 
+run_failure_clusters_test() {
+  local actual
+  actual=$(mktemp -d)
+  trap 'rm -R "${actual}"' EXIT
+
+  cat >"${actual}/failed-plans.tsv" <<'EOF'
+plan_id	file_id	phase	result
+plan-1	file-1	transcode-video	{"detail":{"exit_code":187,"command":"ffmpeg -i '/lib/show/S01E01.mkv' out.mkv","stderr_tail":"cuCtxCreate failed -> CUDA_ERROR_OUT_OF_MEMORY: out of memory"},"error":"ffmpeg exited with exit status: 187"}
+plan-2	file-2	transcode-video	{"detail":null,"error":"storage error: failed to insert transcode outcome: FOREIGN KEY constraint failed"}
+EOF
+
+  cat >"${actual}/files.tsv" <<'EOF'
+id	path
+file-1	/lib/show/S01E01.mkv
+file-2	/lib/show/S01E02.mkv
+EOF
+
+  cat >"${actual}/ffprobe.ndjson" <<'EOF'
+{"path":"/lib/show/S01E01.mkv","container":"mkv","video":[{"index":0,"codec":"h264","width":1920,"height":1080}],"audio":[{"index":1}]}
+{"path":"/lib/show/S01E02.mkv","container":"mkv","video":[{"index":0,"codec":"mpeg4","width":640,"height":480}],"audio":[]}
+EOF
+
+  "lib/failure-clusters.py" \
+    "${actual}/failed-plans.tsv" \
+    "${actual}/failure-clusters.tsv" \
+    "${actual}/failure-clusters.md" \
+    --files-tsv "${actual}/files.tsv" \
+    --pre-ffprobe "${actual}/ffprobe.ndjson"
+
+  cat >"${actual}/expected-clusters.tsv" <<'EOF'
+phase	signature	exit_code	container	video_codec	count	top_resolution	sample_path	sample_plan_id	sample_error
+transcode-video	cuda-context-oom	187	mkv	h264	1	1920x1080	/lib/show/S01E01.mkv	plan-1	ffmpeg exited with exit status: 187 | cuCtxCreate failed -> CUDA_ERROR_OUT_OF_MEMORY: out of memory
+transcode-video	storage-fk-transcode-outcome		mkv	mpeg4	1	640x480	/lib/show/S01E02.mkv	plan-2	storage error: failed to insert transcode outcome: FOREIGN KEY constraint failed
+EOF
+
+  assert_match "${actual}/failure-clusters.tsv" "${actual}/expected-clusters.tsv"
+
+  rm -R "${actual}"
+  trap - EXIT
+}
+
+run_failure_clusters_test
+
 raw_actual=$(mktemp -d)
 trap 'rm -rf "${raw_actual}"' EXIT
 

--- a/scripts/e2e-policy-audit/tests/test.sh
+++ b/scripts/e2e-policy-audit/tests/test.sh
@@ -121,6 +121,40 @@ EOF
 
 run_failure_clusters_test
 
+run_diff_class_summary_test() {
+  local actual
+  actual=$(mktemp -d)
+  trap 'rm -R "${actual}"' EXIT
+
+  cat >"${actual}/diff.tsv" <<'EOF'
+path	side	change-class	details
+/lib/a.mkv	both	subtitle	#2.is_default:False→True
+/lib/b.mkv	both	video	#0.codec:h264→hevc; +#4(png)
+/lib/b.mkv	both	attachment	-#4(png)
+/lib/c.mkv	both	audio	#1.language:und→eng
+EOF
+
+  "lib/diff-class-summary.py" \
+    "${actual}/diff.tsv" \
+    "${actual}/summary.tsv" \
+    "${actual}/summary.md"
+
+  cat >"${actual}/expected.tsv" <<'EOF'
+change-class	signature	rows	files	sample_path
+attachment	png-attachment-removed	1	1	/lib/b.mkv
+audio	language-detected-from-und	1	1	/lib/c.mkv
+subtitle	subtitle-default-enabled	1	1	/lib/a.mkv
+video	attachment-promoted-to-png-video	1	1	/lib/b.mkv
+EOF
+
+  assert_match "${actual}/summary.tsv" "${actual}/expected.tsv"
+
+  rm -R "${actual}"
+  trap - EXIT
+}
+
+run_diff_class_summary_test
+
 raw_actual=$(mktemp -d)
 trap 'rm -rf "${raw_actual}"' EXIT
 

--- a/scripts/e2e-policy-audit/tests/test.sh
+++ b/scripts/e2e-policy-audit/tests/test.sh
@@ -155,6 +155,55 @@ EOF
 
 run_diff_class_summary_test
 
+run_repro_set_test() {
+  local actual
+  actual=$(mktemp -d)
+  trap 'rm -R "${actual}"' EXIT
+  mkdir -p "${actual}/repro" "${actual}/diffs"
+
+  cat >"${actual}/manifest.json" <<'EOF'
+{"library":"/lib"}
+EOF
+
+  cat >"${actual}/repro/failed-plan-files.tsv" <<'EOF'
+path	phase	signature	exit_code	container	video_codec	resolution	plan_id	file_id
+/lib/show/S01E01.mkv	transcode-video	cuda-context-oom	187	mkv	h264	1920x1080	plan-1	file-1
+/lib/show/S01E02.mkv	transcode-video	cuda-context-oom	187	mkv	h264	1920x1080	plan-2	file-2
+EOF
+
+  cat >"${actual}/diffs/db-vs-ffprobe-post.tsv" <<'EOF'
+path	side	change-class	details
+/lib/show/S01E03.mkv	both	subtitle	#2.is_default:False→True
+/lib/show/S01E04.mkv	both	subtitle	#2.is_default:False→True
+/lib/show/S01E05.mkv	both	video	+#4(png)
+EOF
+
+  "lib/build-repro-set.py" "${actual}" --cap-per-signature 1
+
+  cat >"${actual}/expected-minimal.tsv" <<'EOF'
+path	relative_path	source	signature	phase	detail
+/lib/show/S01E01.mkv	show/S01E01.mkv	failed-plan	cuda-context-oom	transcode-video	plan-1
+/lib/show/S01E03.mkv	show/S01E03.mkv	db-vs-ffprobe-post	subtitle-default-enabled		#2.is_default:False→True
+/lib/show/S01E05.mkv	show/S01E05.mkv	db-vs-ffprobe-post	attachment-promoted-to-png-video		+#4(png)
+EOF
+
+  assert_match "${actual}/repro/minimal-covering-set.tsv" "${actual}/expected-minimal.tsv"
+
+  cat >"${actual}/expected-relative-paths" <<'EOF'
+show/S01E01.mkv
+show/S01E03.mkv
+show/S01E05.mkv
+EOF
+  assert_match \
+    "${actual}/repro/minimal-covering-set.relative-paths" \
+    "${actual}/expected-relative-paths"
+
+  rm -R "${actual}"
+  trap - EXIT
+}
+
+run_repro_set_test
+
 raw_actual=$(mktemp -d)
 trap 'rm -rf "${raw_actual}"' EXIT
 


### PR DESCRIPTION
## Summary

- capture environment/tooling artifacts for e2e runs
- cluster failed plans and summarize diff classes for faster post-mortems
- generate repro file sets and a copy script for smaller follow-up libraries
- flag inconsistent process/job accounting when plans fail
- document the new e2e artifacts and repro workflow

## Tests

- `scripts/e2e-policy-audit/tests/test.sh`
