### PR TITLE
Make CLI output agent-friendly

### DIFF
--- a/crates/voom-cli/src/cli.rs
+++ b/crates/voom-cli/src/cli.rs
@@ -1098,6 +1098,23 @@ mod tests {
         assert!(cli.yes);
     }
 
+    #[test]
+    fn test_global_yes_available_to_destructive_commands() {
+        let cases = [
+            vec!["voom", "-y", "db", "reset"],
+            vec!["voom", "-y", "db", "clean-bad"],
+            vec!["voom", "-y", "jobs", "clear"],
+            vec!["voom", "-y", "files", "delete", "550e8400-e29b-41d4-a716-446655440000"],
+            vec!["voom", "-y", "backup", "restore", "/tmp/movie.vbak"],
+            vec!["voom", "-y", "backup", "cleanup", "/tmp"],
+        ];
+
+        for args in &cases {
+            let cli = parse(args);
+            assert!(cli.yes, "expected global yes for {args:?}");
+        }
+    }
+
     // ── Scan ─────────────────────────────────────────────────
 
     #[test]

--- a/crates/voom-cli/src/cli.rs
+++ b/crates/voom-cli/src/cli.rs
@@ -1104,7 +1104,13 @@ mod tests {
             vec!["voom", "-y", "db", "reset"],
             vec!["voom", "-y", "db", "clean-bad"],
             vec!["voom", "-y", "jobs", "clear"],
-            vec!["voom", "-y", "files", "delete", "550e8400-e29b-41d4-a716-446655440000"],
+            vec![
+                "voom",
+                "-y",
+                "files",
+                "delete",
+                "550e8400-e29b-41d4-a716-446655440000",
+            ],
             vec!["voom", "-y", "backup", "restore", "/tmp/movie.vbak"],
             vec!["voom", "-y", "backup", "cleanup", "/tmp"],
         ];

--- a/crates/voom-cli/src/cli.rs
+++ b/crates/voom-cli/src/cli.rs
@@ -346,9 +346,9 @@ pub enum PolicyCommands {
         /// Update snapshot expectations (not available until snapshot mode lands)
         #[arg(long)]
         update: bool,
-        /// Emit machine-readable JSON output
-        #[arg(long)]
-        json: bool,
+        /// Output format
+        #[arg(short, long, default_value = "table")]
+        format: OutputFormat,
     },
 }
 
@@ -439,12 +439,8 @@ pub enum JobsCommands {
 #[derive(clap::Args)]
 pub struct ReportArgs {
     /// Output format (auto-detected: table for TTY, json for pipe)
-    #[arg(short, long, default_value = "table", conflicts_with = "json")]
+    #[arg(short, long, default_value = "table")]
     pub format: OutputFormat,
-
-    /// Emit JSON output
-    #[arg(long)]
-    pub json: bool,
 
     /// Show full library statistics
     #[arg(long)]
@@ -891,11 +887,8 @@ pub enum EnvCommands {
     /// Run live environment checks
     Check {
         /// Output format
-        #[arg(short, long, default_value = "table", conflicts_with = "json")]
+        #[arg(short, long, default_value = "table")]
         format: OutputFormat,
-        /// Emit JSON output
-        #[arg(long)]
-        json: bool,
     },
     /// Show environment check history from the database
     History {
@@ -1448,12 +1441,12 @@ mod tests {
                 paths,
                 policy,
                 update,
-                json,
+                format,
             }) => {
                 assert_eq!(paths, vec![PathBuf::from(".")]);
                 assert_eq!(policy, None);
                 assert!(!update);
-                assert!(!json);
+                assert!(matches!(format, OutputFormat::Table));
             }
             _ => panic!("expected Policy Test"),
         }
@@ -1470,14 +1463,15 @@ mod tests {
             "--policy",
             "override.voom",
             "--update",
-            "--json",
+            "--format",
+            "json",
         ]);
         match cli.command {
             Commands::Policy(PolicyCommands::Test {
                 paths,
                 policy,
                 update,
-                json,
+                format,
             }) => {
                 assert_eq!(
                     paths,
@@ -1488,10 +1482,15 @@ mod tests {
                 );
                 assert_eq!(policy, Some(PathBuf::from("override.voom")));
                 assert!(update);
-                assert!(json);
+                assert!(matches!(format, OutputFormat::Json));
             }
             _ => panic!("expected Policy Test"),
         }
+    }
+
+    #[test]
+    fn test_policy_test_rejects_json_alias() {
+        assert!(try_parse(&["voom", "policy", "test", "--json"]).is_err());
     }
 
     // ── Plugin subcommands ───────────────────────────────────
@@ -1666,6 +1665,11 @@ mod tests {
             Commands::Report(args) => assert!(matches!(args.format, OutputFormat::Json)),
             _ => panic!("expected Report"),
         }
+    }
+
+    #[test]
+    fn test_report_rejects_json_alias() {
+        assert!(try_parse(&["voom", "report", "--json"]).is_err());
     }
 
     // ── Serve ────────────────────────────────────────────────
