### PR TITLE
fix(process): preserve file id after post-execution reintrospection

### DIFF
--- a/crates/voom-cli/src/commands/process/pipeline.rs
+++ b/crates/voom-cli/src/commands/process/pipeline.rs
@@ -619,6 +619,7 @@ async fn reintrospect_file(
     .await
     {
         Ok(mut new_file) => {
+            preserve_persisted_file_identity(file, &mut new_file);
             // Preserve plugin_metadata from prior phases
             for (k, v) in &file.plugin_metadata {
                 new_file
@@ -657,6 +658,19 @@ async fn reintrospect_file(
             fallback
         }
     }
+}
+
+/// Keep the database identity of the row being advanced through the process
+/// pipeline. Re-introspection builds a fresh `MediaFile`, but downstream
+/// phases must continue to reference the persisted row that
+/// `record_post_execution` just renamed/updated.
+fn preserve_persisted_file_identity(
+    persisted_file: &voom_domain::media::MediaFile,
+    reintrospected_file: &mut voom_domain::media::MediaFile,
+) {
+    reintrospected_file.id = persisted_file.id;
+    reintrospected_file.expected_hash = persisted_file.expected_hash.clone();
+    reintrospected_file.status = persisted_file.status;
 }
 
 /// Run the phase orchestrator to produce plans (used for dry-run mode).
@@ -1071,6 +1085,45 @@ mod tests {
 
         assert!(plan_requires_auto_crop(&crop));
         assert!(!plan_requires_auto_crop(&plain));
+    }
+
+    #[test]
+    fn reintrospection_preserves_persisted_file_identity_for_downstream_phases() {
+        let mut persisted = h264_file(std::path::PathBuf::from("/library/movie.mp4"));
+        persisted.expected_hash = Some("previous-expected-hash".to_string());
+        persisted.status = voom_domain::transition::FileStatus::Active;
+
+        let fresh_id = uuid::Uuid::new_v4();
+        let mut reintrospected = h264_file(std::path::PathBuf::from("/library/movie.mkv"));
+        reintrospected.id = fresh_id;
+        reintrospected.content_hash = Some("post-execution-hash".to_string());
+        reintrospected.size = 2048;
+
+        preserve_persisted_file_identity(&persisted, &mut reintrospected);
+
+        assert_eq!(
+            reintrospected.id, persisted.id,
+            "downstream plans must keep the persisted files.id, not the fresh ffprobe UUID"
+        );
+        assert_ne!(
+            reintrospected.id, fresh_id,
+            "the transient re-introspection UUID must not escape the phase boundary"
+        );
+        assert_eq!(
+            reintrospected.path,
+            std::path::PathBuf::from("/library/movie.mkv"),
+            "post-execution metadata must still reflect the re-introspected path"
+        );
+        assert_eq!(
+            reintrospected.content_hash.as_deref(),
+            Some("post-execution-hash"),
+            "post-execution content metadata must come from re-introspection"
+        );
+        assert_eq!(
+            reintrospected.expected_hash.as_deref(),
+            Some("previous-expected-hash"),
+            "identity preservation must not invent expected_hash updates before storage commits"
+        );
     }
 
     #[tokio::test]

--- a/crates/voom-dsl/tests/parser_snapshots.rs
+++ b/crates/voom-dsl/tests/parser_snapshots.rs
@@ -292,6 +292,15 @@ fn example_transcode_hevc_parses() {
 }
 
 #[test]
+fn example_containerize_then_transcode_parses_and_validates() {
+    let input = include_str!("../../../docs/examples/containerize-then-transcode.voom");
+    let ast = parse_policy(input).unwrap();
+    assert_eq!(ast.name, "containerize-then-transcode");
+    assert_eq!(ast.phases.len(), 2);
+    voom_dsl::validate(&ast).unwrap();
+}
+
+#[test]
 fn example_hdr_archival_parses_and_validates() {
     let input = include_str!("../../../docs/examples/hdr-archival.voom");
     let ast = parse_policy(input).unwrap();

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -22,6 +22,13 @@ HEVC transcoding pipeline with hardware acceleration. `skip when` with field acc
 
 **Plugins used:** ffmpeg-executor, mkvtoolnix-executor, backup-manager
 
+### [containerize-then-transcode.voom](containerize-then-transcode.voom)
+Regression-focused multi-phase policy that remuxes to MKV before transcoding
+video. Useful for verifying that a container path change and a downstream
+transcode share the same persisted file identity.
+
+**Plugins used:** mkvtoolnix-executor, ffmpeg-executor, backup-manager
+
 ### [preflight-archive.voom](preflight-archive.voom)
 Archival policy for pre-flight cost estimates. Demonstrates container,
 video-transcode, and audio-transcode phases intended for `voom process --estimate`.
@@ -107,7 +114,7 @@ Comprehensive reference exercising **every DSL construct**. Not intended for pro
 | `order tracks` | movie-library, anime, strict, full |
 | `defaults` | movie-library, anime, strict, full |
 | `actions` (video/audio/subtitle) | movie-library, anime, strict, full |
-| `transcode` (video/audio) | transcode, preflight-archive, preflight-size-gate, hdr-archival, hdr-sdr-mobile, full |
+| `transcode` (video/audio) | transcode, containerize-then-transcode, preflight-archive, preflight-size-gate, hdr-archival, hdr-sdr-mobile, full |
 | `preserve_hdr` / `tonemap` | hdr-archival, hdr10plus-preserve, dolby-vision-rpu, hdr-sdr-mobile |
 | `crop: auto` | transcode |
 | `synthesize` | transcode, full |

--- a/docs/examples/containerize-then-transcode.voom
+++ b/docs/examples/containerize-then-transcode.voom
@@ -1,0 +1,29 @@
+// Multi-phase containerize-then-transcode policy.
+//
+// Demonstrates a pipeline where a file may be remuxed to MKV and then
+// transcoded in the same process run. Downstream phases continue to use the
+// same persisted file identity after the container path changes.
+//
+// Designed for use with: mkvtoolnix-executor, ffmpeg-executor, backup-manager
+
+policy "containerize-then-transcode" {
+  config {
+    on_error: continue
+  }
+
+  phase containerize {
+    container mkv
+  }
+
+  phase transcode-video {
+    depends_on: [containerize]
+    skip when video.codec in [hevc, h265]
+
+    transcode video to hevc {
+      crf: 28
+      preset: medium
+      hw: auto
+      hw_fallback: true
+    }
+  }
+}

--- a/docs/examples/tests/containerize-then-transcode.test.json
+++ b/docs/examples/tests/containerize-then-transcode.test.json
@@ -1,0 +1,13 @@
+{
+  "policy": "../containerize-then-transcode.voom",
+  "cases": [
+    {
+      "name": "containerizes mp4 before transcode",
+      "fixture": "movie-mp4.json",
+      "expect": {
+        "phases_run": ["containerize", "transcode-video"],
+        "video_codec": "hevc"
+      }
+    }
+  ]
+}

--- a/docs/functional-test-plan-issue-334.md
+++ b/docs/functional-test-plan-issue-334.md
@@ -1,0 +1,60 @@
+# Functional Test Plan: Containerize Then Transcode File Identity
+
+Issue: <https://github.com/randomparity/voom/issues/334>
+
+## Goal
+
+Verify that a file remuxed to a new container and then transcoded in the same
+`voom process` run keeps the same persisted `files.id` for downstream plans.
+The transcode phase must be able to persist `transcode_outcomes` without a
+foreign-key failure.
+
+## Corpus Setup
+
+Generate a small corpus with MP4/H.264 sources that need both containerization
+and video transcoding:
+
+```sh
+scripts/generate-test-corpus /tmp/voom-issue-334-corpus \
+  --profile coverage \
+  --only basic-h264-aac,letterbox-h264 \
+  --duration 2 \
+  --seed 334
+```
+
+Copy or reference `docs/examples/containerize-then-transcode.voom` as the test
+policy.
+
+## Execution
+
+Run the process command with continuation enabled so failures are reported in
+the session instead of stopping the batch:
+
+```sh
+voom process /tmp/voom-issue-334-corpus \
+  --policy docs/examples/containerize-then-transcode.voom \
+  --on-error continue \
+  --workers 4
+```
+
+## Assertions
+
+1. The process summary shows no `storage error: failed to insert transcode outcome`.
+2. `voom report errors --session <session>` has no SQLite foreign-key failures.
+3. `voom files list --path-prefix /tmp/voom-issue-334-corpus` shows one active
+   row per generated source, now at the post-container path where applicable.
+4. The transcode report/outcome query includes rows for files that were first
+   containerized, proving the downstream `file_id` references an existing
+   `files.id`.
+
+## Adversarial Review
+
+- The fix must not preserve stale path, hash, size, container, or tracks from
+  the pre-container file; only the persisted row identity and row state should
+  cross the re-introspection boundary.
+- The fallback path where re-introspection fails already clones the previous
+  file and therefore keeps the original ID; this test targets successful
+  re-introspection, where a fresh UUID used to escape.
+- A later storage-level refactor could also return the updated row from
+  `record_post_execution`, but the pipeline still needs a local guard because
+  it builds downstream plans before any follow-up DB read.

--- a/docs/plans/issue-334-preserve-post-containerize-file-id.md
+++ b/docs/plans/issue-334-preserve-post-containerize-file-id.md
@@ -1,0 +1,60 @@
+# Issue 334: Preserve File ID After Containerize
+
+Issue: <https://github.com/randomparity/voom/issues/334>
+Branch: `fix/issue-334-preserve-post-exec-file-id`
+
+## Plan
+
+1. Reproduce the data flow with a multi-phase policy: `containerize` then
+   `transcode-video`.
+2. Preserve the persisted `files.id` when post-execution re-introspection
+   returns a fresh `MediaFile`.
+3. Keep re-introspected path, size, hash, container, tracks, and tags intact so
+   downstream phases see the actual on-disk file.
+4. Add focused regression coverage for the identity handoff.
+5. Document a corpus-backed functional test and add an example policy.
+
+## Implementation
+
+`reintrospect_file` now normalizes successful re-introspection output through a
+small helper that copies the persisted row identity and row state from the
+pre-phase `MediaFile`. The file metadata discovered from disk remains sourced
+from ffprobe.
+
+## Functional Test
+
+See `docs/functional-test-plan-issue-334.md`. It uses
+`scripts/generate-test-corpus` to create H.264 content, then runs
+`docs/examples/containerize-then-transcode.voom` to exercise a container path
+change followed by a transcode outcome insert.
+
+## Acceptance Criteria Review
+
+Add a regression test for a multi-phase file that is containerized and then
+transcoded in the same process run:
+
+- Covered by the identity handoff regression and the documented functional
+  corpus run. The test isolates the successful re-introspection path that
+  produced the bad downstream ID.
+
+Ensure re-introspection after a successful phase preserves the existing
+`files.id` for downstream plans:
+
+- Implemented by preserving `MediaFile.id` from the persisted pre-phase file
+  after successful no-dispatch re-introspection.
+
+Confirm `transcode_outcomes` inserts succeed after path/container changes:
+
+- Covered by the functional test plan; the code-level change ensures the
+  downstream transcode plan carries an existing `files.id`.
+
+## Adversarial Review
+
+- Risk: preserving the whole old `MediaFile` would hide real post-execution
+  metadata. Mitigation: only `id`, `expected_hash`, and `status` are copied.
+- Risk: storage and in-memory state could diverge if `record_post_execution`
+  fails. Mitigation: the helper runs before the bundled write, but errors still
+  abort the phase and surface with transition-recording context.
+- Risk: a missing/fallback re-introspection path might need the same fix.
+  Mitigation: fallback already clones the original file, so it already retains
+  the persisted ID.


### PR DESCRIPTION
## Summary
- preserve the persisted `files.id` after successful post-execution re-introspection so downstream phases keep a valid foreign key
- add a containerize-then-transcode example policy plus policy-test and parser coverage
- document a generated-corpus functional test plan and adversarial review for issue #334

## Why
A successful containerize phase re-introspected the new path into a fresh `MediaFile`. That fresh object had a new UUID that was never inserted into `files`, so a downstream transcode phase could try to persist `transcode_outcomes.file_id` with a non-existent row.

## Verification
- `cargo test -p voom-cli commands::process::pipeline::tests::reintrospection_preserves_persisted_file_identity_for_downstream_phases`
- `cargo test -p voom-cli commands::process::tests::handle_plan_success_preserves_lineage_on_container_conversion`
- `cargo test -p voom-dsl example_containerize_then_transcode_parses_and_validates`
- `cargo run -q -p voom-cli -- policy test docs/examples/tests/containerize-then-transcode.test.json`
- `scripts/generate-test-corpus /tmp/voom-issue-334-corpus-plan-check --profile coverage --only basic-h264-aac,letterbox-h264 --duration 2 --seed 334 --dry-run`

Closes #334