### PR TITLE
Add product version policy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,27 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
+          fetch-depth: 0
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6  # v1.16.1
+      - name: Validate release version
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          tag="${GITHUB_REF_NAME}"
+          if [[ ! "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Release tags must use vMAJOR.MINOR.PATCH, got: ${tag}" >&2
+            exit 1
+          fi
+
+          package_version="$(cargo metadata --no-deps --format-version=1 \
+            | jq -r '.packages[] | select(.name == "voom-cli") | .version')"
+          tag_version="${tag#v}"
+
+          if [[ "${package_version}" != "${tag_version}" ]]; then
+            echo "Tag ${tag} does not match voom-cli package version ${package_version}" >&2
+            exit 1
+          fi
       - run: cargo build --release --bin voom
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,70 @@
+# Releasing VOOM
+
+This project uses SemVer for release versions and an explicit product version
+for development builds.
+
+## Version Policy
+
+- Release versions are plain SemVer, such as `0.1.0`.
+- Release tags use `vMAJOR.MINOR.PATCH`, such as `v0.1.0`.
+- The release tag version must match `crates/voom-cli/Cargo.toml`.
+- Development builds include the package version, a `-dev` suffix, and a commit
+  identifier: `0.1.0-dev+g<short-sha>`.
+- If Git metadata is unavailable, development builds use
+  `0.1.0-dev+unknown`.
+- Native plugin crate versions remain Cargo package versions. The product
+  version policy applies to the `voom` CLI version shown by `voom --version`.
+
+## 0.1.0 Release Process
+
+1. Start from a clean working tree on `main`.
+2. Confirm CI is green for the commit that will be released.
+3. Confirm `crates/voom-cli/Cargo.toml` has the intended release version:
+
+   ```sh
+   cargo metadata --no-deps --format-version=1 \
+     | jq -r '.packages[] | select(.name == "voom-cli") | .version'
+   ```
+
+4. Run the local release checks:
+
+   ```sh
+   cargo fmt --all -- --check
+   cargo clippy --workspace -- -D warnings
+   cargo test --workspace
+   cargo build --release --bin voom
+   ./target/release/voom --version
+   ```
+
+   Before tagging, a non-release build should print a development version such
+   as `voom 0.1.0-dev+g2b683f107a2e`.
+
+5. Create and push the release tag:
+
+   ```sh
+   git tag -a v0.1.0 -m "Release v0.1.0"
+   git push origin v0.1.0
+   ```
+
+6. Wait for the GitHub Actions `Release` workflow to finish. It validates that
+   the tag matches the CLI package version, builds the release binary, and
+   publishes a GitHub release.
+
+7. Download the release artifact and smoke-test it:
+
+   ```sh
+   ./voom --version
+   ```
+
+   The expected output for the `v0.1.0` release is `voom 0.1.0`.
+
+## Failed Release
+
+If the release workflow fails before publishing an artifact, delete the local
+and remote tag, fix the issue, and create the tag again from the corrected
+commit:
+
+```sh
+git tag -d v0.1.0
+git push origin :refs/tags/v0.1.0
+```

--- a/crates/voom-cli/build.rs
+++ b/crates/voom-cli/build.rs
@@ -1,0 +1,70 @@
+use std::{fs, process::Command};
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=GITHUB_REF_NAME");
+    println!("cargo:rerun-if-env-changed=GITHUB_REF_TYPE");
+    emit_git_rerun_instructions();
+
+    let package_version = std::env::var("CARGO_PKG_VERSION").expect("CARGO_PKG_VERSION is set");
+    let product_version = product_version(&package_version);
+    println!("cargo:rustc-env=VOOM_PRODUCT_VERSION={product_version}");
+}
+
+fn emit_git_rerun_instructions() {
+    println!("cargo:rerun-if-changed=../../.git/HEAD");
+    println!("cargo:rerun-if-changed=../../.git/packed-refs");
+    println!("cargo:rerun-if-changed=../../.git/refs/tags");
+
+    let Ok(head) = fs::read_to_string("../../.git/HEAD") else {
+        return;
+    };
+    let Some(reference) = head.trim().strip_prefix("ref: ") else {
+        return;
+    };
+
+    println!("cargo:rerun-if-changed=../../.git/{reference}");
+}
+
+fn product_version(package_version: &str) -> String {
+    let expected_tag = format!("v{package_version}");
+
+    if github_ref_is_release_tag(&expected_tag) || git_head_is_release_tag(&expected_tag) {
+        return package_version.to_owned();
+    }
+
+    match git_short_sha() {
+        Some(sha) => format!("{package_version}-dev+g{sha}"),
+        None => format!("{package_version}-dev+unknown"),
+    }
+}
+
+fn github_ref_is_release_tag(expected_tag: &str) -> bool {
+    std::env::var("GITHUB_REF_TYPE").as_deref() == Ok("tag")
+        && std::env::var("GITHUB_REF_NAME").as_deref() == Ok(expected_tag)
+}
+
+fn git_head_is_release_tag(expected_tag: &str) -> bool {
+    git_output(&[
+        "describe",
+        "--tags",
+        "--exact-match",
+        "--match",
+        "v[0-9]*.[0-9]*.[0-9]*",
+    ])
+    .is_some_and(|tag| tag == expected_tag)
+}
+
+fn git_short_sha() -> Option<String> {
+    git_output(&["rev-parse", "--short=12", "HEAD"])
+}
+
+fn git_output(args: &[&str]) -> Option<String> {
+    let output = Command::new("git").args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    let trimmed = stdout.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_owned())
+}

--- a/crates/voom-cli/src/cli.rs
+++ b/crates/voom-cli/src/cli.rs
@@ -4,7 +4,7 @@ use clap::{Parser, Subcommand, ValueEnum};
 
 /// VOOM — Video Orchestration Operations Manager
 #[derive(Parser)]
-#[command(name = "voom", version, about, long_about = None)]
+#[command(name = "voom", version = env!("VOOM_PRODUCT_VERSION"), about, long_about = None)]
 pub struct Cli {
     /// Increase verbosity (-v info, -vv debug, -vvv trace)
     #[arg(short, long, action = clap::ArgAction::Count, global = true)]

--- a/crates/voom-cli/tests/cli_tests.rs
+++ b/crates/voom-cli/tests/cli_tests.rs
@@ -116,11 +116,14 @@ fn test_help() {
 
 #[test]
 fn test_version() {
+    let package_version = env!("CARGO_PKG_VERSION").replace('.', r"\.");
+    let pattern = format!(r"^voom {package_version}(-dev\+(g[0-9a-f]{{7,12}}|unknown))?\n$");
+
     voom()
         .arg("--version")
         .assert()
         .success()
-        .stdout(predicate::str::contains("voom"));
+        .stdout(predicate::str::is_match(pattern).unwrap());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add build-time VOOM product version generation for release vs development builds
- wire `voom --version` to the generated product version
- document the release/version policy and validate release tags in CI

Closes #349.

## Tests
- `cargo fmt --all -- --check`
- `cargo clippy -p voom-cli -- -D warnings`
- `cargo test -p voom-cli`
- `cargo run -q --bin voom -- --version`
- simulated release-version workflow validation for `v0.1.0`