@@ -1913,9 +1917,8 @@ mod tests {
     fn test_env_check() {
         let cli = parse(&["voom", "env", "check"]);
         match cli.command {
-            Commands::Env(EnvCommands::Check { format, json }) => {
+            Commands::Env(EnvCommands::Check { format }) => {
                 assert!(matches!(format, OutputFormat::Table));
-                assert!(!json);
             }
             _ => panic!("expected Env Check"),
         }
@@ -1925,24 +1928,16 @@ mod tests {
     fn test_env_check_json_format() {
         let cli = parse(&["voom", "env", "check", "--format", "json"]);
         match cli.command {
-            Commands::Env(EnvCommands::Check { format, json }) => {
+            Commands::Env(EnvCommands::Check { format }) => {
                 assert!(matches!(format, OutputFormat::Json));
-                assert!(!json);
             }
             _ => panic!("expected Env Check"),
         }
     }
 
     #[test]
-    fn test_env_check_json_alias() {
-        let cli = parse(&["voom", "env", "check", "--json"]);
-        match cli.command {
-            Commands::Env(EnvCommands::Check { format, json }) => {
-                assert!(matches!(format, OutputFormat::Table));
-                assert!(json);
-            }
-            _ => panic!("expected Env Check"),
-        }
+    fn test_env_check_rejects_json_alias() {
+        assert!(try_parse(&["voom", "env", "check", "--json"]).is_err());
     }
 
     #[test]

--- a/crates/voom-cli/src/cli.rs
+++ b/crates/voom-cli/src/cli.rs
@@ -304,16 +304,26 @@ fn parse_size_bytes(value: &str) -> std::result::Result<u64, String> {
 #[derive(Subcommand)]
 pub enum PolicyCommands {
     /// List loaded policies
-    List,
+    List {
+        /// Output format
+        #[arg(short, long, default_value = "table")]
+        format: OutputFormat,
+    },
     /// Validate a policy file
     Validate {
         /// Policy file to validate
         file: PathBuf,
+        /// Output format
+        #[arg(short, long, default_value = "table")]
+        format: OutputFormat,
     },
     /// Show compiled policy details
     Show {
         /// Policy file to show
         file: PathBuf,
+        /// Output format
+        #[arg(short, long, default_value = "table")]
+        format: OutputFormat,
     },
     /// Auto-format a policy file in place
     Format {
@@ -329,6 +339,9 @@ pub enum PolicyCommands {
         /// Evaluate both policies against this JSON media fixture and diff the plans
         #[arg(long)]
         fixture: Option<PathBuf>,
+        /// Output format
+        #[arg(short, long, default_value = "table")]
+        format: OutputFormat,
     },
     /// Author and inspect policy fixtures
     Fixture {
@@ -366,11 +379,18 @@ pub enum PolicyFixtureCommands {
 #[derive(Subcommand)]
 pub enum PluginCommands {
     /// List registered plugins
-    List,
+    List {
+        /// Output format
+        #[arg(short, long, default_value = "table")]
+        format: OutputFormat,
+    },
     /// Show detailed info about a plugin
     Info {
         /// Plugin name
         name: String,
+        /// Output format
+        #[arg(short, long, default_value = "table")]
+        format: OutputFormat,
     },
     /// Enable a plugin
     Enable {
@@ -404,11 +424,17 @@ pub enum JobsCommands {
         /// Number of jobs to skip
         #[arg(long, default_value = "0")]
         offset: u32,
+        /// Output format
+        #[arg(short, long, default_value = "table")]
+        format: OutputFormat,
     },
     /// Show job details
     Status {
         /// Job ID
         id: String,
+        /// Output format
+        #[arg(short, long, default_value = "table")]
+        format: OutputFormat,
     },
     /// Cancel a running job
     Cancel {
@@ -562,13 +588,20 @@ pub enum DbCommands {
 #[derive(Subcommand)]
 pub enum ConfigCommands {
     /// Show current configuration
-    Show,
+    Show {
+        /// Output format
+        #[arg(short, long, default_value = "table")]
+        format: OutputFormat,
+    },
     /// Open configuration in $EDITOR
     Edit,
     /// Get a configuration value by dot-notation key
     Get {
         /// Dot-notation key (e.g. `auth_token`, `plugins.wasm_dir`, plugin.ffmpeg-executor.hw_accel)
         key: String,
+        /// Output format
+        #[arg(short, long, default_value = "table")]
+        format: OutputFormat,
     },
     /// Set a configuration value by dot-notation key
     Set {
@@ -1338,8 +1371,19 @@ mod tests {
         let cli = parse(&["voom", "policy", "list"]);
         assert!(matches!(
             cli.command,
-            Commands::Policy(PolicyCommands::List)
+            Commands::Policy(PolicyCommands::List { .. })
         ));
+    }
+
+    #[test]
+    fn test_policy_list_json_format() {
+        let cli = parse(&["voom", "policy", "list", "--format", "json"]);
+        match cli.command {
+            Commands::Policy(PolicyCommands::List { format }) => {
+                assert!(matches!(format, OutputFormat::Json));
+            }
+            _ => panic!("expected Policy List"),
+        }
     }
 
     #[test]
@@ -1351,8 +1395,9 @@ mod tests {
     fn test_policy_validate() {
         let cli = parse(&["voom", "policy", "validate", "my.voom"]);
         match cli.command {
-            Commands::Policy(PolicyCommands::Validate { file }) => {
+            Commands::Policy(PolicyCommands::Validate { file, format }) => {
                 assert_eq!(file, PathBuf::from("my.voom"));
+                assert!(matches!(format, OutputFormat::Table));
             }
             _ => panic!("expected Policy Validate"),
         }
@@ -1362,8 +1407,9 @@ mod tests {
     fn test_policy_show() {
         let cli = parse(&["voom", "policy", "show", "my.voom"]);
         match cli.command {
-            Commands::Policy(PolicyCommands::Show { file }) => {
+            Commands::Policy(PolicyCommands::Show { file, format }) => {
                 assert_eq!(file, PathBuf::from("my.voom"));
+                assert!(matches!(format, OutputFormat::Table));
             }
             _ => panic!("expected Policy Show"),
         }
@@ -1384,10 +1430,16 @@ mod tests {
     fn test_policy_diff() {
         let cli = parse(&["voom", "policy", "diff", "a.voom", "b.voom"]);
         match cli.command {
-            Commands::Policy(PolicyCommands::Diff { a, b, fixture }) => {
+            Commands::Policy(PolicyCommands::Diff {
+                a,
+                b,
+                fixture,
+                format,
+            }) => {
                 assert_eq!(a, PathBuf::from("a.voom"));
                 assert_eq!(b, PathBuf::from("b.voom"));
                 assert_eq!(fixture, None);
+                assert!(matches!(format, OutputFormat::Table));
             }
             _ => panic!("expected Policy Diff"),
         }
@@ -1405,7 +1457,7 @@ mod tests {
             "movie.json",
         ]);
         match cli.command {
-            Commands::Policy(PolicyCommands::Diff { a, b, fixture }) => {
+            Commands::Policy(PolicyCommands::Diff { a, b, fixture, .. }) => {
                 assert_eq!(a, PathBuf::from("a.voom"));
                 assert_eq!(b, PathBuf::from("b.voom"));
                 assert_eq!(fixture, Some(PathBuf::from("movie.json")));
@@ -1500,16 +1552,28 @@ mod tests {
         let cli = parse(&["voom", "plugin", "list"]);
         assert!(matches!(
             cli.command,
-            Commands::Plugin(PluginCommands::List)
+            Commands::Plugin(PluginCommands::List { .. })
         ));
+    }
+
+    #[test]
+    fn test_plugin_list_json_format() {
+        let cli = parse(&["voom", "plugin", "list", "--format", "json"]);
+        match cli.command {
+            Commands::Plugin(PluginCommands::List { format }) => {
+                assert!(matches!(format, OutputFormat::Json));
+            }
+            _ => panic!("expected Plugin List"),
+        }
     }
 
     #[test]
     fn test_plugin_info() {
         let cli = parse(&["voom", "plugin", "info", "ffmpeg-executor"]);
         match cli.command {
-            Commands::Plugin(PluginCommands::Info { name }) => {
+            Commands::Plugin(PluginCommands::Info { name, format }) => {
                 assert_eq!(name, "ffmpeg-executor");
+                assert!(matches!(format, OutputFormat::Table));
             }
             _ => panic!("expected Plugin Info"),
         }
@@ -1558,10 +1622,12 @@ mod tests {
                 status,
                 limit,
                 offset,
+                format,
             }) => {
                 assert!(status.is_none());
                 assert_eq!(limit, 50);
                 assert_eq!(offset, 0);
+                assert!(matches!(format, OutputFormat::Table));
             }
             _ => panic!("expected Jobs List"),
         }
@@ -1633,8 +1699,22 @@ mod tests {
     fn test_jobs_status() {
         let cli = parse(&["voom", "jobs", "status", "abc-123"]);
         match cli.command {
-            Commands::Jobs(JobsCommands::Status { id }) => assert_eq!(id, "abc-123"),
+            Commands::Jobs(JobsCommands::Status { id, format }) => {
+                assert_eq!(id, "abc-123");
+                assert!(matches!(format, OutputFormat::Table));
+            }
             _ => panic!("expected Jobs Status"),
+        }
+    }
+
+    #[test]
+    fn test_jobs_list_json_format() {
+        let cli = parse(&["voom", "jobs", "list", "--format", "json"]);
+        match cli.command {
+            Commands::Jobs(JobsCommands::List { format, .. }) => {
+                assert!(matches!(format, OutputFormat::Json));
+            }
+            _ => panic!("expected Jobs List"),
         }
     }
 
@@ -1795,8 +1875,19 @@ mod tests {
         let cli = parse(&["voom", "config", "show"]);
         assert!(matches!(
             cli.command,
-            Commands::Config(ConfigCommands::Show)
+            Commands::Config(ConfigCommands::Show { .. })
         ));
+    }
+
+    #[test]
+    fn test_config_show_json_format() {
+        let cli = parse(&["voom", "config", "show", "--format", "json"]);
+        match cli.command {
+            Commands::Config(ConfigCommands::Show { format }) => {
+                assert!(matches!(format, OutputFormat::Json));
+            }
+            _ => panic!("expected Config Show"),
+        }
     }
 
     #[test]
@@ -1812,8 +1903,9 @@ mod tests {
     fn test_config_get() {
         let cli = parse(&["voom", "config", "get", "auth_token"]);
         match cli.command {
-            Commands::Config(ConfigCommands::Get { key }) => {
+            Commands::Config(ConfigCommands::Get { key, format }) => {
                 assert_eq!(key, "auth_token");
+                assert!(matches!(format, OutputFormat::Table));
             }
             _ => panic!("expected Config Get"),
         }
@@ -1823,7 +1915,7 @@ mod tests {
     fn test_config_get_nested_key() {
         let cli = parse(&["voom", "config", "get", "plugin.ffmpeg-executor.hw_accel"]);
         match cli.command {
-            Commands::Config(ConfigCommands::Get { key }) => {
+            Commands::Config(ConfigCommands::Get { key, .. }) => {
                 assert_eq!(key, "plugin.ffmpeg-executor.hw_accel");
             }
             _ => panic!("expected Config Get"),

--- a/crates/voom-cli/src/commands/config.rs
+++ b/crates/voom-cli/src/commands/config.rs
@@ -1,14 +1,15 @@
 use anyhow::{Result, bail};
 use console::style;
 
-use crate::cli::ConfigCommands;
+use crate::cli::{ConfigCommands, OutputFormat};
 use crate::config;
+use crate::output;
 
 pub fn run(cmd: ConfigCommands) -> Result<()> {
     match cmd {
-        ConfigCommands::Show => show(),
+        ConfigCommands::Show { format } => show(format),
         ConfigCommands::Edit => edit(),
-        ConfigCommands::Get { key } => get(&key),
+        ConfigCommands::Get { key, format } => get(&key, format),
         ConfigCommands::Set { key, value } => set(&key, &value),
     }
 }
@@ -20,8 +21,14 @@ fn is_secret_key(key: &str) -> bool {
     matches!(leaf, "auth_token")
 }
 
-fn show() -> Result<()> {
+fn show(format: OutputFormat) -> Result<()> {
     let path = config::config_path();
+    if matches!(format, OutputFormat::Json) {
+        let mut value = serde_json::to_value(config::load_config()?)?;
+        redact_config_json(&mut value);
+        output::print_json(&value)?;
+        return Ok(());
+    }
 
     if path.exists() {
         let contents = std::fs::read_to_string(&path)?;
@@ -102,16 +109,43 @@ fn edit() -> Result<()> {
     Ok(())
 }
 
-fn get(key: &str) -> Result<()> {
+fn get(key: &str, format: OutputFormat) -> Result<()> {
     let path = config::config_path();
     let raw = load_raw_toml(&path)?;
     let value = resolve_toml_key(&raw, key)?;
+    if matches!(format, OutputFormat::Json) {
+        output::print_json(&serde_json::json!({
+            "key": key,
+            "value": display_config_value(key, &value),
+        }))?;
+        return Ok(());
+    }
     if is_secret_key(key) && value.is_str() {
         println!("[REDACTED]");
     } else {
         println!("{}", format_value(&value));
     }
     Ok(())
+}
+
+fn display_config_value(key: &str, value: &toml::Value) -> serde_json::Value {
+    if is_secret_key(key) && value.is_str() {
+        serde_json::Value::String("[REDACTED]".to_string())
+    } else {
+        serde_json::to_value(value)
+            .unwrap_or_else(|_| serde_json::Value::String(format_value(value)))
+    }
+}
+
+fn redact_config_json(value: &mut serde_json::Value) {
+    if let serde_json::Value::Object(map) = value {
+        if map.get("auth_token").is_some_and(|v| !v.is_null()) {
+            map.insert(
+                "auth_token".to_string(),
+                serde_json::Value::String("[REDACTED]".to_string()),
+            );
+        }
+    }
 }
 
 fn set(key: &str, value: &str) -> Result<()> {

--- a/crates/voom-cli/src/commands/env.rs
+++ b/crates/voom-cli/src/commands/env.rs
@@ -110,10 +110,7 @@ mod retention_coverage {
 /// Dispatch environment diagnostic subcommands.
 pub fn run(cmd: EnvCommands) -> Result<()> {
     match cmd {
-        EnvCommands::Check { format, json } => {
-            let format = if json { OutputFormat::Json } else { format };
-            check(format)
-        }
+        EnvCommands::Check { format } => check(format),
         EnvCommands::History {
             check,
             since,

--- a/crates/voom-cli/src/commands/jobs.rs
+++ b/crates/voom-cli/src/commands/jobs.rs
@@ -4,7 +4,7 @@ use console::style;
 use voom_domain::job::JobStatus;
 use voom_domain::storage::JobFilters;
 
-use crate::cli::JobsCommands;
+use crate::cli::{JobsCommands, OutputFormat};
 use crate::output;
 
 pub fn run(cmd: JobsCommands, global_yes: bool) -> Result<()> {
@@ -13,15 +13,16 @@ pub fn run(cmd: JobsCommands, global_yes: bool) -> Result<()> {
             status,
             limit,
             offset,
-        } => list(status.as_deref(), limit, offset),
-        JobsCommands::Status { id } => status(&id),
+            format,
+        } => list(status.as_deref(), limit, offset, format),
+        JobsCommands::Status { id, format } => status(&id, format),
         JobsCommands::Cancel { id } => cancel(&id),
         JobsCommands::Retry { id } => retry(&id),
         JobsCommands::Clear { status, yes } => clear(status.as_deref(), yes || global_yes),
     }
 }
 
-fn list(status_filter: Option<&str>, limit: u32, offset: u32) -> Result<()> {
+fn list(status_filter: Option<&str>, limit: u32, offset: u32, format: OutputFormat) -> Result<()> {
     let config = crate::config::load_config()?;
     let store = crate::app::open_store(&config)?;
 
@@ -45,6 +46,19 @@ fn list(status_filter: Option<&str>, limit: u32, offset: u32) -> Result<()> {
         filters.offset = Some(offset);
     }
     let jobs = store.list_jobs(&filters).context("failed to list jobs")?;
+    let counts = store
+        .count_jobs_by_status()
+        .context("failed to count jobs by status")?;
+
+    if matches!(format, OutputFormat::Json) {
+        output::print_json(&serde_json::json!({
+            "jobs": jobs,
+            "counts": counts,
+            "limit": limit,
+            "offset": offset,
+        }))?;
+        return Ok(());
+    }
 
     if jobs.is_empty() {
         println!("{} No jobs found.", style("INFO").dim());
@@ -92,9 +106,6 @@ fn list(status_filter: Option<&str>, limit: u32, offset: u32) -> Result<()> {
     println!("{table}");
 
     // Show summary counts
-    let counts = store
-        .count_jobs_by_status()
-        .context("failed to count jobs by status")?;
     if !counts.is_empty() {
         let total: u64 = counts.iter().map(|(_, c)| c).sum();
         let summary: Vec<String> = counts
@@ -115,7 +126,7 @@ fn list(status_filter: Option<&str>, limit: u32, offset: u32) -> Result<()> {
     Ok(())
 }
 
-fn status(id: &str) -> Result<()> {
+fn status(id: &str, format: OutputFormat) -> Result<()> {
     let config = crate::config::load_config()?;
     let store = crate::app::open_store(&config)?;
 
@@ -123,6 +134,10 @@ fn status(id: &str) -> Result<()> {
 
     match store.job(&uuid)? {
         Some(job) => {
+            if matches!(format, OutputFormat::Json) {
+                output::print_json(&job)?;
+                return Ok(());
+            }
             println!("{} {}", style("Job:").bold(), style(&job.id).cyan());
             println!("{} {}", style("Type:").bold(), job.job_type);
             if let Some(ref payload) = job.payload {

--- a/crates/voom-cli/src/commands/plugin.rs
+++ b/crates/voom-cli/src/commands/plugin.rs
@@ -2,21 +2,21 @@ use anyhow::{Context, Result, bail};
 use console::style;
 
 use crate::app;
-use crate::cli::PluginCommands;
+use crate::cli::{OutputFormat, PluginCommands};
 use crate::config;
 use crate::output;
 
 pub fn run(cmd: PluginCommands) -> Result<()> {
     match cmd {
-        PluginCommands::List => list(),
-        PluginCommands::Info { name } => info(&name),
+        PluginCommands::List { format } => list(format),
+        PluginCommands::Info { name, format } => info(&name, format),
         PluginCommands::Enable { name } => enable(&name),
         PluginCommands::Disable { name } => disable(&name),
         PluginCommands::Install { path } => install(&path),
     }
 }
 
-fn list() -> Result<()> {
+fn list(format: OutputFormat) -> Result<()> {
     let config = config::load_config()?;
     let disabled = &config.plugins.disabled_plugins;
     let kernel = app::bootstrap_kernel(&config)?;
@@ -50,7 +50,12 @@ fn list() -> Result<()> {
     }
 
     let total = plugins.len() + disabled_list.len();
-    if total == 0 {
+    if matches!(format, OutputFormat::Json) {
+        output::print_json(&serde_json::json!({
+            "plugins": plugins,
+            "disabled_plugins": disabled_list,
+        }))?;
+    } else if total == 0 {
         println!("{}", style("No plugins registered.").dim());
     } else {
         println!(
@@ -75,13 +80,20 @@ fn list() -> Result<()> {
     Ok(())
 }
 
-fn info(name: &str) -> Result<()> {
+fn info(name: &str, format: OutputFormat) -> Result<()> {
     let config = config::load_config()?;
 
     // Check if it's a known but disabled plugin
     if config.plugins.disabled_plugins.iter().any(|d| d == name)
         && config::KNOWN_PLUGIN_NAMES.contains(&name)
     {
+        if matches!(format, OutputFormat::Json) {
+            output::print_json(&serde_json::json!({
+                "name": name,
+                "status": "disabled",
+            }))?;
+            return Ok(());
+        }
         println!("{} {}", style("Plugin:").bold(), style(name).cyan());
         println!("{} {}", style("Status:").bold(), style("disabled").yellow());
         println!(
@@ -92,10 +104,28 @@ fn info(name: &str) -> Result<()> {
     }
 
     let result = app::bootstrap_kernel_with_store(&config)?;
-    let capabilities = result.collector.snapshot();
+    let executor_capabilities = result.collector.snapshot();
 
     match result.kernel.registry.get(name) {
         Some(plugin) => {
+            let capabilities: Vec<String> = plugin
+                .capabilities()
+                .iter()
+                .map(|cap| cap.kind().to_string())
+                .collect();
+            if matches!(format, OutputFormat::Json) {
+                output::print_json(&serde_json::json!({
+                    "name": plugin.name(),
+                    "version": plugin.version(),
+                    "description": plugin.description(),
+                    "author": plugin.author(),
+                    "license": plugin.license(),
+                    "homepage": plugin.homepage(),
+                    "status": "enabled",
+                    "capabilities": capabilities,
+                }))?;
+                return Ok(());
+            }
             println!(
                 "{} {}",
                 style("Plugin:").bold(),
@@ -116,12 +146,12 @@ fn info(name: &str) -> Result<()> {
             }
             println!("{} {}", style("Status:").bold(), style("enabled").green());
             println!("{}", style("Capabilities:").bold());
-            for cap in plugin.capabilities() {
-                println!("  - {}", cap.kind());
+            for cap in capabilities {
+                println!("  - {cap}");
             }
 
             // Show executor details if available
-            output::format_executor_capabilities(name, &capabilities);
+            output::format_executor_capabilities(name, &executor_capabilities);
         }
         _ => {
             let available = result.kernel.registry.plugin_names().join(", ");

--- a/crates/voom-cli/src/commands/policy.rs
+++ b/crates/voom-cli/src/commands/policy.rs
@@ -9,7 +9,7 @@ use voom_policy_testing::{
     CapabilityFixture, Fixture, SnapshotOutcome, TestSuite, assert_snapshot_file,
 };
 
-use crate::cli::{PolicyCommands, PolicyFixtureCommands};
+use crate::cli::{OutputFormat, PolicyCommands, PolicyFixtureCommands};
 
 pub async fn run(cmd: PolicyCommands) -> Result<()> {
     match cmd {
@@ -23,8 +23,8 @@ pub async fn run(cmd: PolicyCommands) -> Result<()> {
             paths,
             policy,
             update,
-            json,
-        } => test(&paths, policy.as_deref(), update, json),
+            format,
+        } => test(&paths, policy.as_deref(), update, format),
     }
 }
 
@@ -296,7 +296,12 @@ fn diff(a: &std::path::Path, b: &std::path::Path, fixture: Option<&std::path::Pa
     Ok(())
 }
 
-fn test(paths: &[PathBuf], policy_override: Option<&Path>, update: bool, json: bool) -> Result<()> {
+fn test(
+    paths: &[PathBuf],
+    policy_override: Option<&Path>,
+    update: bool,
+    format: OutputFormat,
+) -> Result<()> {
     let suites = discover_test_suites(paths)?;
     if suites.is_empty() {
         bail!("no *.test.json files found");
@@ -311,7 +316,7 @@ fn test(paths: &[PathBuf], policy_override: Option<&Path>, update: bool, json: b
     }
 
     let output = TestOutput::from_cases(cases, snapshots_updated);
-    if json {
+    if matches!(format, OutputFormat::Json) {
         println!("{}", serde_json::to_string_pretty(&output)?);
     } else {
         print_human_test_output(&output);

--- a/crates/voom-cli/src/commands/policy.rs
+++ b/crates/voom-cli/src/commands/policy.rs
@@ -155,7 +155,7 @@ fn list(format: OutputFormat) -> Result<()> {
 fn validate(file: &std::path::Path, format: OutputFormat) -> Result<()> {
     // If the file has a .toml extension, treat it as a policy map.
     if file.extension().is_some_and(|e| e == "toml") {
-        return validate_policy_map(file);
+        return validate_policy_map(file, format);
     }
 
     let file = crate::config::resolve_policy_path(file);
@@ -191,7 +191,7 @@ fn validate(file: &std::path::Path, format: OutputFormat) -> Result<()> {
 }
 
 /// Validate a `.toml` policy map file and all policies it references.
-fn validate_policy_map(file: &std::path::Path) -> Result<()> {
+fn validate_policy_map(file: &std::path::Path, format: OutputFormat) -> Result<()> {
     use crate::policy_map::PolicyResolver;
 
     // Use a dummy root — we only care about compilation, not prefix matching.
@@ -200,6 +200,27 @@ fn validate_policy_map(file: &std::path::Path) -> Result<()> {
         .with_context(|| format!("Policy map validation failed: {}", file.display()))?;
 
     let policies = resolver.policies();
+    if matches!(format, OutputFormat::Json) {
+        let policies: Vec<serde_json::Value> = policies
+            .iter()
+            .map(|(name, compiled)| {
+                serde_json::json!({
+                    "name": name,
+                    "policy": compiled.name,
+                    "phase_count": compiled.phases.len(),
+                    "phase_order": compiled.phase_order,
+                })
+            })
+            .collect();
+        output::print_json(&serde_json::json!({
+            "valid": true,
+            "policy_map": file,
+            "policy_count": policies.len(),
+            "policies": policies,
+        }))?;
+        return Ok(());
+    }
+
     println!(
         "{} Policy map \"{}\" is valid ({} policies)",
         style("OK").bold().green(),

--- a/crates/voom-cli/src/commands/policy.rs
+++ b/crates/voom-cli/src/commands/policy.rs
@@ -10,14 +10,20 @@ use voom_policy_testing::{
 };
 
 use crate::cli::{OutputFormat, PolicyCommands, PolicyFixtureCommands};
+use crate::output;
 
 pub async fn run(cmd: PolicyCommands) -> Result<()> {
     match cmd {
-        PolicyCommands::List => list(),
-        PolicyCommands::Validate { file } => validate(&file),
-        PolicyCommands::Show { file } => show(&file),
+        PolicyCommands::List { format } => list(format),
+        PolicyCommands::Validate { file, format } => validate(&file, format),
+        PolicyCommands::Show { file, format } => show(&file, format),
         PolicyCommands::Format { file } => format(&file),
-        PolicyCommands::Diff { a, b, fixture } => diff(&a, &b, fixture.as_deref()),
+        PolicyCommands::Diff {
+            a,
+            b,
+            fixture,
+            format,
+        } => diff(&a, &b, fixture.as_deref(), format),
         PolicyCommands::Fixture { command } => fixture(command).await,
         PolicyCommands::Test {
             paths,
@@ -73,17 +79,21 @@ fn fixture_from_media(media: voom_domain::media::MediaFile) -> Result<Fixture> {
     })
 }
 
-fn list() -> Result<()> {
+fn list(format: OutputFormat) -> Result<()> {
     // Scan standard policy directories
     let config_dir = crate::config::policies_dir();
 
     if !config_dir.exists() {
+        if matches!(format, OutputFormat::Json) {
+            output::print_json(&Vec::<serde_json::Value>::new())?;
+            return Ok(());
+        }
         println!("{}", style("No policies directory found.").dim());
         println!("Create policies in: {}", style(config_dir.display()).cyan());
         return Ok(());
     }
 
-    let mut found = false;
+    let mut policies = Vec::new();
     for entry in std::fs::read_dir(&config_dir)? {
         let entry = entry?;
         let path = entry.path();
@@ -94,29 +104,55 @@ fn list() -> Result<()> {
                 .to_string_lossy();
             match voom_dsl::compile_policy(&std::fs::read_to_string(&path)?) {
                 Ok(policy) => {
-                    println!(
-                        "  {} {} ({} phases)",
-                        style("OK").green(),
-                        style(&policy.name).bold(),
-                        policy.phases.len()
-                    );
+                    let policy_name = policy.name.clone();
+                    let phase_count = policy.phases.len();
+                    policies.push(serde_json::json!({
+                        "name": policy_name,
+                        "path": path,
+                        "valid": true,
+                        "phase_count": phase_count,
+                        "phase_order": policy.phase_order,
+                    }));
+                    if !matches!(format, OutputFormat::Json) {
+                        println!(
+                            "  {} {} ({} phases)",
+                            style("OK").green(),
+                            style(&policy_name).bold(),
+                            phase_count
+                        );
+                    }
                 }
                 Err(e) => {
-                    println!("  {} {} — {e}", style("ERR").red(), style(&name).bold());
+                    let error = e.to_string();
+                    let policy_name = name.to_string();
+                    policies.push(serde_json::json!({
+                        "name": policy_name,
+                        "path": path,
+                        "valid": false,
+                        "error": error,
+                    }));
+                    if !matches!(format, OutputFormat::Json) {
+                        println!(
+                            "  {} {} — {error}",
+                            style("ERR").red(),
+                            style(&policy_name).bold()
+                        );
+                    }
                 }
             }
-            found = true;
         }
     }
 
-    if !found {
+    if matches!(format, OutputFormat::Json) {
+        output::print_json(&policies)?;
+    } else if policies.is_empty() {
         println!("{}", style("No .voom policy files found.").dim());
     }
 
     Ok(())
 }
 
-fn validate(file: &std::path::Path) -> Result<()> {
+fn validate(file: &std::path::Path, format: OutputFormat) -> Result<()> {
     // If the file has a .toml extension, treat it as a policy map.
     if file.extension().is_some_and(|e| e == "toml") {
         return validate_policy_map(file);
@@ -128,14 +164,23 @@ fn validate(file: &std::path::Path) -> Result<()> {
 
     match voom_dsl::compile_policy(&source) {
         Ok(policy) => {
-            println!(
-                "{} Policy \"{}\" is valid ({} phases, {} phase order: [{}])",
-                style("OK").bold().green(),
-                policy.name,
-                policy.phases.len(),
-                policy.phase_order.len(),
-                policy.phase_order.join(", ")
-            );
+            if matches!(format, OutputFormat::Json) {
+                output::print_json(&serde_json::json!({
+                    "valid": true,
+                    "policy": policy.name,
+                    "phase_count": policy.phases.len(),
+                    "phase_order": policy.phase_order,
+                }))?;
+            } else {
+                println!(
+                    "{} Policy \"{}\" is valid ({} phases, {} phase order: [{}])",
+                    style("OK").bold().green(),
+                    policy.name,
+                    policy.phases.len(),
+                    policy.phase_order.len(),
+                    policy.phase_order.join(", ")
+                );
+            }
         }
         Err(e) => {
             anyhow::bail!("Policy validation failed: {e}");
@@ -174,12 +219,16 @@ fn validate_policy_map(file: &std::path::Path) -> Result<()> {
     Ok(())
 }
 
-fn show(file: &std::path::Path) -> Result<()> {
+fn show(file: &std::path::Path, format: OutputFormat) -> Result<()> {
     let file = crate::config::resolve_policy_path(file);
     let source = std::fs::read_to_string(&file)
         .with_context(|| format!("Failed to read: {}", file.display()))?;
 
     let compiled = voom_dsl::compile_policy(&source).context("policy compilation failed")?;
+    if matches!(format, OutputFormat::Json) {
+        output::print_json(&compiled)?;
+        return Ok(());
+    }
 
     println!(
         "{} \"{}\"",
@@ -255,7 +304,12 @@ fn format(file: &std::path::Path) -> Result<()> {
     Ok(())
 }
 
-fn diff(a: &std::path::Path, b: &std::path::Path, fixture: Option<&std::path::Path>) -> Result<()> {
+fn diff(
+    a: &std::path::Path,
+    b: &std::path::Path,
+    fixture: Option<&std::path::Path>,
+    format: OutputFormat,
+) -> Result<()> {
     let a_path = crate::config::resolve_policy_path(a);
     let b_path = crate::config::resolve_policy_path(b);
 
@@ -276,6 +330,18 @@ fn diff(a: &std::path::Path, b: &std::path::Path, fixture: Option<&std::path::Pa
 
     let mut lines = Vec::new();
     diff_values("", &a_json, &b_json, &mut lines);
+
+    if matches!(format, OutputFormat::Json) {
+        let differences: Vec<String> = lines.iter().map(render_diff_line).collect();
+        output::print_json(&serde_json::json!({
+            "identical": lines.is_empty(),
+            "differences": differences,
+        }))?;
+        if fixture.is_some() && !lines.is_empty() {
+            anyhow::bail!("fixture plan diff found differences");
+        }
+        return Ok(());
+    }
 
     if lines.is_empty() {
         println!("{} Policies are identical.", style("OK").bold().green());
@@ -722,6 +788,25 @@ fn diff_named_arrays(path: &str, a_arr: &[Value], b_arr: &[Value], lines: &mut V
     }
 }
 
+fn render_diff_line(line: &DiffLine) -> String {
+    match line {
+        DiffLine::Added { path, value } => {
+            format!("+ {}: {}", strip_section(path), format_value(value))
+        }
+        DiffLine::Removed { path, value } => {
+            format!("- {}: {}", strip_section(path), format_value(value))
+        }
+        DiffLine::Changed { path, old, new } => {
+            format!(
+                "~ {}: {} -> {}",
+                strip_section(path),
+                format_value(old),
+                format_value(new)
+            )
+        }
+    }
+}
+
 fn print_diff_lines(lines: &[DiffLine]) {
     let mut last_section = String::new();
     for line in lines {
@@ -803,7 +888,7 @@ policy "test-policy" {
         std::fs::write(&file, MINIMAL_POLICY).unwrap();
 
         // validate reads the file and calls voom_dsl::compile_policy
-        let result = validate(&file);
+        let result = validate(&file, OutputFormat::Table);
         assert!(result.is_ok());
     }
 
@@ -820,7 +905,10 @@ policy "test-policy" {
 
     #[test]
     fn validate_nonexistent_file_returns_error() {
-        let result = validate(std::path::Path::new("/nonexistent/test.voom"));
+        let result = validate(
+            std::path::Path::new("/nonexistent/test.voom"),
+            OutputFormat::Table,
+        );
         assert!(result.is_err());
     }
 
@@ -851,13 +939,16 @@ policy "test-policy" {
         let file = dir.path().join("test.voom");
         std::fs::write(&file, MINIMAL_POLICY).unwrap();
 
-        let result = show(&file);
+        let result = show(&file, OutputFormat::Table);
         assert!(result.is_ok());
     }
 
     #[test]
     fn show_nonexistent_file_returns_error() {
-        let result = show(std::path::Path::new("/nonexistent/test.voom"));
+        let result = show(
+            std::path::Path::new("/nonexistent/test.voom"),
+            OutputFormat::Table,
+        );
         assert!(result.is_err());
     }
 
@@ -867,7 +958,7 @@ policy "test-policy" {
         let file = dir.path().join("bad.voom");
         std::fs::write(&file, "garbage content here").unwrap();
 
-        let result = show(&file);
+        let result = show(&file, OutputFormat::Table);
         assert!(result.is_err());
     }
 
@@ -1013,7 +1104,7 @@ policy "test-policy" {
         std::fs::write(&a_file, MINIMAL_POLICY).unwrap();
         std::fs::write(&b_file, MINIMAL_POLICY).unwrap();
 
-        let result = diff(&a_file, &b_file, None);
+        let result = diff(&a_file, &b_file, None, OutputFormat::Table);
         assert!(result.is_ok());
     }
 
@@ -1024,7 +1115,12 @@ policy "test-policy" {
         let fixture_file = write_movie_fixture(dir.path());
         std::fs::write(&policy_file, MINIMAL_POLICY).unwrap();
 
-        let result = diff(&policy_file, &policy_file, Some(&fixture_file));
+        let result = diff(
+            &policy_file,
+            &policy_file,
+            Some(&fixture_file),
+            OutputFormat::Table,
+        );
 
         assert!(result.is_ok());
     }
@@ -1047,7 +1143,7 @@ policy "noop" {
         )
         .unwrap();
 
-        let result = diff(&a_file, &b_file, Some(&fixture_file));
+        let result = diff(&a_file, &b_file, Some(&fixture_file), OutputFormat::Table);
 
         assert!(result.is_err());
     }
@@ -1058,7 +1154,12 @@ policy "noop" {
         let a_file = dir.path().join("a.voom");
         std::fs::write(&a_file, MINIMAL_POLICY).unwrap();
 
-        let result = diff(&a_file, std::path::Path::new("/nonexistent/b.voom"), None);
+        let result = diff(
+            &a_file,
+            std::path::Path::new("/nonexistent/b.voom"),
+            None,
+            OutputFormat::Table,
+        );
         assert!(result.is_err());
     }
 

--- a/crates/voom-cli/src/commands/report.rs
+++ b/crates/voom-cli/src/commands/report.rs
@@ -69,11 +69,7 @@ pub fn run(args: &ReportArgs) -> Result<()> {
 }
 
 fn report_format(args: &ReportArgs) -> OutputFormat {
-    if args.json {
-        OutputFormat::Json
-    } else {
-        args.format
-    }
+    args.format
 }
 
 fn build_request(args: &ReportArgs) -> Result<ReportRequest> {
@@ -2005,7 +2001,6 @@ mod tests {
     fn test_build_request_no_flags_gives_summary() {
         let args = ReportArgs {
             format: OutputFormat::Table,
-            json: false,
             library: false,
             plans: false,
             savings: false,
@@ -2032,7 +2027,6 @@ mod tests {
     fn test_build_request_all_flag() {
         let args = ReportArgs {
             format: OutputFormat::Table,
-            json: false,
             library: false,
             plans: false,
             savings: false,
@@ -2060,7 +2054,6 @@ mod tests {
     fn test_build_request_specific_sections() {
         let args = ReportArgs {
             format: OutputFormat::Table,
-            json: false,
             library: false,
             plans: true,
             savings: false,
@@ -2105,7 +2098,6 @@ mod tests {
     fn test_is_summary_request() {
         let default_args = ReportArgs {
             format: OutputFormat::Table,
-            json: false,
             library: false,
             plans: false,
             savings: false,

--- a/crates/voom-cli/src/main.rs
+++ b/crates/voom-cli/src/main.rs
@@ -121,8 +121,8 @@ fn effective_quiet(cli: &Cli) -> bool {
 
 fn command_output_format(command: &Commands) -> Option<OutputFormat> {
     use cli::{
-        BackupCommands, DbCommands, EnvCommands, FilesCommands, PolicyCommands, ToolsCommands,
-        VerifyCommands,
+        BackupCommands, ConfigCommands, DbCommands, EnvCommands, FilesCommands, JobsCommands,
+        PluginCommands, PolicyCommands, ToolsCommands, VerifyCommands,
     };
 
     match command {
@@ -132,7 +132,17 @@ fn command_output_format(command: &Commands) -> Option<OutputFormat> {
         Commands::Events(args) => Some(args.format),
         Commands::History(args) => Some(args.format),
         Commands::Plans(cli::PlansCommands::Show { format, .. }) => Some(*format),
+        Commands::Policy(PolicyCommands::List { format }) => Some(*format),
+        Commands::Policy(PolicyCommands::Validate { format, .. }) => Some(*format),
+        Commands::Policy(PolicyCommands::Show { format, .. }) => Some(*format),
+        Commands::Policy(PolicyCommands::Diff { format, .. }) => Some(*format),
         Commands::Policy(PolicyCommands::Test { format, .. }) => Some(*format),
+        Commands::Plugin(PluginCommands::List { format }) => Some(*format),
+        Commands::Plugin(PluginCommands::Info { format, .. }) => Some(*format),
+        Commands::Jobs(JobsCommands::List { format, .. }) => Some(*format),
+        Commands::Jobs(JobsCommands::Status { format, .. }) => Some(*format),
+        Commands::Config(ConfigCommands::Show { format }) => Some(*format),
+        Commands::Config(ConfigCommands::Get { format, .. }) => Some(*format),
         Commands::Db(DbCommands::ListBad { format, .. }) => Some(*format),
         Commands::Env(EnvCommands::Check { format }) => Some(*format),
         Commands::Env(EnvCommands::History { format, .. }) => Some(*format),

--- a/crates/voom-cli/src/main.rs
+++ b/crates/voom-cli/src/main.rs
@@ -17,7 +17,7 @@ mod recovery;
 pub mod retention;
 mod tools;
 
-use cli::{Cli, Commands};
+use cli::{Cli, Commands, OutputFormat};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -48,9 +48,7 @@ async fn main() -> Result<()> {
     // blocking the tokio runtime with filesystem I/O at startup.
     tokio::task::spawn_blocking(cleanup_wasm_temp_files);
 
-    // Compute effective quiet: explicit --quiet OR machine-readable format
-    let quiet = cli.quiet
-        || matches!(&cli.command, Commands::Scan(args) if args.format.is_some_and(cli::OutputFormat::is_machine));
+    let quiet = effective_quiet(&cli);
 
     let global_yes = cli.yes;
 
@@ -114,6 +112,41 @@ fn command_needs_lock(command: &Commands) -> bool {
         ),
         Commands::Verify(sub) => matches!(sub, VerifyCommands::Run(_)),
         _ => false,
+    }
+}
+
+fn effective_quiet(cli: &Cli) -> bool {
+    cli.quiet || command_output_format(&cli.command).is_some_and(OutputFormat::is_machine)
+}
+
+fn command_output_format(command: &Commands) -> Option<OutputFormat> {
+    use cli::{
+        BackupCommands, DbCommands, EnvCommands, FilesCommands, PolicyCommands, ToolsCommands,
+        VerifyCommands,
+    };
+
+    match command {
+        Commands::Scan(args) => args.format,
+        Commands::Inspect(args) => Some(args.format),
+        Commands::Report(args) => Some(args.format),
+        Commands::Events(args) => Some(args.format),
+        Commands::History(args) => Some(args.format),
+        Commands::Plans(cli::PlansCommands::Show { format, .. }) => Some(*format),
+        Commands::Policy(PolicyCommands::Test { format, .. }) => Some(*format),
+        Commands::Db(DbCommands::ListBad { format, .. }) => Some(*format),
+        Commands::Env(EnvCommands::Check { format }) => Some(*format),
+        Commands::Env(EnvCommands::History { format, .. }) => Some(*format),
+        Commands::Health(EnvCommands::Check { format }) => Some(*format),
+        Commands::Health(EnvCommands::History { format, .. }) => Some(*format),
+        Commands::Tools(ToolsCommands::List { format }) => Some(*format),
+        Commands::Tools(ToolsCommands::Info { format, .. }) => Some(*format),
+        Commands::Verify(VerifyCommands::Run(args)) => args.format,
+        Commands::Verify(VerifyCommands::Report(args)) => Some(args.format),
+        Commands::Files(FilesCommands::List { format, .. }) => Some(*format),
+        Commands::Files(FilesCommands::Show { format, .. }) => Some(*format),
+        Commands::Backup(BackupCommands::List { format, .. }) => Some(*format),
+        Commands::Backup(BackupCommands::Verify { format, .. }) => Some(*format),
+        _ => None,
     }
 }
 
@@ -247,6 +280,34 @@ mod tests {
         assert!(cli.force);
         let cli = Cli::parse_from(["voom", "scan", "/media", "--force"]);
         assert!(cli.force);
+    }
+
+    #[test]
+    fn test_effective_quiet_for_machine_formats() {
+        use clap::Parser;
+        let cases = [
+            vec!["voom", "scan", "/media", "--format", "json"],
+            vec!["voom", "inspect", "movie.mkv", "--format", "json"],
+            vec!["voom", "events", "--format", "json"],
+            vec!["voom", "report", "--format", "json"],
+            vec!["voom", "tools", "list", "--format", "json"],
+            vec!["voom", "env", "check", "--format", "json"],
+        ];
+
+        for args in &cases {
+            let cli = Cli::parse_from(args);
+            assert!(effective_quiet(&cli), "expected quiet for {args:?}");
+        }
+    }
+
+    #[test]
+    fn test_effective_quiet_for_human_formats() {
+        use clap::Parser;
+        let cli = Cli::parse_from(["voom", "inspect", "movie.mkv"]);
+        assert!(!effective_quiet(&cli));
+
+        let cli = Cli::parse_from(["voom", "--quiet", "inspect", "movie.mkv"]);
+        assert!(effective_quiet(&cli));
     }
 
     #[test]

--- a/crates/voom-cli/src/output.rs
+++ b/crates/voom-cli/src/output.rs
@@ -13,44 +13,6 @@ use voom_domain::utils::format;
 
 use crate::cli::OutputFormat;
 
-// Introduced before command adoption so later phases can share one JSON contract.
-#[allow(dead_code)]
-#[derive(Debug, Serialize)]
-pub struct MachineResponse<T>
-where
-    T: Serialize,
-{
-    pub command: &'static str,
-    pub status: &'static str,
-    pub data: T,
-    pub warnings: Vec<String>,
-    pub errors: Vec<String>,
-}
-
-// Introduced before command adoption so later phases can share one JSON contract.
-#[allow(dead_code)]
-impl<T> MachineResponse<T>
-where
-    T: Serialize,
-{
-    pub fn ok(command: &'static str, data: T) -> Self {
-        Self {
-            command,
-            status: "ok",
-            data,
-            warnings: Vec::new(),
-            errors: Vec::new(),
-        }
-    }
-
-    pub fn with_warning(mut self, warning: impl Into<String>) -> Self {
-        self.warnings.push(warning.into());
-        self
-    }
-}
-
-// Introduced before command adoption so later phases can replace ad hoc JSON printing.
-#[allow(dead_code)]
 pub fn print_json(value: &impl Serialize) -> Result<()> {
     println!("{}", serde_json::to_string_pretty(value)?);
     Ok(())
@@ -514,36 +476,6 @@ pub fn new_table() -> Table {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::json;
-
-    #[test]
-    fn machine_response_serializes_success_envelope() {
-        let response = MachineResponse::ok("jobs.list", json!({"jobs": []}));
-        let value = serde_json::to_value(response).unwrap();
-
-        assert_eq!(value["command"], "jobs.list");
-        assert_eq!(value["status"], "ok");
-        assert_eq!(value["data"], json!({"jobs": []}));
-        assert_eq!(value["warnings"], json!([]));
-        assert_eq!(value["errors"], json!([]));
-    }
-
-    #[test]
-    fn machine_response_serializes_empty_list_data() {
-        let response = MachineResponse::ok("plugin.list", Vec::<String>::new());
-        let value = serde_json::to_value(response).unwrap();
-
-        assert_eq!(value["data"], json!([]));
-    }
-
-    #[test]
-    fn machine_response_serializes_warnings() {
-        let response =
-            MachineResponse::ok("env.check", json!({"passed": false})).with_warning("vmaf missing");
-        let value = serde_json::to_value(response).unwrap();
-
-        assert_eq!(value["warnings"], json!(["vmaf missing"]));
-    }
 
     #[test]
     fn test_sanitize_passes_normal_strings() {

--- a/crates/voom-cli/src/output.rs
+++ b/crates/voom-cli/src/output.rs
@@ -2,14 +2,59 @@
 
 use std::path::Path;
 
+use anyhow::Result;
 use comfy_table::presets::UTF8_FULL_CONDENSED;
 use comfy_table::{Cell, ContentArrangement, Table};
 use console::style;
+use serde::Serialize;
 use voom_domain::media::{MediaFile, Track};
 use voom_domain::transition::{FileTransition, TransitionSource};
 use voom_domain::utils::format;
 
 use crate::cli::OutputFormat;
+
+// Introduced before command adoption so later phases can share one JSON contract.
+#[allow(dead_code)]
+#[derive(Debug, Serialize)]
+pub struct MachineResponse<T>
+where
+    T: Serialize,
+{
+    pub command: &'static str,
+    pub status: &'static str,
+    pub data: T,
+    pub warnings: Vec<String>,
+    pub errors: Vec<String>,
+}
+
+// Introduced before command adoption so later phases can share one JSON contract.
+#[allow(dead_code)]
+impl<T> MachineResponse<T>
+where
+    T: Serialize,
+{
+    pub fn ok(command: &'static str, data: T) -> Self {
+        Self {
+            command,
+            status: "ok",
+            data,
+            warnings: Vec::new(),
+            errors: Vec::new(),
+        }
+    }
+
+    pub fn with_warning(mut self, warning: impl Into<String>) -> Self {
+        self.warnings.push(warning.into());
+        self
+    }
+}
+
+// Introduced before command adoption so later phases can replace ad hoc JSON printing.
+#[allow(dead_code)]
+pub fn print_json(value: &impl Serialize) -> Result<()> {
+    println!("{}", serde_json::to_string_pretty(value)?);
+    Ok(())
+}
 
 /// Strip control characters (ANSI escapes, newlines, null bytes, etc.)
 /// from a string before displaying it in the terminal.
@@ -468,6 +513,36 @@ pub fn new_table() -> Table {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn machine_response_serializes_success_envelope() {
+        let response = MachineResponse::ok("jobs.list", json!({"jobs": []}));
+        let value = serde_json::to_value(response).unwrap();
+
+        assert_eq!(value["command"], "jobs.list");
+        assert_eq!(value["status"], "ok");
+        assert_eq!(value["data"], json!({"jobs": []}));
+        assert_eq!(value["warnings"], json!([]));
+        assert_eq!(value["errors"], json!([]));
+    }
+
+    #[test]
+    fn machine_response_serializes_empty_list_data() {
+        let response = MachineResponse::ok("plugin.list", Vec::<String>::new());
+        let value = serde_json::to_value(response).unwrap();
+
+        assert_eq!(value["data"], json!([]));
+    }
+
+    #[test]
+    fn machine_response_serializes_warnings() {
+        let response =
+            MachineResponse::ok("env.check", json!({"passed": false})).with_warning("vmaf missing");
+        let value = serde_json::to_value(response).unwrap();
+
+        assert_eq!(value["warnings"], json!(["vmaf missing"]));
+    }
 
     #[test]
     fn test_sanitize_passes_normal_strings() {

--- a/crates/voom-cli/src/output.rs
+++ b/crates/voom-cli/src/output.rs
@@ -399,6 +399,7 @@ fn track_details(track: &Track) -> String {
 }
 
 /// Entry for the plugin list table.
+#[derive(Serialize)]
 pub struct PluginListEntry {
     pub name: String,
     pub version: String,

--- a/crates/voom-cli/tests/cli_tests.rs
+++ b/crates/voom-cli/tests/cli_tests.rs
@@ -318,7 +318,7 @@ fn test_existing_json_outputs_are_parseable() {
     let tools = assert_stdout_is_json(&["tools", "list", "--format", "json"]);
     assert!(tools.is_array());
 
-    let env = assert_stdout_is_json(&["env", "check", "--json"]);
+    let env = assert_stdout_is_json(&["env", "check", "--format", "json"]);
     assert!(env.get("passed").is_some());
     assert!(env.get("issue_count").is_some());
 }
@@ -438,7 +438,7 @@ fn test_policy_test_json_reports_failures_and_exits_one() {
     let suite = write_policy_test_suite(tmp.path(), "missing");
 
     let output = voom()
-        .args(["policy", "test", "--json", suite.to_str().unwrap()])
+        .args(["policy", "test", "--format", "json", suite.to_str().unwrap()])
         .assert()
         .failure()
         .get_output()

--- a/crates/voom-cli/tests/cli_tests.rs
+++ b/crates/voom-cli/tests/cli_tests.rs
@@ -17,6 +17,41 @@ fn voom() -> Command {
     cmd
 }
 
+fn assert_stdout_is_json(args: &[&str]) -> Value {
+    let output = voom().args(args).assert().success().get_output().clone();
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "stdout was not valid JSON for {args:?}: {error}\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    })
+}
+
+fn assert_no_human_status_on_json_stdout(args: &[&str], banned: &[&str]) {
+    let output = voom().args(args).assert().success().get_output().clone();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str::<Value>(&stdout).unwrap_or_else(|error| {
+        panic!("stdout was not valid JSON for {args:?}: {error}\nstdout:\n{stdout}")
+    });
+
+    for needle in banned {
+        assert!(
+            !stdout.contains(needle),
+            "stdout for {args:?} contained human status {needle:?}:\n{stdout}"
+        );
+    }
+}
+
+fn assert_human_notes_on_stderr(args: &[&str], needle: &str) {
+    let output = voom().args(args).assert().success().get_output().clone();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(needle),
+        "stderr for {args:?} did not contain {needle:?}:\n{stderr}"
+    );
+}
+
 fn write_policy_test_suite(dir: &std::path::Path, expected_phase: &str) -> std::path::PathBuf {
     let policy_path = dir.join("minimal.voom");
     let fixture_path = dir.join("movie.json");
@@ -264,6 +299,53 @@ fn test_completions_fish() {
         .assert()
         .success()
         .stdout(predicate::str::contains("voom"));
+}
+
+// === Agent-facing output contracts ===
+
+#[test]
+fn test_existing_json_outputs_are_parseable() {
+    let dir = tempfile::tempdir().unwrap();
+    let empty_scan = assert_stdout_is_json(&[
+        "scan",
+        dir.path().to_str().unwrap(),
+        "--format",
+        "json",
+        "--no-hash",
+    ]);
+    assert_eq!(empty_scan, Value::Array(vec![]));
+
+    let tools = assert_stdout_is_json(&["tools", "list", "--format", "json"]);
+    assert!(tools.is_array());
+
+    let env = assert_stdout_is_json(&["env", "check", "--json"]);
+    assert!(env.get("passed").is_some());
+    assert!(env.get("issue_count").is_some());
+}
+
+#[test]
+fn test_json_stdout_excludes_human_status_text() {
+    let dir = tempfile::tempdir().unwrap();
+    assert_no_human_status_on_json_stdout(
+        &[
+            "scan",
+            dir.path().to_str().unwrap(),
+            "--format",
+            "json",
+            "--no-hash",
+        ],
+        &["No media files found", "Scanning", "Pruned"],
+    );
+    assert_no_human_status_on_json_stdout(
+        &["tools", "list", "--format", "json"],
+        &["tool(s) detected", "No external tools detected"],
+    );
+}
+
+#[test]
+fn test_human_notes_use_stderr_for_human_commands() {
+    let dir = tempfile::tempdir().unwrap();
+    assert_human_notes_on_stderr(&["scan", dir.path().to_str().unwrap()], "No media files found");
 }
 
 // === Policy validation ===

--- a/crates/voom-cli/tests/cli_tests.rs
+++ b/crates/voom-cli/tests/cli_tests.rs
@@ -324,6 +324,31 @@ fn test_existing_json_outputs_are_parseable() {
 }
 
 #[test]
+fn test_new_query_json_outputs_are_parseable() {
+    let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../crates/voom-dsl/tests/fixtures/production-normalize.voom");
+
+    let policy = assert_stdout_is_json(&[
+        "policy",
+        "validate",
+        fixture.to_str().unwrap(),
+        "--format",
+        "json",
+    ]);
+    assert_eq!(policy["valid"], true);
+
+    let plugins = assert_stdout_is_json(&["plugin", "list", "--format", "json"]);
+    assert!(plugins["plugins"].is_array());
+    assert!(plugins["disabled_plugins"].is_array());
+
+    let config = assert_stdout_is_json(&["config", "show", "--format", "json"]);
+    assert!(config["data_dir"].is_string());
+
+    let jobs = assert_stdout_is_json(&["jobs", "list", "--format", "json"]);
+    assert!(jobs["jobs"].is_array());
+}
+
+#[test]
 fn test_json_stdout_excludes_human_status_text() {
     let dir = tempfile::tempdir().unwrap();
     assert_no_human_status_on_json_stdout(
@@ -345,7 +370,10 @@ fn test_json_stdout_excludes_human_status_text() {
 #[test]
 fn test_human_notes_use_stderr_for_human_commands() {
     let dir = tempfile::tempdir().unwrap();
-    assert_human_notes_on_stderr(&["scan", dir.path().to_str().unwrap()], "No media files found");
+    assert_human_notes_on_stderr(
+        &["scan", dir.path().to_str().unwrap()],
+        "No media files found",
+    );
 }
 
 // === Policy validation ===
@@ -438,7 +466,13 @@ fn test_policy_test_json_reports_failures_and_exits_one() {
     let suite = write_policy_test_suite(tmp.path(), "missing");
 
     let output = voom()
-        .args(["policy", "test", "--format", "json", suite.to_str().unwrap()])
+        .args([
+            "policy",
+            "test",
+            "--format",
+            "json",
+            suite.to_str().unwrap(),
+        ])
         .assert()
         .failure()
         .get_output()

--- a/crates/voom-cli/tests/cli_tests.rs
+++ b/crates/voom-cli/tests/cli_tests.rs
@@ -349,6 +349,48 @@ fn test_new_query_json_outputs_are_parseable() {
 }
 
 #[test]
+fn test_policy_validate_map_json_is_parseable() {
+    let dir = tempfile::tempdir().unwrap();
+    let policy = dir.path().join("minimal.voom");
+    let policy_map = dir.path().join("map.toml");
+
+    std::fs::write(
+        &policy,
+        r#"policy "minimal" {
+  phase containerize {
+    container mkv
+  }
+}
+"#,
+    )
+    .unwrap();
+
+    std::fs::write(
+        &policy_map,
+        r#"default = "minimal.voom"
+
+[[mapping]]
+prefix = "movies"
+policy = "minimal.voom"
+"#,
+    )
+    .unwrap();
+
+    let json = assert_stdout_is_json(&[
+        "policy",
+        "validate",
+        policy_map.to_str().unwrap(),
+        "--format",
+        "json",
+    ]);
+
+    assert_eq!(json["valid"], true);
+    assert_eq!(json["policy_count"], 1);
+    assert!(json["policies"].is_array());
+    assert_eq!(json["policies"][0]["policy"], "minimal");
+}
+
+#[test]
 fn test_json_stdout_excludes_human_status_text() {
     let dir = tempfile::tempdir().unwrap();
     assert_no_human_status_on_json_stdout(

--- a/crates/voom-cli/tests/env_libvmaf.rs
+++ b/crates/voom-cli/tests/env_libvmaf.rs
@@ -29,9 +29,9 @@ fn env_check_json_reports_libvmaf_when_ffmpeg_is_present() {
     let out = Command::cargo_bin("voom")
         .unwrap()
         .env("XDG_CONFIG_HOME", cfg_dir.path())
-        .args(["env", "check", "--json"])
+        .args(["env", "check", "--format", "json"])
         .output()
-        .expect("run voom env check --json");
+        .expect("run voom env check --format json");
 
     assert!(out.status.success());
     let value: serde_json::Value =

--- a/crates/voom-cli/tests/functional_tests.rs
+++ b/crates/voom-cli/tests/functional_tests.rs
@@ -4665,9 +4665,9 @@ mod test_verify {
 
         let output = env
             .voom()
-            .args(["report", "--vmaf", "--json"])
+            .args(["report", "--vmaf", "--format", "json"])
             .output()
-            .expect("run report --vmaf --json");
+            .expect("run report --vmaf --format json");
         assert!(output.status.success());
         let json: serde_json::Value =
             serde_json::from_slice(&output.stdout).expect("parse report JSON");

--- a/docs/cli-agent-friendliness-audit.md
+++ b/docs/cli-agent-friendliness-audit.md
@@ -1,0 +1,83 @@
+# CLI Agent-Friendliness Audit
+
+Issue: <https://github.com/randomparity/voom/issues/345>
+
+This audit captures the starting point for the CLI tree before the
+agent-friendly output work. It should be updated as phases land.
+
+## Output Rules Under Review
+
+- Machine-readable stdout must be valid for the requested format.
+- Human status, progress, warnings, and deprecation notices belong on stderr.
+- Destructive commands need a tested non-interactive path.
+- JSON output should prefer stable command-specific objects or natural domain
+  data over prose strings.
+
+## Command Inventory
+
+| Command | Mutates state | Format flag | JSON support | Empty JSON shape | Prompts | Progress/status notes |
+|---|---:|---:|---:|---|---:|---|
+| `scan` | yes | partial | yes | `[]` | no | progress/status should be quiet for machine formats |
+| `inspect` | no | yes | yes | n/a | no | may introspect missing DB entries |
+| `process` | yes | no | `--plan-only` only | `[]` for no plans | optional approval | long-running progress/status |
+| `estimate` | yes, calibration data | no | no | n/a | no | summary is human-only |
+| `policy list` | no | no | no | n/a | no | human-only |
+| `policy validate` | no | no | no | n/a | no | result split between stdout/stderr |
+| `policy show` | no | no | no | n/a | no | prints human summary plus JSON block |
+| `policy format` | yes | no | no | n/a | no | file-editing command |
+| `policy diff` | no | no | no | n/a | no | human diff only |
+| `policy fixture extract` | no | no | yes | n/a | no | always JSON today |
+| `policy test` | no | `--json` boolean | yes | summary object | no | should move to `--format json` |
+| `plugin list` | no | no | no | n/a | no | human-only |
+| `plugin info` | no | no | no | n/a | no | human-only |
+| `plugin enable` | config | no | no | n/a | no | status text |
+| `plugin disable` | config | no | no | n/a | no | status text |
+| `plugin install` | config/files | no | no | n/a | no | status text |
+| `jobs list` | no | no | no | n/a | no | human table |
+| `jobs status` | no | no | no | n/a | no | human details |
+| `jobs cancel` | yes | no | no | n/a | no | status text |
+| `jobs retry` | yes | no | no | n/a | no | status text |
+| `jobs clear` | yes | no | no | n/a | yes | command/global yes paths need coverage |
+| `report` | no, except `--snapshot` | `--format` plus `--json` | yes | object/arrays by section | no | mixed section output |
+| `files list` | no | yes | yes | `[]` | no | query command |
+| `files show` | no | yes | yes | n/a | no | query command |
+| `files delete` | yes | no | no | n/a | yes | global yes path should be covered |
+| `plans show` | no | yes | yes | `[]` | no | query command |
+| `events` | no | yes | yes | `[]` | no | follow mode streams JSON lines |
+| `env check` | yes, stores checks | `--format` plus `--json` | yes | status object | no | should move to `--format json` |
+| `env history` | no | yes | yes | `[]` | no | query command |
+| `health` | yes, deprecated alias | `--format` plus `--json` | yes | status object | no | deprecation warning on stderr |
+| `doctor` | yes, deprecated alias | no | no | n/a | no | deprecation warning on stderr |
+| `serve` | no | no | no | n/a | no | long-running server command |
+| `db prune` | yes | no | no | n/a | no | has dry-run |
+| `db vacuum` | yes | no | no | n/a | no | status text |
+| `db reset` | yes | no | no | n/a | yes | command/global yes paths need coverage |
+| `db list-bad` | no | yes | yes | `[]` | no | query command |
+| `db purge-bad` | yes | no | no | n/a | no | status text |
+| `db clean-bad` | yes | no | no | n/a | yes | command/global yes paths need coverage |
+| `config show` | no | no | no | n/a | no | redacted human TOML |
+| `config edit` | yes | no | no | n/a | external editor | interactive by design |
+| `config get` | no | no | no | n/a | no | value text |
+| `config set` | yes | no | no | n/a | no | status text |
+| `tools list` | no | yes | yes | `[]` | no | query command |
+| `tools info` | no | yes | yes | n/a | no | query command |
+| `verify run` | yes | partial | yes | summary object | no | progress/status |
+| `verify report` | no | yes | yes | `[]` | no | query command |
+| `history` | no | yes | yes | `[]` | no | query command |
+| `backup list` | no | yes | yes | `[]` | no | query command |
+| `backup restore` | yes | no | no | n/a | yes | command/global yes paths need coverage |
+| `backup verify` | no | yes | yes | `[]` | no | query command |
+| `backup cleanup` | yes | no | no | n/a | yes | command/global yes paths need coverage |
+| `bug-report generate` | writes report dir | no | file output | n/a | no | local-first report generation |
+| `bug-report upload` | external GitHub write | no | no | n/a | no | uses `gh` |
+| `init` | yes | no | no | n/a | no | human setup wizard output |
+| `completions` | no | no | shell text | n/a | no | machine output by shell format |
+
+## Phase 1 Test Coverage
+
+The initial contract tests cover:
+
+- Existing JSON stdout parses for `scan --format json`, `tools list --format
+  json`, and `env check --json`.
+- JSON stdout excludes representative human status text.
+- Human scan status is emitted on stderr for table/human output.

--- a/docs/cli-agent-friendliness-audit.md
+++ b/docs/cli-agent-friendliness-audit.md
@@ -21,20 +21,20 @@ agent-friendly output work. It should be updated as phases land.
 | `inspect` | no | yes | yes | n/a | no | may introspect missing DB entries |
 | `process` | yes | no | `--plan-only` only | `[]` for no plans | optional approval | long-running progress/status |
 | `estimate` | yes, calibration data | no | no | n/a | no | summary is human-only |
-| `policy list` | no | no | no | n/a | no | human-only |
-| `policy validate` | no | no | no | n/a | no | result split between stdout/stderr |
-| `policy show` | no | no | no | n/a | no | prints human summary plus JSON block |
+| `policy list` | no | yes | yes | `[]` | no | query command |
+| `policy validate` | no | yes | yes | validation object | no | query command |
+| `policy show` | no | yes | yes | compiled policy object | no | query command |
 | `policy format` | yes | no | no | n/a | no | file-editing command |
-| `policy diff` | no | no | no | n/a | no | human diff only |
+| `policy diff` | no | yes | yes | diff summary object | no | query command |
 | `policy fixture extract` | no | no | yes | n/a | no | always JSON today |
 | `policy test` | no | yes | yes | summary object | no | uses `--format json` |
-| `plugin list` | no | no | no | n/a | no | human-only |
-| `plugin info` | no | no | no | n/a | no | human-only |
+| `plugin list` | no | yes | yes | plugin list object | no | query command |
+| `plugin info` | no | yes | yes | plugin descriptor object | no | query command |
 | `plugin enable` | config | no | no | n/a | no | status text |
 | `plugin disable` | config | no | no | n/a | no | status text |
 | `plugin install` | config/files | no | no | n/a | no | status text |
-| `jobs list` | no | no | no | n/a | no | human table |
-| `jobs status` | no | no | no | n/a | no | human details |
+| `jobs list` | no | yes | yes | jobs/counts object | no | query command |
+| `jobs status` | no | yes | yes | job object | no | query command |
 | `jobs cancel` | yes | no | no | n/a | no | status text |
 | `jobs retry` | yes | no | no | n/a | no | status text |
 | `jobs clear` | yes | no | no | n/a | yes | command/global yes paths need coverage |
@@ -55,9 +55,9 @@ agent-friendly output work. It should be updated as phases land.
 | `db list-bad` | no | yes | yes | `[]` | no | query command |
 | `db purge-bad` | yes | no | no | n/a | no | status text |
 | `db clean-bad` | yes | no | no | n/a | yes | command/global yes paths need coverage |
-| `config show` | no | no | no | n/a | no | redacted human TOML |
+| `config show` | no | yes | yes | redacted config object | no | query command |
 | `config edit` | yes | no | no | n/a | external editor | interactive by design |
-| `config get` | no | no | no | n/a | no | value text |
+| `config get` | no | yes | yes | key/value object | no | query command |
 | `config set` | yes | no | no | n/a | no | status text |
 | `tools list` | no | yes | yes | `[]` | no | query command |
 | `tools info` | no | yes | yes | n/a | no | query command |

--- a/docs/cli-agent-friendliness-audit.md
+++ b/docs/cli-agent-friendliness-audit.md
@@ -27,7 +27,7 @@ agent-friendly output work. It should be updated as phases land.
 | `policy format` | yes | no | no | n/a | no | file-editing command |
 | `policy diff` | no | no | no | n/a | no | human diff only |
 | `policy fixture extract` | no | no | yes | n/a | no | always JSON today |
-| `policy test` | no | `--json` boolean | yes | summary object | no | should move to `--format json` |
+| `policy test` | no | yes | yes | summary object | no | uses `--format json` |
 | `plugin list` | no | no | no | n/a | no | human-only |
 | `plugin info` | no | no | no | n/a | no | human-only |
 | `plugin enable` | config | no | no | n/a | no | status text |
@@ -38,15 +38,15 @@ agent-friendly output work. It should be updated as phases land.
 | `jobs cancel` | yes | no | no | n/a | no | status text |
 | `jobs retry` | yes | no | no | n/a | no | status text |
 | `jobs clear` | yes | no | no | n/a | yes | command/global yes paths need coverage |
-| `report` | no, except `--snapshot` | `--format` plus `--json` | yes | object/arrays by section | no | mixed section output |
+| `report` | no, except `--snapshot` | yes | yes | object/arrays by section | no | mixed section output |
 | `files list` | no | yes | yes | `[]` | no | query command |
 | `files show` | no | yes | yes | n/a | no | query command |
 | `files delete` | yes | no | no | n/a | yes | global yes path should be covered |
 | `plans show` | no | yes | yes | `[]` | no | query command |
 | `events` | no | yes | yes | `[]` | no | follow mode streams JSON lines |
-| `env check` | yes, stores checks | `--format` plus `--json` | yes | status object | no | should move to `--format json` |
+| `env check` | yes, stores checks | yes | yes | status object | no | uses `--format json` |
 | `env history` | no | yes | yes | `[]` | no | query command |
-| `health` | yes, deprecated alias | `--format` plus `--json` | yes | status object | no | deprecation warning on stderr |
+| `health` | yes, deprecated alias | yes | yes | status object | no | deprecation warning on stderr |
 | `doctor` | yes, deprecated alias | no | no | n/a | no | deprecation warning on stderr |
 | `serve` | no | no | no | n/a | no | long-running server command |
 | `db prune` | yes | no | no | n/a | no | has dry-run |
@@ -78,6 +78,6 @@ agent-friendly output work. It should be updated as phases land.
 The initial contract tests cover:
 
 - Existing JSON stdout parses for `scan --format json`, `tools list --format
-  json`, and `env check --json`.
+  json`, and `env check --format json`.
 - JSON stdout excludes representative human status text.
 - Human scan status is emitted on stderr for table/human output.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -18,6 +18,8 @@ voom [OPTIONS] <COMMAND>
 Verbosity can also be controlled via the `RUST_LOG` environment variable (e.g., `RUST_LOG=debug`).
 
 Output formats accept `table`, `json`, `plain`, or `csv` where applicable.
+When a machine-readable format is requested, stdout contains only that format;
+progress, warnings, status notes, and deprecation notices are written to stderr.
 
 ---
 
@@ -168,7 +170,7 @@ Policy file management.
 List all loaded policies.
 
 ```bash
-voom policy list
+voom policy list [--format table|json]
 ```
 
 #### `voom policy validate`
@@ -176,7 +178,7 @@ voom policy list
 Validate a policy file for syntax and semantic errors.
 
 ```
-voom policy validate <FILE>
+voom policy validate <FILE> [--format table|json]
 ```
 
 Reports errors with source locations and suggestions (e.g., "Unknown codec 'h256'. Did you mean 'h265'?").
@@ -186,7 +188,7 @@ Reports errors with source locations and suggestions (e.g., "Unknown codec 'h256
 Show the compiled form of a policy.
 
 ```
-voom policy show <FILE>
+voom policy show <FILE> [--format table|json]
 ```
 
 #### `voom policy format`
@@ -202,16 +204,26 @@ voom policy format <FILE>
 Compare two compiled policies side by side.
 
 ```
-voom policy diff <A> <B>
+voom policy diff <A> <B> [--fixture <JSON>] [--format table|json]
+```
+
+#### `voom policy test`
+
+Run JSON policy test suites.
+
+```
+voom policy test [PATHS]... [--policy <FILE>] [--update] [--format table|json]
 ```
 
 **Examples:**
 
 ```bash
 voom policy validate my-policy.voom
+voom policy validate my-policy.voom --format json
 voom policy format my-policy.voom
-voom policy show my-policy.voom
+voom policy show my-policy.voom --format json
 voom policy diff old-policy.voom new-policy.voom
+voom policy test docs/examples/tests --format json
 ```
 
 ---
@@ -225,7 +237,7 @@ Plugin management.
 List all registered plugins (native and WASM) with their status and capabilities.
 
 ```bash
-voom plugin list
+voom plugin list [--format table|json]
 ```
 
 #### `voom plugin info`
@@ -233,7 +245,7 @@ voom plugin list
 Show detailed information about a plugin.
 
 ```
-voom plugin info <NAME>
+voom plugin info <NAME> [--format table|json]
 ```
 
 #### `voom plugin enable` / `voom plugin disable`
@@ -274,6 +286,7 @@ voom jobs list [OPTIONS]
 | `--status <STATUS>` | *none* | Filter by status |
 | `-n`, `--limit <N>` | `50` | Maximum number of jobs to display |
 | `--offset <N>` | `0` | Number of jobs to skip |
+| `-f`, `--format <FORMAT>` | `table` | Output format: `table` or `json` |
 
 Status values: `pending`, `running`, `completed`, `failed`, `cancelled`.
 
@@ -282,7 +295,7 @@ Status values: `pending`, `running`, `completed`, `failed`, `cancelled`.
 Show details for a specific job.
 
 ```
-voom jobs status <ID>
+voom jobs status <ID> [--format table|json]
 ```
 
 #### `voom jobs cancel`
@@ -314,6 +327,13 @@ voom jobs clear [OPTIONS]
 | `--status <STATUS>` | *none* | Only delete jobs with this status |
 | `--yes` | `false` | Skip confirmation prompt |
 
+**Examples:**
+
+```bash
+voom jobs list --format json
+voom jobs status <ID> --format json
+```
+
 ---
 
 ### `voom report`
@@ -340,6 +360,8 @@ voom report [OPTIONS]
 | `--integrity` | `false` | Show aggregate verification and integrity counts |
 | `--loudness` | `false` | Show aggregate audio LUFS and true-peak measurements |
 
+`--format json` replaces the old `--json` flag.
+
 `voom report --integrity` reports aggregate counts for total files, never verified files,
 stale files using a 30-day cutoff, files with errors, files with warnings, and hash
 mismatches. The integrity summary supports `table`, `json`, `plain`, and `csv` formats
@@ -348,6 +370,13 @@ through `--format`.
 `voom report --loudness` reports measured audio tracks, average integrated LUFS,
 average true peak, and files outside the -23 LUFS broadcast target by more than
 0.5 LUFS. Use it after running a policy with `normalize`.
+
+**Examples:**
+
+```bash
+voom report --format json
+voom report --errors --session <UUID> --format json
+```
 
 ---
 
@@ -478,6 +507,7 @@ Run live environment checks. Verifies:
 
 ```bash
 voom env check
+voom env check --format json
 ```
 
 When `[plugin.backup-manager].destinations` is configured, the check reports
@@ -610,7 +640,7 @@ Configuration management.
 Display the current configuration.
 
 ```bash
-voom config show
+voom config show [--format table|json]
 ```
 
 #### `voom config edit`
@@ -626,13 +656,14 @@ voom config edit
 Get a configuration value by dot-notation key.
 
 ```
-voom config get <KEY>
+voom config get <KEY> [--format table|json]
 ```
 
 **Examples:**
 
 ```bash
 voom config get auth_token
+voom config get auth_token --format json
 voom config get plugin.ffmpeg-executor.hw_accel
 voom config get plugin.ffmpeg-executor.nvenc_max_parallel
 ```

--- a/docs/plans/issue-345-agent-friendly-cli.md
+++ b/docs/plans/issue-345-agent-friendly-cli.md
@@ -1,0 +1,362 @@
+# Issue 345 Agent-Friendly CLI Plan
+
+Issue: <https://github.com/randomparity/voom/issues/345>
+Suggested branch: `feat/issue-345-agent-friendly-cli`
+
+## Problem
+
+The CLI needs a tree-wide pass to make commands predictable for agents and
+scripts. The current CLI already has several machine-readable paths through
+`OutputFormat::{Json, Plain, Csv}`, but support is uneven: some commands have
+only human output, some use command-specific `--json` booleans, progress
+suppression is only partially tied to machine output, and success/error messages
+are not represented through a shared machine-readable contract.
+
+Because VOOM is pre-release, this work should replace inconsistent interfaces
+instead of adding compatibility shims.
+
+## Goals
+
+- Every read/query command can emit valid JSON without unrelated human text on
+  stdout.
+- Every mutating command has deterministic non-interactive behavior through
+  existing global `--yes` or command-level confirmation flags.
+- Machine-readable output has stable object shapes with command, status, data,
+  warnings, and errors where applicable.
+- Progress, diagnostics, and deprecation notices go to stderr, not stdout.
+- Help text makes automation affordances discoverable without marketing copy.
+- Tests lock in stdout/stderr separation, JSON validity, parse behavior, and
+  representative empty-result shapes.
+
+## Non-Goals
+
+- Do not add a new CLI framework or dependency.
+- Do not build a separate agent protocol or daemon API.
+- Do not preserve old pre-release flag aliases when a cleaner interface
+  replaces them.
+- Do not turn every human table into an identical schema in one giant refactor;
+  normalize shared command plumbing first, then high-value command groups.
+
+## Current CLI Surfaces
+
+- Parser and command tree: `crates/voom-cli/src/cli.rs`
+- Dispatch, quiet behavior, lock policy: `crates/voom-cli/src/main.rs`
+- Formatting helpers: `crates/voom-cli/src/output.rs`
+- Command implementations: `crates/voom-cli/src/commands/*.rs`
+- Integration-style CLI assertions: `crates/voom-cli/tests/cli_tests.rs`
+- User-facing docs: `docs/cli-reference.md`
+
+## Proposed Interface Rules
+
+1. Keep `--format <table|json|plain|csv>` as the single output selector for
+   commands that return data.
+2. Remove command-specific `--json` booleans where `--format json` can express
+   the same behavior.
+3. Add `--format json` to read/query commands that currently lack it:
+   `policy list`, `policy validate`, `policy show`, `policy diff`,
+   `plugin list`, `plugin info`, `jobs list`, `jobs status`, `config show`,
+   `config get`, and `bug-report` status-like paths if needed.
+4. Keep commands that primarily edit files or launch services human-only unless
+   there is a concrete data result to return.
+5. When a command runs in a machine format, stdout must contain only the chosen
+   data format. Human progress, warnings, and deprecation notices must use
+   stderr.
+6. Empty JSON results should use the natural empty shape for the command:
+   arrays for list commands and objects with `status` plus empty fields for
+   status/summary commands.
+7. JSON errors should be added only if there is an explicit machine-output
+   request. Clap parse errors can remain clap-native unless a global error
+   format is introduced in a later issue.
+
+## Output Envelope
+
+Use a small shared envelope for commands that currently only print human status
+or summaries:
+
+```json
+{
+  "command": "jobs.list",
+  "status": "ok",
+  "data": {},
+  "warnings": [],
+  "errors": []
+}
+```
+
+Do not wrap domain data that already has a clear stable JSON shape unless the
+command also needs status/warnings/errors. For example, `inspect --format json`
+can continue returning a serialized `MediaFile`, while `policy validate
+--format json` should return a validation result object.
+
+## Implementation Tasks
+
+### Task 1: CLI Inventory and Contract Tests
+
+Files:
+- Modify: `crates/voom-cli/tests/cli_tests.rs`
+- Create: `docs/cli-agent-friendliness-audit.md`
+
+Steps:
+1. Add a focused CLI smoke matrix in `cli_tests.rs` that runs representative
+   commands with `--help`, default output, and JSON output where already
+   supported.
+2. Add helpers:
+   - `assert_stdout_is_json(command)`
+   - `assert_no_human_status_on_json_stdout(command)`
+   - `assert_human_notes_on_stderr(command)`
+3. Document the current command inventory in
+   `docs/cli-agent-friendliness-audit.md` with columns:
+   command, mutates state, supports `--format`, supports JSON, empty JSON shape,
+   prompts, progress output, notes.
+4. Run:
+   ```sh
+   cargo test -p voom-cli --test cli_tests
+   ```
+5. Commit:
+   ```sh
+   git add crates/voom-cli/tests/cli_tests.rs docs/cli-agent-friendliness-audit.md
+   git commit -m "test(cli): inventory agent-facing command output"
+   ```
+
+### Task 2: Shared Machine Output Helpers
+
+Files:
+- Modify: `crates/voom-cli/src/output.rs`
+- Modify: `crates/voom-cli/src/cli.rs`
+
+Steps:
+1. Add tests in `output.rs` for serializing a success envelope, an empty list,
+   and a warning-bearing response.
+2. Add a small `CommandStatus` or `MachineResponse<T>` type in `output.rs` with
+   `command`, `status`, `data`, `warnings`, and `errors`.
+3. Add `print_json<T: serde::Serialize>(&T) -> anyhow::Result<()>` to centralize
+   pretty JSON output and avoid repeated `expect` calls at display boundaries.
+4. Keep `OutputFormat::is_machine()` and use it for quiet/progress decisions.
+5. Run:
+   ```sh
+   cargo test -p voom-cli output::tests
+   cargo test -p voom-cli cli::tests::test_output_format_is_machine
+   ```
+6. Commit:
+   ```sh
+   git add crates/voom-cli/src/output.rs crates/voom-cli/src/cli.rs
+   git commit -m "feat(cli): add shared machine output helpers"
+   ```
+
+### Task 3: Normalize Format Flags
+
+Files:
+- Modify: `crates/voom-cli/src/cli.rs`
+- Modify: `crates/voom-cli/src/commands/report.rs`
+- Modify: `crates/voom-cli/src/commands/env.rs`
+- Modify: `crates/voom-cli/src/commands/policy.rs`
+
+Steps:
+1. Replace command-specific `--json` booleans on `report`, `env check`, and
+   `policy test` with `--format json` unless a command has a strong reason for
+   a dedicated boolean.
+2. Add parser tests that old `--json` flags are rejected after replacement.
+3. Add `--format` to high-value read commands that lack it:
+   `policy list`, `policy validate`, `policy show`, `policy diff`,
+   `plugin list`, `plugin info`, `jobs list`, `jobs status`, `config show`,
+   and `config get`.
+4. Leave mutating commands without JSON unless they have a useful result object.
+5. Run:
+   ```sh
+   cargo test -p voom-cli cli::tests
+   ```
+6. Commit:
+   ```sh
+   git add crates/voom-cli/src/cli.rs \
+     crates/voom-cli/src/commands/report.rs \
+     crates/voom-cli/src/commands/env.rs \
+     crates/voom-cli/src/commands/policy.rs
+   git commit -m "feat(cli): normalize machine output flags"
+   ```
+
+### Task 4: Stdout/Stderr Separation
+
+Files:
+- Modify: `crates/voom-cli/src/main.rs`
+- Modify: `crates/voom-cli/src/commands/scan.rs`
+- Modify: `crates/voom-cli/src/commands/process/mod.rs`
+- Modify: `crates/voom-cli/src/commands/inspect.rs`
+- Modify: `crates/voom-cli/src/commands/events.rs`
+- Modify: `crates/voom-cli/src/commands/report.rs`
+- Modify: `crates/voom-cli/src/commands/verify.rs`
+- Modify: `crates/voom-cli/src/commands/backup.rs`
+- Modify: `crates/voom-cli/src/commands/tools.rs`
+- Modify: `crates/voom-cli/src/commands/env.rs`
+
+Steps:
+1. Replace ad hoc quiet detection in `main.rs` with an `effective_quiet`
+   function that checks `cli.quiet` and machine formats across the full command
+   tree.
+2. Add unit tests for `effective_quiet` covering `scan --format json`,
+   `inspect --format json`, `events --format json`, `report --format json`,
+   and a normal table command.
+3. Move human-only informational messages from stdout to stderr where they can
+   accompany data output.
+4. Ensure empty JSON outputs are still printed to stdout, not suppressed by
+   quiet mode.
+5. Run:
+   ```sh
+   cargo test -p voom-cli main::tests
+   cargo test -p voom-cli --test cli_tests
+   ```
+6. Commit:
+   ```sh
+   git add crates/voom-cli/src/main.rs \
+     crates/voom-cli/src/commands/scan.rs \
+     crates/voom-cli/src/commands/process/mod.rs \
+     crates/voom-cli/src/commands/inspect.rs \
+     crates/voom-cli/src/commands/events.rs \
+     crates/voom-cli/src/commands/report.rs \
+     crates/voom-cli/src/commands/verify.rs \
+     crates/voom-cli/src/commands/backup.rs \
+     crates/voom-cli/src/commands/tools.rs \
+     crates/voom-cli/src/commands/env.rs
+   git commit -m "fix(cli): keep machine stdout parseable"
+   ```
+
+### Task 5: JSON Coverage for Query Commands
+
+Files:
+- Modify: `crates/voom-cli/src/commands/policy.rs`
+- Modify: `crates/voom-cli/src/commands/plugin.rs`
+- Modify: `crates/voom-cli/src/commands/jobs.rs`
+- Modify: `crates/voom-cli/src/commands/config.rs`
+
+Steps:
+1. For each command, add tests that execute JSON mode and parse stdout with
+   `serde_json`.
+2. Use natural JSON data:
+   - `policy validate`: `{ "valid": true, "errors": [] }`
+   - `policy list`: array of policy descriptors
+   - `policy diff`: structured diff summary, with fixture plan diff when used
+   - `plugin list`: array of registered/disabled plugin descriptors
+   - `plugin info`: plugin descriptor object
+   - `jobs list`: array plus pagination metadata
+   - `jobs status`: single job descriptor or not-found error
+   - `config show`: redacted config object
+   - `config get`: `{ "key": "...", "value": ... }`
+3. Do not parse table output in tests. Assert behavior, not table layout.
+4. Run:
+   ```sh
+   cargo test -p voom-cli --test cli_tests
+   cargo test -p voom-cli commands::policy
+   cargo test -p voom-cli commands::plugin
+   cargo test -p voom-cli commands::jobs
+   cargo test -p voom-cli commands::config
+   ```
+5. Commit:
+   ```sh
+   git add crates/voom-cli/src/commands/policy.rs \
+     crates/voom-cli/src/commands/plugin.rs \
+     crates/voom-cli/src/commands/jobs.rs \
+     crates/voom-cli/src/commands/config.rs \
+     crates/voom-cli/tests/cli_tests.rs
+   git commit -m "feat(cli): add JSON output for query commands"
+   ```
+
+### Task 6: Non-Interactive Safety Review
+
+Files:
+- Modify: `crates/voom-cli/src/main.rs`
+- Modify: `crates/voom-cli/src/commands/backup.rs`
+- Modify: `crates/voom-cli/src/commands/db.rs`
+- Modify: `crates/voom-cli/src/commands/files.rs`
+- Modify: `crates/voom-cli/src/commands/jobs.rs`
+
+Steps:
+1. Verify every destructive command accepts either global `--yes` or a
+   command-level `--yes`, and that global `--yes` is honored consistently.
+2. Add tests for declining prompts and accepting through global `--yes`.
+3. Make refusal messages clear and actionable on stderr.
+4. Do not add new force flags unless a command has no existing confirmation
+   path.
+5. Run:
+   ```sh
+   cargo test -p voom-cli main::tests::test_global_yes
+   cargo test -p voom-cli --test cli_tests
+   ```
+6. Commit:
+   ```sh
+   git add crates/voom-cli/src/main.rs \
+     crates/voom-cli/src/commands/backup.rs \
+     crates/voom-cli/src/commands/db.rs \
+     crates/voom-cli/src/commands/files.rs \
+     crates/voom-cli/src/commands/jobs.rs
+   git commit -m "fix(cli): make confirmations automation friendly"
+   ```
+
+### Task 7: Help and Documentation
+
+Files:
+- Modify: `docs/cli-reference.md`
+- Modify: `crates/voom-cli/src/cli.rs`
+- Modify: `docs/INDEX.md` if the new audit document should be listed
+
+Steps:
+1. Update help strings so output flags describe machine-friendly use directly:
+   `--format json` for structured output, `--format plain` for line-oriented
+   paths, and `--quiet` for suppressing progress/status.
+2. Document stdout/stderr rules in `docs/cli-reference.md`.
+3. Document JSON support command by command.
+4. Link `docs/cli-agent-friendliness-audit.md` from `docs/INDEX.md` only if the
+   audit is intended to remain as maintained documentation.
+5. Run:
+   ```sh
+   cargo test -p voom-cli cli::tests
+   ```
+6. Commit:
+   ```sh
+   git add crates/voom-cli/src/cli.rs docs/cli-reference.md docs/INDEX.md
+   git commit -m "docs(cli): document agent-friendly output"
+   ```
+
+### Task 8: Final Verification
+
+Run:
+
+```sh
+cargo fmt --all --check
+cargo test -p voom-cli
+cargo clippy -p voom-cli --all-targets --all-features -- -D warnings
+```
+
+Manual smoke checks:
+
+```sh
+cargo run -p voom-cli -- --help
+cargo run -p voom-cli -- env check --format json | jq .
+cargo run -p voom-cli -- tools list --format json | jq .
+cargo run -p voom-cli -- policy validate docs/examples/minimal.voom --format json | jq .
+cargo run -p voom-cli -- plugin list --format json | jq .
+```
+
+Before opening the PR, re-read the diff for duplicate output code. If the same
+JSON/table branching appears in three command modules, move only the common
+printing primitive into `output.rs`; keep command-specific data construction in
+the command modules.
+
+## Open Questions
+
+- Should `inspect --format json` remain a raw `MediaFile`, or should it move
+  into an envelope for consistency? Recommendation: keep it raw because it is
+  already direct domain data and likely useful to scripts.
+- Should clap parse errors support JSON? Recommendation: defer. It requires
+  global error handling and is less valuable than ensuring successful
+  machine-output commands are parseable.
+- Should `plain` and `csv` be available everywhere JSON is? Recommendation:
+  only for list-like commands where line-oriented output has a natural shape.
+
+## Acceptance Criteria
+
+- `cargo test -p voom-cli --test cli_tests` includes coverage for every command
+  group that claims JSON support.
+- All commands documented with `--format json` produce valid JSON on stdout with
+  no human prose mixed in.
+- Human progress/status/deprecation messages are on stderr.
+- Destructive commands have a tested non-interactive path.
+- `docs/cli-reference.md` matches the implemented command tree.

--- a/docs/plans/issue-345-e2e-agent-friendly-cli-consumer.md
+++ b/docs/plans/issue-345-e2e-agent-friendly-cli-consumer.md
@@ -1,0 +1,451 @@
+# E2E Agent-Friendly CLI Consumer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Update the e2e policy audit scripts to consume the new agent-friendly `--format json` command shape for low-risk internal harness outputs.
+
+**Architecture:** Keep the audit harness behavior unchanged for operators, but make its machine-consumed artifacts JSON-first. `run.sh` remains the producer of run artifacts; `build-summary.sh` becomes the first internal consumer of `voom jobs list --format json`; `preflight.sh` captures `voom config show --format json` as a redacted environment artifact.
+
+**Tech Stack:** Bash with `set -euo pipefail`, `jq`, existing VOOM CLI commands, and the current `scripts/e2e-policy-audit/tests/test.sh` fixture test harness.
+
+---
+
+## File Structure
+
+- Modify `scripts/e2e-policy-audit/run.sh`
+  - Change low-risk VOOM invocations to the new command shape:
+    - `policy validate <file> --format json`
+    - `jobs list --format json`
+    - `report --all --format json`
+  - Save JSON artifacts as `.json` files and keep raw command logs under `logs/`.
+- Modify `scripts/e2e-policy-audit/lib/build-summary.sh`
+  - Read `reports/jobs.json` with `jq` for straggler and failed-job checks.
+  - Keep `reports/jobs.txt` as a fallback only for older run directories.
+- Modify `scripts/e2e-policy-audit/lib/preflight.sh`
+  - Capture `voom config show --format json` into `env/voom-config.redacted.json`.
+  - Keep the existing TOML redaction snapshot as a compatibility/readability artifact.
+- Modify `scripts/e2e-policy-audit/tests/test.sh`
+  - Change the summary fixture from `reports/jobs.txt` to `reports/jobs.json`.
+  - Add a straggler fixture so the JSON status check is covered by behavior, not just syntax.
+- Modify `scripts/e2e-policy-audit/README.md`
+  - Document the JSON artifacts produced by the harness.
+
+## Task 1: Teach Summary Tests About `jobs.json`
+
+**Files:**
+- Modify: `scripts/e2e-policy-audit/tests/test.sh`
+- No production code changes in this task.
+
+- [ ] **Step 1: Replace the completed-jobs text fixture with JSON**
+
+In `run_summary_failed_phase_test`, replace:
+
+```bash
+  cat >"${actual}/reports/jobs.txt" <<'EOF'
+job-1 completed
+job-2 completed
+EOF
+```
+
+with:
+
+```bash
+  cat >"${actual}/reports/jobs.json" <<'EOF'
+{
+  "data": [
+    {"id": "job-1", "status": "completed"},
+    {"id": "job-2", "status": "completed"}
+  ]
+}
+EOF
+```
+
+- [ ] **Step 2: Add a failing behavior test for JSON stragglers**
+
+Add this function after `run_summary_failed_phase_test`:
+
+```bash
+run_summary_jobs_json_straggler_test() {
+  local actual
+  local summary
+
+  actual=$(mktemp -d)
+  trap 'rm -R "${actual}"' EXIT
+
+  mkdir -p \
+    "${actual}/logs" \
+    "${actual}/reports" \
+    "${actual}/db-export" \
+    "${actual}/diffs"
+
+  for log_name in doctor policy-validate scan; do
+    printf '0\n' >"${actual}/logs/${log_name}.log.rc"
+  done
+
+  cat >"${actual}/diffs/files-summary.md" <<'EOF'
+# Snapshot Diff Summary
+
+Disappeared paths: 0
+Missing backup post-run: 0
+EOF
+
+  cat >"${actual}/reports/jobs.json" <<'EOF'
+{
+  "data": [
+    {"id": "job-1", "status": "completed"},
+    {"id": "job-2", "status": "running"}
+  ]
+}
+EOF
+
+  "lib/build-summary.sh" "${actual}" 2 2
+
+  summary="${actual}/summary.md"
+  if ! grep -Fq "FAIL: jobs report contains non-terminal states (running/pending)" "${summary}"; then
+    echo "FAIL: jobs.json straggler was not reported" >&2
+    fail=1
+  fi
+
+  rm -R "${actual}"
+  trap - EXIT
+}
+```
+
+Then call it immediately after `run_summary_failed_phase_test`:
+
+```bash
+run_summary_failed_phase_test
+run_summary_jobs_json_straggler_test
+```
+
+- [ ] **Step 3: Run the focused script test and verify it fails**
+
+Run:
+
+```bash
+scripts/e2e-policy-audit/tests/test.sh
+```
+
+Expected: failure with `FAIL: jobs.json straggler was not reported`, because `build-summary.sh` does not read `reports/jobs.json` yet.
+
+- [ ] **Step 4: Commit the failing test**
+
+```bash
+git add scripts/e2e-policy-audit/tests/test.sh
+git commit -m "test(scripts): cover json jobs summary"
+```
+
+## Task 2: Consume `jobs.json` In The Summary Builder
+
+**Files:**
+- Modify: `scripts/e2e-policy-audit/lib/build-summary.sh`
+- Test: `scripts/e2e-policy-audit/tests/test.sh`
+
+- [ ] **Step 1: Add explicit JSON and text job report paths**
+
+In `build-summary.sh`, replace:
+
+```bash
+# Job stragglers
+jobs_report="${run}/reports/jobs.txt"
+if [[ -f "${jobs_report}" ]]; then
+  if grep -Eqi '\b(running|pending)\b' "${jobs_report}"; then
+    note_fail "jobs report contains non-terminal states (running/pending)"
+  fi
+fi
+```
+
+with:
+
+```bash
+# Job stragglers
+jobs_json="${run}/reports/jobs.json"
+jobs_report="${run}/reports/jobs.txt"
+if [[ -f "${jobs_json}" ]]; then
+  if jq -e '.data[]? | select(.status == "running" or .status == "pending")' \
+    "${jobs_json}" >/dev/null; then
+    note_fail "jobs report contains non-terminal states (running/pending)"
+  fi
+elif [[ -f "${jobs_report}" ]]; then
+  if grep -Eqi '\b(running|pending)\b' "${jobs_report}"; then
+    note_fail "jobs report contains non-terminal states (running/pending)"
+  fi
+fi
+```
+
+- [ ] **Step 2: Convert failed-plan job status checks to prefer JSON**
+
+In the `if ((total_failed_plans > 0)); then` block, replace:
+
+```bash
+  if [[ -f "${jobs_report}" ]] &&
+    grep -qE 'completed:[[:space:]]+[1-9][0-9]*' "${jobs_report}" &&
+    ! grep -qE 'failed:[[:space:]]+[1-9][0-9]*' "${jobs_report}"; then
+    note_warn "jobs report has completed jobs but no failed jobs despite ${total_failed_plans} failed plan(s)"
+  fi
+```
+
+with:
+
+```bash
+  if [[ -f "${jobs_json}" ]]; then
+    completed_jobs=$(jq '[.data[]? | select(.status == "completed")] | length' "${jobs_json}")
+    failed_jobs=$(jq '[.data[]? | select(.status == "failed")] | length' "${jobs_json}")
+    if ((completed_jobs > 0 && failed_jobs == 0)); then
+      note_warn "jobs report has completed jobs but no failed jobs despite ${total_failed_plans} failed plan(s)"
+    fi
+  elif [[ -f "${jobs_report}" ]] &&
+    grep -qE 'completed:[[:space:]]+[1-9][0-9]*' "${jobs_report}" &&
+    ! grep -qE 'failed:[[:space:]]+[1-9][0-9]*' "${jobs_report}"; then
+    note_warn "jobs report has completed jobs but no failed jobs despite ${total_failed_plans} failed plan(s)"
+  fi
+```
+
+- [ ] **Step 3: Run the focused script test**
+
+Run:
+
+```bash
+scripts/e2e-policy-audit/tests/test.sh
+```
+
+Expected: PASS with no `diff -u` output and no `FAIL:` lines.
+
+- [ ] **Step 4: Run shell lint for touched scripts**
+
+Run:
+
+```bash
+shellcheck scripts/e2e-policy-audit/lib/build-summary.sh scripts/e2e-policy-audit/tests/test.sh
+```
+
+Expected: no output and exit code 0.
+
+- [ ] **Step 5: Commit the summary consumer**
+
+```bash
+git add scripts/e2e-policy-audit/lib/build-summary.sh scripts/e2e-policy-audit/tests/test.sh
+git commit -m "fix(scripts): consume json jobs report"
+```
+
+## Task 3: Produce JSON Artifacts From The E2E Harness
+
+**Files:**
+- Modify: `scripts/e2e-policy-audit/run.sh`
+- Test: `scripts/e2e-policy-audit/tests/test.sh`
+
+- [ ] **Step 1: Update policy validation to use the new JSON command shape**
+
+In `run.sh`, replace:
+
+```bash
+log_run policy-validate "${voom_bin}" policy validate "${policy}"
+```
+
+with:
+
+```bash
+log_run policy-validate "${voom_bin}" policy validate "${policy}" --format json
+```
+
+- [ ] **Step 2: Save the jobs query as JSON**
+
+In `run.sh`, replace:
+
+```bash
+log_run jobs-list "${voom_bin}" jobs list
+cp "${run_dir}/logs/jobs-list.log" "${run_dir}/reports/jobs.txt"
+```
+
+with:
+
+```bash
+log_run jobs-list "${voom_bin}" jobs list --format json
+cp "${run_dir}/logs/jobs-list.log" "${run_dir}/reports/jobs.json"
+```
+
+- [ ] **Step 3: Save the report query as JSON**
+
+In `run.sh`, replace:
+
+```bash
+log_run report "${voom_bin}" report --all
+cp "${run_dir}/logs/report.log" "${run_dir}/reports/report.txt"
+```
+
+with:
+
+```bash
+log_run report "${voom_bin}" report --all --format json
+cp "${run_dir}/logs/report.log" "${run_dir}/reports/report.json"
+```
+
+- [ ] **Step 4: Run the focused script test**
+
+Run:
+
+```bash
+scripts/e2e-policy-audit/tests/test.sh
+```
+
+Expected: PASS with no `diff -u` output and no `FAIL:` lines.
+
+- [ ] **Step 5: Run shell lint for the producer script**
+
+Run:
+
+```bash
+shellcheck scripts/e2e-policy-audit/run.sh
+```
+
+Expected: no output and exit code 0.
+
+- [ ] **Step 6: Commit the producer changes**
+
+```bash
+git add scripts/e2e-policy-audit/run.sh
+git commit -m "chore(scripts): write e2e cli json artifacts"
+```
+
+## Task 4: Capture JSON Config In Preflight
+
+**Files:**
+- Modify: `scripts/e2e-policy-audit/lib/preflight.sh`
+
+- [ ] **Step 1: Add a JSON config snapshot next to the existing TOML snapshot**
+
+In `preflight.sh`, after the existing config redaction block:
+
+```bash
+config_file="${config_dir}/config.toml"
+if [[ -r "${config_file}" ]]; then
+    sed -E 's/(password|token|secret|key|credential)([[:space:]]*=[[:space:]]*).*/\1\2"<redacted>"/I' \
+        "${config_file}" >"${env_dir}/voom-config.redacted.toml" || true
+fi
+```
+
+add:
+
+```bash
+"${voom_bin}" config show --format json >"${env_dir}/voom-config.redacted.json" 2>/dev/null || true
+```
+
+- [ ] **Step 2: Run shell lint for preflight**
+
+Run:
+
+```bash
+shellcheck scripts/e2e-policy-audit/lib/preflight.sh
+```
+
+Expected: no output and exit code 0.
+
+- [ ] **Step 3: Commit the preflight snapshot**
+
+```bash
+git add scripts/e2e-policy-audit/lib/preflight.sh
+git commit -m "chore(scripts): capture json config snapshot"
+```
+
+## Task 5: Document The New JSON Artifacts
+
+**Files:**
+- Modify: `scripts/e2e-policy-audit/README.md`
+
+- [ ] **Step 1: Update the artifact tree**
+
+Find the artifact tree section that includes:
+
+```markdown
+├── env/                          tool versions, GPU state, policy copy, redacted config
+├── reports/                      voom report --all, files, plans, jobs, events.json
+```
+
+Replace it with:
+
+```markdown
+├── env/                          tool versions, GPU state, policy copy, redacted config JSON/TOML
+├── reports/                      VOOM JSON reports, files CSV, plans JSON, jobs JSON, events JSON
+```
+
+- [ ] **Step 2: Add a short compatibility note**
+
+After the artifact tree, add:
+
+```markdown
+The harness stores machine-consumed VOOM CLI outputs as JSON. Raw command
+output remains available in `logs/`, where each command also has a matching
+`.log.rc` file for exit-code checks.
+```
+
+- [ ] **Step 3: Run a docs diff review**
+
+Run:
+
+```bash
+git diff -- scripts/e2e-policy-audit/README.md
+```
+
+Expected: the README only describes the new artifact names and JSON behavior; it should not describe unimplemented options or change harness usage.
+
+- [ ] **Step 4: Commit the docs update**
+
+```bash
+git add scripts/e2e-policy-audit/README.md
+git commit -m "docs(scripts): document e2e json artifacts"
+```
+
+## Task 6: Final Verification
+
+**Files:**
+- Verify all modified files.
+
+- [ ] **Step 1: Run script behavior tests**
+
+Run:
+
+```bash
+scripts/e2e-policy-audit/tests/test.sh
+```
+
+Expected: PASS with no `diff -u` output and no `FAIL:` lines.
+
+- [ ] **Step 2: Run shell lint**
+
+Run:
+
+```bash
+shellcheck \
+  scripts/e2e-policy-audit/run.sh \
+  scripts/e2e-policy-audit/lib/build-summary.sh \
+  scripts/e2e-policy-audit/lib/preflight.sh \
+  scripts/e2e-policy-audit/tests/test.sh
+```
+
+Expected: no output and exit code 0.
+
+- [ ] **Step 3: Run CLI package tests as regression coverage**
+
+Run:
+
+```bash
+cargo test -p voom-cli
+```
+
+Expected: all `voom-cli` tests pass.
+
+- [ ] **Step 4: Check repository state**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: clean working tree.
+
+## Self-Review
+
+- Spec coverage: The plan updates the low-priority script consumers identified in this branch: jobs JSON consumption, policy validation JSON output, report JSON output, and config JSON snapshot. It leaves raw command logs intact.
+- Placeholder scan: No task uses `TBD`, vague error handling, or unspecified tests.
+- Type consistency: All JSON examples use the existing `MachineResponse`-style `data` wrapper expected from the new CLI output helpers.

--- a/docs/plans/issue-345-e2e-agent-friendly-cli-consumer.md
+++ b/docs/plans/issue-345-e2e-agent-friendly-cli-consumer.md
@@ -52,10 +52,13 @@ with:
 ```bash
   cat >"${actual}/reports/jobs.json" <<'EOF'
 {
-  "data": [
+  "jobs": [
     {"id": "job-1", "status": "completed"},
     {"id": "job-2", "status": "completed"}
-  ]
+  ],
+  "counts": [["completed", 2]],
+  "limit": 50,
+  "offset": 0
 }
 EOF
 ```
@@ -91,10 +94,13 @@ EOF
 
   cat >"${actual}/reports/jobs.json" <<'EOF'
 {
-  "data": [
+  "jobs": [
     {"id": "job-1", "status": "completed"},
     {"id": "job-2", "status": "running"}
-  ]
+  ],
+  "counts": [["completed", 1], ["running", 1]],
+  "limit": 50,
+  "offset": 0
 }
 EOF
 
@@ -162,7 +168,7 @@ with:
 jobs_json="${run}/reports/jobs.json"
 jobs_report="${run}/reports/jobs.txt"
 if [[ -f "${jobs_json}" ]]; then
-  if jq -e '.data[]? | select(.status == "running" or .status == "pending")' \
+  if jq -e '.jobs[]? | select(.status == "running" or .status == "pending")' \
     "${jobs_json}" >/dev/null; then
     note_fail "jobs report contains non-terminal states (running/pending)"
   fi
@@ -189,8 +195,8 @@ with:
 
 ```bash
   if [[ -f "${jobs_json}" ]]; then
-    completed_jobs=$(jq '[.data[]? | select(.status == "completed")] | length' "${jobs_json}")
-    failed_jobs=$(jq '[.data[]? | select(.status == "failed")] | length' "${jobs_json}")
+    completed_jobs=$(jq '[.jobs[]? | select(.status == "completed")] | length' "${jobs_json}")
+    failed_jobs=$(jq '[.jobs[]? | select(.status == "failed")] | length' "${jobs_json}")
     if ((completed_jobs > 0 && failed_jobs == 0)); then
       note_warn "jobs report has completed jobs but no failed jobs despite ${total_failed_plans} failed plan(s)"
     fi
@@ -448,4 +454,4 @@ Expected: clean working tree.
 
 - Spec coverage: The plan updates the low-priority script consumers identified in this branch: jobs JSON consumption, policy validation JSON output, report JSON output, and config JSON snapshot. It leaves raw command logs intact.
 - Placeholder scan: No task uses `TBD`, vague error handling, or unspecified tests.
-- Type consistency: All JSON examples use the existing `MachineResponse`-style `data` wrapper expected from the new CLI output helpers.
+- Type consistency: Jobs JSON examples use the actual `jobs`, `counts`, `limit`, and `offset` fields emitted by `voom jobs list --format json`.

--- a/docs/plans/issue-345-simplification-review-fixes.md
+++ b/docs/plans/issue-345-simplification-review-fixes.md
@@ -1,0 +1,547 @@
+# Issue 345 Simplification Review Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Address all simplification-review findings on the issue #345 branch without changing the intended agent-friendly CLI behavior.
+
+**Architecture:** Remove unused machine-output scaffolding, align the e2e consumer plan with the JSON shapes the CLI actually emits, make `policy validate --format json` consistent for `.voom` and `.toml` inputs, and update the remaining stale test call site from `--json` to `--format json`. Keep this as cleanup on top of the current branch, with one commit per recommendation.
+
+**Tech Stack:** Rust 2024, clap, serde_json, assert_cmd integration tests, Bash/JQ plan examples, and the existing `cargo fmt`, `cargo test`, and `cargo clippy` verification flow.
+
+---
+
+## File Structure
+
+- Modify `crates/voom-cli/src/output.rs`
+  - Delete unused `MachineResponse<T>` and its tests.
+  - Keep `print_json()` as the one shared JSON printing helper because commands now use it.
+- Modify `docs/plans/issue-345-e2e-agent-friendly-cli-consumer.md`
+  - Change planned jobs fixtures and `jq` filters from a non-existent `data` wrapper to the actual `jobs` field.
+  - Remove the claim that these examples use a `MachineResponse`-style wrapper.
+- Modify `crates/voom-cli/src/commands/policy.rs`
+  - Thread `OutputFormat` into `validate_policy_map()`.
+  - Emit structured JSON for `.toml` policy-map validation.
+- Modify `crates/voom-cli/tests/cli_tests.rs`
+  - Add an integration test proving `policy validate map.toml --format json` emits parseable JSON.
+- Modify `crates/voom-cli/tests/functional_tests.rs`
+  - Replace the remaining stale `report --vmaf --json` test invocation with `report --vmaf --format json`.
+
+## Task 1: Remove Unused `MachineResponse`
+
+**Files:**
+- Modify: `crates/voom-cli/src/output.rs`
+
+- [ ] **Step 1: Delete the unused type and impl**
+
+In `crates/voom-cli/src/output.rs`, remove this whole block:
+
+```rust
+// Introduced before command adoption so later phases can share one JSON contract.
+#[allow(dead_code)]
+#[derive(Debug, Serialize)]
+pub struct MachineResponse<T>
+where
+    T: Serialize,
+{
+    pub command: &'static str,
+    pub status: &'static str,
+    pub data: T,
+    pub warnings: Vec<String>,
+    pub errors: Vec<String>,
+}
+
+// Introduced before command adoption so later phases can share one JSON contract.
+#[allow(dead_code)]
+impl<T> MachineResponse<T>
+where
+    T: Serialize,
+{
+    pub fn ok(command: &'static str, data: T) -> Self {
+        Self {
+            command,
+            status: "ok",
+            data,
+            warnings: Vec::new(),
+            errors: Vec::new(),
+        }
+    }
+
+    pub fn with_warning(mut self, warning: impl Into<String>) -> Self {
+        self.warnings.push(warning.into());
+        self
+    }
+}
+```
+
+- [ ] **Step 2: Keep `print_json()` and remove the dead-code allow**
+
+Replace:
+
+```rust
+// Introduced before command adoption so later phases can replace ad hoc JSON printing.
+#[allow(dead_code)]
+pub fn print_json(value: &impl Serialize) -> Result<()> {
+    println!("{}", serde_json::to_string_pretty(value)?);
+    Ok(())
+}
+```
+
+with:
+
+```rust
+pub fn print_json(value: &impl Serialize) -> Result<()> {
+    println!("{}", serde_json::to_string_pretty(value)?);
+    Ok(())
+}
+```
+
+- [ ] **Step 3: Delete the unused tests**
+
+In the `#[cfg(test)] mod tests` block in `crates/voom-cli/src/output.rs`, remove:
+
+```rust
+use serde_json::json;
+
+#[test]
+fn machine_response_serializes_success_envelope() {
+    let response = MachineResponse::ok("jobs.list", json!({"jobs": []}));
+    let value = serde_json::to_value(response).unwrap();
+
+    assert_eq!(value["command"], "jobs.list");
+    assert_eq!(value["status"], "ok");
+    assert_eq!(value["data"], json!({"jobs": []}));
+    assert_eq!(value["warnings"], json!([]));
+    assert_eq!(value["errors"], json!([]));
+}
+
+#[test]
+fn machine_response_serializes_empty_list_data() {
+    let response = MachineResponse::ok("plugin.list", Vec::<String>::new());
+    let value = serde_json::to_value(response).unwrap();
+
+    assert_eq!(value["data"], json!([]));
+}
+
+#[test]
+fn machine_response_serializes_warnings() {
+    let response =
+        MachineResponse::ok("env.check", json!({"passed": false})).with_warning("vmaf missing");
+    let value = serde_json::to_value(response).unwrap();
+
+    assert_eq!(value["warnings"], json!(["vmaf missing"]));
+}
+```
+
+- [ ] **Step 4: Verify the type is gone**
+
+Run:
+
+```bash
+rg -n "MachineResponse|with_warning|success_envelope" crates/voom-cli/src/output.rs
+```
+
+Expected: no matches and exit code 1.
+
+- [ ] **Step 5: Run focused Rust checks**
+
+Run:
+
+```bash
+cargo test -p voom-cli output::
+cargo clippy -p voom-cli --all-targets --all-features -- -D warnings
+```
+
+Expected: output tests pass, and clippy exits 0 with no warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/voom-cli/src/output.rs
+git commit -m "refactor(cli): remove unused machine response"
+```
+
+## Task 2: Align The E2E Consumer Plan With Actual Jobs JSON
+
+**Files:**
+- Modify: `docs/plans/issue-345-e2e-agent-friendly-cli-consumer.md`
+
+- [ ] **Step 1: Replace planned jobs fixtures with the actual top-level `jobs` field**
+
+Replace the completed-jobs fixture:
+
+```json
+{
+  "data": [
+    {"id": "job-1", "status": "completed"},
+    {"id": "job-2", "status": "completed"}
+  ]
+}
+```
+
+with:
+
+```json
+{
+  "jobs": [
+    {"id": "job-1", "status": "completed"},
+    {"id": "job-2", "status": "completed"}
+  ],
+  "counts": [["completed", 2]],
+  "limit": 50,
+  "offset": 0
+}
+```
+
+Replace the straggler fixture:
+
+```json
+{
+  "data": [
+    {"id": "job-1", "status": "completed"},
+    {"id": "job-2", "status": "running"}
+  ]
+}
+```
+
+with:
+
+```json
+{
+  "jobs": [
+    {"id": "job-1", "status": "completed"},
+    {"id": "job-2", "status": "running"}
+  ],
+  "counts": [["completed", 1], ["running", 1]],
+  "limit": 50,
+  "offset": 0
+}
+```
+
+- [ ] **Step 2: Replace `jq` filters that read `.data`**
+
+Replace:
+
+```bash
+jq -e '.data[]? | select(.status == "running" or .status == "pending")' \
+```
+
+with:
+
+```bash
+jq -e '.jobs[]? | select(.status == "running" or .status == "pending")' \
+```
+
+Replace:
+
+```bash
+completed_jobs=$(jq '[.data[]? | select(.status == "completed")] | length' "${jobs_json}")
+failed_jobs=$(jq '[.data[]? | select(.status == "failed")] | length' "${jobs_json}")
+```
+
+with:
+
+```bash
+completed_jobs=$(jq '[.jobs[]? | select(.status == "completed")] | length' "${jobs_json}")
+failed_jobs=$(jq '[.jobs[]? | select(.status == "failed")] | length' "${jobs_json}")
+```
+
+- [ ] **Step 3: Remove the stale `MachineResponse` assertion from self-review**
+
+Replace:
+
+```markdown
+- Type consistency: All JSON examples use the existing `MachineResponse`-style `data` wrapper expected from the new CLI output helpers.
+```
+
+with:
+
+```markdown
+- Type consistency: Jobs JSON examples use the actual `jobs`, `counts`, `limit`, and `offset` fields emitted by `voom jobs list --format json`.
+```
+
+- [ ] **Step 4: Verify the plan no longer references the wrong shape**
+
+Run:
+
+```bash
+rg -n "MachineResponse|\\.data\\[\\]|\"data\"" docs/plans/issue-345-e2e-agent-friendly-cli-consumer.md
+```
+
+Expected: no matches and exit code 1.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/plans/issue-345-e2e-agent-friendly-cli-consumer.md
+git commit -m "docs(scripts): align e2e jobs json plan"
+```
+
+## Task 3: Make Policy Map Validation JSON-Aware
+
+**Files:**
+- Modify: `crates/voom-cli/src/commands/policy.rs`
+- Modify: `crates/voom-cli/tests/cli_tests.rs`
+
+- [ ] **Step 1: Add a failing integration test**
+
+In `crates/voom-cli/tests/cli_tests.rs`, add this test near the other policy validation tests:
+
+```rust
+#[test]
+fn test_policy_validate_map_json_is_parseable() {
+    let dir = tempfile::tempdir().unwrap();
+    let policy = dir.path().join("minimal.voom");
+    let policy_map = dir.path().join("map.toml");
+
+    std::fs::write(
+        &policy,
+        r#"policy "minimal" {
+  phase containerize {
+    container mkv
+  }
+}
+"#,
+    )
+    .unwrap();
+
+    std::fs::write(
+        &policy_map,
+        r#"default = "minimal.voom"
+
+[[mapping]]
+prefix = "movies"
+policy = "minimal.voom"
+"#,
+    )
+    .unwrap();
+
+    let json = assert_stdout_is_json(&[
+        "policy",
+        "validate",
+        policy_map.to_str().unwrap(),
+        "--format",
+        "json",
+    ]);
+
+    assert_eq!(json["valid"], true);
+    assert_eq!(json["policy_count"], 1);
+    assert!(json["policies"].is_array());
+    assert_eq!(json["policies"][0]["policy"], "minimal");
+}
+```
+
+- [ ] **Step 2: Run the failing test**
+
+Run:
+
+```bash
+cargo test -p voom-cli --test cli_tests test_policy_validate_map_json_is_parseable
+```
+
+Expected: FAIL because `policy validate map.toml --format json` currently prints human text for policy maps.
+
+- [ ] **Step 3: Thread `format` into policy-map validation**
+
+In `crates/voom-cli/src/commands/policy.rs`, replace:
+
+```rust
+if file.extension().is_some_and(|e| e == "toml") {
+    return validate_policy_map(file);
+}
+```
+
+with:
+
+```rust
+if file.extension().is_some_and(|e| e == "toml") {
+    return validate_policy_map(file, format);
+}
+```
+
+Replace the function signature:
+
+```rust
+fn validate_policy_map(file: &std::path::Path) -> Result<()> {
+```
+
+with:
+
+```rust
+fn validate_policy_map(file: &std::path::Path, format: OutputFormat) -> Result<()> {
+```
+
+- [ ] **Step 4: Emit JSON for policy maps**
+
+Inside `validate_policy_map()`, after:
+
+```rust
+let policies = resolver.policies();
+```
+
+insert:
+
+```rust
+if matches!(format, OutputFormat::Json) {
+    let policies: Vec<serde_json::Value> = policies
+        .iter()
+        .map(|(name, compiled)| {
+            serde_json::json!({
+                "name": name,
+                "policy": compiled.name,
+                "phase_count": compiled.phases.len(),
+                "phase_order": compiled.phase_order,
+            })
+        })
+        .collect();
+    output::print_json(&serde_json::json!({
+        "valid": true,
+        "policy_map": file,
+        "policy_count": policies.len(),
+        "policies": policies,
+    }))?;
+    return Ok(());
+}
+```
+
+Keep the existing human table output below this new JSON branch.
+
+- [ ] **Step 5: Run the focused test again**
+
+Run:
+
+```bash
+cargo test -p voom-cli --test cli_tests test_policy_validate_map_json_is_parseable
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run related CLI tests**
+
+Run:
+
+```bash
+cargo test -p voom-cli --test cli_tests test_new_query_json_outputs_are_parseable test_policy_validate_map_json_is_parseable
+```
+
+Expected: both tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/voom-cli/src/commands/policy.rs crates/voom-cli/tests/cli_tests.rs
+git commit -m "fix(cli): emit json for policy maps"
+```
+
+## Task 4: Update Remaining Stale `--json` Test Call Site
+
+**Files:**
+- Modify: `crates/voom-cli/tests/functional_tests.rs`
+
+- [ ] **Step 1: Replace the stale report alias call**
+
+In `crates/voom-cli/tests/functional_tests.rs`, replace:
+
+```rust
+.args(["report", "--vmaf", "--json"])
+.output()
+.expect("run report --vmaf --json");
+```
+
+with:
+
+```rust
+.args(["report", "--vmaf", "--format", "json"])
+.output()
+.expect("run report --vmaf --format json");
+```
+
+- [ ] **Step 2: Verify no stale report alias remains**
+
+Run:
+
+```bash
+rg -n 'report.*--json|--vmaf.*--json|run report --vmaf --json' crates/voom-cli/tests
+```
+
+Expected: no matches and exit code 1.
+
+- [ ] **Step 3: Run the focused test**
+
+Run:
+
+```bash
+cargo test -p voom-cli --test functional_tests vmaf_summary_json_is_stable
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/voom-cli/tests/functional_tests.rs
+git commit -m "test(cli): update vmaf report json format"
+```
+
+## Task 5: Final Verification
+
+**Files:**
+- Verify all modified files.
+
+- [ ] **Step 1: Format check**
+
+Run:
+
+```bash
+cargo fmt --all --check
+```
+
+Expected: no output and exit code 0.
+
+- [ ] **Step 2: Run the CLI package tests**
+
+Run:
+
+```bash
+cargo test -p voom-cli
+```
+
+Expected: all `voom-cli` tests pass.
+
+- [ ] **Step 3: Run clippy**
+
+Run:
+
+```bash
+cargo clippy -p voom-cli --all-targets --all-features -- -D warnings
+```
+
+Expected: no warnings and exit code 0.
+
+- [ ] **Step 4: Run targeted stale-shape searches**
+
+Run:
+
+```bash
+rg -n "MachineResponse|\\.data\\[\\]|report.*--json|--vmaf.*--json" \
+  crates/voom-cli/src \
+  crates/voom-cli/tests \
+  docs/plans/issue-345-e2e-agent-friendly-cli-consumer.md
+```
+
+Expected: no matches except parser-rejection tests that intentionally mention `--json`; if those appear, confirm they are rejection tests and not command invocations.
+
+- [ ] **Step 5: Check repository state**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: clean working tree.
+
+## Self-Review
+
+- Spec coverage: The plan maps one task to each simplification-review recommendation: unused `MachineResponse`, e2e consumer shape mismatch, policy-map JSON consistency, and stale `--json` test usage.
+- Placeholder scan: No task contains deferred implementation language or unspecified tests.
+- Type consistency: The e2e plan uses the actual `jobs` JSON object shape from `crates/voom-cli/src/commands/jobs.rs`; the policy-map JSON test asserts the same fields emitted by the planned implementation.


### PR DESCRIPTION
## Summary
- Normalize machine-readable CLI output around `--format json` and remove older command-specific `--json` aliases.
- Add JSON output for policy, plugin, jobs, and config query commands, including policy-map validation.
- Keep machine-readable stdout clean by treating machine formats as quiet mode, and document the stdout/stderr contract.
- Add CLI contract tests and simplify unused machine-output scaffolding.

## Test Plan
- `cargo fmt --all --check`
- `cargo test -p voom-cli`
- `cargo clippy -p voom-cli --all-targets --all-features -- -D warnings`
- `cargo test -p voom-cli --features functional --test functional_tests vmaf_summary_json_is_stable`
- JSON smoke checks for `env check`, `tools list`, `policy validate`, and `plugin list`