### PR TITLE
fix(ffmpeg): preserve stream metadata explicitly

### DIFF
--- a/crates/voom-dsl/tests/parser_snapshots.rs
+++ b/crates/voom-dsl/tests/parser_snapshots.rs
@@ -328,6 +328,15 @@ fn example_transcode_video_drop_attachments_parses_and_validates() {
 }
 
 #[test]
+fn example_metadata_stable_transcode_parses_and_validates() {
+    let input = include_str!("../../../docs/examples/metadata-stable-transcode.voom");
+    let ast = parse_policy(input).unwrap();
+    assert_eq!(ast.name, "metadata-stable-transcode");
+    assert_eq!(ast.phases.len(), 1);
+    voom_dsl::validate(&ast).unwrap();
+}
+
+#[test]
 fn example_hdr_archival_parses_and_validates() {
     let input = include_str!("../../../docs/examples/hdr-archival.voom");
     let ast = parse_policy(input).unwrap();

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -50,6 +50,14 @@ attachments cannot become PNG/JPEG video streams.
 
 **Plugins used:** ffmpeg-executor, mkvtoolnix-executor, backup-manager
 
+### [metadata-stable-transcode.voom](metadata-stable-transcode.voom)
+Metadata-stable video transcode policy. Demonstrates ffmpeg-backed
+transcode/containerize behavior that preserves stream languages, titles,
+default/forced flags, global metadata, and chapters unless policy actions
+explicitly change them.
+
+**Plugins used:** ffmpeg-executor, backup-manager
+
 ### [preflight-archive.voom](preflight-archive.voom)
 Archival policy for pre-flight cost estimates. Demonstrates container,
 video-transcode, and audio-transcode phases intended for `voom process --estimate`.
@@ -135,7 +143,7 @@ Comprehensive reference exercising **every DSL construct**. Not intended for pro
 | `order tracks` | movie-library, anime, strict, full |
 | `defaults` | movie-library, anime, strict, full |
 | `actions` (video/audio/subtitle) | movie-library, anime, strict, full |
-| `transcode` (video/audio) | transcode, containerize-then-transcode, hw-nvenc-hevc, transcode-video-drop-attachments, preflight-archive, preflight-size-gate, hdr-archival, hdr-sdr-mobile, full |
+| `transcode` (video/audio) | transcode, containerize-then-transcode, hw-nvenc-hevc, transcode-video-drop-attachments, metadata-stable-transcode, preflight-archive, preflight-size-gate, hdr-archival, hdr-sdr-mobile, full |
 | `preserve_hdr` / `tonemap` | hdr-archival, hdr10plus-preserve, dolby-vision-rpu, hdr-sdr-mobile |
 | `crop: auto` | transcode |
 | `synthesize` | transcode, full |

--- a/docs/examples/metadata-stable-transcode.voom
+++ b/docs/examples/metadata-stable-transcode.voom
@@ -1,0 +1,27 @@
+// Metadata-stable video transcode policy.
+//
+// FFmpeg transcode/containerize commands explicitly preserve global metadata,
+// chapters, stream language tags, stream titles, and default/forced flags.
+// Policy actions such as set_language, set_default, or clear_forced still win
+// over the preserved source state.
+//
+// Designed for use with: ffmpeg-executor, backup-manager
+
+policy "metadata-stable-transcode" {
+  config {
+    languages audio: [eng, und]
+    languages subtitle: [eng, und]
+    on_error: continue
+  }
+
+  phase transcode-video {
+    skip when video.codec in [hevc, h265]
+
+    transcode video to hevc {
+      crf: 28
+      preset: medium
+      hw: auto
+      hw_fallback: true
+    }
+  }
+}

--- a/docs/examples/tests/metadata-stable-transcode.test.json
+++ b/docs/examples/tests/metadata-stable-transcode.test.json
@@ -1,0 +1,13 @@
+{
+  "policy": "../metadata-stable-transcode.voom",
+  "cases": [
+    {
+      "name": "plans h264 rich fixture transcode without metadata cleanup actions",
+      "fixture": "rich-movie.json",
+      "expect": {
+        "phases_run": ["transcode-video"],
+        "video_codec": "hevc"
+      }
+    }
+  ]
+}

--- a/docs/functional-test-plan-issue-336.md
+++ b/docs/functional-test-plan-issue-336.md
@@ -1,0 +1,58 @@
+# Functional Test Plan: Stream Metadata-Stable Processing
+
+Issue: <https://github.com/randomparity/voom/issues/336>
+
+## Goal
+
+Verify that ffmpeg-backed transcode/containerize operations preserve stream
+language tags, titles, and default/forced dispositions unless policy actions
+explicitly change them.
+
+## Corpus Setup
+
+Generate fixtures with unknown languages, non-default subtitles, forced
+subtitles, WebVTT subtitles, and multiple audio/subtitle tracks:
+
+```sh
+scripts/generate-test-corpus /tmp/voom-issue-336-corpus \
+  --profile coverage \
+  --only hevc-surround,multichannel-flac,vp9-opus,pillarbox-h264,mp4-text-subtitle \
+  --duration 2 \
+  --seed 336
+```
+
+Use `docs/examples/metadata-stable-transcode.voom` as the policy.
+
+## Execution
+
+Capture stream metadata before and after processing:
+
+```sh
+voom inspect /tmp/voom-issue-336-corpus --format json > /tmp/voom-issue-336-before.json
+voom process /tmp/voom-issue-336-corpus \
+  --policy docs/examples/metadata-stable-transcode.voom \
+  --on-error continue \
+  --workers 2
+voom inspect /tmp/voom-issue-336-corpus --format json > /tmp/voom-issue-336-after.json
+```
+
+## Assertions
+
+1. Stream `language` values are unchanged for tracks that survive processing,
+   including `und`.
+2. Stream `title` values are unchanged for tracks that survive processing.
+3. Subtitle `is_default: false` does not drift to `true`.
+4. Forced subtitle `is_forced: true` remains true.
+5. Global metadata and chapters are copied from the source input.
+6. Container-incompatible subtitle conversions are reported through existing
+   plan safeguard/warning paths instead of silently changing metadata.
+
+## Adversarial Review
+
+- A preservation flag must not override a policy action such as `set_language`
+  or `clear_forced`.
+- Explicit stream metadata must use output stream indexes, not input indexes,
+  after attachment streams are excluded from video transcode maps.
+- Unknown language (`und`) is a real value and must be emitted explicitly.
+- Empty stream titles must be emitted as `title=` so ffmpeg cannot synthesize a
+  stale title from prior output metadata.

--- a/docs/plans/issue-336-stream-metadata-preservation.md
+++ b/docs/plans/issue-336-stream-metadata-preservation.md
@@ -1,0 +1,61 @@
+# Issue 336: Stream Metadata Preservation
+
+Issue: <https://github.com/randomparity/voom/issues/336>
+Branch: `fix/issue-336-preserve-stream-metadata`
+
+## Plan
+
+1. Make ffmpeg command construction explicitly preserve global metadata and
+   chapters with `-map_metadata 0` and `-map_chapters 0`.
+2. Compute the final stream metadata state from the source track inventory plus
+   policy metadata/disposition actions.
+3. Emit explicit per-output-stream `language`, `title`, and `default`/`forced`
+   disposition arguments.
+4. Add command-builder regression tests, an example policy, generated-corpus
+   functional test steps, and an adversarial review.
+
+## Implementation
+
+FFmpeg commands now build a per-output-stream metadata table before the output
+path is appended. The table starts from VOOM's source track inventory and then
+applies policy actions such as `set_language`, `set_default`, and
+`clear_forced`. The final values are emitted once, using output stream indexes,
+so preservation does not fight explicit policy changes.
+
+## Functional Test
+
+See `docs/functional-test-plan-issue-336.md`. It uses
+`scripts/generate-test-corpus` to generate multilingual, multi-subtitle, and
+unknown-language fixtures and then processes them with
+`docs/examples/metadata-stable-transcode.voom`.
+
+## Acceptance Criteria Review
+
+Add fixtures that include non-default subtitles, `und` language tags, and MP4
+text subtitle inputs:
+
+- Covered by the new `mp4-text-subtitle` generated-corpus fixture, existing
+  multilingual corpus fixtures, and command-builder fixtures.
+
+Verify transcode/containerize preserves dispositions and language metadata where
+the output container supports them:
+
+- Covered by ffmpeg command-builder regression tests that assert explicit
+  metadata/disposition flags.
+
+Where preservation is impossible, record/report the intentional change:
+
+- Existing container compatibility safeguards continue to report incompatible
+  surviving codecs before execution. This change does not bypass those checks.
+
+## Adversarial Review
+
+- Risk: explicit preservation could override policy metadata actions.
+  Mitigation: final stream metadata is computed after applying policy actions.
+- Risk: output stream indexes differ from input indexes after attachment
+  exclusion. Mitigation: preservation uses the enumerated output stream order.
+- Risk: forcing `title=` on streams with no title is noisy. Mitigation: it
+  prevents stale or synthesized title metadata from leaking into outputs.
+- Risk: mkvtoolnix structural remux paths may have separate metadata behavior.
+  Mitigation: mkvtoolnix is already metadata-preserving for remux by default
+  and its explicit metadata operations use mkvpropedit.

--- a/plugins/ffmpeg-executor/src/command.rs
+++ b/plugins/ffmpeg-executor/src/command.rs
@@ -74,6 +74,22 @@ impl FfmpegCommand {
         self
     }
 
+    /// Copy global metadata from an input (`-map_metadata {input_index}`).
+    #[must_use]
+    pub fn map_metadata(mut self, input_index: u32) -> Self {
+        self.args.push("-map_metadata".to_string());
+        self.args.push(input_index.to_string());
+        self
+    }
+
+    /// Copy chapters from an input (`-map_chapters {input_index}`).
+    #[must_use]
+    pub fn map_chapters(mut self, input_index: u32) -> Self {
+        self.args.push("-map_chapters".to_string());
+        self.args.push(input_index.to_string());
+        self
+    }
+
     /// Copy all codecs (`-c copy`).
     #[must_use]
     pub fn codec_copy(mut self) -> Self {
@@ -714,6 +730,113 @@ fn action_allows_direct_hw_decode(
     hw_cfg.decoder_input_args(&track.codec)
 }
 
+#[derive(Debug, Clone)]
+struct OutputTrackMetadata {
+    output_index: u32,
+    input_index: u32,
+    language: String,
+    title: String,
+    is_default: bool,
+    is_forced: bool,
+}
+
+impl OutputTrackMetadata {
+    fn from_track(output_index: u32, track: &Track) -> Self {
+        Self {
+            output_index,
+            input_index: track.index,
+            language: track.language.clone(),
+            title: track.title.clone(),
+            is_default: track.is_default,
+            is_forced: track.is_forced,
+        }
+    }
+
+    fn disposition_value(&self) -> &'static str {
+        match (self.is_default, self.is_forced) {
+            (true, true) => "default+forced",
+            (true, false) => "default",
+            (false, true) => "forced",
+            (false, false) => "0",
+        }
+    }
+}
+
+fn output_track_metadata(file: &MediaFile, exclude_attachments: bool) -> Vec<OutputTrackMetadata> {
+    file.tracks
+        .iter()
+        .filter(|track| !(exclude_attachments && track.track_type == TrackType::Attachment))
+        .enumerate()
+        .map(|(output_index, track)| OutputTrackMetadata::from_track(output_index as u32, track))
+        .collect()
+}
+
+fn apply_track_metadata_actions(
+    streams: &mut [OutputTrackMetadata],
+    actions: &[&PlannedAction],
+) -> Result<()> {
+    for action in actions {
+        let Some(track_index) = action.track_index else {
+            continue;
+        };
+        let Some(stream) = streams
+            .iter_mut()
+            .find(|stream| stream.input_index == track_index)
+        else {
+            continue;
+        };
+
+        match action.operation {
+            OperationType::SetDefault => stream.is_default = true,
+            OperationType::ClearDefault => stream.is_default = false,
+            OperationType::SetForced => stream.is_forced = true,
+            OperationType::ClearForced => stream.is_forced = false,
+            OperationType::SetTitle => {
+                if let ActionParams::Title { title } = &action.parameters {
+                    validate_metadata_value(title)?;
+                    stream.title.clone_from(title);
+                }
+            }
+            OperationType::SetLanguage => {
+                if let ActionParams::Language { language } = &action.parameters {
+                    validate_metadata_value(language)?;
+                    stream.language.clone_from(language);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    Ok(())
+}
+
+fn apply_preserved_stream_metadata(
+    mut cmd: FfmpegCommand,
+    file: &MediaFile,
+    exclude_attachments: bool,
+    actions: &[&PlannedAction],
+) -> Result<FfmpegCommand> {
+    let mut streams = output_track_metadata(file, exclude_attachments);
+    if streams.is_empty() {
+        return Ok(cmd);
+    }
+
+    apply_track_metadata_actions(&mut streams, actions)?;
+
+    cmd = cmd.map_metadata(0).map_chapters(0);
+
+    for stream in streams {
+        validate_metadata_value(&stream.language)?;
+        validate_metadata_value(&stream.title)?;
+        cmd = cmd
+            .metadata(Some(stream.output_index), "language", &stream.language)
+            .metadata(Some(stream.output_index), "title", &stream.title)
+            .disposition(stream.output_index, stream.disposition_value());
+    }
+
+    Ok(cmd)
+}
+
 /// Build an `FFmpeg` command from a plan's actions.
 ///
 /// Groups all actions into a single `FFmpeg` invocation where possible.
@@ -757,11 +880,12 @@ pub fn build_ffmpeg_command(
         cmd = cmd.arg(&arg);
     }
 
-    cmd = cmd.input(&file.path);
-    if actions
+    let exclude_attachments = actions
         .iter()
-        .any(|action| action.operation == OperationType::TranscodeVideo)
-    {
+        .any(|action| action.operation == OperationType::TranscodeVideo);
+
+    cmd = cmd.input(&file.path);
+    if exclude_attachments {
         cmd = cmd.map_non_attachment_tracks(file);
     } else {
         cmd = cmd.map_all();
@@ -785,38 +909,13 @@ pub fn build_ffmpeg_command(
             OperationType::SynthesizeAudio => {
                 cmd = apply_synthesize_audio(cmd, action);
             }
-            OperationType::SetDefault => {
-                if let Some(stream) = action.track_index {
-                    cmd = cmd.disposition(stream, "default");
-                }
-            }
-            // Both clear operations use disposition "0" — ffmpeg clears all
-            // disposition flags on the stream when set to 0.
-            OperationType::ClearDefault | OperationType::ClearForced => {
-                if let Some(stream) = action.track_index {
-                    cmd = cmd.disposition(stream, "0");
-                }
-            }
-            OperationType::SetForced => {
-                if let Some(stream) = action.track_index {
-                    cmd = cmd.disposition(stream, "forced");
-                }
-            }
-            OperationType::SetTitle => {
-                if let Some(stream) = action.track_index {
-                    if let ActionParams::Title { title } = &action.parameters {
-                        validate_metadata_value(title)?;
-                        cmd = cmd.metadata(Some(stream), "title", title);
-                    }
-                }
-            }
-            OperationType::SetLanguage => {
-                if let Some(stream) = action.track_index {
-                    if let ActionParams::Language { language } = &action.parameters {
-                        validate_metadata_value(language)?;
-                        cmd = cmd.metadata(Some(stream), "language", language);
-                    }
-                }
+            OperationType::SetDefault
+            | OperationType::ClearDefault
+            | OperationType::SetForced
+            | OperationType::ClearForced
+            | OperationType::SetTitle
+            | OperationType::SetLanguage => {
+                // Applied once below after output stream indexes are known.
             }
             OperationType::SetContainerTag => {
                 if let ActionParams::SetTag { tag, value } = &action.parameters {
@@ -848,6 +947,8 @@ pub fn build_ffmpeg_command(
             }
         }
     }
+
+    cmd = apply_preserved_stream_metadata(cmd, file, exclude_attachments, actions)?;
 
     cmd = cmd.output(output_path);
     Ok(cmd.build())
@@ -911,6 +1012,29 @@ mod tests {
         file
     }
 
+    fn sample_mkv_with_stream_metadata() -> MediaFile {
+        let mut file = MediaFile::new(PathBuf::from("/media/video.mkv"));
+        file.container = Container::Mkv;
+        file.duration = 120.0;
+
+        let mut video = Track::new(0, TrackType::Video, "h264".into());
+        video.language = "und".into();
+        video.title = "Main Video".into();
+
+        let mut audio = Track::new(1, TrackType::AudioMain, "aac".into());
+        audio.language = "und".into();
+        audio.title = "Original Mix".into();
+        audio.is_default = true;
+
+        let mut subtitle = Track::new(2, TrackType::SubtitleForced, "srt".into());
+        subtitle.language = "eng".into();
+        subtitle.title = "Forced Signs".into();
+        subtitle.is_forced = true;
+
+        file.tracks = vec![video, audio, subtitle];
+        file
+    }
+
     fn sample_hdr10_file() -> MediaFile {
         let mut file = sample_mp4_file();
         let video = &mut file.tracks[0];
@@ -943,6 +1067,14 @@ mod tests {
         args.iter()
             .position(|arg| arg == needle)
             .unwrap_or_else(|| panic!("{needle} not found in {args:?}"))
+    }
+
+    fn assert_arg_pair(args: &[String], flag: &str, value: &str) {
+        assert!(
+            args.windows(2)
+                .any(|pair| pair[0] == flag && pair[1] == value),
+            "expected {flag} {value} in {args:?}"
+        );
     }
 
     #[test]
@@ -1036,6 +1168,63 @@ mod tests {
                 .any(|pair| pair[0] == "-map" && pair[1] == "0:2"),
             "attachment stream must not be mapped into ffmpeg transcode output: {args:?}"
         );
+    }
+
+    #[test]
+    fn test_build_command_preserves_stream_metadata_and_dispositions() {
+        let file = sample_mkv_with_stream_metadata();
+        let action = PlannedAction::file_op(
+            OperationType::ConvertContainer,
+            ActionParams::Container {
+                container: Container::Mp4,
+            },
+            "Convert MKV to MP4",
+        );
+        let output = Path::new("/tmp/output.mp4");
+
+        let args = build_ffmpeg_command(&file, &[&action], output, None).unwrap();
+
+        assert_arg_pair(&args, "-map_metadata", "0");
+        assert_arg_pair(&args, "-map_chapters", "0");
+        assert_arg_pair(&args, "-metadata:s:0", "language=und");
+        assert_arg_pair(&args, "-metadata:s:0", "title=Main Video");
+        assert_arg_pair(&args, "-disposition:0", "0");
+        assert_arg_pair(&args, "-metadata:s:1", "language=und");
+        assert_arg_pair(&args, "-metadata:s:1", "title=Original Mix");
+        assert_arg_pair(&args, "-disposition:1", "default");
+        assert_arg_pair(&args, "-metadata:s:2", "language=eng");
+        assert_arg_pair(&args, "-metadata:s:2", "title=Forced Signs");
+        assert_arg_pair(&args, "-disposition:2", "forced");
+    }
+
+    #[test]
+    fn test_build_command_preserves_metadata_after_policy_updates() {
+        let file = sample_mkv_with_stream_metadata();
+        let set_language = PlannedAction::track_op(
+            OperationType::SetLanguage,
+            1,
+            ActionParams::Language {
+                language: "fra".into(),
+            },
+            "Set audio language",
+        );
+        let clear_forced = PlannedAction::track_op(
+            OperationType::ClearForced,
+            2,
+            ActionParams::Empty,
+            "Clear forced",
+        );
+        let output = Path::new("/tmp/output.mkv");
+
+        let args =
+            build_ffmpeg_command(&file, &[&set_language, &clear_forced], output, None).unwrap();
+
+        assert_arg_pair(&args, "-metadata:s:1", "language=fra");
+        assert_arg_pair(&args, "-metadata:s:1", "title=Original Mix");
+        assert_arg_pair(&args, "-disposition:1", "default");
+        assert_arg_pair(&args, "-metadata:s:2", "language=eng");
+        assert_arg_pair(&args, "-metadata:s:2", "title=Forced Signs");
+        assert_arg_pair(&args, "-disposition:2", "0");
     }
 
     #[test]

--- a/scripts/generate-test-corpus
+++ b/scripts/generate-test-corpus
@@ -509,6 +509,17 @@ def build_video_feature_specs():
             "subs": [{"format": "webvtt", "lang": "eng"}],
             "special": [],
         },
+        {
+            "stem": "mp4-text-subtitle",
+            "ext": "mp4",
+            "profiles": ["coverage"],
+            "covers": ["video.codec.h264", "audio.codec.aac", "subtitle.format.mov_text"],
+            "expect": {"bad_file": False, "container": "mp4"},
+            "video": {"codec": "libx264", "size": "1280x720", "fps": 24},
+            "audio": [{"codec": "aac", "channels": 2}],
+            "subs": [{"format": "srt", "lang": "eng"}],
+            "special": [],
+        },
     ]
 
 


### PR DESCRIPTION
## Summary
- emit explicit ffmpeg global metadata/chapter mapping plus per-output-stream language, title, and default/forced disposition arguments
- compute final stream metadata from source tracks plus policy metadata/disposition actions so policy changes still win
- add deterministic `mp4-text-subtitle` corpus generation support for repeatable mov_text coverage
- add metadata-stable transcode docs, policy fixture, functional test plan using `scripts/generate-test-corpus`, and adversarial review notes

## Verification
- `cargo fmt --all --check`
- `cargo test -p voom-ffmpeg-executor`
- `cargo test -p voom-dsl example_metadata_stable_transcode_parses_and_validates`
- `cargo run -q -p voom-cli -- policy test docs/examples/tests/metadata-stable-transcode.test.json`
- `scripts/generate-test-corpus /tmp/voom-issue-336-corpus-plan-check --profile coverage --only hevc-surround,multichannel-flac,vp9-opus,pillarbox-h264,mp4-text-subtitle --duration 2 --seed 336 --dry-run`

## Not run
- `python -m pytest tests/scripts/test_generate_test_corpus.py` (environment lacks `pytest`: `/usr/bin/python: No module named pytest`)

Closes #336