### PR TITLE
fix(process): fail file jobs when executable plans fail

### DIFF
--- a/crates/voom-cli/src/commands/process/pipeline.rs
+++ b/crates/voom-cli/src/commands/process/pipeline.rs
@@ -236,6 +236,7 @@ async fn process_single_file_execute(
     let mut any_executed = false;
     let mut modified_counted = false;
     let mut plans_evaluated: usize = 0;
+    let mut failed_plan_count: usize = 0;
 
     for phase_name in &compiled.phase_order {
         if ctx.token.is_cancelled() {
@@ -309,6 +310,7 @@ async fn process_single_file_execute(
                     phase_name.clone(),
                     voom_policy_evaluator::EvaluationOutcome::ExecutionFailed,
                 );
+                failed_plan_count += 1;
                 drop(acquired);
                 continue;
             }
@@ -325,6 +327,7 @@ async fn process_single_file_execute(
                 phase_name.clone(),
                 voom_policy_evaluator::EvaluationOutcome::SafeguardFailed,
             );
+            failed_plan_count += 1;
             continue;
         }
 
@@ -363,6 +366,7 @@ async fn process_single_file_execute(
                         phase_name.clone(),
                         voom_policy_evaluator::EvaluationOutcome::SafeguardFailed,
                     );
+                    failed_plan_count += 1;
                     continue;
                 }
                 // Post-execution safeguard: check duration shrinkage.
@@ -374,6 +378,7 @@ async fn process_single_file_execute(
                         phase_name.clone(),
                         voom_policy_evaluator::EvaluationOutcome::SafeguardFailed,
                     );
+                    failed_plan_count += 1;
                     continue;
                 }
                 any_executed = true;
@@ -414,10 +419,17 @@ async fn process_single_file_execute(
                     plan.phase_name.clone(),
                     voom_policy_evaluator::EvaluationOutcome::ExecutionFailed,
                 );
+                failed_plan_count += 1;
                 // Downstream phases still evaluate; run_if gates block
                 // them via ExecutionFailed in phase_outcomes.
             }
         }
