### PR TITLE
fix(ffmpeg): exclude attachments from video transcode maps

### DIFF
--- a/crates/voom-dsl/tests/parser_snapshots.rs
+++ b/crates/voom-dsl/tests/parser_snapshots.rs
@@ -319,6 +319,15 @@ fn example_hw_nvenc_hevc_parses_and_validates() {
 }
 
 #[test]
+fn example_transcode_video_drop_attachments_parses_and_validates() {
+    let input = include_str!("../../../docs/examples/transcode-video-drop-attachments.voom");
+    let ast = parse_policy(input).unwrap();
+    assert_eq!(ast.name, "transcode-video-drop-attachments");
+    assert_eq!(ast.phases.len(), 1);
+    voom_dsl::validate(&ast).unwrap();
+}
+
+#[test]
 fn example_hdr_archival_parses_and_validates() {
     let input = include_str!("../../../docs/examples/hdr-archival.voom");
     let ast = parse_policy(input).unwrap();

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -43,6 +43,13 @@ limiting independently from `voom process --workers`.
 
 **Plugins used:** ffmpeg-executor, backup-manager
 
+### [transcode-video-drop-attachments.voom](transcode-video-drop-attachments.voom)
+Attachment-safe video transcode policy. Demonstrates that ffmpeg video
+transcodes exclude Matroska attachments from the output mapping so image
+attachments cannot become PNG/JPEG video streams.
+
+**Plugins used:** ffmpeg-executor, mkvtoolnix-executor, backup-manager
+
 ### [preflight-archive.voom](preflight-archive.voom)
 Archival policy for pre-flight cost estimates. Demonstrates container,
 video-transcode, and audio-transcode phases intended for `voom process --estimate`.
@@ -128,7 +135,7 @@ Comprehensive reference exercising **every DSL construct**. Not intended for pro
 | `order tracks` | movie-library, anime, strict, full |
 | `defaults` | movie-library, anime, strict, full |
 | `actions` (video/audio/subtitle) | movie-library, anime, strict, full |
-| `transcode` (video/audio) | transcode, containerize-then-transcode, hw-nvenc-hevc, preflight-archive, preflight-size-gate, hdr-archival, hdr-sdr-mobile, full |
+| `transcode` (video/audio) | transcode, containerize-then-transcode, hw-nvenc-hevc, transcode-video-drop-attachments, preflight-archive, preflight-size-gate, hdr-archival, hdr-sdr-mobile, full |
 | `preserve_hdr` / `tonemap` | hdr-archival, hdr10plus-preserve, dolby-vision-rpu, hdr-sdr-mobile |
 | `crop: auto` | transcode |
 | `synthesize` | transcode, full |

--- a/docs/examples/tests/transcode-video-drop-attachments.test.json
+++ b/docs/examples/tests/transcode-video-drop-attachments.test.json
@@ -1,0 +1,13 @@
+{
+  "policy": "../transcode-video-drop-attachments.voom",
+  "cases": [
+    {
+      "name": "plans h264 attachment fixture transcode",
+      "fixture": "rich-movie.json",
+      "expect": {
+        "phases_run": ["transcode-video"],
+        "video_codec": "hevc"
+      }
+    }
+  ]
+}

--- a/docs/examples/transcode-video-drop-attachments.voom
+++ b/docs/examples/transcode-video-drop-attachments.voom
@@ -1,0 +1,25 @@
+// Video transcode with attachment-safe ffmpeg mapping.
+//
+// FFmpeg video transcodes intentionally exclude Matroska attachment streams
+// from the ffmpeg output mapping so cover art/font attachments cannot turn into
+// PNG video streams. Use an attachment-management phase with mkvtoolnix when
+// attachment preservation or cleanup is required before/after transcoding.
+//
+// Designed for use with: ffmpeg-executor, mkvtoolnix-executor, backup-manager
+
+policy "transcode-video-drop-attachments" {
+  config {
+    on_error: continue
+  }
+
+  phase transcode-video {
+    skip when video.codec in [hevc, h265]
+
+    transcode video to hevc {
+      crf: 28
+      preset: medium
+      hw: auto
+      hw_fallback: true
+    }
+  }
+}

--- a/docs/functional-test-plan-issue-335.md
+++ b/docs/functional-test-plan-issue-335.md
@@ -1,0 +1,49 @@
+# Functional Test Plan: Attachment-Safe Video Transcode Mapping
+
+Issue: <https://github.com/randomparity/voom/issues/335>
+
+## Goal
+
+Verify that an ffmpeg video transcode does not map Matroska attachments into
+the output as PNG/JPEG video streams.
+
+## Corpus Setup
+
+Generate a fixture with font and image attachments:
+
+```sh
+scripts/generate-test-corpus /tmp/voom-issue-335-corpus \
+  --profile coverage \
+  --only attachment,cover-art \
+  --duration 2 \
+  --seed 335
+```
+
+Use `docs/examples/transcode-video-drop-attachments.voom` as the policy.
+
+## Execution
+
+```sh
+voom process /tmp/voom-issue-335-corpus \
+  --policy docs/examples/transcode-video-drop-attachments.voom \
+  --on-error continue \
+  --workers 2
+```
+
+## Assertions
+
+1. `ffprobe` post-run output contains no extra PNG/JPEG video stream created
+   from an attachment.
+2. `voom inspect <file> --format json` does not show attachment images
+   reclassified as `Video` tracks.
+3. If attachment preservation is required, run an explicit mkvtoolnix-backed
+   attachment policy before or after the ffmpeg transcode instead of relying on
+   ffmpeg stream-copy behavior.
+
+## Adversarial Review
+
+- The ffmpeg transcode path should not use `-map 0` when attachments are known
+  in the VOOM track list.
+- Audio and subtitle tracks must still be mapped explicitly.
+- Files with no track inventory should fall back to `-map 0` rather than
+  producing an empty output mapping.

--- a/docs/plans/issue-335-attachment-safe-ffmpeg-mapping.md
+++ b/docs/plans/issue-335-attachment-safe-ffmpeg-mapping.md
@@ -1,0 +1,58 @@
+# Issue 335: Attachment-Safe FFmpeg Mapping
+
+Issue: <https://github.com/randomparity/voom/issues/335>
+Branch: `fix/issue-335-preserve-mkv-attachments`
+
+## Plan
+
+1. Replace ffmpeg video-transcode `-map 0` usage with explicit mapping from
+   VOOM's track inventory.
+2. Exclude tracks classified as `attachment` from ffmpeg video-transcode output
+   so image attachments cannot become video streams.
+3. Preserve existing `-map 0` fallback for non-video-transcode paths and for
+   files with no track inventory.
+4. Add command-builder regression coverage, generated-corpus functional test
+   steps, and an example policy documenting the behavior.
+
+## Implementation
+
+Video transcode commands now map each non-attachment track explicitly. This is
+an intentional drop of attachment streams in the ffmpeg transcode path; VOOM's
+attachment-management policies should be used when users need to preserve,
+remove, or normalize attachments with mkvtoolnix.
+
+## Functional Test
+
+See `docs/functional-test-plan-issue-335.md`. It uses
+`scripts/generate-test-corpus` to generate `attachment` and `cover-art`
+fixtures, then runs `docs/examples/transcode-video-drop-attachments.voom`.
+
+## Acceptance Criteria Review
+
+Add a fixture with a Matroska attachment and run a video transcode:
+
+- Covered by the generated-corpus functional plan.
+
+Verify the output does not contain an extra PNG video stream:
+
+- Covered by command-builder regression coverage and the functional test
+  assertions.
+
+Preserve attachments using correct ffmpeg mapping/metadata options, or
+explicitly exclude attachments from video stream mapping and document policy
+behavior:
+
+- Implemented by explicitly excluding attachment tracks from ffmpeg video
+  transcode mapping and documenting that attachment preservation should use the
+  attachment-management/mkvtoolnix path.
+
+## Adversarial Review
+
+- Risk: dropping attachments is lossy. Mitigation: the behavior is explicit in
+  docs and example policy comments, and it prevents silent attachment-to-video
+  stream conversion.
+- Risk: incomplete track inventory could omit streams. Mitigation: when no
+  non-attachment tracks are available, command construction falls back to
+  `-map 0`.
+- Risk: this does not solve all metadata drift. Mitigation: stream metadata and
+  disposition preservation remain tracked by issue #336.

--- a/plugins/ffmpeg-executor/src/command.rs
+++ b/plugins/ffmpeg-executor/src/command.rs
@@ -49,6 +49,23 @@ impl FfmpegCommand {
         self
     }
 
+    /// Map all non-attachment tracks from input.
+    #[must_use]
+    pub fn map_non_attachment_tracks(mut self, file: &MediaFile) -> Self {
+        let mut mapped = 0_u32;
+        for track in &file.tracks {
+            if track.track_type == TrackType::Attachment {
+                continue;
+            }
+            self = self.map_track(track.index);
+            mapped += 1;
+        }
+        if mapped == 0 {
+            return self.map_all();
+        }
+        self
+    }
+
     /// Map a specific track by index (`-map 0:{index}`).
     #[must_use]
     pub fn map_track(mut self, index: u32) -> Self {
@@ -741,7 +758,14 @@ pub fn build_ffmpeg_command(
     }
 
     cmd = cmd.input(&file.path);
-    cmd = cmd.map_all();
+    if actions
+        .iter()
+        .any(|action| action.operation == OperationType::TranscodeVideo)
+    {
+        cmd = cmd.map_non_attachment_tracks(file);
+    } else {
+        cmd = cmd.map_all();
+    }
 
     // Start with codec copy for all streams
     cmd = cmd.codec_copy();
@@ -875,6 +899,18 @@ mod tests {
         file
     }
 
+    fn sample_mkv_with_attachment() -> MediaFile {
+        let mut file = MediaFile::new(PathBuf::from("/media/video.mkv"));
+        file.container = Container::Mkv;
+        file.duration = 120.0;
+        file.tracks = vec![
+            Track::new(0, TrackType::Video, "h264".into()),
+            Track::new(1, TrackType::AudioMain, "aac".into()),
+            Track::new(2, TrackType::Attachment, "png".into()),
+        ];
+        file
+    }
+
     fn sample_hdr10_file() -> MediaFile {
         let mut file = sample_mp4_file();
         let video = &mut file.tracks[0];
@@ -960,6 +996,46 @@ mod tests {
         assert!(args.contains(&"23".to_string()));
         assert!(args.contains(&"-preset".to_string()));
         assert!(args.contains(&"medium".to_string()));
+    }
+
+    #[test]
+    fn test_transcode_video_excludes_attachment_streams_from_mapping() {
+        let file = sample_mkv_with_attachment();
+        let action = PlannedAction::track_op(
+            OperationType::TranscodeVideo,
+            0,
+            ActionParams::Transcode {
+                codec: "hevc".into(),
+                settings: TranscodeSettings::default().with_crf(Some(28)),
+            },
+            "Transcode video to HEVC",
+        );
+        let output = Path::new("/tmp/output.mkv");
+
+        let args = build_ffmpeg_command(&file, &[&action], output, None).unwrap();
+
+        assert!(
+            !args
+                .windows(2)
+                .any(|pair| pair[0] == "-map" && pair[1] == "0"),
+            "video transcode should not use map-all when attachments are present: {args:?}"
+        );
+        assert!(
+            args.windows(2)
+                .any(|pair| pair[0] == "-map" && pair[1] == "0:0"),
+            "primary video should be mapped explicitly: {args:?}"
+        );
+        assert!(
+            args.windows(2)
+                .any(|pair| pair[0] == "-map" && pair[1] == "0:1"),
+            "audio should be mapped explicitly: {args:?}"
+        );
+        assert!(
+            !args
+                .windows(2)
+                .any(|pair| pair[0] == "-map" && pair[1] == "0:2"),
+            "attachment stream must not be mapped into ffmpeg transcode output: {args:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- replace ffmpeg video-transcode `-map 0` with explicit non-attachment stream mapping when VOOM has track inventory
- document that ffmpeg video transcodes intentionally drop Matroska attachments, with preservation/cleanup handled through mkvtoolnix-backed attachment-management policies
- add an example policy, policy fixture test, functional test plan using `scripts/generate-test-corpus`, and adversarial review notes

## Verification
- `cargo fmt --all --check`
- `cargo test -p voom-ffmpeg-executor test_transcode_video_excludes_attachment_streams_from_mapping`
- `cargo test -p voom-dsl example_transcode_video_drop_attachments_parses_and_validates`
- `cargo run -q -p voom-cli -- policy test docs/examples/tests/transcode-video-drop-attachments.test.json`
- `scripts/generate-test-corpus /tmp/voom-issue-335-corpus-plan-check --profile coverage --only attachment,cover-art --duration 2 --seed 335 --dry-run`

Closes #335