### PR TITLE
Upgrade Rust edition to 2024

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ Plugins communicate exclusively through an **event bus** (synchronous priority-o
 
 ## Tech Stack
 
-Rust 2021 edition. Key crates: clap (CLI), axum/tokio (web + async), pest (DSL parser), wasmtime/wit-bindgen (WASM plugins), rusqlite (SQLite), serde/rmp-serde (serialization), tracing (logging), insta (snapshot tests), thiserror/anyhow (errors), walkdir/rayon (file walking), xxhash-rust (hashing).
+Rust 2024 edition. Key crates: clap (CLI), axum/tokio (web + async), pest (DSL parser), wasmtime/wit-bindgen (WASM plugins), rusqlite (SQLite), serde/rmp-serde (serialization), tracing (logging), insta (snapshot tests), thiserror/anyhow (errors), walkdir/rayon (file walking), xxhash-rust (hashing).
 
 Web frontend: htmx + Alpine.js with Tera templates.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,10 +43,10 @@ exclude = [
 missing_errors_doc = "allow"
 
 [workspace.package]
-edition = "2021"
+edition = "2024"
 authors = ["David Christensen"]
 license = "AGPL-3.0-or-later"
-rust-version = "1.82"
+rust-version = "1.85"
 repository = "https://github.com/randomparity/voom"
 readme = "README.md"
 keywords = ["video", "media", "policy", "mkvtoolnix", "ffmpeg"]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Release](https://github.com/randomparity/voom/actions/workflows/release.yml/badge.svg)](https://github.com/randomparity/voom/actions/workflows/release.yml)
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 [![Rust](https://img.shields.io/badge/Rust-stable-orange.svg)](https://www.rust-lang.org/)
+[![MSRV](https://img.shields.io/badge/MSRV-1.85-blue.svg)](https://www.rust-lang.org/)
 
 **Policy-driven video library management, built in Rust.**
 

--- a/crates/voom-cli/src/app.rs
+++ b/crates/voom-cli/src/app.rs
@@ -102,7 +102,7 @@ pub fn bootstrap_kernel_with_store(config: &AppConfig) -> Result<BootstrapResult
 
     // Helper macro to conditionally register a plugin (skips if disabled).
     macro_rules! register_if_enabled {
-        ($name:expr, $plugin:expr, $priority:expr, $label:expr) => {
+        ($name:expr_2021, $plugin:expr_2021, $priority:expr_2021, $label:expr_2021) => {
             if !disabled.iter().any(|d| d == $name) {
                 let ctx = voom_kernel::PluginContext::new(plugin_json($name), data_dir.clone());
                 kernel
@@ -110,7 +110,7 @@ pub fn bootstrap_kernel_with_store(config: &AppConfig) -> Result<BootstrapResult
                     .with_context(|| format!("Failed to initialize {}", $label))?;
             }
         };
-        ($name:expr, $plugin:expr, $priority:expr, $label:expr, $ctx:expr) => {
+        ($name:expr_2021, $plugin:expr_2021, $priority:expr_2021, $label:expr_2021, $ctx:expr_2021) => {
             if !disabled.iter().any(|d| d == $name) {
                 kernel
                     .init_and_register(Arc::new($plugin), $priority, $ctx)
@@ -456,10 +456,12 @@ mod tests {
         };
         let result = bootstrap_kernel_with_store(&config).expect("bootstrap should succeed");
         // Verify the store is functional
-        assert!(result
-            .store
-            .list_files(&voom_domain::FileFilters::default())
-            .is_ok());
+        assert!(
+            result
+                .store
+                .list_files(&voom_domain::FileFilters::default())
+                .is_ok()
+        );
     }
 
     #[test]

--- a/crates/voom-cli/src/cli.rs
+++ b/crates/voom-cli/src/cli.rs
@@ -1175,16 +1175,18 @@ mod tests {
 
     #[test]
     fn test_process_policy_and_map_conflict() {
-        assert!(try_parse(&[
-            "voom",
-            "process",
-            "/media",
-            "--policy",
-            "p.voom",
-            "--policy-map",
-            "map.toml"
-        ])
-        .is_err());
+        assert!(
+            try_parse(&[
+                "voom",
+                "process",
+                "/media",
+                "--policy",
+                "p.voom",
+                "--policy-map",
+                "map.toml"
+            ])
+            .is_err()
+        );
     }
 
     #[test]
@@ -2038,16 +2040,18 @@ mod tests {
 
     #[test]
     fn test_invalid_on_error_rejected() {
-        assert!(try_parse(&[
-            "voom",
-            "process",
-            "/m",
-            "--policy",
-            "p",
-            "--on-error",
-            "retry"
-        ])
-        .is_err());
+        assert!(
+            try_parse(&[
+                "voom",
+                "process",
+                "/m",
+                "--policy",
+                "p",
+                "--on-error",
+                "retry"
+            ])
+            .is_err()
+        );
     }
 
     // ── Tools subcommands ─────────────────────────────────────

--- a/crates/voom-cli/src/commands/backup.rs
+++ b/crates/voom-cli/src/commands/backup.rs
@@ -1,9 +1,9 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use chrono::{DateTime, Utc};
-use console::{style, StyledObject};
+use console::{StyledObject, style};
 use serde::Serialize;
 use voom_backup_manager::destination::BackupDestinationConfig;
 use voom_backup_manager::inventory::{RemoteBackupInventory, RemoteBackupInventoryRecord};
@@ -643,7 +643,8 @@ fn cleanup(roots: &[PathBuf], destination: Option<&str>, yes: bool) -> Result<()
     let mut removed = 0u64;
     let mut errors = 0u64;
     for entry in &entries {
-        match voom_backup_manager::backup::remove_vbak_file(&entry.backup_path) {
+        let remove_result = voom_backup_manager::backup::remove_vbak_file(&entry.backup_path);
+        match remove_result {
             Ok(()) => removed += 1,
             Err(e) => {
                 eprintln!(
@@ -699,10 +700,11 @@ fn cleanup_remote(destination: &str, yes: bool) -> Result<()> {
     let mut deleted_ids = HashSet::new();
     let mut errors = 0u64;
     for record in &plan.delete {
-        match voom_backup_manager::destination::delete_with_rclone(
+        let delete_result = voom_backup_manager::destination::delete_with_rclone(
             &backup_config.rclone_path,
             &record.remote_path,
-        ) {
+        );
+        match delete_result {
             Ok(()) => {
                 deleted_ids.insert(record.backup_id);
             }

--- a/crates/voom-cli/src/commands/config.rs
+++ b/crates/voom-cli/src/commands/config.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use console::style;
 
 use crate::cli::ConfigCommands;

--- a/crates/voom-cli/src/commands/env.rs
+++ b/crates/voom-cli/src/commands/env.rs
@@ -5,10 +5,10 @@ use std::time::Duration;
 use uuid::Uuid;
 use voom_backup_manager::destination::{BackupDestinationConfig, DestinationKind};
 use voom_domain::storage::{HealthCheckFilters, HealthCheckRecord};
-use voom_ffmpeg_executor::hwaccel::{resolve_hw_config, HwAccelBackend};
+use voom_ffmpeg_executor::hwaccel::{HwAccelBackend, resolve_hw_config};
 use voom_ffmpeg_executor::probe::{
-    enumerate_gpus, probe_hw_capabilities, validate_hw_encoder, validate_hw_encoder_on_device,
-    validate_hw_encoders_parallel_with_status, GpuDevice, HwCapabilities,
+    GpuDevice, HwCapabilities, enumerate_gpus, probe_hw_capabilities, validate_hw_encoder,
+    validate_hw_encoder_on_device, validate_hw_encoders_parallel_with_status,
 };
 
 use crate::app;
@@ -1138,11 +1138,13 @@ mod tests {
         let record: HealthCheckRecord = super::env_snapshot_record(&report, true, &[]);
 
         assert!(!record.passed);
-        assert!(record
-            .details
-            .as_deref()
-            .unwrap_or_default()
-            .contains("\"vmaf_model_status\":\"missing\""));
+        assert!(
+            record
+                .details
+                .as_deref()
+                .unwrap_or_default()
+                .contains("\"vmaf_model_status\":\"missing\"")
+        );
     }
 
     #[test]
@@ -1177,11 +1179,13 @@ remote = "s3:bucket/secret-path"
             checks[0].status,
             super::BackupDestinationHealthStatus::Healthy
         );
-        assert!(!checks[0]
-            .details
-            .as_deref()
-            .unwrap_or_default()
-            .contains("secret-path"));
+        assert!(
+            !checks[0]
+                .details
+                .as_deref()
+                .unwrap_or_default()
+                .contains("secret-path")
+        );
         assert!(commands.iter().any(|args| args[0] == "copyto"));
         assert!(commands.iter().any(|args| args[0] == "deletefile"));
     }
@@ -1281,17 +1285,19 @@ remote = "s3:bucket-b"
             super::BackupDestinationHealthStatus::ConfigInvalid
         );
         assert!(!checks[0].passed);
-        assert!(checks[0]
-            .details
-            .as_deref()
-            .unwrap_or_default()
-            .contains("duplicate backup destination"));
+        assert!(
+            checks[0]
+                .details
+                .as_deref()
+                .unwrap_or_default()
+                .contains("duplicate backup destination")
+        );
     }
 }
 
 #[cfg(test)]
 mod retention_coverage_tests {
-    use super::retention_coverage::{evaluate, evaluate_query_results, CoverageStatus};
+    use super::retention_coverage::{CoverageStatus, evaluate, evaluate_query_results};
     use chrono::{Duration, Utc};
     use voom_domain::errors::{StorageErrorKind, VoomError};
 

--- a/crates/voom-cli/src/commands/estimate.rs
+++ b/crates/voom-cli/src/commands/estimate.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use tokio_util::sync::CancellationToken;
 
 use crate::app;
@@ -461,8 +461,8 @@ mod tests {
     use chrono::TimeZone;
 
     use crate::commands::estimate::{
-        accuracy_report_from_benchmarks, cost_model_sample_from_benchmark,
-        CalibrationBenchmarkResult,
+        CalibrationBenchmarkResult, accuracy_report_from_benchmarks,
+        cost_model_sample_from_benchmark,
     };
 
     #[test]

--- a/crates/voom-cli/src/commands/files.rs
+++ b/crates/voom-cli/src/commands/files.rs
@@ -2,9 +2,9 @@ use anyhow::{Context, Result};
 use comfy_table::Cell;
 use console::style;
 
+use voom_domain::FileFilters;
 use voom_domain::media::Container;
 use voom_domain::utils::format::{format_duration, format_size};
-use voom_domain::FileFilters;
 
 use crate::cli::{FilesCommands, OutputFormat};
 use crate::{app, config, output};

--- a/crates/voom-cli/src/commands/history.rs
+++ b/crates/voom-cli/src/commands/history.rs
@@ -27,7 +27,8 @@ pub(crate) fn collect_lineage(store: &dyn FileStorage, start_id: Uuid) -> Vec<Uu
             break;
         }
 
-        match store.predecessor_id_of(&current) {
+        let predecessor_result = store.predecessor_id_of(&current);
+        match predecessor_result {
             Ok(Some(pred_id)) => {
                 if !seen.insert(pred_id) {
                     tracing::warn!("cycle detected in predecessor chain at {}", pred_id);
@@ -55,7 +56,8 @@ pub(crate) fn collect_lineage_transitions(
 ) -> Vec<FileTransition> {
     let mut all_transitions = Vec::new();
     for file_id in lineage {
-        match store.transitions_for_file(file_id) {
+        let transitions_result = store.transitions_for_file(file_id);
+        match transitions_result {
             Ok(transitions) => all_transitions.extend(transitions),
             Err(e) => {
                 tracing::warn!("failed to load transitions for {file_id}: {e}");

--- a/crates/voom-cli/src/commands/plugin.rs
+++ b/crates/voom-cli/src/commands/plugin.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use console::style;
 
 use crate::app;
@@ -25,7 +25,8 @@ fn list() -> Result<()> {
     let mut plugins: Vec<output::PluginListEntry> = Vec::new();
 
     for name in &names {
-        if let Some(plugin) = kernel.registry.get(name) {
+        let plugin_result = kernel.registry.get(name);
+        if let Some(plugin) = plugin_result {
             let caps: Vec<String> = plugin
                 .capabilities()
                 .iter()
@@ -93,36 +94,39 @@ fn info(name: &str) -> Result<()> {
     let result = app::bootstrap_kernel_with_store(&config)?;
     let capabilities = result.collector.snapshot();
 
-    if let Some(plugin) = result.kernel.registry.get(name) {
-        println!(
-            "{} {}",
-            style("Plugin:").bold(),
-            style(plugin.name()).cyan()
-        );
-        println!("{} {}", style("Version:").bold(), plugin.version());
-        if !plugin.description().is_empty() {
-            println!("{} {}", style("Description:").bold(), plugin.description());
-        }
-        if !plugin.author().is_empty() {
-            println!("{} {}", style("Author:").bold(), plugin.author());
-        }
-        if !plugin.license().is_empty() {
-            println!("{} {}", style("License:").bold(), plugin.license());
-        }
-        if !plugin.homepage().is_empty() {
-            println!("{} {}", style("Homepage:").bold(), plugin.homepage());
-        }
-        println!("{} {}", style("Status:").bold(), style("enabled").green());
-        println!("{}", style("Capabilities:").bold());
-        for cap in plugin.capabilities() {
-            println!("  - {}", cap.kind());
-        }
+    match result.kernel.registry.get(name) {
+        Some(plugin) => {
+            println!(
+                "{} {}",
+                style("Plugin:").bold(),
+                style(plugin.name()).cyan()
+            );
+            println!("{} {}", style("Version:").bold(), plugin.version());
+            if !plugin.description().is_empty() {
+                println!("{} {}", style("Description:").bold(), plugin.description());
+            }
+            if !plugin.author().is_empty() {
+                println!("{} {}", style("Author:").bold(), plugin.author());
+            }
+            if !plugin.license().is_empty() {
+                println!("{} {}", style("License:").bold(), plugin.license());
+            }
+            if !plugin.homepage().is_empty() {
+                println!("{} {}", style("Homepage:").bold(), plugin.homepage());
+            }
+            println!("{} {}", style("Status:").bold(), style("enabled").green());
+            println!("{}", style("Capabilities:").bold());
+            for cap in plugin.capabilities() {
+                println!("  - {}", cap.kind());
+            }
 
-        // Show executor details if available
-        output::format_executor_capabilities(name, &capabilities);
-    } else {
-        let available = result.kernel.registry.plugin_names().join(", ");
-        anyhow::bail!("Plugin \"{name}\" not found. Available: {available}");
+            // Show executor details if available
+            output::format_executor_capabilities(name, &capabilities);
+        }
+        _ => {
+            let available = result.kernel.registry.plugin_names().join(", ");
+            anyhow::bail!("Plugin \"{name}\" not found. Available: {available}");
+        }
     }
 
     Ok(())

--- a/crates/voom-cli/src/commands/policy.rs
+++ b/crates/voom-cli/src/commands/policy.rs
@@ -1,12 +1,12 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use console::style;
 use serde::Serialize;
 use serde_json::Value;
 use voom_policy_testing::{
-    assert_snapshot_file, CapabilityFixture, Fixture, SnapshotOutcome, TestSuite,
+    CapabilityFixture, Fixture, SnapshotOutcome, TestSuite, assert_snapshot_file,
 };
 
 use crate::cli::{PolicyCommands, PolicyFixtureCommands};

--- a/crates/voom-cli/src/commands/process/audio_language.rs
+++ b/crates/voom-cli/src/commands/process/audio_language.rs
@@ -96,7 +96,7 @@ mod tests {
 
     use voom_domain::media::{MediaFile, Track, TrackType};
 
-    use super::{apply_detected_languages, AUDIO_LANGUAGE_DETECTOR_PLUGIN};
+    use super::{AUDIO_LANGUAGE_DETECTOR_PLUGIN, apply_detected_languages};
 
     fn make_file_with_audio_tracks() -> MediaFile {
         let mut file = MediaFile::new(PathBuf::from("/tmp/test.mkv"));

--- a/crates/voom-cli/src/commands/process/mod.rs
+++ b/crates/voom-cli/src/commands/process/mod.rs
@@ -6,8 +6,8 @@ mod safeguards;
 mod transitions;
 
 use std::collections::{BTreeMap, HashMap};
-use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
 
 use anyhow::{Context, Result};
 use console::style;
@@ -137,7 +137,8 @@ pub async fn run(args: ProcessArgs, quiet: bool, token: CancellationToken) -> Re
 
         // Auto-prune stale file entries under the target directories
         for path in &paths {
-            match store.prune_missing_files_under(path) {
+            let prune_result = store.prune_missing_files_under(path);
+            match prune_result {
                 Ok(n) if n > 0 && !plan_only && !quiet => eprintln!("Pruned {n} stale entries."),
                 Ok(_) => {}
                 Err(e) => tracing::warn!(error = %e, "auto-prune failed"),

--- a/crates/voom-cli/src/commands/process/pipeline.rs
+++ b/crates/voom-cli/src/commands/process/pipeline.rs
@@ -30,10 +30,10 @@ use super::safeguards::{
     collect_safeguard_violations, dispatch_safeguard_violations,
 };
 use super::transitions::{
-    record_failure_transition, record_file_transition, FailureTransitionContext,
-    FileTransitionContext,
+    FailureTransitionContext, FileTransitionContext, record_failure_transition,
+    record_file_transition,
 };
-use super::{record_phase_stat, PhaseOutcomeKind, ProcessContext};
+use super::{PhaseOutcomeKind, ProcessContext, record_phase_stat};
 
 use crate::introspect::DiscoveredFilePayload;
 
@@ -620,7 +620,7 @@ async fn reintrospect_file(
 
     let ffp = ctx.ffprobe_path.map(String::from);
     let kernel_clone = ctx.kernel.clone();
-    match crate::introspect::introspect_file_no_dispatch(
+    let introspection_result = crate::introspect::introspect_file_no_dispatch(
         current_path.clone(),
         size,
         hash.clone(),
@@ -628,8 +628,8 @@ async fn reintrospect_file(
         ffp.as_deref(),
         ctx.animation_detection_mode,
     )
-    .await
-    {
+    .await;
+    match introspection_result {
         Ok(mut new_file) => {
             preserve_persisted_file_identity(file, &mut new_file);
             // Preserve plugin_metadata from prior phases
@@ -875,8 +875,8 @@ fn savings_below_threshold(plan: &Plan, ctx: &ProcessContext<'_>) -> bool {
 mod tests {
     use std::future::Future;
     use std::pin::Pin;
-    use std::sync::mpsc;
     use std::sync::Arc;
+    use std::sync::mpsc;
     use std::time::Duration;
 
     use voom_domain::capabilities::Capability;

--- a/crates/voom-cli/src/commands/process/safeguards.rs
+++ b/crates/voom-cli/src/commands/process/safeguards.rs
@@ -14,10 +14,10 @@
 use voom_domain::events::{Event, PlanFailedEvent};
 use voom_domain::utils::format::format_size;
 
-use super::dispatch::{dispatch_and_log, PlanDispatcher};
+use super::dispatch::{PlanDispatcher, dispatch_and_log};
 use super::pipeline::resolve_post_execution_path;
-use super::transitions::{record_failure_transition, FailureTransitionContext};
-use super::{record_phase_stat, PhaseOutcomeKind, ProcessContext};
+use super::transitions::{FailureTransitionContext, record_failure_transition};
+use super::{PhaseOutcomeKind, ProcessContext, record_phase_stat};
 
 /// Dispatch `PlanFailed`, record phase stats, and write a failure transition.
 ///

--- a/crates/voom-cli/src/commands/process/transitions.rs
+++ b/crates/voom-cli/src/commands/process/transitions.rs
@@ -6,8 +6,8 @@
 //! module.
 
 use super::ProcessContext;
-use voom_domain::errors::StorageErrorKind;
 use voom_domain::VoomError;
+use voom_domain::errors::StorageErrorKind;
 
 /// Grouped arguments for `record_file_transition`.
 pub(super) struct FileTransitionContext<'a> {

--- a/crates/voom-cli/src/commands/scan.rs
+++ b/crates/voom-cli/src/commands/scan.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use crate::app;
@@ -20,7 +20,7 @@ use voom_domain::storage::StorageTrait;
 use voom_domain::verification::{VerificationMode, VerificationOutcome, VerificationRecord};
 use voom_verifier::VerifierConfig;
 
-use crate::commands::verify::{run_quick_pass, QuickVerifyTarget};
+use crate::commands::verify::{QuickVerifyTarget, run_quick_pass};
 
 /// Run the scan command.
 ///

--- a/crates/voom-cli/src/commands/serve.rs
+++ b/crates/voom-cli/src/commands/serve.rs
@@ -4,10 +4,10 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use console::style;
 use tokio_util::sync::CancellationToken;
-use voom_web_server::server::{start_server, ServerConfig};
+use voom_web_server::server::{ServerConfig, start_server};
 use voom_web_server::state::{
-    ProcessRunLaunchRequest, ProcessRunLaunchResponse, ProcessRunLauncher, SseEvent,
-    SSE_CHANNEL_CAPACITY,
+    ProcessRunLaunchRequest, ProcessRunLaunchResponse, ProcessRunLauncher, SSE_CHANNEL_CAPACITY,
+    SseEvent,
 };
 
 use crate::cli::{ErrorHandling, ProcessArgs, ServeArgs};

--- a/crates/voom-cli/src/commands/verify.rs
+++ b/crates/voom-cli/src/commands/verify.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 use chrono::{DateTime, Utc};
 use console::style;
 use rayon::prelude::*;
@@ -16,8 +16,8 @@ use voom_domain::storage::StorageTrait;
 use voom_domain::verification::{
     VerificationFilters, VerificationMode, VerificationOutcome, VerificationRecord,
 };
-use voom_verifier::hwaccel::{self as verifier_hwaccel, HwAccelMode};
 use voom_verifier::VerifierConfig;
+use voom_verifier::hwaccel::{self as verifier_hwaccel, HwAccelMode};
 
 use crate::app;
 use crate::cli::{HwAccelArg, OutputFormat, VerifyArgs, VerifyCommands, VerifyReportArgs};

--- a/crates/voom-cli/src/lock.rs
+++ b/crates/voom-cli/src/lock.rs
@@ -50,6 +50,12 @@ impl ProcessLock {
     }
 }
 
+impl Drop for ProcessLock {
+    fn drop(&mut self) {
+        let _ = fs2::FileExt::unlock(&self._file);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -59,9 +65,15 @@ mod tests {
     // locks simultaneously. Serialize all lock tests to prevent flakes.
     static LOCK_TEST: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+    fn lock_test_guard() -> std::sync::MutexGuard<'static, ()> {
+        LOCK_TEST
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
     #[test]
     fn test_acquire_succeeds_in_fresh_dir() {
-        let _guard = LOCK_TEST.lock().expect("test mutex");
+        let _guard = lock_test_guard();
         let dir = tempfile::tempdir().expect("tempdir");
         let _lock = ProcessLock::acquire(dir.path()).expect("acquire");
         assert!(dir.path().join("voom.lock").exists());
@@ -69,7 +81,7 @@ mod tests {
 
     #[test]
     fn test_second_acquire_fails() {
-        let _guard = LOCK_TEST.lock().expect("test mutex");
+        let _guard = lock_test_guard();
         let dir = tempfile::tempdir().expect("tempdir");
         let _first = ProcessLock::acquire(dir.path()).expect("first acquire");
         let result = ProcessLock::acquire(dir.path());
@@ -90,18 +102,18 @@ mod tests {
 
     #[test]
     fn test_lock_released_on_drop() {
-        let _guard = LOCK_TEST.lock().expect("test mutex");
+        let _guard = lock_test_guard();
         let dir = tempfile::tempdir().expect("tempdir");
         {
             let _lock = ProcessLock::acquire(dir.path()).expect("first acquire");
         }
         // First lock is dropped; acquiring again must succeed.
-        ProcessLock::acquire(dir.path()).expect("re-acquire after drop");
+        let _lock = ProcessLock::acquire(dir.path()).expect("re-acquire after drop");
     }
 
     #[test]
     fn test_creates_nested_dirs() {
-        let _guard = LOCK_TEST.lock().expect("test mutex");
+        let _guard = lock_test_guard();
         let dir = tempfile::tempdir().expect("tempdir");
         let nested = dir.path().join("a").join("b").join("c");
         assert!(!nested.exists());
@@ -111,7 +123,7 @@ mod tests {
 
     #[test]
     fn test_lock_file_is_named_voom_lock() {
-        let _guard = LOCK_TEST.lock().expect("test mutex");
+        let _guard = lock_test_guard();
         let dir = tempfile::tempdir().expect("tempdir");
         let _lock = ProcessLock::acquire(dir.path()).expect("acquire");
         assert!(dir.path().join("voom.lock").exists());

--- a/crates/voom-cli/src/main.rs
+++ b/crates/voom-cli/src/main.rs
@@ -145,9 +145,10 @@ fn cleanup_wasm_temp_files_in(dir: &std::path::Path) {
             continue;
         };
         if modified < cutoff {
-            if let Err(e) = std::fs::remove_file(entry.path()) {
+            let path = entry.path();
+            if let Err(e) = std::fs::remove_file(&path) {
                 tracing::warn!(
-                    path = %entry.path().display(),
+                    path = %path.display(),
                     error = %e,
                     "failed to remove orphaned WASM temp file"
                 );

--- a/crates/voom-cli/src/output.rs
+++ b/crates/voom-cli/src/output.rs
@@ -453,11 +453,7 @@ fn print_format_section(formats: &[String]) {
 
 /// Truncate a hash to a 12-character preview for table display.
 pub fn hash_preview(hash: &str) -> &str {
-    if hash.len() >= 12 {
-        &hash[..12]
-    } else {
-        hash
-    }
+    if hash.len() >= 12 { &hash[..12] } else { hash }
 }
 
 /// Create a table with the standard VOOM style.

--- a/crates/voom-cli/src/progress.rs
+++ b/crates/voom-cli/src/progress.rs
@@ -7,15 +7,15 @@
 
 use std::collections::HashMap;
 use std::path::Path;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 use console::style;
 use indicatif::{HumanDuration, ProgressBar, ProgressStyle};
 use parking_lot::Mutex;
 
-use crate::output::{max_filename_len, shrink_filename, PROGRESS_FIXED_WIDTH};
+use crate::output::{PROGRESS_FIXED_WIDTH, max_filename_len, shrink_filename};
 use voom_domain::events::FileDiscoveredEvent;
 use voom_job_manager::progress::ProgressReporter;
 

--- a/crates/voom-cli/src/recovery.rs
+++ b/crates/voom-cli/src/recovery.rs
@@ -10,8 +10,8 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 
 use crate::config::RecoveryConfig;
-use voom_domain::transition::TransitionSource;
 use voom_domain::FileTransition;
+use voom_domain::transition::TransitionSource;
 
 /// An orphaned backup file found on disk with no corresponding completion.
 #[derive(Debug)]
@@ -117,7 +117,8 @@ fn clean_stale_pending_ops(
             path = %op.file_path.display(),
             "stale pending operation with no backup — removing"
         );
-        if let Err(e) = store.delete_pending_op(&op.id) {
+        let delete_result = store.delete_pending_op(&op.id);
+        if let Err(e) = delete_result {
             tracing::warn!(
                 plan_id = %op.id,
                 path = %op.file_path.display(),
@@ -148,7 +149,8 @@ fn resolve_single_orphan(
                 .iter()
                 .filter(|op| *op.file_path.to_string_lossy() == path_str)
             {
-                if let Err(e) = store.delete_pending_op(&op.id) {
+                let delete_result = store.delete_pending_op(&op.id);
+                if let Err(e) = delete_result {
                     tracing::warn!(
                         plan_id = %op.id,
                         path = %op.file_path.display(),

--- a/crates/voom-cli/tests/cli_tests.rs
+++ b/crates/voom-cli/tests/cli_tests.rs
@@ -366,10 +366,12 @@ fn test_policy_test_json_reports_failures_and_exits_one() {
     assert_eq!(json["summary"]["total"], 1);
     assert_eq!(json["cases"][0]["name"], "containerizes mp4");
     assert_eq!(json["cases"][0]["status"], "fail");
-    assert!(json["cases"][0]["failures"][0]
-        .as_str()
-        .unwrap()
-        .contains("missing"));
+    assert!(
+        json["cases"][0]["failures"][0]
+            .as_str()
+            .unwrap()
+            .contains("missing")
+    );
 }
 
 #[test]

--- a/crates/voom-cli/tests/functional_tests.rs
+++ b/crates/voom-cli/tests/functional_tests.rs
@@ -1740,10 +1740,14 @@ mod test_health {
 
         assert!(doctor.status.success());
         assert!(health.status.success());
-        assert!(String::from_utf8_lossy(&health.stderr)
-            .contains("warning: `voom health` is deprecated; use `voom env` instead"));
-        assert!(String::from_utf8_lossy(&doctor.stderr)
-            .contains("warning: `voom doctor` is deprecated; use `voom env check` instead"));
+        assert!(
+            String::from_utf8_lossy(&health.stderr)
+                .contains("warning: `voom health` is deprecated; use `voom env` instead")
+        );
+        assert!(
+            String::from_utf8_lossy(&doctor.stderr)
+                .contains("warning: `voom doctor` is deprecated; use `voom env check` instead")
+        );
         let h = String::from_utf8_lossy(&health.stdout);
         let d = String::from_utf8_lossy(&doctor.stdout);
         assert!(h.contains("VOOM Environment Check"));
@@ -4257,9 +4261,11 @@ policy "fixture-extract" {
         let fixture_json: serde_json::Value =
             serde_json::from_slice(&output.stdout).expect("fixture extract emits JSON");
         assert_eq!(fixture_json["path"], "basic-h264-aac.mp4");
-        assert!(fixture_json["tracks"]
-            .as_array()
-            .is_some_and(|tracks| !tracks.is_empty()));
+        assert!(
+            fixture_json["tracks"]
+                .as_array()
+                .is_some_and(|tracks| !tracks.is_empty())
+        );
         for stripped_field in [
             "bitrate",
             "content_hash",

--- a/crates/voom-domain/src/estimate.rs
+++ b/crates/voom-domain/src/estimate.rs
@@ -318,7 +318,7 @@ mod tests {
     use chrono::TimeZone;
 
     use crate::estimate::{
-        estimate_plans, CostModelSample, EstimateInput, EstimateModel, EstimateOperationKey,
+        CostModelSample, EstimateInput, EstimateModel, EstimateOperationKey, estimate_plans,
     };
     use crate::media::{Container, MediaFile, Track, TrackType};
     use crate::plan::{ActionParams, OperationType, Plan, PlannedAction, TranscodeSettings};

--- a/crates/voom-domain/src/lib.rs
+++ b/crates/voom-domain/src/lib.rs
@@ -32,16 +32,16 @@ pub use capabilities::Capability;
 pub use capability_map::CapabilityMap;
 pub use errors::{Result, VoomError};
 pub use estimate::{
-    estimate_plans, ActionEstimate, CostModelSample, EstimateInput, EstimateModel,
-    EstimateOperationKey, EstimateRun, FileEstimate,
+    ActionEstimate, CostModelSample, EstimateInput, EstimateModel, EstimateOperationKey,
+    EstimateRun, FileEstimate, estimate_plans,
 };
 pub use events::Event;
 pub use job::{DiscoveredFilePayload, Job, JobStatus, JobUpdate};
 pub use media::{Container, CropDetection, CropRect, MediaFile, Track, TrackType};
 pub use plan::{
-    ActionParams, ActionResult, CropSettings, OperationType, PhaseOutcome, PhaseOutput,
-    PhaseResult, Plan, PlannedAction, SampleStrategy, TranscodeChannels, TranscodeFallback,
-    TranscodeSettings, PHASE_OUTPUT_FIELDS,
+    ActionParams, ActionResult, CropSettings, OperationType, PHASE_OUTPUT_FIELDS, PhaseOutcome,
+    PhaseOutput, PhaseResult, Plan, PlannedAction, SampleStrategy, TranscodeChannels,
+    TranscodeFallback, TranscodeSettings,
 };
 pub use safeguard::{SafeguardKind, SafeguardViolation};
 pub use snapshot::MetadataSnapshot;

--- a/crates/voom-dsl/fuzz/Cargo.toml
+++ b/crates/voom-dsl/fuzz/Cargo.toml
@@ -2,7 +2,7 @@
 name = "voom-dsl-fuzz"
 version = "0.0.0"
 publish = false
-edition = "2021"
+edition = "2024"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/voom-dsl/src/compiler.rs
+++ b/crates/voom-dsl/src/compiler.rs
@@ -802,7 +802,7 @@ fn topological_sort(ast: &PolicyAst) -> std::result::Result<Vec<String>, DslErro
 
     let mut queue: Vec<&str> = in_degree
         .iter()
-        .filter(|(_, &d)| d == 0)
+        .filter(|&(_, &d)| d == 0)
         .map(|(&n, _)| n)
         .collect();
     queue.sort_unstable(); // deterministic ordering

--- a/crates/voom-dsl/src/parser.rs
+++ b/crates/voom-dsl/src/parser.rs
@@ -8,8 +8,8 @@
 //! the grammar says they must be.
 #![allow(clippy::unwrap_used)]
 
-use pest::iterators::Pair;
 use pest::Parser;
+use pest::iterators::Pair;
 use pest_derive::Parser;
 
 use crate::ast::{
@@ -1302,9 +1302,11 @@ mod tests {
         assert_eq!(settings.len(), 6);
         assert!(settings.iter().any(|(key, _)| key == "target_vmaf"));
         assert!(settings.iter().any(|(key, _)| key == "fallback"));
-        assert!(settings
-            .iter()
-            .any(|(key, _)| key == "target_vmaf_when content.animation"));
+        assert!(
+            settings
+                .iter()
+                .any(|(key, _)| key == "target_vmaf_when content.animation")
+        );
     }
 
     #[test]

--- a/crates/voom-dsl/src/validator.rs
+++ b/crates/voom-dsl/src/validator.rs
@@ -1930,10 +1930,11 @@ mod tests {
         let ast = parse_policy(input).unwrap();
         let err = validate(&ast).unwrap_err();
 
-        assert!(err
-            .errors
-            .iter()
-            .any(|e| format!("{e}").contains("target_vmaf must be from 60 to 100")));
+        assert!(
+            err.errors
+                .iter()
+                .any(|e| format!("{e}").contains("target_vmaf must be from 60 to 100"))
+        );
     }
 
     #[test]
@@ -1949,10 +1950,11 @@ mod tests {
         let ast = parse_policy(input).unwrap();
         let err = validate(&ast).unwrap_err();
 
-        assert!(err
-            .errors
-            .iter()
-            .any(|e| format!("{e}").contains("min_bitrate must be less")));
+        assert!(
+            err.errors
+                .iter()
+                .any(|e| format!("{e}").contains("min_bitrate must be less"))
+        );
     }
 
     #[test]
@@ -1970,10 +1972,11 @@ mod tests {
         let ast = parse_policy(input).unwrap();
         let err = validate(&ast).unwrap_err();
 
-        assert!(err
-            .errors
-            .iter()
-            .any(|e| format!("{e}").contains("fallback.crf must be from 0 to 51")));
+        assert!(
+            err.errors
+                .iter()
+                .any(|e| format!("{e}").contains("fallback.crf must be from 0 to 51"))
+        );
     }
 
     #[test]
@@ -2815,9 +2818,11 @@ mod tests {
         let (warnings, result) = validate_with_warnings(&ast);
         assert!(result.is_ok(), "typo in plugin name should not be an error");
         assert_eq!(warnings.len(), 1);
-        assert!(warnings[0]
-            .message
-            .contains("unknown plugin name \"radrr\""));
+        assert!(
+            warnings[0]
+                .message
+                .contains("unknown plugin name \"radrr\"")
+        );
         assert!(
             warnings[0].suggestion.as_ref().unwrap().contains("radarr"),
             "should suggest radarr, got: {:?}",
@@ -2871,9 +2876,11 @@ mod tests {
         let (warnings, result) = validate_with_warnings(&ast);
         assert!(result.is_ok());
         assert_eq!(warnings.len(), 1);
-        assert!(warnings[0]
-            .message
-            .contains("unknown plugin name \"sonar\""));
+        assert!(
+            warnings[0]
+                .message
+                .contains("unknown plugin name \"sonar\"")
+        );
         assert!(
             warnings[0].suggestion.is_some(),
             "close name should have suggestion"
@@ -3259,10 +3266,9 @@ mod tests {
 
     #[test]
     fn validate_filter_and_recurses_into_invalid_inner() {
-        let (errors, _) =
-            run_validate_filter(FilterNode::And(vec![FilterNode::LangIn(
-                vec!["xxx".into()],
-            )]));
+        let (errors, _) = run_validate_filter(FilterNode::And(vec![FilterNode::LangIn(vec![
+            "xxx".into(),
+        ])]));
         assert!(
             !errors.is_empty(),
             "expected And to recurse into LangIn and surface its error, got none"

--- a/crates/voom-kernel/src/bus.rs
+++ b/crates/voom-kernel/src/bus.rs
@@ -1,4 +1,4 @@
-use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::Arc;
 
 use parking_lot::RwLock;

--- a/crates/voom-kernel/src/host/functions.rs
+++ b/crates/voom-kernel/src/host/functions.rs
@@ -7,7 +7,7 @@ use std::io::Read as _;
 use std::path::Path;
 use std::time::Duration;
 
-use super::{HostState, HttpResponse, ToolOutput, MAX_PLUGIN_DATA_VALUE_SIZE};
+use super::{HostState, HttpResponse, MAX_PLUGIN_DATA_VALUE_SIZE, ToolOutput};
 
 /// Extract the host (domain) from a URL string.
 /// Supports `scheme://[user@]host[:port]/...` forms.
@@ -562,9 +562,11 @@ mod tests {
 
         let result = state.get_path_transitions("/etc/passwd");
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .contains("not within allowed directories"));
+        assert!(
+            result
+                .unwrap_err()
+                .contains("not within allowed directories")
+        );
     }
 
     #[test]
@@ -740,9 +742,11 @@ mod tests {
     fn test_check_http_domain_allowed_host_passes() {
         // No network call — check_http_domain is a pure allowlist check.
         let state = HostState::new("test".into()).with_http_domains(vec!["api.example.com".into()]);
-        assert!(state
-            .check_http_domain("https://api.example.com/v1/resource")
-            .is_ok());
+        assert!(
+            state
+                .check_http_domain("https://api.example.com/v1/resource")
+                .is_ok()
+        );
     }
 
     #[test]

--- a/crates/voom-kernel/src/host/mod.rs
+++ b/crates/voom-kernel/src/host/mod.rs
@@ -425,9 +425,11 @@ mod tests {
             .with_capabilities(HashSet::from(["execute:tool".to_string()]));
         let result = state.run_tool("echo", &["/etc/passwd".into()], 5000);
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .contains("not within allowed directories"));
+        assert!(
+            result
+                .unwrap_err()
+                .contains("not within allowed directories")
+        );
     }
 
     #[test]
@@ -445,9 +447,11 @@ mod tests {
         // /etc/passwd exists and will canonicalize to itself — outside allowed dir
         let result = state.run_tool("echo", &["/etc/passwd".into()], 5000);
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .contains("not within allowed directories"));
+        assert!(
+            result
+                .unwrap_err()
+                .contains("not within allowed directories")
+        );
     }
 
     #[test]

--- a/crates/voom-kernel/src/lib.rs
+++ b/crates/voom-kernel/src/lib.rs
@@ -11,8 +11,8 @@ pub mod registry;
 use std::any::{Any, TypeId};
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use voom_domain::capabilities::Capability;
 use voom_domain::errors::Result;
 use voom_domain::events::{Event, EventResult};
@@ -342,10 +342,14 @@ impl Kernel {
 
         let subscribers = self.bus.subscribers_ordered();
         for (name, plugin) in subscribers.iter().rev() {
-            if let Err(e) = plugin.shutdown() {
-                tracing::error!(plugin = %name, error = %e, "plugin shutdown failed");
-            } else {
-                tracing::debug!(plugin = %name, "plugin shut down");
+            let shutdown_result = plugin.shutdown();
+            match shutdown_result {
+                Err(e) => {
+                    tracing::error!(plugin = %name, error = %e, "plugin shutdown failed");
+                }
+                _ => {
+                    tracing::debug!(plugin = %name, "plugin shut down");
+                }
             }
         }
         tracing::info!("kernel shutdown complete");

--- a/crates/voom-kernel/src/loader.rs
+++ b/crates/voom-kernel/src/loader.rs
@@ -19,10 +19,10 @@ fn expand_tilde(path: &str) -> std::path::PathBuf {
 pub mod wasm {
     use std::sync::Arc;
 
+    use crate::Plugin;
     use crate::errors::WasmLoadError;
     use crate::host::HostState;
     use crate::manifest::PluginManifest;
-    use crate::Plugin;
     use parking_lot::Mutex;
     use std::path::Path;
     use std::sync::atomic::{AtomicBool, Ordering};
@@ -712,7 +712,7 @@ pub mod wasm {
                 return Err(WasmLoadError::UnexpectedValue(format!(
                     "expected Record for event-result, got {:?}",
                     std::mem::discriminant(other)
-                )))
+                )));
             }
         };
 
@@ -1584,14 +1584,18 @@ Evaluate = {}
 
             let state = HostState::new("test-plugin".into());
             let metadata = read_file_metadata(&state, &file_path.to_string_lossy());
-            assert!(metadata
-                .unwrap_err()
-                .contains("not within allowed directories"));
+            assert!(
+                metadata
+                    .unwrap_err()
+                    .contains("not within allowed directories")
+            );
 
             let files = list_files(&state, &dir.path().to_string_lossy(), "");
-            assert!(files
-                .unwrap_err()
-                .contains("not within allowed directories"));
+            assert!(
+                files
+                    .unwrap_err()
+                    .contains("not within allowed directories")
+            );
         }
 
         #[test]
@@ -1628,14 +1632,18 @@ Evaluate = {}
             let state = HostState::new("test-plugin".into()).with_paths(vec![allowed_dir]);
 
             let metadata = read_file_metadata(&state, &blocked_file.to_string_lossy());
-            assert!(metadata
-                .unwrap_err()
-                .contains("not within allowed directories"));
+            assert!(
+                metadata
+                    .unwrap_err()
+                    .contains("not within allowed directories")
+            );
 
             let files = list_files(&state, &blocked_dir.path().to_string_lossy(), "");
-            assert!(files
-                .unwrap_err()
-                .contains("not within allowed directories"));
+            assert!(
+                files
+                    .unwrap_err()
+                    .contains("not within allowed directories")
+            );
         }
 
         #[test]

--- a/crates/voom-kernel/src/manifest.rs
+++ b/crates/voom-kernel/src/manifest.rs
@@ -70,11 +70,14 @@ impl PluginManifest {
         }
         if self.version.is_empty() {
             errors.push("plugin version cannot be empty".to_string());
-        } else if let Err(e) = semver::Version::parse(&self.version) {
-            errors.push(format!(
-                "plugin version '{}' is not valid semver: {e}",
-                self.version
-            ));
+        } else {
+            let parse_result = semver::Version::parse(&self.version);
+            if let Err(e) = parse_result {
+                errors.push(format!(
+                    "plugin version '{}' is not valid semver: {e}",
+                    self.version
+                ));
+            }
         }
         if self.capabilities.is_empty() && self.handles_events.is_empty() {
             errors.push("plugin must declare at least one capability or handled event".to_string());

--- a/crates/voom-plugin-sdk/src/event.rs
+++ b/crates/voom-plugin-sdk/src/event.rs
@@ -1,7 +1,7 @@
 //! Event serialization/deserialization helpers for the WASM boundary.
 
-use serde::de::DeserializeOwned;
 use serde::Serialize;
+use serde::de::DeserializeOwned;
 use voom_domain::errors::{Result, VoomError};
 use voom_domain::events::Event;
 

--- a/crates/voom-policy-testing/tests/policy_testing.rs
+++ b/crates/voom-policy-testing/tests/policy_testing.rs
@@ -5,10 +5,10 @@ use std::path::PathBuf;
 use voom_domain::media::{Container, MediaFile, Track, TrackType};
 use voom_domain::plan::{ActionParams, OperationType, Plan, PlannedAction};
 use voom_policy_testing::{
-    all_capabilities, assert_audio_tracks_kept, assert_audio_tracks_synthesized,
-    assert_no_warnings, assert_phases_run, assert_phases_skipped, assert_snapshot_file,
-    assert_subtitle_tracks_kept, assert_video_codec, canonicalize_plans_for_snapshot,
-    snapshot_json, Assertions, Fixture, SnapshotOutcome, TestCase, TestSuite,
+    Assertions, Fixture, SnapshotOutcome, TestCase, TestSuite, all_capabilities,
+    assert_audio_tracks_kept, assert_audio_tracks_synthesized, assert_no_warnings,
+    assert_phases_run, assert_phases_skipped, assert_snapshot_file, assert_subtitle_tracks_kept,
+    assert_video_codec, canonicalize_plans_for_snapshot, snapshot_json,
 };
 
 fn track(index: u32, track_type: TrackType, codec: &str) -> Track {

--- a/crates/voom-process/src/lib.rs
+++ b/crates/voom-process/src/lib.rs
@@ -530,11 +530,10 @@ mod tests {
             "#!/bin/sh\npython3 - <<'PY'\nimport sys\nsys.stdout.write('a' * 40)\nPY\n",
         )
         .expect("write script");
-        make_executable(&script);
 
         let output = run_with_timeout_env_config(
-            script.to_str().expect("utf8 path"),
-            &[] as &[&str],
+            "sh",
+            &[script.to_str().expect("utf8 path")],
             Duration::from_secs(5),
             &[],
             CaptureConfig {
@@ -561,11 +560,10 @@ mod tests {
             "#!/bin/sh\npython3 - <<'PY'\nimport sys\nsys.stderr.write('first\\nsecond\\nthird\\nfourth\\n')\nPY\n",
         )
         .expect("write script");
-        make_executable(&script);
 
         let output = run_with_timeout_env_config(
-            script.to_str().expect("utf8 path"),
-            &[] as &[&str],
+            "sh",
+            &[script.to_str().expect("utf8 path")],
             Duration::from_secs(5),
             &[],
             CaptureConfig {
@@ -623,15 +621,6 @@ mod tests {
             }
             other => panic!("expected ToolExecution, got: {other}"),
         }
-    }
-
-    #[cfg(unix)]
-    fn make_executable(path: &std::path::Path) {
-        use std::os::unix::fs::PermissionsExt;
-
-        let mut perms = std::fs::metadata(path).expect("metadata").permissions();
-        perms.set_mode(0o755);
-        std::fs::set_permissions(path, perms).expect("chmod");
     }
 
     #[test]

--- a/crates/voom-wit/src/convert.rs
+++ b/crates/voom-wit/src/convert.rs
@@ -645,8 +645,9 @@ mod tests {
         })
         .unwrap_err();
 
-        assert!(err
-            .to_string()
-            .contains("failed to deserialize execution detail"));
+        assert!(
+            err.to_string()
+                .contains("failed to deserialize execution detail")
+        );
     }
 }

--- a/crates/voom-wit/src/lib.rs
+++ b/crates/voom-wit/src/lib.rs
@@ -7,8 +7,8 @@
 pub mod convert;
 
 pub use convert::{
-    capability_from_wit, capability_to_wit, event_from_wasm, event_result_from_wasm,
-    event_result_to_wasm, event_to_wasm, WasmEventResult,
+    WasmEventResult, capability_from_wit, capability_to_wit, event_from_wasm,
+    event_result_from_wasm, event_result_to_wasm, event_to_wasm,
 };
 
 /// The path to the WIT interface definitions, for use by `bindgen!` and `wit_bindgen::generate!`.

--- a/docs/INITIAL_DESIGN.md
+++ b/docs/INITIAL_DESIGN.md
@@ -14,7 +14,7 @@
 
 | Component | Technology | Crate |
 |-----------|-----------|-------|
-| Language | Rust (2021 edition) | — |
+| Language | Rust (2024 edition) | — |
 | CLI | clap (derive) | `clap` |
 | Web server | axum | `axum`, `tower`, `tokio` |
 | Web frontend | htmx + Alpine.js | — (static assets) |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -339,7 +339,7 @@ Built with axum 0.7, Tera templates, htmx for server-driven updates, and Alpine.
 
 | Component | Technology |
 |-----------|-----------|
-| Language | Rust 2021 edition |
+| Language | Rust 2024 edition |
 | CLI | clap (derive) |
 | Web server | axum 0.7 + tower + tokio |
 | Web frontend | htmx + Alpine.js + Tera templates |

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -127,7 +127,7 @@ plugins/
 [package]
 name = "my-plugin"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 voom-kernel = { path = "../../crates/voom-kernel" }
@@ -300,7 +300,7 @@ wasm-plugins/
 [package]
 name = "my-wasm-plugin"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- **Rust** (2021 edition, stable toolchain)
+- **Rust** (2024 edition, stable toolchain)
 - **ffprobe** and **ffmpeg** (for media introspection and transcoding)
 - **mkvtoolnix** (mkvpropedit + mkvmerge, for MKV operations)
 - **Python 3.11+** with VOOM's setup-managed `.venv` for Python scripts/tests

--- a/justfile
+++ b/justfile
@@ -16,6 +16,7 @@ setup:
     echo "=== VOOM Developer Setup ==="
     echo ""
     errors=0
+    rust_msrv="1.85.0"
 
     install_mode="${VOOM_SETUP_INSTALL:-prompt}"
     if [[ "$install_mode" != "0" && "$install_mode" != "1" && "$install_mode" != "prompt" ]]; then
@@ -29,6 +30,52 @@ setup:
 
     version_line() {
         "$@" 2>/dev/null | head -1 || true
+    }
+
+    parse_semver() {
+        line="$1"
+        if [[ "$line" =~ ([0-9]+)\.([0-9]+)(\.([0-9]+))? ]]; then
+            patch="${BASH_REMATCH[4]:-0}"
+            echo "${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.$patch"
+        fi
+    }
+
+    semver_ge() {
+        IFS=. read -r have_major have_minor have_patch <<< "$1"
+        IFS=. read -r want_major want_minor want_patch <<< "$2"
+        have_patch="${have_patch:-0}"
+        want_patch="${want_patch:-0}"
+
+        if (( have_major != want_major )); then
+            (( have_major > want_major ))
+            return
+        fi
+        if (( have_minor != want_minor )); then
+            (( have_minor > want_minor ))
+            return
+        fi
+        (( have_patch >= want_patch ))
+    }
+
+    check_rust_tool_version() {
+        command_name="$1"
+        label="$2"
+        line="$(version_line "$command_name" --version)"
+        version="$(parse_semver "$line")"
+        if [[ -z "$version" ]]; then
+            echo "✗ could not parse $label version from: $line"
+            errors=$((errors + 1))
+            return 1
+        fi
+        if semver_ge "$version" "$rust_msrv"; then
+            echo "✓ $line"
+            return 0
+        fi
+
+        echo "✗ $label $version is below VOOM's Rust MSRV $rust_msrv"
+        echo "  Suggested install: rustup update && rustup default stable"
+        errors=$((errors + 1))
+        return 1
     }
 
     package_manager() {
@@ -243,9 +290,16 @@ setup:
     fi
 
     if have cargo; then
-        echo "✓ $(cargo --version)"
+        check_rust_tool_version cargo cargo || true
     else
         echo "✗ cargo not found — install Rust via https://rustup.rs"
+        errors=$((errors + 1))
+    fi
+
+    if have rustc; then
+        check_rust_tool_version rustc rustc || true
+    else
+        echo "✗ rustc not found — install Rust via https://rustup.rs"
         errors=$((errors + 1))
     fi
 

--- a/plugins/backup-manager/src/backup.rs
+++ b/plugins/backup-manager/src/backup.rs
@@ -11,10 +11,10 @@ use uuid::Uuid;
 use voom_domain::errors::Result;
 
 use crate::destination::{
-    remote_path_for, upload_with_rclone, RemoteBackupRecord, RemoteUploadReceipt,
-    RemoteUploadRequest,
+    RemoteBackupRecord, RemoteUploadReceipt, RemoteUploadRequest, remote_path_for,
+    upload_with_rclone,
 };
-use crate::{plugin_err, BackupConfig, BackupRecord};
+use crate::{BackupConfig, BackupRecord, plugin_err};
 
 /// Create a backup of the given file.
 ///
@@ -357,14 +357,18 @@ mod tests {
 
         assert_eq!(record.remote_backups.len(), 2);
         assert_eq!(uploads.borrow().len(), 2);
-        assert!(record
-            .remote_backups
-            .iter()
-            .any(|backup| backup.destination_name == "offsite"));
-        assert!(record
-            .remote_backups
-            .iter()
-            .any(|backup| backup.destination_name == "archive-s3"));
+        assert!(
+            record
+                .remote_backups
+                .iter()
+                .any(|backup| backup.destination_name == "offsite")
+        );
+        assert!(
+            record
+                .remote_backups
+                .iter()
+                .any(|backup| backup.destination_name == "archive-s3")
+        );
     }
 
     #[test]

--- a/plugins/backup-manager/src/lib.rs
+++ b/plugins/backup-manager/src/lib.rs
@@ -539,9 +539,11 @@ mod tests {
         let path = Path::new("/media/movies/Movie.mkv");
         let backup = plugin.backup_path_for(path, Uuid::new_v4());
 
-        assert!(backup
-            .to_string_lossy()
-            .starts_with("/media/movies/.voom-backup/Movie.mkv."));
+        assert!(
+            backup
+                .to_string_lossy()
+                .starts_with("/media/movies/.voom-backup/Movie.mkv.")
+        );
         assert!(backup.to_string_lossy().ends_with(".vbak"));
     }
 

--- a/plugins/bus-tracer/src/lib.rs
+++ b/plugins/bus-tracer/src/lib.rs
@@ -282,10 +282,12 @@ mod tests {
 
         let parsed: serde_json::Value = serde_json::from_str(contents.trim()).unwrap();
         assert_eq!(parsed["event"], "file.discovered");
-        assert!(parsed["summary"]
-            .as_str()
-            .unwrap()
-            .contains("/media/test.mkv"));
+        assert!(
+            parsed["summary"]
+                .as_str()
+                .unwrap()
+                .contains("/media/test.mkv")
+        );
     }
 
     #[test]

--- a/plugins/capability-collector/src/lib.rs
+++ b/plugins/capability-collector/src/lib.rs
@@ -58,7 +58,7 @@ impl voom_kernel::Plugin for CapabilityCollectorPlugin {
     }
 
     fn on_event(&self, event: &Event) -> voom_domain::errors::Result<Option<EventResult>> {
-        if let Event::ExecutorCapabilities(ref caps) = event {
+        if let Event::ExecutorCapabilities(caps) = event {
             self.map.lock().register(caps.clone());
         }
         Ok(None)

--- a/plugins/discovery/src/lib.rs
+++ b/plugins/discovery/src/lib.rs
@@ -262,8 +262,8 @@ mod tests {
     #[test]
     fn test_scan_reuses_cached_hash_when_fingerprint_matches() {
         use chrono::Utc;
-        use std::sync::atomic::{AtomicUsize, Ordering};
         use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
         use voom_domain::media::StoredFingerprint;
 
         let dir = tempfile::tempdir().unwrap();
@@ -313,8 +313,8 @@ mod tests {
     #[test]
     fn test_scan_rehashes_when_size_differs() {
         use chrono::Utc;
-        use std::sync::atomic::{AtomicUsize, Ordering};
         use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
         use voom_domain::media::StoredFingerprint;
 
         let dir = tempfile::tempdir().unwrap();
@@ -352,8 +352,8 @@ mod tests {
     #[test]
     fn test_scan_rehashes_when_mtime_is_newer_than_last_seen() {
         use chrono::Utc;
-        use std::sync::atomic::{AtomicUsize, Ordering};
         use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
         use voom_domain::media::StoredFingerprint;
 
         let dir = tempfile::tempdir().unwrap();

--- a/plugins/ffmpeg-executor/src/executor.rs
+++ b/plugins/ffmpeg-executor/src/executor.rs
@@ -19,7 +19,7 @@ use voom_domain::temp_file::temp_path_with_ext;
 use crate::command::{build_ffmpeg_command, output_extension};
 use crate::hwaccel::HwAccelConfig;
 use crate::vmaf::FullSample;
-use crate::vmaf_iterate::{iterate_to_target, BitrateBounds, IterationError, IterationResult};
+use crate::vmaf_iterate::{BitrateBounds, IterationError, IterationResult, iterate_to_target};
 
 /// Default timeout for `FFmpeg` operations (4 hours — transcode can be slow).
 const FFMPEG_TIMEOUT: Duration = Duration::from_secs(4 * 60 * 60);
@@ -219,12 +219,10 @@ fn execute_plan_with_runners(
                 stderr_tail: tail,
                 duration_ms,
             };
-            let action_results = vec![ActionResult::failure(
-                actions[0].operation,
-                &actions[0].description,
-                &error_msg,
-            )
-            .with_execution_detail(detail)];
+            let action_results = vec![
+                ActionResult::failure(actions[0].operation, &actions[0].description, &error_msg)
+                    .with_execution_detail(detail),
+            ];
             Ok(PlanExecution {
                 action_results,
                 transcode_outcomes,

--- a/plugins/ffmpeg-executor/src/lib.rs
+++ b/plugins/ffmpeg-executor/src/lib.rs
@@ -29,10 +29,10 @@ use voom_domain::utils::language::is_valid_language;
 use voom_domain::utils::sanitize::validate_metadata_value;
 use voom_kernel::{Plugin, PluginContext};
 
-use crate::hwaccel::{resolve_hw_config, HwAccelBackend, HwAccelConfig};
+use crate::hwaccel::{HwAccelBackend, HwAccelConfig, resolve_hw_config};
 use crate::probe::{
-    enumerate_gpus, probe_capabilities, validate_hw_encoder, validate_hw_encoder_on_device,
-    validate_hw_encoders_parallel, GpuDevice,
+    GpuDevice, enumerate_gpus, probe_capabilities, validate_hw_encoder,
+    validate_hw_encoder_on_device, validate_hw_encoders_parallel,
 };
 
 /// Per-plugin configuration from `[plugin.ffmpeg-executor]` in config.toml.
@@ -412,11 +412,10 @@ impl FfmpegExecutorPlugin {
                     stderr_tail: String::new(),
                     duration_ms,
                 };
-                Ok(vec![voom_domain::plan::ActionResult::success(
-                    action.operation,
-                    &action.description,
-                )
-                .with_execution_detail(detail)])
+                Ok(vec![
+                    voom_domain::plan::ActionResult::success(action.operation, &action.description)
+                        .with_execution_detail(detail),
+                ])
             }
             Ok(o) => {
                 let _ = std::fs::remove_file(&temp_path);
@@ -438,12 +437,14 @@ impl FfmpegExecutorPlugin {
                     stderr_tail: tail,
                     duration_ms,
                 };
-                Ok(vec![voom_domain::plan::ActionResult::failure(
-                    action.operation,
-                    &action.description,
-                    &error_msg,
-                )
-                .with_execution_detail(detail)])
+                Ok(vec![
+                    voom_domain::plan::ActionResult::failure(
+                        action.operation,
+                        &action.description,
+                        &error_msg,
+                    )
+                    .with_execution_detail(detail),
+                ])
             }
             Err(e) => {
                 let _ = std::fs::remove_file(&temp_path);

--- a/plugins/ffmpeg-executor/src/progress.rs
+++ b/plugins/ffmpeg-executor/src/progress.rs
@@ -92,11 +92,7 @@ pub fn parse_progress(output: &str) -> Option<ProgressInfo> {
         }
     }
 
-    if found_any {
-        Some(info)
-    } else {
-        None
-    }
+    if found_any { Some(info) } else { None }
 }
 
 /// Calculate completion percentage given progress time and total duration.
@@ -194,11 +190,7 @@ fn extract_value<'a>(line: &'a str, key: &str) -> Option<&'a str> {
         .unwrap_or(rest.len());
 
     let value = rest[..end].trim();
-    if value.is_empty() {
-        None
-    } else {
-        Some(value)
-    }
+    if value.is_empty() { None } else { Some(value) }
 }
 
 /// Parse a time string like `00:01:30.50` to microseconds.
@@ -270,8 +262,7 @@ progress=end
 
     #[test]
     fn test_parse_stderr_progress() {
-        let line =
-            "frame=  120 fps= 30 q=28.0 size=    1024kB time=00:00:04.00 bitrate=2097.2kbits/s speed=1.5x";
+        let line = "frame=  120 fps= 30 q=28.0 size=    1024kB time=00:00:04.00 bitrate=2097.2kbits/s speed=1.5x";
         let info = parse_stderr_progress(line).unwrap();
         assert_eq!(info.frame, Some(120));
         assert_eq!(info.fps, Some(30.0));

--- a/plugins/ffmpeg-executor/src/vmaf_iterate.rs
+++ b/plugins/ffmpeg-executor/src/vmaf_iterate.rs
@@ -6,7 +6,7 @@ use std::process::Output;
 use std::time::Duration;
 
 use crate::vmaf::{
-    compute_vmaf, pick_model_for_resolution, SampleError, SampleExtractor, VmafError, VmafModel,
+    SampleError, SampleExtractor, VmafError, VmafModel, compute_vmaf, pick_model_for_resolution,
 };
 
 const DEFAULT_START_CRF: u32 = 23;

--- a/plugins/ffmpeg-executor/tests/vmaf.rs
+++ b/plugins/ffmpeg-executor/tests/vmaf.rs
@@ -2,8 +2,8 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use voom_ffmpeg_executor::vmaf::{
-    compute_vmaf, pick_model_for_resolution, FullSample, SampleExtractor, SceneSample,
-    UniformSample, VmafError, VmafModel,
+    FullSample, SampleExtractor, SceneSample, UniformSample, VmafError, VmafModel, compute_vmaf,
+    pick_model_for_resolution,
 };
 
 fn ffmpeg_available() -> bool {

--- a/plugins/ffmpeg-executor/tests/vmaf_iterate.rs
+++ b/plugins/ffmpeg-executor/tests/vmaf_iterate.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use voom_ffmpeg_executor::vmaf::{SampleError, SampleExtractor, VmafError, VmafModel};
 use voom_ffmpeg_executor::vmaf_iterate::{
-    iterate_to_target_with, BitrateBounds, EncodeAttempt, IterationResult,
+    BitrateBounds, EncodeAttempt, IterationResult, iterate_to_target_with,
 };
 
 struct MockSampleExtractor;

--- a/plugins/ffprobe-introspector/src/parser.rs
+++ b/plugins/ffprobe-introspector/src/parser.rs
@@ -772,10 +772,12 @@ mod tests {
         assert_eq!(track.color_matrix.as_deref(), Some("bt2020nc"));
         assert_eq!(track.max_cll, Some(1000));
         assert_eq!(track.max_fall, Some(400));
-        assert!(track
-            .master_display
-            .as_deref()
-            .is_some_and(|value| value.contains("G(8500,39850)")));
+        assert!(
+            track
+                .master_display
+                .as_deref()
+                .is_some_and(|value| value.contains("G(8500,39850)"))
+        );
         assert_eq!(track.is_animation, None);
     }
 

--- a/plugins/job-manager/src/progress.rs
+++ b/plugins/job-manager/src/progress.rs
@@ -163,8 +163,8 @@ impl ProgressReporter for StorageReporter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::atomic::{AtomicU32, Ordering};
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicU32, Ordering};
 
     struct CountingReporter {
         batch_starts: AtomicU32,

--- a/plugins/job-manager/src/worker.rs
+++ b/plugins/job-manager/src/worker.rs
@@ -1,10 +1,10 @@
 //! Worker pool for concurrent job processing using tokio tasks.
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
-use tokio::sync::{mpsc, Semaphore};
+use tokio::sync::{Semaphore, mpsc};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
@@ -465,7 +465,8 @@ impl WorkerPool {
         }
 
         for handle in handles {
-            if let Err(e) = handle.await {
+            let join_result = handle.await;
+            if let Err(e) = join_result {
                 tracing::error!(error = %e, "worker task join error");
             }
         }
@@ -485,21 +486,25 @@ async fn cancel_unstarted_jobs(queue: Arc<JobQueue>, job_ids: Vec<Uuid>) {
     }
 
     let cancelled = job_ids.len();
-    if let Err(e) = tokio::task::spawn_blocking(move || {
+    let cancel_result = tokio::task::spawn_blocking(move || {
         for job_id in job_ids {
-            if let Err(e) = queue.cancel(&job_id) {
+            let job_cancel_result = queue.cancel(&job_id);
+            if let Err(e) = job_cancel_result {
                 tracing::warn!(%job_id, error = %e, "failed to cancel unstarted job");
             }
         }
     })
-    .await
-    {
-        tracing::error!(error = %e, "failed to cancel unstarted jobs");
-    } else {
-        tracing::debug!(
-            cancelled,
-            "cancelled unstarted jobs after batch cancellation"
-        );
+    .await;
+    match cancel_result {
+        Err(e) => {
+            tracing::error!(error = %e, "failed to cancel unstarted jobs");
+        }
+        _ => {
+            tracing::debug!(
+                cancelled,
+                "cancelled unstarted jobs after batch cancellation"
+            );
+        }
     }
 }
 
@@ -864,9 +869,11 @@ mod tests {
             "entered"
         });
 
-        assert!(tokio::time::timeout(Duration::from_millis(20), entered_rx)
-            .await
-            .is_err());
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), entered_rx)
+                .await
+                .is_err()
+        );
 
         drop(first);
         assert_eq!(
@@ -1533,10 +1540,12 @@ mod tests {
         assert_eq!(processor_called.load(Ordering::SeqCst), 0);
         assert_eq!(pool.failed_count(), 1);
         assert_eq!(results.len(), 1);
-        assert!(results[0]
-            .outcome
-            .error()
-            .is_some_and(|error| error.contains("enqueue failed")));
+        assert!(
+            results[0]
+                .outcome
+                .error()
+                .is_some_and(|error| error.contains("enqueue failed"))
+        );
     }
 
     #[tokio::test]

--- a/plugins/mkvtoolnix-executor/src/lib.rs
+++ b/plugins/mkvtoolnix-executor/src/lib.rs
@@ -329,11 +329,10 @@ impl MkvtoolnixExecutorPlugin {
                     stderr_tail: voom_process::stderr_tail(&o.stderr, 20),
                     duration_ms,
                 };
-                Ok(vec![ActionResult::success(
-                    action.operation,
-                    &action.description,
-                )
-                .with_execution_detail(detail)])
+                Ok(vec![
+                    ActionResult::success(action.operation, &action.description)
+                        .with_execution_detail(detail),
+                ])
             }
             Ok(o) => {
                 let tail = voom_process::stderr_tail(&o.stderr, 20);
@@ -354,12 +353,10 @@ impl MkvtoolnixExecutorPlugin {
                     stderr_tail: tail,
                     duration_ms,
                 };
-                Ok(vec![ActionResult::failure(
-                    action.operation,
-                    &action.description,
-                    &error_msg,
-                )
-                .with_execution_detail(detail)])
+                Ok(vec![
+                    ActionResult::failure(action.operation, &action.description, &error_msg)
+                        .with_execution_detail(detail),
+                ])
             }
             Err(e) => Err(VoomError::ToolExecution {
                 tool: "mkvmerge".into(),

--- a/plugins/mkvtoolnix-executor/src/merge.rs
+++ b/plugins/mkvtoolnix-executor/src/merge.rs
@@ -111,12 +111,10 @@ pub fn execute_merge_actions(path: &Path, actions: &[&PlannedAction]) -> Result<
             stderr_tail: tail,
             duration_ms,
         };
-        Ok(vec![ActionResult::failure(
-            actions[0].operation,
-            &actions[0].description,
-            &error_msg,
-        )
-        .with_execution_detail(detail)])
+        Ok(vec![
+            ActionResult::failure(actions[0].operation, &actions[0].description, &error_msg)
+                .with_execution_detail(detail),
+        ])
     }
 }
 

--- a/plugins/policy-evaluator/src/condition.rs
+++ b/plugins/policy-evaluator/src/condition.rs
@@ -533,13 +533,13 @@ mod tests {
             CompiledCondition::Exists {
                 target: TrackTarget::Audio,
                 filter: Some(voom_dsl::compiled::CompiledFilter::LangIn(vec![
-                    "eng".into()
+                    "eng".into(),
                 ])),
             },
             CompiledCondition::Exists {
                 target: TrackTarget::Audio,
                 filter: Some(voom_dsl::compiled::CompiledFilter::LangIn(vec![
-                    "jpn".into()
+                    "jpn".into(),
                 ])),
             },
         ]);
@@ -549,7 +549,7 @@ mod tests {
         let not_cond = CompiledCondition::Not(Box::new(CompiledCondition::Exists {
             target: TrackTarget::Audio,
             filter: Some(voom_dsl::compiled::CompiledFilter::LangIn(vec![
-                "fre".into()
+                "fre".into(),
             ])),
         }));
         assert!(evaluate_condition(&not_cond, &file, &ctx));

--- a/plugins/policy-evaluator/src/evaluator.rs
+++ b/plugins/policy-evaluator/src/evaluator.rs
@@ -21,7 +21,7 @@ use voom_dsl::compiled::{
 };
 
 use crate::condition::{
-    evaluate_condition, resolve_value_or_field, EvalContext, PhaseOutputLookup,
+    EvalContext, PhaseOutputLookup, evaluate_condition, resolve_value_or_field,
 };
 use crate::container_compat::codec_supported;
 use crate::filter::{track_matches_with_context, tracks_for_target};
@@ -289,7 +289,8 @@ fn evaluate_phase(
     };
 
     for op in &phase.operations {
-        if let Err(msg) = emit_operation(op, &mut ctx) {
+        let emit_result = emit_operation(op, &mut ctx);
+        if let Err(msg) = emit_result {
             match phase.on_error {
                 ErrorStrategy::Abort => {
                     ctx.plan.warnings.push(format!("Error (aborting): {msg}"));
@@ -1685,11 +1686,13 @@ mod tests {
         let result = evaluate(&policy, &file);
         // containerize produces no actions (already MKV), so not modified
         assert!(result.plans[1].is_skipped());
-        assert!(result.plans[1]
-            .skip_reason
-            .as_ref()
-            .unwrap()
-            .contains("run_if"));
+        assert!(
+            result.plans[1]
+                .skip_reason
+                .as_ref()
+                .unwrap()
+                .contains("run_if")
+        );
     }
 
     #[test]
@@ -1754,11 +1757,13 @@ mod tests {
         assert!(result.plans[0].is_skipped(), "tc should be skipped");
         // post_tc has run_if tc.completed — tc was skipped not completed, so post_tc skips
         assert!(result.plans[1].is_skipped(), "post_tc should be skipped");
-        assert!(result.plans[1]
-            .skip_reason
-            .as_ref()
-            .expect("skip reason")
-            .contains("run_if"));
+        assert!(
+            result.plans[1]
+                .skip_reason
+                .as_ref()
+                .expect("skip reason")
+                .contains("run_if")
+        );
     }
 
     #[test]
@@ -2160,11 +2165,12 @@ mod tests {
             .filter(|a| a.operation == OperationType::RemoveTrack)
             .collect();
         assert_eq!(removes.len(), 0, "safeguard should retract video removal");
-        assert!(plan
-            .safeguard_violations
-            .iter()
-            .any(|v| v.kind == voom_domain::SafeguardKind::NoVideoTrack
-                || v.kind == voom_domain::SafeguardKind::AllTracksRemoved));
+        assert!(
+            plan.safeguard_violations
+                .iter()
+                .any(|v| v.kind == voom_domain::SafeguardKind::NoVideoTrack
+                    || v.kind == voom_domain::SafeguardKind::AllTracksRemoved)
+        );
     }
 
     // --- ContainerIncompatible safeguard tests ---
@@ -2200,10 +2206,11 @@ mod tests {
                 .any(|a| a.operation == OperationType::ConvertContainer),
             "ConvertContainer should be retracted"
         );
-        assert!(plan
-            .safeguard_violations
-            .iter()
-            .any(|v| v.kind == SafeguardKind::ContainerIncompatible));
+        assert!(
+            plan.safeguard_violations
+                .iter()
+                .any(|v| v.kind == SafeguardKind::ContainerIncompatible)
+        );
     }
 
     #[test]
@@ -2225,10 +2232,11 @@ mod tests {
                 .any(|a| a.operation == OperationType::ConvertContainer),
             "ConvertContainer should remain"
         );
-        assert!(plan
-            .safeguard_violations
-            .iter()
-            .all(|v| v.kind != SafeguardKind::ContainerIncompatible));
+        assert!(
+            plan.safeguard_violations
+                .iter()
+                .all(|v| v.kind != SafeguardKind::ContainerIncompatible)
+        );
     }
 
     #[test]
@@ -2241,10 +2249,11 @@ mod tests {
         let policy = test_policy(r#"policy "p" { phase init { container mkv } }"#);
         let result = evaluate(&policy, &file);
         let plan = &result.plans[0];
-        assert!(plan
-            .safeguard_violations
-            .iter()
-            .all(|v| v.kind != SafeguardKind::ContainerIncompatible));
+        assert!(
+            plan.safeguard_violations
+                .iter()
+                .all(|v| v.kind != SafeguardKind::ContainerIncompatible)
+        );
     }
 
     #[test]
@@ -2280,10 +2289,11 @@ mod tests {
                 .any(|a| a.operation == OperationType::ConvertContainer),
             "ConvertContainer should remain — dts track is removed"
         );
-        assert!(plan
-            .safeguard_violations
-            .iter()
-            .all(|v| v.kind != SafeguardKind::ContainerIncompatible));
+        assert!(
+            plan.safeguard_violations
+                .iter()
+                .all(|v| v.kind != SafeguardKind::ContainerIncompatible)
+        );
     }
 
     #[test]
@@ -2315,10 +2325,11 @@ mod tests {
                 .any(|a| a.operation == OperationType::ConvertContainer),
             "ConvertContainer should remain — dts is transcoded to aac"
         );
-        assert!(plan
-            .safeguard_violations
-            .iter()
-            .all(|v| v.kind != SafeguardKind::ContainerIncompatible));
+        assert!(
+            plan.safeguard_violations
+                .iter()
+                .all(|v| v.kind != SafeguardKind::ContainerIncompatible)
+        );
     }
 
     #[test]
@@ -2397,10 +2408,11 @@ mod tests {
                 .any(|a| a.operation == OperationType::ConvertContainer),
             "ConvertContainer should remain — synthesized Opus is WebM-compatible"
         );
-        assert!(plan
-            .safeguard_violations
-            .iter()
-            .all(|v| v.kind != SafeguardKind::ContainerIncompatible));
+        assert!(
+            plan.safeguard_violations
+                .iter()
+                .all(|v| v.kind != SafeguardKind::ContainerIncompatible)
+        );
     }
 
     #[test]
@@ -2420,10 +2432,11 @@ mod tests {
                 .any(|a| a.operation == OperationType::ConvertContainer),
             "ConvertContainer should remain — mov is unmodeled"
         );
-        assert!(plan
-            .safeguard_violations
-            .iter()
-            .all(|v| v.kind != SafeguardKind::ContainerIncompatible));
+        assert!(
+            plan.safeguard_violations
+                .iter()
+                .all(|v| v.kind != SafeguardKind::ContainerIncompatible)
+        );
     }
 
     // --- Verify operation tests ---
@@ -2785,11 +2798,13 @@ mod tests {
                 result.plans[0].is_skipped(),
                 "Should skip when nvenc unavailable and hw_fallback is false"
             );
-            assert!(result.plans[0]
-                .skip_reason
-                .as_ref()
-                .expect("skip reason")
-                .contains("nvenc"));
+            assert!(
+                result.plans[0]
+                    .skip_reason
+                    .as_ref()
+                    .expect("skip reason")
+                    .contains("nvenc")
+            );
         }
 
         #[test]
@@ -3156,11 +3171,12 @@ mod tests {
         let plan = evaluate_single_phase("post_tc", &policy, &file, &outcomes, None);
         let plan = plan.expect("phase should be evaluated");
         assert!(plan.is_skipped());
-        assert!(plan
-            .skip_reason
-            .as_ref()
-            .expect("should have skip reason")
-            .contains("run_if"));
+        assert!(
+            plan.skip_reason
+                .as_ref()
+                .expect("should have skip reason")
+                .contains("run_if")
+        );
     }
 
     #[test]
@@ -3189,11 +3205,12 @@ mod tests {
         let plan = evaluate_single_phase("post_tc", &policy, &file, &outcomes, None);
         let plan = plan.expect("phase should be evaluated");
         assert!(plan.is_skipped());
-        assert!(plan
-            .skip_reason
-            .as_ref()
-            .expect("should have skip reason")
-            .contains("run_if"));
+        assert!(
+            plan.skip_reason
+                .as_ref()
+                .expect("should have skip reason")
+                .contains("run_if")
+        );
     }
 
     #[test]
@@ -3252,11 +3269,12 @@ mod tests {
         let plan = evaluate_single_phase("post_tc", &policy, &file, &outcomes, None);
         let plan = plan.expect("phase should be evaluated");
         assert!(plan.is_skipped());
-        assert!(plan
-            .skip_reason
-            .as_ref()
-            .expect("should have skip reason")
-            .contains("run_if"));
+        assert!(
+            plan.skip_reason
+                .as_ref()
+                .expect("should have skip reason")
+                .contains("run_if")
+        );
     }
 
     #[test]
@@ -3285,11 +3303,12 @@ mod tests {
         let plan = evaluate_single_phase("post_tc", &policy, &file, &outcomes, None);
         let plan = plan.expect("phase should be evaluated");
         assert!(plan.is_skipped());
-        assert!(plan
-            .skip_reason
-            .as_ref()
-            .expect("should have skip reason")
-            .contains("run_if"));
+        assert!(
+            plan.skip_reason
+                .as_ref()
+                .expect("should have skip reason")
+                .contains("run_if")
+        );
     }
 
     #[test]

--- a/plugins/policy-evaluator/src/filter.rs
+++ b/plugins/policy-evaluator/src/filter.rs
@@ -3,7 +3,7 @@
 use voom_domain::media::{MediaFile, Track, TrackType};
 use voom_dsl::compiled::{CompiledCompareOp, CompiledFilter, TrackTarget};
 
-use crate::condition::{resolve_field, EvalContext};
+use crate::condition::{EvalContext, resolve_field};
 
 /// Returns true if the track matches the filter (no field resolution context).
 ///

--- a/plugins/policy-evaluator/src/lib.rs
+++ b/plugins/policy-evaluator/src/lib.rs
@@ -16,8 +16,8 @@ use voom_domain::media::MediaFile;
 use voom_dsl::compiled::CompiledPolicy;
 
 pub use evaluator::{
-    apply_capability_hints, evaluate, evaluate_with_context, evaluate_with_phase_outputs,
-    EvaluationOutcome,
+    EvaluationOutcome, apply_capability_hints, evaluate, evaluate_with_context,
+    evaluate_with_phase_outputs,
 };
 
 /// Evaluate a policy with system capabilities available to conditions,

--- a/plugins/report/src/lib.rs
+++ b/plugins/report/src/lib.rs
@@ -4,11 +4,11 @@ pub mod query;
 
 use std::sync::Arc;
 
+use voom_domain::Capability;
 use voom_domain::errors::{Result, VoomError};
 use voom_domain::events::{Event, EventResult};
 use voom_domain::stats::SnapshotTrigger;
 use voom_domain::storage::StorageTrait;
-use voom_domain::Capability;
 use voom_kernel::Plugin;
 
 pub use query::{DatabaseStats, IssueReport, ReportRequest, ReportResult, ReportSection};

--- a/plugins/sqlite-store/benches/verification_due.rs
+++ b/plugins/sqlite-store/benches/verification_due.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use chrono::Utc;
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use tempfile::TempDir;
 use uuid::Uuid;
 use voom_domain::media::MediaFile;

--- a/plugins/sqlite-store/src/store/bad_file_storage.rs
+++ b/plugins/sqlite-store/src/store/bad_file_storage.rs
@@ -7,7 +7,7 @@ use voom_domain::bad_file::BadFile;
 use voom_domain::errors::Result;
 use voom_domain::storage::{BadFileFilters, BadFileStorage};
 
-use super::{escape_like, row_to_bad_file, storage_err, OptionalExt, SqlQuery, SqliteStore};
+use super::{OptionalExt, SqlQuery, SqliteStore, escape_like, row_to_bad_file, storage_err};
 
 /// Delete the `bad_files` row at `path` using the supplied connection.
 /// Accepts any `&rusqlite::Connection`, including one obtained via `Deref`
@@ -306,10 +306,12 @@ mod tests {
             .unwrap()
             .unwrap();
         store.delete_bad_file(&stored.id).unwrap();
-        assert!(store
-            .bad_file_by_path(Path::new("/media/bad.mkv"))
-            .unwrap()
-            .is_none());
+        assert!(
+            store
+                .bad_file_by_path(Path::new("/media/bad.mkv"))
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[test]
@@ -321,10 +323,12 @@ mod tests {
         store
             .delete_bad_file_by_path(Path::new("/media/bad.mkv"))
             .unwrap();
-        assert!(store
-            .bad_file_by_path(Path::new("/media/bad.mkv"))
-            .unwrap()
-            .is_none());
+        assert!(
+            store
+                .bad_file_by_path(Path::new("/media/bad.mkv"))
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[test]

--- a/plugins/sqlite-store/src/store/discovered_file_storage.rs
+++ b/plugins/sqlite-store/src/store/discovered_file_storage.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 use voom_domain::errors::Result;
 
 use super::{
-    checked_i64_to_u64, format_datetime, parse_required_datetime, storage_err, SqliteStore,
+    SqliteStore, checked_i64_to_u64, format_datetime, parse_required_datetime, storage_err,
 };
 
 /// Status of a discovered file in the staging pipeline.
@@ -145,11 +145,7 @@ impl SqliteStore {
                     size: checked_i64_to_u64(row.get("size")?, "discovered_files.size")?,
                     content_hash: {
                         let h: String = row.get("content_hash")?;
-                        if h.is_empty() {
-                            None
-                        } else {
-                            Some(h)
-                        }
+                        if h.is_empty() { None } else { Some(h) }
                     },
                     status: DiscoveredStatus::parse(&status_str).ok_or_else(|| {
                         rusqlite::Error::FromSqlConversionFailure(

--- a/plugins/sqlite-store/src/store/estimate_storage.rs
+++ b/plugins/sqlite-store/src/store/estimate_storage.rs
@@ -1,6 +1,6 @@
 //! `EstimateStorage` implementation backed by SQLite.
 
-use rusqlite::{params, Row};
+use rusqlite::{Row, params};
 use uuid::Uuid;
 
 use voom_domain::errors::Result;
@@ -8,8 +8,8 @@ use voom_domain::estimate::{CostModelSample, EstimateOperationKey, EstimateRun, 
 use voom_domain::storage::{CostModelSampleFilters, EstimateStorage};
 
 use super::{
-    checked_i64_to_u64, format_datetime, other_storage_err, parse_required_datetime, row_uuid,
-    storage_err, OptionalExt, SqlQuery, SqliteStore,
+    OptionalExt, SqlQuery, SqliteStore, checked_i64_to_u64, format_datetime, other_storage_err,
+    parse_required_datetime, row_uuid, storage_err,
 };
 
 fn usize_to_i64(value: usize, field: &str) -> Result<i64> {

--- a/plugins/sqlite-store/src/store/event_log_storage.rs
+++ b/plugins/sqlite-store/src/store/event_log_storage.rs
@@ -1,11 +1,11 @@
-use rusqlite::{params, OptionalExtension};
+use rusqlite::{OptionalExtension, params};
 
 use voom_domain::errors::Result;
 use voom_domain::storage::{
     EventLogFilters, EventLogRecord, EventLogStorage, PruneReport, RetentionPolicy,
 };
 
-use super::{format_datetime, parse_datetime, storage_err, SqliteStore};
+use super::{SqliteStore, format_datetime, parse_datetime, storage_err};
 
 impl EventLogStorage for SqliteStore {
     fn insert_event_log(&self, record: &EventLogRecord) -> Result<i64> {

--- a/plugins/sqlite-store/src/store/file_storage.rs
+++ b/plugins/sqlite-store/src/store/file_storage.rs
@@ -13,8 +13,8 @@ use voom_domain::transition::{
 };
 
 use super::{
-    escape_like, format_datetime, other_storage_err, parse_datetime, row_to_file, storage_err,
-    FileRow, OptionalExt, SqlQuery, SqliteStore,
+    FileRow, OptionalExt, SqlQuery, SqliteStore, escape_like, format_datetime, other_storage_err,
+    parse_datetime, row_to_file, storage_err,
 };
 
 fn filename_string(path: &Path) -> String {
@@ -1300,10 +1300,12 @@ mod tests {
             .unwrap();
 
         // Old path no longer maps to a row
-        assert!(store
-            .file_by_path(Path::new("/media/movie.mp4"))
-            .unwrap()
-            .is_none());
+        assert!(
+            store
+                .file_by_path(Path::new("/media/movie.mp4"))
+                .unwrap()
+                .is_none()
+        );
 
         // New path maps to the same row (same id, same hash, status untouched)
         let stored_after = store
@@ -1600,10 +1602,12 @@ mod tests {
             .unwrap();
 
         // 1. Path is renamed
-        assert!(store
-            .file_by_path(Path::new("/media/movie.mp4"))
-            .unwrap()
-            .is_none());
+        assert!(
+            store
+                .file_by_path(Path::new("/media/movie.mp4"))
+                .unwrap()
+                .is_none()
+        );
         let renamed = store
             .file_by_path(Path::new("/media/movie.mkv"))
             .unwrap()

--- a/plugins/sqlite-store/src/store/file_transition_storage.rs
+++ b/plugins/sqlite-store/src/store/file_transition_storage.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
-use rusqlite::params;
 use rusqlite::OptionalExtension;
+use rusqlite::params;
 use uuid::Uuid;
 
 use voom_domain::errors::Result;
@@ -12,8 +12,8 @@ use voom_domain::storage::{FileTransitionStorage, PruneReport, RetentionPolicy};
 use voom_domain::transition::{FileTransition, TransitionSource};
 
 use super::{
-    checked_i64_to_u64, checked_optional_i64_to_u32, checked_optional_i64_to_u64, format_datetime,
-    storage_err, SqliteStore,
+    SqliteStore, checked_i64_to_u64, checked_optional_i64_to_u32, checked_optional_i64_to_u64,
+    format_datetime, storage_err,
 };
 
 /// Insert a `FileTransition` into `file_transitions`. Accepts any

--- a/plugins/sqlite-store/src/store/health_check_storage.rs
+++ b/plugins/sqlite-store/src/store/health_check_storage.rs
@@ -3,7 +3,7 @@ use rusqlite::params;
 use voom_domain::errors::Result;
 use voom_domain::storage::{HealthCheckFilters, HealthCheckRecord, HealthCheckStorage};
 
-use super::{format_datetime, storage_err, SqliteStore};
+use super::{SqliteStore, format_datetime, storage_err};
 
 impl HealthCheckStorage for SqliteStore {
     fn insert_health_check(&self, record: &HealthCheckRecord) -> Result<()> {

--- a/plugins/sqlite-store/src/store/job_storage.rs
+++ b/plugins/sqlite-store/src/store/job_storage.rs
@@ -7,8 +7,8 @@ use voom_domain::job::{Job, JobStatus, JobUpdate};
 use voom_domain::storage::{JobFilters, JobStorage, PruneReport, RetentionPolicy};
 
 use super::{
-    format_datetime, other_storage_err, parse_datetime, row_to_job, storage_err, SqlQuery,
-    SqliteStore,
+    SqlQuery, SqliteStore, format_datetime, other_storage_err, parse_datetime, row_to_job,
+    storage_err,
 };
 
 fn serialize_json(value: &serde_json::Value) -> Result<String> {

--- a/plugins/sqlite-store/src/store/maintenance_storage.rs
+++ b/plugins/sqlite-store/src/store/maintenance_storage.rs
@@ -5,7 +5,7 @@ use rusqlite::params;
 use voom_domain::errors::Result;
 use voom_domain::storage::{MaintenanceStorage, PageStats};
 
-use super::{escape_like, storage_err, PruneTarget, SqliteStore};
+use super::{PruneTarget, SqliteStore, escape_like, storage_err};
 
 impl MaintenanceStorage for SqliteStore {
     fn vacuum(&self) -> Result<()> {
@@ -30,12 +30,10 @@ impl MaintenanceStorage for SqliteStore {
                 let mut stmt = conn
                     .prepare("SELECT id, path FROM bad_files WHERE path LIKE ?1 || '%' ESCAPE '\\'")
                     .map_err(storage_err("failed to prepare bad_files prune"))?;
-                let result = stmt
-                    .query_map(params![root_str], |row| Ok((row.get(0)?, row.get(1)?)))
+                stmt.query_map(params![root_str], |row| Ok((row.get(0)?, row.get(1)?)))
                     .map_err(storage_err("failed to query bad_files"))?
                     .collect::<rusqlite::Result<Vec<_>>>()
-                    .map_err(storage_err("failed to collect bad_files"))?;
-                result
+                    .map_err(storage_err("failed to collect bad_files"))?
             };
             let missing_bad_ids: Vec<&str> = bad_files
                 .iter()
@@ -52,12 +50,10 @@ impl MaintenanceStorage for SqliteStore {
                 .prepare("SELECT id, path FROM files WHERE status = 'active' AND path LIKE ?1 || '%' ESCAPE '\\'")
                 .map_err(storage_err("failed to prepare prune query"))?;
 
-            let result = stmt
-                .query_map(params![root_str], |row| Ok((row.get(0)?, row.get(1)?)))
+            stmt.query_map(params![root_str], |row| Ok((row.get(0)?, row.get(1)?)))
                 .map_err(storage_err("failed to query files"))?
                 .collect::<rusqlite::Result<Vec<_>>>()
-                .map_err(storage_err("failed to collect files"))?;
-            result
+                .map_err(storage_err("failed to collect files"))?
         };
 
         // Phase 2: Check filesystem (no connection held)

--- a/plugins/sqlite-store/src/store/mod.rs
+++ b/plugins/sqlite-store/src/store/mod.rs
@@ -29,9 +29,9 @@ use voom_domain::errors::{Result, StorageErrorKind, VoomError};
 use voom_domain::media::Track;
 
 pub(crate) use row_mappers::{
-    checked_i64_to_u64, checked_optional_i64_to_u32, checked_optional_i64_to_u64,
+    FileRow, checked_i64_to_u64, checked_optional_i64_to_u32, checked_optional_i64_to_u64,
     parse_optional_datetime, parse_required_datetime, row_to_bad_file, row_to_file, row_to_job,
-    row_to_track, row_uuid, FileRow,
+    row_to_track, row_uuid,
 };
 
 use crate::schema;

--- a/plugins/sqlite-store/src/store/pending_ops_storage.rs
+++ b/plugins/sqlite-store/src/store/pending_ops_storage.rs
@@ -4,7 +4,7 @@ use uuid::Uuid;
 use voom_domain::errors::Result;
 use voom_domain::storage::PendingOperation;
 
-use super::{format_datetime, other_storage_err, storage_err, SqliteStore};
+use super::{SqliteStore, format_datetime, other_storage_err, storage_err};
 
 impl voom_domain::storage::PendingOpsStorage for SqliteStore {
     fn insert_pending_op(&self, op: &PendingOperation) -> Result<()> {

--- a/plugins/sqlite-store/src/store/plan_storage.rs
+++ b/plugins/sqlite-store/src/store/plan_storage.rs
@@ -7,8 +7,8 @@ use voom_domain::plan::{Plan, PlannedAction};
 use voom_domain::storage::{PlanPhaseStat, PlanStatus, PlanStorage, PlanSummary};
 
 use super::{
-    format_datetime, other_storage_err, parse_optional_datetime, row_uuid, storage_err,
-    OptionalExt, SqliteStore,
+    OptionalExt, SqliteStore, format_datetime, other_storage_err, parse_optional_datetime,
+    row_uuid, storage_err,
 };
 
 /// Internal DTO for mapping database rows. Not exposed outside this crate.
@@ -254,11 +254,11 @@ impl PlanStorage for SqliteStore {
 mod tests {
     use super::*;
     use std::path::PathBuf;
+    use voom_domain::TranscodeSettings;
     use voom_domain::media::{Container, MediaFile, Track, TrackType};
     use voom_domain::plan::TranscodeChannels;
     use voom_domain::plan::{ActionParams, OperationType};
     use voom_domain::storage::FileStorage;
-    use voom_domain::TranscodeSettings;
 
     fn test_store() -> SqliteStore {
         SqliteStore::in_memory().expect("in-memory store")

--- a/plugins/sqlite-store/src/store/plugin_data_storage.rs
+++ b/plugins/sqlite-store/src/store/plugin_data_storage.rs
@@ -4,7 +4,7 @@ use rusqlite::params;
 use voom_domain::errors::Result;
 use voom_domain::storage::PluginDataStorage;
 
-use super::{format_datetime, storage_err, OptionalExt, SqliteStore};
+use super::{OptionalExt, SqliteStore, format_datetime, storage_err};
 
 impl PluginDataStorage for SqliteStore {
     fn plugin_data(&self, plugin: &str, key: &str) -> Result<Option<Vec<u8>>> {
@@ -121,10 +121,12 @@ mod tests {
 
         // Deleting one does not affect the other.
         store.delete_plugin_data("plugin-a", "shared-key").unwrap();
-        assert!(store
-            .plugin_data("plugin-a", "shared-key")
-            .unwrap()
-            .is_none());
+        assert!(
+            store
+                .plugin_data("plugin-a", "shared-key")
+                .unwrap()
+                .is_none()
+        );
         assert_eq!(
             store
                 .plugin_data("plugin-b", "shared-key")

--- a/plugins/sqlite-store/src/store/row_mappers.rs
+++ b/plugins/sqlite-store/src/store/row_mappers.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use chrono::{DateTime, Utc};
-use rusqlite::types::Type;
 use rusqlite::Row;
+use rusqlite::types::Type;
 use uuid::Uuid;
 
 use voom_domain::bad_file::{BadFile, BadFileSource};

--- a/plugins/sqlite-store/src/store/snapshot_storage.rs
+++ b/plugins/sqlite-store/src/store/snapshot_storage.rs
@@ -7,7 +7,7 @@ use voom_domain::stats::{
 };
 use voom_domain::storage::SnapshotStorage;
 
-use super::{format_datetime, storage_err, SqliteStore};
+use super::{SqliteStore, format_datetime, storage_err};
 
 impl SnapshotStorage for SqliteStore {
     fn gather_library_stats(&self, trigger: SnapshotTrigger) -> Result<LibrarySnapshot> {

--- a/plugins/sqlite-store/src/store/subtitle_storage.rs
+++ b/plugins/sqlite-store/src/store/subtitle_storage.rs
@@ -4,7 +4,7 @@ use rusqlite::params;
 
 use voom_domain::errors::Result;
 
-use super::{storage_err, SqliteStore};
+use super::{SqliteStore, storage_err};
 
 /// A row from the `subtitles` table.
 #[derive(Debug, Clone)]

--- a/plugins/sqlite-store/src/store/transcode_outcome_storage.rs
+++ b/plugins/sqlite-store/src/store/transcode_outcome_storage.rs
@@ -1,13 +1,13 @@
 //! `TranscodeOutcomeStorage` implementation backed by SQLite.
 
-use rusqlite::{params, Row};
+use rusqlite::{Row, params};
 
 use voom_domain::errors::Result;
 use voom_domain::storage::{TranscodeOutcomeFilters, TranscodeOutcomeStorage};
 use voom_domain::transcode::TranscodeOutcome;
 
-use super::{format_datetime, parse_required_datetime, row_uuid, storage_err, SqlQuery};
-use super::{other_storage_err, SqliteStore};
+use super::{SqlQuery, format_datetime, parse_required_datetime, row_uuid, storage_err};
+use super::{SqliteStore, other_storage_err};
 
 const SELECT_TRANSCODE_OUTCOME: &str = "SELECT id, file_id, target_vmaf, achieved_vmaf, \
     crf_used, bitrate_used, iterations, sample_strategy, fallback_used, completed_at \

--- a/plugins/sqlite-store/src/store/verification_storage.rs
+++ b/plugins/sqlite-store/src/store/verification_storage.rs
@@ -1,7 +1,7 @@
 //! `VerificationStorage` implementation backed by SQLite.
 
 use chrono::{DateTime, Utc};
-use rusqlite::{params, Row};
+use rusqlite::{Row, params};
 
 use voom_domain::errors::Result;
 use voom_domain::media::{Container, MediaFile};
@@ -13,7 +13,7 @@ use voom_domain::verification::{
 };
 
 use super::row_mappers::row_to_verification;
-use super::{format_datetime, parse_datetime, storage_err, SqlQuery, SqliteStore};
+use super::{SqlQuery, SqliteStore, format_datetime, parse_datetime, storage_err};
 
 const SELECT_VERIFICATION: &str = "SELECT id, file_id, verified_at, mode, outcome, \
     error_count, warning_count, content_hash, details FROM verifications";

--- a/plugins/web-server/src/api/estimates.rs
+++ b/plugins/web-server/src/api/estimates.rs
@@ -1,11 +1,11 @@
 //! Pre-flight estimate API endpoints.
 
-use axum::extract::{Path, Query, State};
 use axum::Json;
+use axum::extract::{Path, Query, State};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::errors::{spawn_store_op, WebError};
+use crate::errors::{WebError, spawn_store_op};
 use crate::state::AppState;
 
 const DEFAULT_ESTIMATE_LIMIT: u32 = 25;

--- a/plugins/web-server/src/api/files.rs
+++ b/plugins/web-server/src/api/files.rs
@@ -1,14 +1,14 @@
 //! File-related API endpoints.
 
-use axum::extract::{Path, Query, State};
 use axum::Json;
+use axum::extract::{Path, Query, State};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use voom_domain::media::{Container, MediaFile};
 use voom_domain::storage::FileFilters;
 
-use crate::errors::{spawn_store_op, WebError};
+use crate::errors::{WebError, spawn_store_op};
 use crate::state::AppState;
 
 /// Shared filter fields used by both API and page handlers.

--- a/plugins/web-server/src/api/health.rs
+++ b/plugins/web-server/src/api/health.rs
@@ -1,11 +1,11 @@
 //! Health check API endpoints.
 
-use axum::extract::State;
 use axum::Json;
+use axum::extract::State;
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 
-use crate::errors::{spawn_store_op, WebError};
+use crate::errors::{WebError, spawn_store_op};
 use crate::state::AppState;
 
 #[derive(Debug, Serialize)]

--- a/plugins/web-server/src/api/jobs.rs
+++ b/plugins/web-server/src/api/jobs.rs
@@ -1,11 +1,11 @@
 //! Job-related API endpoints.
 
-use axum::extract::{Path, Query, State};
 use axum::Json;
+use axum::extract::{Path, Query, State};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::errors::{spawn_store_op, WebError};
+use crate::errors::{WebError, spawn_store_op};
 use crate::state::AppState;
 use voom_domain::job::{Job, JobStatus};
 use voom_domain::storage::JobFilters;

--- a/plugins/web-server/src/api/plugins.rs
+++ b/plugins/web-server/src/api/plugins.rs
@@ -1,7 +1,7 @@
 //! Plugin-related API endpoints.
 
-use axum::extract::State;
 use axum::Json;
+use axum::extract::State;
 use serde::Serialize;
 
 use crate::errors::WebError;

--- a/plugins/web-server/src/api/policy.rs
+++ b/plugins/web-server/src/api/policy.rs
@@ -207,10 +207,12 @@ mod tests {
         };
         let json = serde_json::to_value(&response).unwrap();
         assert_eq!(json["errors"][0]["suggestion"], "did you mean \"hevc\"?");
-        assert!(!json["errors"][0]["message"]
-            .as_str()
-            .unwrap()
-            .contains("suggestion"));
+        assert!(
+            !json["errors"][0]["message"]
+                .as_str()
+                .unwrap()
+                .contains("suggestion")
+        );
     }
 
     #[test]

--- a/plugins/web-server/src/api/process_runs.rs
+++ b/plugins/web-server/src/api/process_runs.rs
@@ -2,12 +2,12 @@
 
 use std::path::PathBuf;
 
-use axum::extract::State;
 use axum::Json;
+use axum::extract::State;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::errors::{spawn_store_op, WebError};
+use crate::errors::{WebError, spawn_store_op};
 use crate::state::{AppState, ProcessRunLaunchRequest, ProcessRunLaunchResponse};
 
 #[derive(Debug, Deserialize)]

--- a/plugins/web-server/src/api/stats.rs
+++ b/plugins/web-server/src/api/stats.rs
@@ -1,14 +1,14 @@
 //! Stats-related API endpoints.
 
-use axum::extract::{Query, State};
 use axum::Json;
+use axum::extract::{Query, State};
 use serde::Serialize;
 
 use voom_domain::errors::VoomError;
 use voom_domain::stats::LibrarySnapshot;
 use voom_report::{ReportPlugin, ReportRequest, ReportSection};
 
-use crate::errors::{spawn_store_op, WebError};
+use crate::errors::{WebError, spawn_store_op};
 use crate::state::AppState;
 
 #[derive(Debug, Serialize)]

--- a/plugins/web-server/src/api/tools.rs
+++ b/plugins/web-server/src/api/tools.rs
@@ -1,10 +1,10 @@
 //! Tool detection API endpoints.
 
-use axum::extract::State;
 use axum::Json;
+use axum::extract::State;
 use serde::{Deserialize, Serialize};
 
-use crate::errors::{spawn_store_op, WebError};
+use crate::errors::{WebError, spawn_store_op};
 use crate::state::AppState;
 
 /// Known tool names that the tool-detector plugin reports.

--- a/plugins/web-server/src/api/transitions.rs
+++ b/plugins/web-server/src/api/transitions.rs
@@ -1,13 +1,13 @@
 //! File transition history API endpoint.
 
-use axum::extract::{Path, State};
 use axum::Json;
+use axum::extract::{Path, State};
 use serde::Serialize;
 use uuid::Uuid;
 
 use voom_domain::transition::FileTransition;
 
-use crate::errors::{spawn_store_op, WebError};
+use crate::errors::{WebError, spawn_store_op};
 use crate::state::AppState;
 
 #[derive(Debug, Serialize)]

--- a/plugins/web-server/src/api/verify.rs
+++ b/plugins/web-server/src/api/verify.rs
@@ -1,7 +1,7 @@
 //! Verification and integrity API endpoints.
 
-use axum::extract::{Path, Query, State};
 use axum::Json;
+use axum::extract::{Path, Query, State};
 use serde::Deserialize;
 
 use voom_domain::utils::since::parse_since;
@@ -10,7 +10,7 @@ use voom_domain::verification::{
     VerificationRecord,
 };
 
-use crate::errors::{spawn_store_op, WebError};
+use crate::errors::{WebError, spawn_store_op};
 use crate::state::AppState;
 
 /// Default page size when the caller does not specify `limit`.

--- a/plugins/web-server/src/router.rs
+++ b/plugins/web-server/src/router.rs
@@ -1,15 +1,15 @@
 //! Axum router construction.
 
-use axum::http::{header, StatusCode};
+use axum::Router;
+use axum::http::{StatusCode, header};
 use axum::middleware;
 use axum::response::IntoResponse;
 use axum::routing::{get, post};
-use axum::Router;
 use tower::limit::ConcurrencyLimitLayer;
 
 use crate::api;
 use crate::errors::ApiError;
-use crate::middleware::{auth_middleware, RateLimitLayer, RequestIdLayer, SecurityHeadersLayer};
+use crate::middleware::{RateLimitLayer, RequestIdLayer, SecurityHeadersLayer, auth_middleware};
 use crate::sse;
 use crate::state::AppState;
 use crate::templates;

--- a/plugins/web-server/src/server.rs
+++ b/plugins/web-server/src/server.rs
@@ -136,7 +136,7 @@ fn load_templates(template_dir: Option<&str>) -> Result<tera::Tera, ServerError>
 /// template set without starting the full server.
 pub fn embedded_templates() -> Result<tera::Tera, ServerError> {
     macro_rules! register_templates {
-        ($tera:expr, $( $name:literal ),+ $(,)?) => {
+        ($tera:expr_2021, $( $name:literal ),+ $(,)?) => {
             $(
                 $tera
                     .add_raw_template(

--- a/plugins/web-server/src/sse.rs
+++ b/plugins/web-server/src/sse.rs
@@ -1,17 +1,17 @@
 //! Server-Sent Events (SSE) for live updates.
 
 use std::convert::Infallible;
-use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
 
 use axum::extract::State;
 use axum::http::StatusCode;
-use axum::response::sse::{Event as SseAxumEvent, KeepAlive, Sse};
 use axum::response::IntoResponse;
-use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
-use tokio_stream::wrappers::BroadcastStream;
+use axum::response::sse::{Event as SseAxumEvent, KeepAlive, Sse};
 use tokio_stream::Stream;
 use tokio_stream::StreamExt;
+use tokio_stream::wrappers::BroadcastStream;
+use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
 
 use crate::state::{AppState, SseEvent};
 

--- a/plugins/web-server/src/state.rs
+++ b/plugins/web-server/src/state.rs
@@ -1,7 +1,7 @@
 //! Shared application state for the web server.
 
-use std::sync::atomic::AtomicU32;
 use std::sync::Arc;
+use std::sync::atomic::AtomicU32;
 
 use tokio::sync::broadcast;
 use voom_domain::storage::StorageTrait;

--- a/plugins/web-server/src/templates.rs
+++ b/plugins/web-server/src/templates.rs
@@ -1,8 +1,8 @@
 //! Tera template rendering and page handlers.
 
+use axum::Extension;
 use axum::extract::{Path, Query, State};
 use axum::response::Html;
-use axum::Extension;
 use serde::Deserialize;
 use std::collections::HashSet;
 
@@ -11,10 +11,10 @@ use voom_domain::storage::{FileFilters, JobFilters};
 use voom_domain::verification::{VerificationFilters, VerificationOutcome};
 
 use crate::api::files::FileFilterParams;
-use crate::errors::{spawn_store_op, WebError};
+use crate::errors::{WebError, spawn_store_op};
 use crate::middleware::CspNonce;
 use crate::state::AppState;
-use crate::views::{file_views, transition_views, verification_views, IntegrityErrorView};
+use crate::views::{IntegrityErrorView, file_views, transition_views, verification_views};
 
 type HtmlResult = Result<Html<String>, WebError>;
 const FILE_VERIFICATION_LIMIT: u32 = 25;

--- a/plugins/web-server/tests/api_tests.rs
+++ b/plugins/web-server/tests/api_tests.rs
@@ -1,7 +1,7 @@
 //! Integration tests for the web server REST API.
 
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use axum_test::TestServer;
 use serde_json::json;

--- a/plugins/web-server/tests/sse_stream.rs
+++ b/plugins/web-server/tests/sse_stream.rs
@@ -19,7 +19,7 @@ use tokio::sync::broadcast;
 use tokio::time::timeout;
 
 use voom_domain::test_support::InMemoryStore;
-use voom_web_server::state::{AppState, SseEvent, SSE_CHANNEL_CAPACITY};
+use voom_web_server::state::{AppState, SSE_CHANNEL_CAPACITY, SseEvent};
 
 /// Read from the socket until the HTTP response header block (`\r\n\r\n`) has
 /// been consumed. Returns any bytes already read past the header boundary so

--- a/wasm-plugins/audio-language-detector/Cargo.toml
+++ b/wasm-plugins/audio-language-detector/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "audio-language-detector"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 description = "VOOM WASM plugin for audio language detection via Whisper (uses host tool runner)"
 
 [lib]

--- a/wasm-plugins/audio-synthesizer/Cargo.toml
+++ b/wasm-plugins/audio-synthesizer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "audio-synthesizer"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 description = "VOOM WASM plugin for audio synthesis via host tool runner"
 
 [lib]

--- a/wasm-plugins/audio-synthesizer/src/lib.rs
+++ b/wasm-plugins/audio-synthesizer/src/lib.rs
@@ -283,6 +283,7 @@ mod tests {
                 title: None,
                 position: None,
                 source_track: None,
+                loudness: None,
             },
             "Synthesize English audio description",
         ))
@@ -362,6 +363,7 @@ mod tests {
                 title: None,
                 position: None,
                 source_track: None,
+                loudness: None,
             },
             "empty synth",
         ));

--- a/wasm-plugins/example-metadata/Cargo.toml
+++ b/wasm-plugins/example-metadata/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "example-metadata"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 description = "Example VOOM WASM plugin demonstrating metadata enrichment"
 
 [lib]

--- a/wasm-plugins/handbrake-executor/Cargo.toml
+++ b/wasm-plugins/handbrake-executor/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "handbrake-executor"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 description = "VOOM WASM plugin for video transcoding via HandBrakeCLI (uses host tool runner)"
 
 [lib]

--- a/wasm-plugins/radarr-metadata/Cargo.toml
+++ b/wasm-plugins/radarr-metadata/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "radarr-metadata"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 description = "VOOM WASM plugin for movie metadata enrichment via Radarr API"
 
 [lib]

--- a/wasm-plugins/sonarr-metadata/Cargo.toml
+++ b/wasm-plugins/sonarr-metadata/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sonarr-metadata"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 description = "VOOM WASM plugin for TV series metadata enrichment via Sonarr API"
 
 [lib]

--- a/wasm-plugins/subtitle-generator/Cargo.toml
+++ b/wasm-plugins/subtitle-generator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "subtitle-generator"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 description = "VOOM WASM plugin for generating forced subtitle files from multi-language transcripts"
 
 [lib]

--- a/wasm-plugins/whisper-transcriber/Cargo.toml
+++ b/wasm-plugins/whisper-transcriber/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "whisper-transcriber"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 description = "VOOM WASM plugin for audio transcription via Whisper (uses host tool runner)"
 
 [lib]


### PR DESCRIPTION
## Summary
- upgrade the workspace and standalone Rust manifests to Rust 2024
- raise MSRV to Rust 1.85 and advertise it in the README badge
- make `just setup` fail clearly when cargo/rustc are below the MSRV
- apply Rust 2024 compatibility rewrites and formatting

Closes #263

## Validation
- `VOOM_SETUP_INSTALL=0 just setup`
- fake `cargo/rustc 1.84.0` setup negative check
- `cargo fmt --all -- --check`
- `RUSTFLAGS='-Wrust-2024-compatibility' cargo check --workspace --all-targets`\n- standalone excluded crate checks with `RUSTFLAGS='-Wrust-2024-compatibility'`\n- `cargo clippy --workspace -- -D warnings`\n- `cargo clippy -p voom-kernel --features wasm -- -D warnings`\n- `cargo test --workspace`\n- `cargo test -p voom-kernel --features wasm`