+    }
+
+    if failed_plan_count > 0 {
+        return Err(format!(
+            "{failed_plan_count} executable plan(s) failed for {file_path_str}"
+        ));
     }
 
     Ok(Some(serde_json::json!({
@@ -907,6 +919,36 @@ mod tests {
         }
     }
 
+    struct FailingExecutor;
+
+    impl voom_kernel::Plugin for FailingExecutor {
+        fn name(&self) -> &'static str {
+            "failing-executor"
+        }
+
+        fn version(&self) -> &'static str {
+            "0.1.0"
+        }
+
+        fn capabilities(&self) -> &[Capability] {
+            &[]
+        }
+
+        fn handles(&self, event_type: &str) -> bool {
+            event_type == Event::PLAN_CREATED
+        }
+
+        fn on_event(&self, event: &Event) -> voom_domain::errors::Result<Option<EventResult>> {
+            if let Event::PlanCreated(_) = event {
+                return Ok(Some(EventResult::plan_failed(
+                    self.name(),
+                    "simulated executor failure",
+                )));
+            }
+            Ok(None)
+        }
+    }
+
     fn nvenc_policy() -> &'static str {
         r#"policy "test" {
                 phase transcode-video {
@@ -1124,6 +1166,39 @@ mod tests {
             Some("previous-expected-hash"),
             "identity preservation must not invent expected_hash updates before storage commits"
         );
+    }
+
+    #[tokio::test]
+    async fn failed_executable_plan_returns_file_job_error() {
+        let policy = global_hw_policy();
+        let fixture = process_tests::TestFixture::with_policy(policy);
+        let path = fixture.dir_path().join("movie.mkv");
+        let file = h264_file(path);
+        let compiled = voom_dsl::compile_policy(policy).unwrap();
+
+        let mut kernel = voom_kernel::Kernel::new();
+        kernel
+            .register_plugin(Arc::new(FailingExecutor), 50)
+            .unwrap();
+        let ctx = fixture.make_ctx(
+            Arc::new(kernel),
+            Arc::new(voom_domain::test_support::InMemoryStore::new()),
+        );
+
+        let error = process_single_file_execute(&file, &compiled, &ctx)
+            .await
+            .expect_err("failed executable plans must fail the file job");
+
+        assert!(
+            error.contains("1 executable plan(s) failed"),
+            "unexpected error: {error}"
+        );
+        let stats = ctx.counters.phase_stats.lock();
+        let phase = stats
+            .get("transcode-video")
+            .expect("failed phase should be recorded");
+        assert_eq!(phase.failed, 1);
+        assert_eq!(phase.completed, 0);
     }
 
     #[tokio::test]

--- a/crates/voom-dsl/tests/parser_snapshots.rs
+++ b/crates/voom-dsl/tests/parser_snapshots.rs
@@ -301,6 +301,15 @@ fn example_containerize_then_transcode_parses_and_validates() {
 }
 
 #[test]
+fn example_continue_on_error_transcode_parses_and_validates() {
+    let input = include_str!("../../../docs/examples/continue-on-error-transcode.voom");
+    let ast = parse_policy(input).unwrap();
+    assert_eq!(ast.name, "continue-on-error-transcode");
+    assert_eq!(ast.phases.len(), 1);
+    voom_dsl::validate(&ast).unwrap();
+}
+
+#[test]
 fn example_hdr_archival_parses_and_validates() {
     let input = include_str!("../../../docs/examples/hdr-archival.voom");
     let ast = parse_policy(input).unwrap();

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -109,8 +109,13 @@ voom process <PATH>... [--policy <FILE> | --policy-map <TOML>] [OPTIONS]
 Before processing, stale database entries for files that no longer exist under the target directory are automatically pruned (along with their associated plans and processing stats). Files that previously failed introspection (tracked as "bad files") are automatically skipped unless `--force-rescan` is set.
 
 Error handling strategies:
-- **`fail`** — Stop processing on first error
-- **`continue`** — Continue processing remaining phases for the failed file
+- **`fail`** — Stop processing the batch on the first file job error.
+- **`continue`** — Continue processing remaining files after a file job error.
+
+If an executable plan fails, the file job is marked failed and the final
+summary error count is non-zero. With `--on-error continue`, the command still
+finishes the batch; inspect `voom jobs list --status failed` and
+`voom report errors --session <session>` for details.
 
 **Examples:**
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -29,6 +29,13 @@ transcode share the same persisted file identity.
 
 **Plugins used:** mkvtoolnix-executor, ffmpeg-executor, backup-manager
 
+### [continue-on-error-transcode.voom](continue-on-error-transcode.voom)
+Batch-oriented transcode policy with `on_error: continue`. Useful for testing
+that failed executable plans are visible in job accounting and summaries while
+the rest of the batch continues.
+
+**Plugins used:** ffmpeg-executor, backup-manager
+
 ### [preflight-archive.voom](preflight-archive.voom)
 Archival policy for pre-flight cost estimates. Demonstrates container,
 video-transcode, and audio-transcode phases intended for `voom process --estimate`.
@@ -108,7 +115,7 @@ Comprehensive reference exercising **every DSL construct**. Not intended for pro
 | `depends_on` | all except minimal |
 | `skip when` | transcode, full |
 | `run_if` (modified/completed) | anime, transcode, strict, full |
-| `on_error` | movie-library, transcode, strict, full, speech-language-filter, speech-transcription-check |
+| `on_error` | movie-library, transcode, continue-on-error-transcode, strict, full, speech-language-filter, speech-transcription-check |
 | `container` | minimal, movie-library, anime, transcode, full |
 | `keep` / `remove` | movie-library, anime, attachment, strict, full, speech-language-filter |
 | `order tracks` | movie-library, anime, strict, full |

--- a/docs/examples/continue-on-error-transcode.voom
+++ b/docs/examples/continue-on-error-transcode.voom
@@ -1,0 +1,25 @@
+// Continue-on-error transcode policy.
+//
+// Demonstrates a batch-oriented policy where one file can fail execution while
+// the rest of the run continues. Failed executable plans are recorded as
+// failed file jobs and appear in the final process summary and job reports.
+//
+// Designed for use with: ffmpeg-executor, backup-manager
+
+policy "continue-on-error-transcode" {
+  config {
+    on_error: continue
+  }
+
+  phase transcode-video {
+    on_error: continue
+    skip when video.codec in [hevc, h265]
+
+    transcode video to hevc {
+      crf: 28
+      preset: medium
+      hw: auto
+      hw_fallback: true
+    }
+  }
+}

--- a/docs/examples/tests/continue-on-error-transcode.test.json
+++ b/docs/examples/tests/continue-on-error-transcode.test.json
@@ -1,0 +1,13 @@
+{
+  "policy": "../continue-on-error-transcode.voom",
+  "cases": [
+    {
+      "name": "plans h264 source with continue-on-error policy",
+      "fixture": "movie-mp4.json",
+      "expect": {
+        "phases_run": ["transcode-video"],
+        "video_codec": "hevc"
+      }
+    }
+  ]
+}

--- a/docs/functional-test-plan-issue-333.md
+++ b/docs/functional-test-plan-issue-333.md
@@ -1,0 +1,59 @@
+# Functional Test Plan: Failed Plans Surface In Job Accounting
+
+Issue: <https://github.com/randomparity/voom/issues/333>
+
+## Goal
+
+Verify that an executable plan failure is reflected as a failed file job and an
+unambiguous process summary, even when `--on-error continue` lets the batch keep
+running.
+
+## Corpus Setup
+
+Generate a small corpus with multiple H.264 inputs so one induced executor
+failure can be compared with successful files in the same run:
+
+```sh
+scripts/generate-test-corpus /tmp/voom-issue-333-corpus \
+  --profile coverage \
+  --only basic-h264-aac,letterbox-h264 \
+  --duration 2 \
+  --seed 333
+```
+
+Use `docs/examples/continue-on-error-transcode.voom` as the policy.
+
+## Execution
+
+Run once with a deliberately constrained or broken executor environment for one
+file, then run the same command after restoring the executor. In local manual
+testing, the failure can be induced by temporarily moving one generated file
+away after discovery in a debugger, by injecting a failing executor in a test
+build, or by using an ffmpeg wrapper that exits non-zero for one selected input.
+
+```sh
+voom process /tmp/voom-issue-333-corpus \
+  --policy docs/examples/continue-on-error-transcode.voom \
+  --on-error continue \
+  --workers 2
+```
+
+## Assertions
+
+1. The final process summary reports a non-zero error count when any executable
+   plan fails.
+2. The phase breakdown reports the failed phase with the same non-zero error
+   count.
+3. `voom jobs list --status failed` includes the file job whose plan failed.
+4. `voom report errors --session <session>` includes the plan failure details.
+5. The command may still exit `0` with `--on-error continue`; the visible
+   summary and job/reporting state are the source of truth for partial failure.
+
+## Adversarial Review
+
+- A skipped plan must not fail the file job; only failed executable or
+  safeguard plans should affect job failure accounting.
+- `--on-error continue` must continue processing other files after one file job
+  fails.
+- `--on-error fail` should still cancel the batch through the worker pool once
+  a failed plan causes the file job to return an error.

--- a/docs/plans/issue-333-failed-plan-accounting.md
+++ b/docs/plans/issue-333-failed-plan-accounting.md
@@ -1,0 +1,74 @@
+# Issue 333: Failed Plan Accounting
+
+Issue: <https://github.com/randomparity/voom/issues/333>
+Branch: `fix/issue-333-plan-failure-accounting`
+
+## Plan
+
+1. Track failed executable plans inside the per-file process pipeline.
+2. Continue evaluating the current file according to existing dependency and
+   `run_if` semantics, but return a file-job error after the phase loop if any
+   executable plan failed.
+3. Let the existing worker-pool error strategy decide whether the batch
+   continues (`--on-error continue`) or cancels (`--on-error fail`).
+4. Keep the process command exit-code behavior unchanged for
+   `--on-error continue`; make the summary and job/reporting state
+   unambiguous.
+5. Add regression tests, example policy coverage, generated-corpus functional
+   test instructions, and adversarial review notes.
+
+## Implementation
+
+The process pipeline now counts failed executable/safeguard plans and returns
+an error for the file job after the phase loop. This routes the failure through
+the existing worker-pool path, marking the job failed and incrementing the
+summary error count without changing plan failure event recording.
+
+## Functional Test
+
+See `docs/functional-test-plan-issue-333.md`. It uses
+`scripts/generate-test-corpus` and
+`docs/examples/continue-on-error-transcode.voom` to validate user-visible
+summary, jobs, and report behavior.
+
+## Acceptance Criteria Review
+
+Add a regression test where one file has a failed plan and `--on-error continue`
+is active:
+
+- Covered by a focused pipeline test that forces an executor failure and by the
+  generated-corpus functional plan for batch behavior.
+
+CLI summary uses plan/file failure counts consistently:
+
+- A failed executable plan now makes the file job fail, so the worker-pool error
+  count and phase breakdown both become non-zero.
+
+Jobs/reporting distinguish successful jobs from jobs with failed plans, or
+expose a `partial` outcome:
+
+- Implemented by marking the file job failed when any executable plan fails.
+  A dedicated `partial` status is deferred until a UI/API design requires it.
+
+Decide and document exit-code semantics for `--on-error continue`:
+
+- Exit `0` remains intentional for continued batch runs. The process summary,
+  `voom jobs list --status failed`, and `voom report errors --session <id>`
+  expose the partial failure.
+
+## Deferred Work
+
+No follow-up issue is required for `partial` job status yet. The current
+accepted behavior uses existing failed job status, and no user-facing API has
+been designed around a separate partial state.
+
+## Adversarial Review
+
+- Risk: returning early on first plan failure would skip useful downstream
+  accounting. Mitigation: the pipeline records all phase outcomes first, then
+  returns the job error at the end.
+- Risk: skipped or empty phases could be misclassified as failures. Mitigation:
+  the counter is incremented only on explicit plan/safeguard failure paths.
+- Risk: changing exit codes could break existing automation. Mitigation:
+  `--on-error continue` keeps command completion semantics unchanged while
+  making failure state visible in summaries and jobs.


### PR DESCRIPTION
## Summary
- return a file-job error when any executable or safeguard plan fails during processing
- keep `--on-error continue` batch completion semantics while making job status and summary errors reflect failed plans
- add a continue-on-error example policy, parser/policy-test coverage, generated-corpus functional test plan, and adversarial review notes

## Why
The process pipeline recorded `PlanFailed` events but still returned `Ok` for the file job. The worker pool therefore counted those jobs as completed and the final summary could say `0 errors` even when the phase breakdown showed failed plans.

## Verification
- `cargo test -p voom-cli commands::process::pipeline::tests::failed_executable_plan_returns_file_job_error`
- `cargo test -p voom-dsl example_continue_on_error_transcode_parses_and_validates`
- `cargo run -q -p voom-cli -- policy test docs/examples/tests/continue-on-error-transcode.test.json`
- `scripts/generate-test-corpus /tmp/voom-issue-333-corpus-plan-check --profile coverage --only basic-h264-aac,letterbox-h264 --duration 2 --seed 333 --dry-run`

Closes #333