### PR TITLE
fix(ffmpeg): lower default nvenc concurrency

### DIFF
--- a/crates/voom-cli/src/config.rs
+++ b/crates/voom-cli/src/config.rs
@@ -363,10 +363,10 @@ pub fn default_config_contents() -> String {
 # # GPU device for HW encoding. NVIDIA: "0", "1". VA-API/QSV: "/dev/dri/renderD128".
 # # Omit to use system default.
 # # gpu_device = "0"
-# # Maximum simultaneous NVENC encode sessions. Default: 4.
-# # Lower this to 2 on small GPUs or when CUDA OOM appears under load.
+# # Maximum simultaneous NVENC encode sessions. Default: 2.
+# # Increase cautiously on large GPUs after validating an e2e run.
 # # Applies only when NVENC is active; 0 uses the default.
-# # nvenc_max_parallel = 4
+# # nvenc_max_parallel = 2
 # # Opportunistically use hardware decode when a matching decoder was probed.
 # # Disable this if a GPU driver or source profile fails with hwaccel enabled.
 # # Defaults to true.

--- a/crates/voom-dsl/tests/parser_snapshots.rs
+++ b/crates/voom-dsl/tests/parser_snapshots.rs
@@ -310,6 +310,15 @@ fn example_continue_on_error_transcode_parses_and_validates() {
 }
 
 #[test]
+fn example_hw_nvenc_hevc_parses_and_validates() {
+    let input = include_str!("../../../docs/examples/hw-nvenc-hevc.voom");
+    let ast = parse_policy(input).unwrap();
+    assert_eq!(ast.name, "hw-nvenc-hevc");
+    assert_eq!(ast.phases.len(), 1);
+    voom_dsl::validate(&ast).unwrap();
+}
+
+#[test]
 fn example_hdr_archival_parses_and_validates() {
     let input = include_str!("../../../docs/examples/hdr-archival.voom");
     let ast = parse_policy(input).unwrap();

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -6,6 +6,7 @@
 | [architecture.md](architecture.md) | System architecture overview |
 | [cli-reference.md](cli-reference.md) | Complete CLI command and REST API reference |
 | [dsl-reference.md](dsl-reference.md) | DSL language reference for `.voom` policy files |
+| [hardware-transcoding.md](hardware-transcoding.md) | Hardware encoder configuration and NVENC concurrency tuning |
 | [hdr-transcoding.md](hdr-transcoding.md) | HDR preservation and SDR tone-mapping guide |
 | [loudness-normalization.md](loudness-normalization.md) | EBU R128 / LUFS audio normalization policies and reporting |
 | [quickstart.md](quickstart.md) | Getting started guide |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -587,6 +587,7 @@ voom config get <KEY>
 ```bash
 voom config get auth_token
 voom config get plugin.ffmpeg-executor.hw_accel
+voom config get plugin.ffmpeg-executor.nvenc_max_parallel
 ```
 
 #### `voom config set`
@@ -602,9 +603,12 @@ voom config set <KEY> <VALUE>
 ```bash
 voom config set auth_token mytoken
 voom config set plugin.ffmpeg-executor.hw_accel nvenc
+voom config set plugin.ffmpeg-executor.nvenc_max_parallel 2
 ```
 
 Configuration file location: `~/.config/voom/config.toml`
+
+For hardware transcoding, see [Hardware Transcoding](hardware-transcoding.md).
 
 ---
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -36,6 +36,13 @@ the rest of the batch continues.
 
 **Plugins used:** ffmpeg-executor, backup-manager
 
+### [hw-nvenc-hevc.voom](hw-nvenc-hevc.voom)
+Explicit NVENC HEVC transcode policy. Pair with
+`[plugin.ffmpeg-executor] nvenc_max_parallel` to validate hardware resource
+limiting independently from `voom process --workers`.
+
+**Plugins used:** ffmpeg-executor, backup-manager
+
 ### [preflight-archive.voom](preflight-archive.voom)
 Archival policy for pre-flight cost estimates. Demonstrates container,
 video-transcode, and audio-transcode phases intended for `voom process --estimate`.
@@ -121,7 +128,7 @@ Comprehensive reference exercising **every DSL construct**. Not intended for pro
 | `order tracks` | movie-library, anime, strict, full |
 | `defaults` | movie-library, anime, strict, full |
 | `actions` (video/audio/subtitle) | movie-library, anime, strict, full |
-| `transcode` (video/audio) | transcode, containerize-then-transcode, preflight-archive, preflight-size-gate, hdr-archival, hdr-sdr-mobile, full |
+| `transcode` (video/audio) | transcode, containerize-then-transcode, hw-nvenc-hevc, preflight-archive, preflight-size-gate, hdr-archival, hdr-sdr-mobile, full |
 | `preserve_hdr` / `tonemap` | hdr-archival, hdr10plus-preserve, dolby-vision-rpu, hdr-sdr-mobile |
 | `crop: auto` | transcode |
 | `synthesize` | transcode, full |

--- a/docs/examples/hw-nvenc-hevc.voom
+++ b/docs/examples/hw-nvenc-hevc.voom
@@ -1,0 +1,24 @@
+// NVENC HEVC transcode policy.
+//
+// Demonstrates explicit NVENC use with the process-level hardware limiter.
+// Set `[plugin.ffmpeg-executor] nvenc_max_parallel` in config.toml to tune
+// concurrent hardware transcodes independently of `voom process --workers`.
+//
+// Designed for use with: ffmpeg-executor, backup-manager
+
+policy "hw-nvenc-hevc" {
+  config {
+    on_error: continue
+  }
+
+  phase transcode-video {
+    skip when video.codec in [hevc, h265]
+
+    transcode video to hevc {
+      crf: 32
+      preset: medium
+      hw: nvenc
+      hw_fallback: true
+    }
+  }
+}

--- a/docs/examples/tests/hw-nvenc-hevc.test.json
+++ b/docs/examples/tests/hw-nvenc-hevc.test.json
@@ -1,0 +1,13 @@
+{
+  "policy": "../hw-nvenc-hevc.voom",
+  "cases": [
+    {
+      "name": "plans explicit nvenc hevc transcode",
+      "fixture": "movie-mp4.json",
+      "expect": {
+        "phases_run": ["transcode-video"],
+        "video_codec": "hevc"
+      }
+    }
+  ]
+}

--- a/docs/functional-test-plan-issue-332.md
+++ b/docs/functional-test-plan-issue-332.md
@@ -1,0 +1,60 @@
+# Functional Test Plan: NVENC Resource Limiting
+
+Issue: <https://github.com/randomparity/voom/issues/332>
+
+## Goal
+
+Verify that hardware HEVC transcode runs respect the plan-level `hw:nvenc`
+limiter even when the file worker count is higher than the configured NVENC
+parallelism.
+
+## Corpus Setup
+
+```sh
+scripts/generate-test-corpus /tmp/voom-issue-332-corpus \
+  --profile coverage \
+  --only basic-h264-aac,letterbox-h264 \
+  --duration 2 \
+  --seed 332
+```
+
+Use `docs/examples/hw-nvenc-hevc.voom` as the policy.
+
+## Configuration
+
+Start with the conservative default or set it explicitly:
+
+```toml
+[plugin.ffmpeg-executor]
+hw_accel = "nvenc"
+gpu_device = "0"
+nvenc_max_parallel = 2
+```
+
+## Execution
+
+Run with file workers above the NVENC limit:
+
+```sh
+voom process /tmp/voom-issue-332-corpus \
+  --policy docs/examples/hw-nvenc-hevc.voom \
+  --on-error continue \
+  --workers 8
+```
+
+## Assertions
+
+1. The run does not produce CUDA/NVENC out-of-memory failures.
+2. The phase breakdown does not show mass `transcode-video` errors.
+3. `hw: nvenc`, `hw: auto`, and default-hardware video transcode plans acquire
+   the same `hw:nvenc` limiter when NVENC is the active backend.
+4. Raising `--workers` above `nvenc_max_parallel` increases queued file work but
+   does not increase concurrent NVENC ffmpeg executions beyond the configured
+   limit.
+
+## Adversarial Review
+
+- A high `--workers` value should not bypass the hardware limiter.
+- `hw: none` must remain software and must not consume an NVENC permit.
+- The default limit must be conservative enough for CUDA decode+encode
+  workloads; users can raise `nvenc_max_parallel` after validating their GPU.

--- a/docs/hardware-transcoding.md
+++ b/docs/hardware-transcoding.md
@@ -1,0 +1,61 @@
+# Hardware Transcoding
+
+VOOM can route video transcodes through hardware encoders such as NVENC, QSV,
+VA-API, and VideoToolbox. Hardware jobs still run inside the normal
+`voom process --workers` file worker pool, but executor-advertised hardware
+resources add a second plan-level limit so many file workers do not create too
+many GPU contexts at once.
+
+## NVENC Concurrency
+
+When `[plugin.ffmpeg-executor] hw_accel = "nvenc"` is active, the ffmpeg
+executor advertises a `hw:nvenc` plan limit. `transcode video` plans with
+`hw: nvenc`, `hw: auto`, or no per-action `hw` setting acquire that limiter
+before executor dispatch. `hw: none` stays software and does not consume an
+NVENC permit.
+
+The default NVENC limit is `2` concurrent plans per process. This conservative
+default is intended for decode+encode workloads where each ffmpeg process may
+create CUDA decoder and encoder contexts.
+
+Tune the limit in `~/.config/voom/config.toml`:
+
+```toml
+[plugin.ffmpeg-executor]
+hw_accel = "nvenc"
+gpu_device = "0"
+nvenc_max_parallel = 2
+```
+
+Use `1` for small GPUs or when CUDA/NVENC out-of-memory errors appear. Increase
+only after a representative e2e run completes without GPU allocation failures.
+The file worker count can still be higher; extra hardware transcode plans wait
+on the NVENC permit while software-only work continues.
+
+## Functional Check
+
+Generate a small hardware-transcode corpus:
+
+```sh
+scripts/generate-test-corpus /tmp/voom-hw-transcode \
+  --profile coverage \
+  --only basic-h264-aac,letterbox-h264 \
+  --duration 2 \
+  --seed 332
+```
+
+Run with more file workers than the NVENC limit:
+
+```sh
+voom process /tmp/voom-hw-transcode \
+  --policy docs/examples/hw-nvenc-hevc.voom \
+  --on-error continue \
+  --workers 8
+```
+
+Expected results:
+
+- no CUDA/NVENC out-of-memory failures in the phase breakdown
+- no more than `nvenc_max_parallel` ffmpeg NVENC plans executing at once
+- `voom report errors --session <session>` is empty or contains only unrelated
+  file-specific failures

--- a/docs/plans/issue-332-nvenc-resource-limiter.md
+++ b/docs/plans/issue-332-nvenc-resource-limiter.md
@@ -1,0 +1,66 @@
+# Issue 332: NVENC Resource Limiter
+
+Issue: <https://github.com/randomparity/voom/issues/332>
+Branch: `fix/issue-332-nvenc-limiter-docs`
+
+## Plan
+
+1. Confirm the process command builds a `PlanExecutionLimiter` from executor
+   `parallel_limits`.
+2. Confirm video transcode plans with `hw: auto` or missing per-action hardware
+   use the active executor-level hardware backend as their default resource.
+3. Lower the default NVENC limit to a conservative value for CUDA decode+encode
+   workloads.
+4. Document user-facing configuration and add a policy example plus functional
+   test steps using `scripts/generate-test-corpus`.
+
+## Implementation
+
+The limiter implementation was already present on `main`: the ffmpeg executor
+advertises `hw:nvenc`, the process command passes the best detected hardware
+backend as the default resource, and job-manager tests cover explicit NVENC,
+`hw: auto`, missing `hw`, and `hw: none`.
+
+This issue lowers the default NVENC parallelism from `4` to `2` and documents
+`nvenc_max_parallel` so high-worker e2e runs can be tuned without code changes.
+
+## Functional Test
+
+See `docs/functional-test-plan-issue-332.md`. It generates a small H.264 corpus
+and runs `docs/examples/hw-nvenc-hevc.voom` with `--workers` above
+`nvenc_max_parallel`.
+
+## Acceptance Criteria Review
+
+Reproduce with a small batch and high `--workers` value:
+
+- Covered by the functional test plan using `scripts/generate-test-corpus` and
+  `--workers 8`.
+
+Confirm NVENC plans acquire the `hw:nvenc` semaphore even when the policy uses
+auto/default hardware:
+
+- Existing tests cover default-resource acquisition in `job-manager` and the
+  process pipeline.
+
+Add test coverage for limiter classification of HEVC NVENC transcode plans:
+
+- Existing `PlanParallelResource` and pipeline limiter tests cover explicit
+  `hw: nvenc`, `hw: auto`, missing `hw`, and `hw: none`.
+
+Either lower the default NVENC limit or make it configurable/documented enough
+that e2e can run without mass OOM failures:
+
+- Default lowered to `2`.
+- `nvenc_max_parallel` is documented in config comments and
+  `docs/hardware-transcoding.md`.
+
+## Adversarial Review
+
+- Risk: lower default underuses large GPUs. Mitigation: users can raise
+  `nvenc_max_parallel` after a representative e2e run passes.
+- Risk: file workers may still be high. Mitigation: the limiter sits at plan
+  dispatch, so extra workers wait before ffmpeg creates CUDA contexts.
+- Risk: non-NVENC hardware could need similar tuning. Mitigation: QSV/VA-API
+  resource names already flow through the same limiter; per-backend defaults
+  can be added if e2e evidence shows a problem.

--- a/plugins/ffmpeg-executor/src/lib.rs
+++ b/plugins/ffmpeg-executor/src/lib.rs
@@ -48,7 +48,7 @@ struct FfmpegExecutorConfig {
     hw_decode: Option<bool>,
 }
 
-const DEFAULT_NVENC_MAX_PARALLEL_PER_GPU: usize = 4;
+const DEFAULT_NVENC_MAX_PARALLEL_PER_GPU: usize = 2;
 
 fn positive_or_default(value: Option<usize>, default: usize) -> usize {
     match value {


### PR DESCRIPTION
## Summary
- lower the default NVENC plan concurrency from 4 to 2
- document `nvenc_max_parallel` tuning and the relationship between file workers and hardware permits
- add an explicit NVENC HEVC policy example, parser/policy-test coverage, generated-corpus functional test plan, and adversarial review notes

## Why
High `--workers` runs can create many concurrent CUDA decode/encode contexts when NVENC plans are not bounded conservatively. The plan limiter already classifies explicit NVENC and active-default hardware transcodes; this change makes the default safer and documents how to tune it.

## Verification
- `cargo test -p voom-ffmpeg-executor test_config_nvenc_parallel_limits_default`
- `cargo test -p voom-cli process_pipeline_limits_transcode_without_per_action_hw`
- `cargo test -p voom-dsl example_hw_nvenc_hevc_parses_and_validates`
- `cargo run -q -p voom-cli -- policy test docs/examples/tests/hw-nvenc-hevc.test.json`
- `scripts/generate-test-corpus /tmp/voom-issue-332-corpus-plan-check --profile coverage --only basic-h264-aac,letterbox-h264 --duration 2 --seed 332 --dry-run`

Closes #332