### PR TITLE
Add policy composition support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3830,6 +3830,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "voom-domain",
  "voom-dsl",

--- a/crates/voom-cli/src/cli.rs
+++ b/crates/voom-cli/src/cli.rs
@@ -325,6 +325,14 @@ pub enum PolicyCommands {
         #[arg(short, long, default_value = "table")]
         format: OutputFormat,
     },
+    /// Describe resolved policy composition
+    Describe {
+        /// Policy file to describe
+        file: PathBuf,
+        /// Output format
+        #[arg(short, long, default_value = "table")]
+        format: OutputFormat,
+    },
     /// Auto-format a policy file in place
     Format {
         /// Policy file to format
@@ -1435,6 +1443,18 @@ mod tests {
                 assert!(matches!(format, OutputFormat::Table));
             }
             _ => panic!("expected Policy Show"),
+        }
+    }
+
+    #[test]
+    fn test_policy_describe() {
+        let cli = parse(&["voom", "policy", "describe", "my.voom", "--format", "json"]);
+        match cli.command {
+            Commands::Policy(PolicyCommands::Describe { file, format }) => {
+                assert_eq!(file, PathBuf::from("my.voom"));
+                assert!(matches!(format, OutputFormat::Json));
+            }
+            _ => panic!("expected Policy Describe"),
         }
     }
 

--- a/crates/voom-cli/src/commands/policy.rs
+++ b/crates/voom-cli/src/commands/policy.rs
@@ -5,6 +5,7 @@ use anyhow::{Context, Result, bail};
 use console::style;
 use serde::Serialize;
 use serde_json::Value;
+use voom_dsl::compiled::{CompiledPhase, CompiledPhaseComposition, PhaseCompositionKind};
 use voom_policy_testing::{
     CapabilityFixture, Fixture, SnapshotOutcome, TestSuite, assert_snapshot_file,
 };
@@ -17,6 +18,7 @@ pub async fn run(cmd: PolicyCommands) -> Result<()> {
         PolicyCommands::List { format } => list(format),
         PolicyCommands::Validate { file, format } => validate(&file, format),
         PolicyCommands::Show { file, format } => show(&file, format),
+        PolicyCommands::Describe { file, format } => describe(&file, format),
         PolicyCommands::Format { file } => format(&file),
         PolicyCommands::Diff {
             a,
@@ -102,7 +104,7 @@ fn list(format: OutputFormat) -> Result<()> {
                 .file_stem()
                 .expect("file has .voom extension so stem exists")
                 .to_string_lossy();
-            match voom_dsl::compile_policy(&std::fs::read_to_string(&path)?) {
+            match voom_dsl::compile_policy_file(&path) {
                 Ok(policy) => {
                     let policy_name = policy.name.clone();
                     let phase_count = policy.phases.len();
@@ -159,10 +161,8 @@ fn validate(file: &std::path::Path, format: OutputFormat) -> Result<()> {
     }
 
     let file = crate::config::resolve_policy_path(file);
-    let source = std::fs::read_to_string(&file)
-        .with_context(|| format!("Failed to read: {}", file.display()))?;
 
-    match voom_dsl::compile_policy(&source) {
+    match voom_dsl::compile_policy_file(&file) {
         Ok(policy) => {
             if matches!(format, OutputFormat::Json) {
                 output::print_json(&serde_json::json!({
@@ -242,10 +242,8 @@ fn validate_policy_map(file: &std::path::Path, format: OutputFormat) -> Result<(
 
 fn show(file: &std::path::Path, format: OutputFormat) -> Result<()> {
     let file = crate::config::resolve_policy_path(file);
-    let source = std::fs::read_to_string(&file)
-        .with_context(|| format!("Failed to read: {}", file.display()))?;
 
-    let compiled = voom_dsl::compile_policy(&source).context("policy compilation failed")?;
+    let compiled = compile_policy_file(&file, "policy")?;
     if matches!(format, OutputFormat::Json) {
         output::print_json(&compiled)?;
         return Ok(());
@@ -302,6 +300,20 @@ fn show(file: &std::path::Path, format: OutputFormat) -> Result<()> {
         serde_json::to_string_pretty(&compiled).unwrap_or_else(|_| "Failed to serialize".into())
     );
 
+    Ok(())
+}
+
+fn describe(file: &std::path::Path, format: OutputFormat) -> Result<()> {
+    let file = crate::config::resolve_policy_path(file);
+    let compiled = compile_policy_file(&file, "policy")?;
+    let output = DescribeOutput::from_policy(&compiled);
+
+    if matches!(format, OutputFormat::Json) {
+        output::print_json(&output)?;
+        return Ok(());
+    }
+
+    print_human_describe(&output, &compiled.metadata.version);
     Ok(())
 }
 
@@ -463,9 +475,7 @@ fn run_test_suite(
     let policy_path = policy_override
         .map(Path::to_path_buf)
         .unwrap_or_else(|| resolve_relative(suite_dir, &suite.policy));
-    let source = std::fs::read_to_string(&policy_path)
-        .with_context(|| format!("failed to read policy {}", policy_path.display()))?;
-    let policy = voom_dsl::compile_policy(&source)
+    let policy = voom_dsl::compile_policy_file(&policy_path)
         .with_context(|| format!("failed to compile policy {}", policy_path.display()))?;
 
     let mut snapshots_updated = 0;
@@ -562,6 +572,127 @@ fn print_human_test_output(output: &TestOutput) {
 }
 
 #[derive(Debug, Serialize)]
+struct DescribeOutput {
+    policy: String,
+    extends_chain: Vec<String>,
+    metadata: DescribeMetadata,
+    phase_order: Vec<String>,
+    phases: Vec<DescribePhase>,
+}
+
+impl DescribeOutput {
+    fn from_policy(policy: &voom_dsl::CompiledPolicy) -> Self {
+        Self {
+            policy: policy.name.clone(),
+            extends_chain: policy.metadata.extends_chain.clone(),
+            metadata: DescribeMetadata::from_metadata(&policy.metadata),
+            phase_order: policy.phase_order.clone(),
+            phases: policy
+                .phases
+                .iter()
+                .map(DescribePhase::from_phase)
+                .collect(),
+        }
+    }
+}
+
+#[derive(Debug, Default, Serialize)]
+struct DescribeMetadata {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    author: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    requires_voom: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    requires_tools: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    test_fixtures: Vec<String>,
+}
+
+impl DescribeMetadata {
+    fn from_metadata(metadata: &voom_dsl::CompiledMetadata) -> Self {
+        Self {
+            version: metadata.version.clone(),
+            author: metadata.author.clone(),
+            description: metadata.description.clone(),
+            requires_voom: metadata.requires_voom.clone(),
+            requires_tools: metadata.requires_tools.clone(),
+            test_fixtures: metadata.test_fixtures.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct DescribePhase {
+    name: String,
+    composition: CompiledPhaseComposition,
+}
+
+impl DescribePhase {
+    fn from_phase(phase: &CompiledPhase) -> Self {
+        Self {
+            name: phase.name.clone(),
+            composition: phase.composition.clone(),
+        }
+    }
+}
+
+fn print_human_describe(output: &DescribeOutput, version: &Option<String>) {
+    println!("Policy: {}", output.policy);
+    println!("Extends: {}", format_extends_chain(&output.extends_chain));
+    if let Some(version) = version {
+        println!("Version: {version}");
+    }
+    println!("Effective phases: {}", output.phase_order.join(", "));
+
+    let width = output
+        .phases
+        .iter()
+        .map(|phase| phase.name.len())
+        .max()
+        .unwrap_or(0);
+    for phase in &output.phases {
+        println!(
+            "  {:width$}  {}",
+            phase.name,
+            format_composition(&phase.composition),
+            width = width,
+        );
+    }
+}
+
+fn format_extends_chain(extends_chain: &[String]) -> String {
+    if extends_chain.is_empty() {
+        "none".to_string()
+    } else {
+        extends_chain.join(" -> ")
+    }
+}
+
+fn format_composition(composition: &CompiledPhaseComposition) -> String {
+    match composition.kind {
+        PhaseCompositionKind::Local => "local".to_string(),
+        PhaseCompositionKind::Inherited => {
+            let source = composition.source.as_deref().unwrap_or("unknown");
+            format!("inherited from {source}")
+        }
+        PhaseCompositionKind::Extended => {
+            let count = composition.added_operations;
+            let operation = if count == 1 {
+                "operation"
+            } else {
+                "operations"
+            };
+            format!("extended ({count} {operation} added)")
+        }
+        PhaseCompositionKind::Overridden => "overridden".to_string(),
+    }
+}
+
+#[derive(Debug, Serialize)]
 struct TestOutput {
     cases: Vec<TestCaseOutput>,
     summary: TestSummary,
@@ -612,9 +743,7 @@ enum TestStatus {
 }
 
 fn compile_policy_file(path: &std::path::Path, label: &str) -> Result<voom_dsl::CompiledPolicy> {
-    let source = std::fs::read_to_string(path)
-        .with_context(|| format!("Failed to read: {}", path.display()))?;
-    voom_dsl::compile_policy(&source).with_context(|| format!("failed to compile {label} policy"))
+    voom_dsl::compile_policy_file(path).with_context(|| format!("failed to compile {label} policy"))
 }
 
 fn fixture_plan_json(

--- a/crates/voom-cli/src/commands/policy.rs
+++ b/crates/voom-cli/src/commands/policy.rs
@@ -5,9 +5,7 @@ use anyhow::{Context, Result, bail};
 use console::style;
 use serde::Serialize;
 use serde_json::Value;
-use voom_dsl::compiled::{
-    CompiledMetadata, CompiledPhase, CompiledPhaseComposition, PhaseCompositionKind,
-};
+use voom_dsl::compiled::{CompiledPhase, CompiledPhaseComposition, PhaseCompositionKind};
 use voom_policy_testing::{
     CapabilityFixture, Fixture, SnapshotOutcome, TestSuite, assert_snapshot_file,
 };
@@ -577,7 +575,7 @@ fn print_human_test_output(output: &TestOutput) {
 struct DescribeOutput {
     policy: String,
     extends_chain: Vec<String>,
-    metadata: CompiledMetadata,
+    metadata: DescribeMetadata,
     phase_order: Vec<String>,
     phases: Vec<DescribePhase>,
 }
@@ -587,9 +585,32 @@ impl DescribeOutput {
         Self {
             policy: policy.name.clone(),
             extends_chain: policy.metadata.extends_chain.clone(),
-            metadata: policy.metadata.clone(),
+            metadata: DescribeMetadata::from_metadata(&policy.metadata),
             phase_order: policy.phase_order.clone(),
             phases: ordered_describe_phases(policy),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct DescribeMetadata {
+    version: Option<String>,
+    author: Option<String>,
+    description: Option<String>,
+    requires_voom: Option<String>,
+    requires_tools: Vec<String>,
+    test_fixtures: Vec<String>,
+}
+
+impl DescribeMetadata {
+    fn from_metadata(metadata: &voom_dsl::compiled::CompiledMetadata) -> Self {
+        Self {
+            version: metadata.version.clone(),
+            author: metadata.author.clone(),
+            description: metadata.description.clone(),
+            requires_voom: metadata.requires_voom.clone(),
+            requires_tools: metadata.requires_tools.clone(),
+            test_fixtures: metadata.test_fixtures.clone(),
         }
     }
 }

--- a/crates/voom-cli/src/commands/policy.rs
+++ b/crates/voom-cli/src/commands/policy.rs
@@ -5,7 +5,9 @@ use anyhow::{Context, Result, bail};
 use console::style;
 use serde::Serialize;
 use serde_json::Value;
-use voom_dsl::compiled::{CompiledPhase, CompiledPhaseComposition, PhaseCompositionKind};
+use voom_dsl::compiled::{
+    CompiledMetadata, CompiledPhase, CompiledPhaseComposition, PhaseCompositionKind,
+};
 use voom_policy_testing::{
     CapabilityFixture, Fixture, SnapshotOutcome, TestSuite, assert_snapshot_file,
 };
@@ -575,7 +577,7 @@ fn print_human_test_output(output: &TestOutput) {
 struct DescribeOutput {
     policy: String,
     extends_chain: Vec<String>,
-    metadata: DescribeMetadata,
+    metadata: CompiledMetadata,
     phase_order: Vec<String>,
     phases: Vec<DescribePhase>,
 }
@@ -585,32 +587,9 @@ impl DescribeOutput {
         Self {
             policy: policy.name.clone(),
             extends_chain: policy.metadata.extends_chain.clone(),
-            metadata: DescribeMetadata::from_metadata(&policy.metadata),
+            metadata: policy.metadata.clone(),
             phase_order: policy.phase_order.clone(),
             phases: ordered_describe_phases(policy),
-        }
-    }
-}
-
-#[derive(Debug, Default, Serialize)]
-struct DescribeMetadata {
-    version: Option<String>,
-    author: Option<String>,
-    description: Option<String>,
-    requires_voom: Option<String>,
-    requires_tools: Vec<String>,
-    test_fixtures: Vec<String>,
-}
-
-impl DescribeMetadata {
-    fn from_metadata(metadata: &voom_dsl::CompiledMetadata) -> Self {
-        Self {
-            version: metadata.version.clone(),
-            author: metadata.author.clone(),
-            description: metadata.description.clone(),
-            requires_voom: metadata.requires_voom.clone(),
-            requires_tools: metadata.requires_tools.clone(),
-            test_fixtures: metadata.test_fixtures.clone(),
         }
     }
 }

--- a/crates/voom-cli/src/commands/policy.rs
+++ b/crates/voom-cli/src/commands/policy.rs
@@ -587,28 +587,18 @@ impl DescribeOutput {
             extends_chain: policy.metadata.extends_chain.clone(),
             metadata: DescribeMetadata::from_metadata(&policy.metadata),
             phase_order: policy.phase_order.clone(),
-            phases: policy
-                .phases
-                .iter()
-                .map(DescribePhase::from_phase)
-                .collect(),
+            phases: ordered_describe_phases(policy),
         }
     }
 }
 
 #[derive(Debug, Default, Serialize)]
 struct DescribeMetadata {
-    #[serde(skip_serializing_if = "Option::is_none")]
     version: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     author: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     description: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     requires_voom: Option<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     requires_tools: Vec<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     test_fixtures: Vec<String>,
 }
 
@@ -640,13 +630,49 @@ impl DescribePhase {
     }
 }
 
-fn print_human_describe(output: &DescribeOutput, version: &Option<String>) {
-    println!("Policy: {}", output.policy);
-    println!("Extends: {}", format_extends_chain(&output.extends_chain));
-    if let Some(version) = version {
-        println!("Version: {version}");
+fn ordered_describe_phases(policy: &voom_dsl::CompiledPolicy) -> Vec<DescribePhase> {
+    let mut phases = Vec::with_capacity(policy.phases.len());
+    let mut used = vec![false; policy.phases.len()];
+
+    for phase_name in &policy.phase_order {
+        if let Some((index, phase)) = policy
+            .phases
+            .iter()
+            .enumerate()
+            .find(|(index, phase)| !used[*index] && phase.name == *phase_name)
+        {
+            phases.push(DescribePhase::from_phase(phase));
+            used[index] = true;
+        }
     }
-    println!("Effective phases: {}", output.phase_order.join(", "));
+
+    for (index, phase) in policy.phases.iter().enumerate() {
+        if !used[index] {
+            phases.push(DescribePhase::from_phase(phase));
+        }
+    }
+
+    phases
+}
+
+fn print_human_describe(output: &DescribeOutput, version: &Option<String>) {
+    print!("{}", render_human_describe(output, version));
+}
+
+fn render_human_describe(output: &DescribeOutput, version: &Option<String>) -> String {
+    let mut rendered = String::new();
+    rendered.push_str(&format!("Policy: {}\n", output.policy));
+    rendered.push_str(&format!(
+        "Extends: {}\n",
+        format_extends_chain(&output.extends_chain)
+    ));
+    if let Some(version) = version {
+        rendered.push_str(&format!("Version: {version}\n"));
+    }
+    rendered.push_str(&format!(
+        "Effective phases: {}\n",
+        output.phase_order.join(", ")
+    ));
 
     let width = output
         .phases
@@ -655,13 +681,14 @@ fn print_human_describe(output: &DescribeOutput, version: &Option<String>) {
         .max()
         .unwrap_or(0);
     for phase in &output.phases {
-        println!(
-            "  {:width$}  {}",
+        rendered.push_str(&format!(
+            "  {:width$}  {}\n",
             phase.name,
             format_composition(&phase.composition),
             width = width,
-        );
+        ));
     }
+    rendered
 }
 
 fn format_extends_chain(extends_chain: &[String]) -> String {
@@ -680,15 +707,19 @@ fn format_composition(composition: &CompiledPhaseComposition) -> String {
             format!("inherited from {source}")
         }
         PhaseCompositionKind::Extended => {
+            let source = composition.source.as_deref().unwrap_or("unknown");
             let count = composition.added_operations;
             let operation = if count == 1 {
                 "operation"
             } else {
                 "operations"
             };
-            format!("extended ({count} {operation} added)")
+            format!("extended from {source} ({count} {operation} added)")
         }
-        PhaseCompositionKind::Overridden => "overridden".to_string(),
+        PhaseCompositionKind::Overridden => {
+            let source = composition.source.as_deref().unwrap_or("unknown");
+            format!("overridden by {source}")
+        }
     }
 }
 
@@ -743,7 +774,8 @@ enum TestStatus {
 }
 
 fn compile_policy_file(path: &std::path::Path, label: &str) -> Result<voom_dsl::CompiledPolicy> {
-    voom_dsl::compile_policy_file(path).with_context(|| format!("failed to compile {label} policy"))
+    voom_dsl::compile_policy_file(path)
+        .with_context(|| format!("failed to compile {label} policy {}", path.display()))
 }
 
 fn fixture_plan_json(
@@ -1110,6 +1142,92 @@ policy "test-policy" {
 
         let result = show(&file, OutputFormat::Table);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn describe_json_includes_stable_fields_and_composition() {
+        let policy = voom_dsl::compile_policy_with_bundled(
+            r#"policy "child" extends "anime-base" {
+                phase audio { extend keep audio where lang == eng }
+                phase subtitles { keep subtitles where lang == eng }
+            }"#,
+        )
+        .unwrap();
+
+        let output = DescribeOutput::from_policy(&policy);
+        let value = serde_json::to_value(output).unwrap();
+
+        assert_eq!(value["policy"], "child");
+        assert_eq!(value["extends_chain"], serde_json::json!(["anime-base"]));
+        assert_eq!(value["phase_order"], serde_json::json!(policy.phase_order));
+        let phase_names: Vec<&str> = value["phases"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|phase| phase["name"].as_str().unwrap())
+            .collect();
+        assert_eq!(phase_names, policy.phase_order);
+        assert!(value["metadata"].get("version").is_some());
+        assert!(value["metadata"].get("author").is_some());
+        assert!(value["metadata"].get("description").is_some());
+        assert!(value["metadata"].get("requires_voom").is_some());
+        assert!(value["metadata"].get("requires_tools").is_some());
+        assert!(value["metadata"].get("test_fixtures").is_some());
+        assert_describe_phase(&value, "containerize", "Inherited", Some("anime-base"), 0);
+        assert_describe_phase(&value, "audio", "Extended", Some("anime-base"), 1);
+        assert_describe_phase(&value, "subtitles", "Overridden", Some("inline"), 0);
+
+        let local_policy =
+            voom_dsl::compile_policy(r#"policy "standalone" { phase local { keep audio } }"#)
+                .unwrap();
+        let local_output = serde_json::to_value(DescribeOutput::from_policy(&local_policy))
+            .expect("describe output serializes");
+        assert_describe_phase(&local_output, "local", "Local", None, 0);
+    }
+
+    #[test]
+    fn describe_human_uses_sources_and_phase_order() {
+        let mut policy = voom_dsl::compile_policy_with_bundled(
+            r#"policy "child" extends "anime-base" {
+                metadata { version: "2.0.0" }
+                phase audio { extend keep audio where lang == eng }
+                phase subtitles { keep subtitles where lang == eng }
+            }"#,
+        )
+        .unwrap();
+        policy.phases.reverse();
+
+        let output = DescribeOutput::from_policy(&policy);
+        let rendered = render_human_describe(&output, &policy.metadata.version);
+
+        let row_order: Vec<&str> = rendered
+            .lines()
+            .filter_map(|line| line.strip_prefix("  "))
+            .map(|line| line.split_whitespace().next().unwrap())
+            .collect();
+        assert_eq!(row_order, policy.phase_order);
+        assert!(rendered.contains("containerize  inherited from anime-base"));
+        assert!(rendered.contains("audio         extended from anime-base (1 operation added)"));
+        assert!(rendered.contains("subtitles     overridden by inline"));
+    }
+
+    fn assert_describe_phase(
+        value: &Value,
+        name: &str,
+        kind: &str,
+        source: Option<&str>,
+        added_operations: usize,
+    ) {
+        let phase = value["phases"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|phase| phase["name"] == name)
+            .unwrap();
+        assert_eq!(phase["name"], name);
+        assert_eq!(phase["composition"]["kind"], kind);
+        assert_eq!(phase["composition"]["source"], serde_json::json!(source));
+        assert_eq!(phase["composition"]["added_operations"], added_operations);
     }
 
     // ── Diff tests ──────────────────────────────────────────

--- a/crates/voom-cli/src/commands/process/mod.rs
+++ b/crates/voom-cli/src/commands/process/mod.rs
@@ -563,9 +563,8 @@ fn build_policy_resolver(
 ) -> Result<PolicyResolver> {
     if let Some(ref policy_path) = args.policy {
         let resolved = crate::config::resolve_policy_path(policy_path);
-        let source = std::fs::read_to_string(&resolved)
-            .with_context(|| format!("Failed to read policy: {}", resolved.display()))?;
-        let compiled = voom_dsl::compile_policy(&source).context("policy compilation failed")?;
+        let compiled = voom_dsl::compile_policy_file(&resolved)
+            .with_context(|| format!("failed to compile policy: {}", resolved.display()))?;
         Ok(PolicyResolver::from_single(compiled, root))
     } else if let Some(ref map_path) = args.policy_map {
         PolicyResolver::from_map_file(map_path, root)

--- a/crates/voom-cli/src/main.rs
+++ b/crates/voom-cli/src/main.rs
@@ -135,6 +135,7 @@ fn command_output_format(command: &Commands) -> Option<OutputFormat> {
         Commands::Policy(PolicyCommands::List { format }) => Some(*format),
         Commands::Policy(PolicyCommands::Validate { format, .. }) => Some(*format),
         Commands::Policy(PolicyCommands::Show { format, .. }) => Some(*format),
+        Commands::Policy(PolicyCommands::Describe { format, .. }) => Some(*format),
         Commands::Policy(PolicyCommands::Diff { format, .. }) => Some(*format),
         Commands::Policy(PolicyCommands::Test { format, .. }) => Some(*format),
         Commands::Plugin(PluginCommands::List { format }) => Some(*format),

--- a/crates/voom-cli/src/policy_map.rs
+++ b/crates/voom-cli/src/policy_map.rs
@@ -180,10 +180,8 @@ impl PolicyResolver {
 
         for policy_path_str in &policy_paths {
             let resolved = resolve_policy_in_context(policy_path_str, base_dir);
-            let source = std::fs::read_to_string(&resolved)
-                .with_context(|| format!("failed to read policy: {}", resolved.display()))?;
-            let compiled =
-                voom_dsl::compile_policy(&source).context("policy compilation failed")?;
+            let compiled = voom_dsl::compile_policy_file(&resolved)
+                .with_context(|| format!("failed to compile policy: {}", resolved.display()))?;
             let idx = policies.len();
             policies.push((policy_path_str.clone(), compiled));
             path_to_index.insert(policy_path_str.clone(), idx);

--- a/crates/voom-cli/tests/cli_tests.rs
+++ b/crates/voom-cli/tests/cli_tests.rs
@@ -434,6 +434,99 @@ fn test_policy_validate_valid_file() {
 }
 
 #[test]
+fn policy_validate_accepts_file_extends() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("base.voom"),
+        r#"policy "base" { phase base { container mkv } }"#,
+    )
+    .unwrap();
+    let child = dir.path().join("child.voom");
+    std::fs::write(
+        &child,
+        r#"policy "child" extends "file://./base.voom" {
+            phase child { depends_on: [base] keep audio }
+        }"#,
+    )
+    .unwrap();
+
+    voom()
+        .args(["policy", "validate", child.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Policy \"child\" is valid"));
+}
+
+#[test]
+fn policy_describe_reports_extended_phase() {
+    let dir = tempfile::tempdir().unwrap();
+    let child = dir.path().join("child.voom");
+    std::fs::write(
+        &child,
+        r#"policy "child" extends "anime-base" {
+            phase audio { extend keep audio where lang == eng }
+        }"#,
+    )
+    .unwrap();
+
+    voom()
+        .args(["policy", "describe", child.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Extends: anime-base"))
+        .stdout(predicate::str::contains("audio"))
+        .stdout(predicate::str::contains("extended"));
+}
+
+#[test]
+fn policy_describe_json_reports_file_parent_composition() {
+    let dir = tempfile::tempdir().unwrap();
+    let base = dir.path().join("base.voom");
+    std::fs::write(
+        &base,
+        r#"policy "base" {
+            phase containerize { container mkv }
+            phase audio { keep audio where lang == eng }
+            phase subtitles { keep subtitles where lang == und }
+        }"#,
+    )
+    .unwrap();
+    let child = dir.path().join("child.voom");
+    std::fs::write(
+        &child,
+        r#"policy "child" extends "file://./base.voom" {
+            phase audio { extend keep audio where lang == und }
+            phase subtitles { keep subtitles where lang == eng }
+        }"#,
+    )
+    .unwrap();
+
+    let output = voom()
+        .args([
+            "policy",
+            "describe",
+            child.to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|error| panic!("stdout was not valid JSON: {error}\nstdout:\n{stdout}"));
+    let parent = std::fs::canonicalize(&base).unwrap().display().to_string();
+    let child_source = std::fs::canonicalize(&child).unwrap().display().to_string();
+
+    assert_eq!(json["policy"], "child");
+    assert_eq!(json["extends_chain"], serde_json::json!([parent]));
+    assert_describe_phase_composition(&json, "containerize", "Inherited", Some(&parent), 0);
+    assert_describe_phase_composition(&json, "audio", "Extended", Some(&parent), 1);
+    assert_describe_phase_composition(&json, "subtitles", "Overridden", Some(&child_source), 0);
+}
+
+#[test]
 fn test_policy_validate_invalid_file() {
     let tmp = tempfile::NamedTempFile::new().unwrap();
     std::fs::write(tmp.path(), "this is not valid voom syntax").unwrap();
@@ -451,6 +544,25 @@ fn test_policy_validate_missing_file() {
         .args(["policy", "validate", "/nonexistent/policy.voom"])
         .assert()
         .failure();
+}
+
+fn assert_describe_phase_composition(
+    value: &Value,
+    name: &str,
+    kind: &str,
+    source: Option<&str>,
+    added_operations: usize,
+) {
+    let phase = value["phases"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|phase| phase["name"] == name)
+        .unwrap_or_else(|| panic!("missing describe phase {name:?}: {value}"));
+
+    assert_eq!(phase["composition"]["kind"], kind);
+    assert_eq!(phase["composition"]["source"], serde_json::json!(source));
+    assert_eq!(phase["composition"]["added_operations"], added_operations);
 }
 
 #[test]

--- a/crates/voom-cli/tests/cli_tests.rs
+++ b/crates/voom-cli/tests/cli_tests.rs
@@ -474,8 +474,7 @@ fn policy_describe_reports_extended_phase() {
         .assert()
         .success()
         .stdout(predicate::str::contains("Extends: anime-base"))
-        .stdout(predicate::str::contains("audio"))
-        .stdout(predicate::str::contains("extended"));
+        .stdout(predicate::str::contains("extended from anime-base"));
 }
 
 #[test]
@@ -501,21 +500,8 @@ fn policy_describe_json_reports_file_parent_composition() {
     )
     .unwrap();
 
-    let output = voom()
-        .args([
-            "policy",
-            "describe",
-            child.to_str().unwrap(),
-            "--format",
-            "json",
-        ])
-        .assert()
-        .success()
-        .get_output()
-        .clone();
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let json: Value = serde_json::from_str(&stdout)
-        .unwrap_or_else(|error| panic!("stdout was not valid JSON: {error}\nstdout:\n{stdout}"));
+    let child_arg = child.to_str().unwrap();
+    let json = assert_stdout_is_json(&["policy", "describe", child_arg, "--format", "json"]);
     let parent = std::fs::canonicalize(&base).unwrap().display().to_string();
     let child_source = std::fs::canonicalize(&child).unwrap().display().to_string();
 
@@ -555,7 +541,7 @@ fn assert_describe_phase_composition(
 ) {
     let phase = value["phases"]
         .as_array()
-        .unwrap()
+        .unwrap_or_else(|| panic!("describe output missing phases array: {value}"))
         .iter()
         .find(|phase| phase["name"] == name)
         .unwrap_or_else(|| panic!("missing describe phase {name:?}: {value}"));

--- a/crates/voom-cli/tests/cli_tests.rs
+++ b/crates/voom-cli/tests/cli_tests.rs
@@ -507,6 +507,10 @@ fn policy_describe_json_reports_file_parent_composition() {
 
     assert_eq!(json["policy"], "child");
     assert_eq!(json["extends_chain"], serde_json::json!([parent]));
+    assert_eq!(
+        json["metadata"]["extends_chain"],
+        serde_json::json!([parent])
+    );
     assert_describe_phase_composition(&json, "containerize", "Inherited", Some(&parent), 0);
     assert_describe_phase_composition(&json, "audio", "Extended", Some(&parent), 1);
     assert_describe_phase_composition(&json, "subtitles", "Overridden", Some(&child_source), 0);

--- a/crates/voom-cli/tests/cli_tests.rs
+++ b/crates/voom-cli/tests/cli_tests.rs
@@ -507,10 +507,7 @@ fn policy_describe_json_reports_file_parent_composition() {
 
     assert_eq!(json["policy"], "child");
     assert_eq!(json["extends_chain"], serde_json::json!([parent]));
-    assert_eq!(
-        json["metadata"]["extends_chain"],
-        serde_json::json!([parent])
-    );
+    assert!(json["metadata"].get("extends_chain").is_none());
     assert_describe_phase_composition(&json, "containerize", "Inherited", Some(&parent), 0);
     assert_describe_phase_composition(&json, "audio", "Extended", Some(&parent), 1);
     assert_describe_phase_composition(&json, "subtitles", "Overridden", Some(&child_source), 0);

--- a/crates/voom-dsl/Cargo.toml
+++ b/crates/voom-dsl/Cargo.toml
@@ -35,4 +35,5 @@ workspace = true
 insta = { workspace = true }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
+tempfile = { workspace = true }
 voom-dsl = { path = ".", features = ["proptest"] }

--- a/crates/voom-dsl/src/ast.rs
+++ b/crates/voom-dsl/src/ast.rs
@@ -56,8 +56,8 @@ pub struct MetadataNode {
     pub author: Option<String>,
     pub description: Option<String>,
     pub requires_voom: Option<String>,
-    pub requires_tools: Vec<String>,
-    pub test_fixtures: Vec<String>,
+    pub requires_tools: Option<Vec<String>>,
+    pub test_fixtures: Option<Vec<String>>,
     pub span: Span,
 }
 

--- a/crates/voom-dsl/src/ast.rs
+++ b/crates/voom-dsl/src/ast.rs
@@ -80,7 +80,7 @@ pub struct PhaseNode {
     pub name: String,
     pub extend: bool,
     pub skip_when: Option<ConditionNode>,
-    pub depends_on: Vec<String>,
+    pub depends_on: Option<Vec<String>>,
     pub run_if: Option<RunIfNode>,
     pub on_error: Option<ErrorStrategyNode>,
     pub operations: Vec<SpannedOperation>,

--- a/crates/voom-dsl/src/ast.rs
+++ b/crates/voom-dsl/src/ast.rs
@@ -33,8 +33,31 @@ impl Span {
 #[derive(Debug, Clone, Serialize)]
 pub struct PolicyAst {
     pub name: String,
+    pub extends: Option<ExtendsSource>,
+    pub metadata: Option<MetadataNode>,
     pub config: Option<ConfigNode>,
     pub phases: Vec<PhaseNode>,
+    pub span: Span,
+}
+
+/// Source of a parent policy extended by this policy.
+#[non_exhaustive]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub enum ExtendsSource {
+    Bundled(String),
+    File(String),
+}
+
+/// Policy metadata block.
+#[non_exhaustive]
+#[derive(Debug, Clone, Serialize)]
+pub struct MetadataNode {
+    pub version: Option<String>,
+    pub author: Option<String>,
+    pub description: Option<String>,
+    pub requires_voom: Option<String>,
+    pub requires_tools: Vec<String>,
+    pub test_fixtures: Vec<String>,
     pub span: Span,
 }
 
@@ -55,6 +78,7 @@ pub struct ConfigNode {
 #[derive(Debug, Clone, Serialize)]
 pub struct PhaseNode {
     pub name: String,
+    pub extend: bool,
     pub skip_when: Option<ConditionNode>,
     pub depends_on: Vec<String>,
     pub run_if: Option<RunIfNode>,

--- a/crates/voom-dsl/src/bundled.rs
+++ b/crates/voom-dsl/src/bundled.rs
@@ -1,24 +1,27 @@
+const BUNDLED_POLICIES: [(&str, &str); 5] = [
+    ("archival", include_str!("bundled/archival.voom")),
+    ("space-saver", include_str!("bundled/space-saver.voom")),
+    (
+        "mobile-friendly",
+        include_str!("bundled/mobile-friendly.voom"),
+    ),
+    ("anime-base", include_str!("bundled/anime-base.voom")),
+    (
+        "passthrough-audit",
+        include_str!("bundled/passthrough-audit.voom"),
+    ),
+];
+
 /// Return the stable names of policies bundled into the DSL crate.
 pub fn bundled_policy_names() -> [&'static str; 5] {
-    [
-        "archival",
-        "space-saver",
-        "mobile-friendly",
-        "anime-base",
-        "passthrough-audit",
-    ]
+    BUNDLED_POLICIES.map(|(name, _source)| name)
 }
 
 /// Return the source text for a bundled policy by name.
 pub fn bundled_policy(name: &str) -> Option<&'static str> {
-    match name {
-        "archival" => Some(include_str!("bundled/archival.voom")),
-        "space-saver" => Some(include_str!("bundled/space-saver.voom")),
-        "mobile-friendly" => Some(include_str!("bundled/mobile-friendly.voom")),
-        "anime-base" => Some(include_str!("bundled/anime-base.voom")),
-        "passthrough-audit" => Some(include_str!("bundled/passthrough-audit.voom")),
-        _ => None,
-    }
+    BUNDLED_POLICIES
+        .iter()
+        .find_map(|(policy_name, source)| (*policy_name == name).then_some(*source))
 }
 
 #[cfg(test)]

--- a/crates/voom-dsl/src/bundled.rs
+++ b/crates/voom-dsl/src/bundled.rs
@@ -23,7 +23,7 @@ pub fn bundled_policy(name: &str) -> Option<&'static str> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{bundled_policy, bundled_policy_names, parse_policy};
+    use crate::{bundled_policy, bundled_policy_names, parse_policy, validate};
 
     #[test]
     fn exposes_expected_bundled_policy_names() {
@@ -45,6 +45,7 @@ mod tests {
             let source = bundled_policy(name).expect("bundled policy exists");
             let ast = parse_policy(source).expect(name);
             assert_eq!(ast.name, name);
+            validate(&ast).expect(name);
             assert!(ast.extends.is_none());
         }
     }

--- a/crates/voom-dsl/src/bundled.rs
+++ b/crates/voom-dsl/src/bundled.rs
@@ -1,0 +1,56 @@
+/// Return the stable names of policies bundled into the DSL crate.
+pub fn bundled_policy_names() -> [&'static str; 5] {
+    [
+        "archival",
+        "space-saver",
+        "mobile-friendly",
+        "anime-base",
+        "passthrough-audit",
+    ]
+}
+
+/// Return the source text for a bundled policy by name.
+pub fn bundled_policy(name: &str) -> Option<&'static str> {
+    match name {
+        "archival" => Some(include_str!("bundled/archival.voom")),
+        "space-saver" => Some(include_str!("bundled/space-saver.voom")),
+        "mobile-friendly" => Some(include_str!("bundled/mobile-friendly.voom")),
+        "anime-base" => Some(include_str!("bundled/anime-base.voom")),
+        "passthrough-audit" => Some(include_str!("bundled/passthrough-audit.voom")),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{bundled_policy, bundled_policy_names, parse_policy};
+
+    #[test]
+    fn exposes_expected_bundled_policy_names() {
+        assert_eq!(
+            bundled_policy_names(),
+            [
+                "archival",
+                "space-saver",
+                "mobile-friendly",
+                "anime-base",
+                "passthrough-audit"
+            ]
+        );
+    }
+
+    #[test]
+    fn bundled_policies_parse() {
+        for name in bundled_policy_names() {
+            let source = bundled_policy(name).expect("bundled policy exists");
+            let ast = parse_policy(source).expect(name);
+            assert_eq!(ast.name, name);
+            assert!(ast.extends.is_none());
+        }
+    }
+
+    #[test]
+    fn unknown_bundled_policy_returns_none() {
+        assert!(bundled_policy("registry://anime-base").is_none());
+    }
+}

--- a/crates/voom-dsl/src/bundled/anime-base.voom
+++ b/crates/voom-dsl/src/bundled/anime-base.voom
@@ -1,0 +1,30 @@
+policy "anime-base" {
+  metadata {
+    version: "1.0.0"
+    description: "Base anime policy with multi-language audio and subtitle handling"
+    requires_tools: [ffmpeg, mkvmerge, mkvextract]
+  }
+
+  config {
+    languages audio: [jpn, eng, und]
+    languages subtitle: [eng, jpn]
+  }
+
+  phase containerize {
+    container mkv
+  }
+
+  phase audio {
+    depends_on: [containerize]
+    keep audio where lang in [jpn, eng, und]
+    defaults {
+      audio: first_per_language
+    }
+  }
+
+  phase subtitles {
+    depends_on: [audio]
+    keep subtitles where lang in [eng, jpn] and not commentary
+    remove attachments where not font
+  }
+}

--- a/crates/voom-dsl/src/bundled/archival.voom
+++ b/crates/voom-dsl/src/bundled/archival.voom
@@ -1,0 +1,30 @@
+policy "archival" {
+  metadata {
+    version: "1.0.0"
+    description: "Conservative archival policy that preserves common languages and fonts"
+    requires_tools: [ffmpeg, mkvmerge, mkvextract]
+  }
+
+  config {
+    languages audio: [eng, jpn, fre, ger, spa, und]
+    languages subtitle: [eng, jpn, fre, ger, spa, und]
+    on_error: abort
+    keep_backups: true
+  }
+
+  phase containerize {
+    container mkv
+  }
+
+  phase preserve-tracks {
+    depends_on: [containerize]
+    keep audio where lang in [eng, jpn, fre, ger, spa, und]
+    keep subtitles where lang in [eng, jpn, fre, ger, spa, und]
+    remove attachments where not font
+  }
+
+  phase validate {
+    depends_on: [preserve-tracks]
+    verify quick
+  }
+}

--- a/crates/voom-dsl/src/bundled/mobile-friendly.voom
+++ b/crates/voom-dsl/src/bundled/mobile-friendly.voom
@@ -1,0 +1,31 @@
+policy "mobile-friendly" {
+  metadata {
+    version: "1.0.0"
+    description: "Mobile playback policy with MP4 container and normalized audio"
+    requires_tools: [ffmpeg]
+  }
+
+  config {
+    languages audio: [eng, und]
+    languages subtitle: [eng]
+  }
+
+  phase containerize {
+    container mp4
+  }
+
+  phase audio {
+    depends_on: [containerize]
+    keep audio where lang in [eng, und] and not commentary {
+      normalize: mobile
+    }
+    defaults {
+      audio: first
+    }
+  }
+
+  phase subtitles {
+    depends_on: [audio]
+    keep subtitles where lang == eng and not commentary
+  }
+}

--- a/crates/voom-dsl/src/bundled/passthrough-audit.voom
+++ b/crates/voom-dsl/src/bundled/passthrough-audit.voom
@@ -1,0 +1,21 @@
+policy "passthrough-audit" {
+  metadata {
+    version: "1.0.0"
+    description: "Audit-only policy that verifies media without changing tracks"
+    requires_tools: [ffmpeg, mkvmerge]
+  }
+
+  phase identify {
+    verify quick
+  }
+
+  phase inspect-tracks {
+    depends_on: [identify]
+    when count(video) == 0 {
+      warn "No video track found"
+    }
+    when count(audio) == 0 {
+      warn "No audio track found"
+    }
+  }
+}

--- a/crates/voom-dsl/src/bundled/space-saver.voom
+++ b/crates/voom-dsl/src/bundled/space-saver.voom
@@ -1,0 +1,31 @@
+policy "space-saver" {
+  metadata {
+    version: "1.0.0"
+    description: "Compact policy that keeps primary tracks and removes non-font attachments"
+    requires_tools: [ffmpeg, mkvmerge]
+  }
+
+  config {
+    languages audio: [eng, und]
+    languages subtitle: [eng, und]
+  }
+
+  phase containerize {
+    container mkv
+  }
+
+  phase prune-tracks {
+    depends_on: [containerize]
+    keep audio where lang in [eng, und] and not commentary
+    keep subtitles where lang in [eng, und] and not commentary
+    remove attachments where not font
+  }
+
+  phase defaults {
+    depends_on: [prune-tracks]
+    defaults {
+      audio: first
+      subtitle: none
+    }
+  }
+}

--- a/crates/voom-dsl/src/compiled.rs
+++ b/crates/voom-dsl/src/compiled.rs
@@ -179,7 +179,7 @@ pub struct CompiledPhase {
 #[non_exhaustive]
 pub struct CompiledPhaseComposition {
     pub kind: PhaseCompositionKind,
-    /// The policy source that supplied the inherited parent phase.
+    /// The policy source associated with this composed phase.
     ///
     /// `Inherited` and `Extended` point at the parent policy source. `Overridden`
     /// points at the source that replaced the parent phase. `Local` has no source.

--- a/crates/voom-dsl/src/compiled.rs
+++ b/crates/voom-dsl/src/compiled.rs
@@ -75,6 +75,7 @@ impl<'de> Deserialize<'de> for CompiledRegex {
 #[non_exhaustive]
 pub struct CompiledPolicy {
     pub name: String,
+    pub metadata: CompiledMetadata,
     pub config: CompiledConfig,
     pub phases: Vec<CompiledPhase>,
     /// Topologically sorted phase execution order.
@@ -88,6 +89,7 @@ impl CompiledPolicy {
     #[must_use]
     pub fn new(
         name: String,
+        metadata: CompiledMetadata,
         config: CompiledConfig,
         phases: Vec<CompiledPhase>,
         phase_order: Vec<String>,
@@ -95,12 +97,26 @@ impl CompiledPolicy {
     ) -> Self {
         Self {
             name,
+            metadata,
             config,
             phases,
             phase_order,
             source_hash,
         }
     }
+}
+
+/// Compiled policy metadata and policy composition summary.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct CompiledMetadata {
+    pub version: Option<String>,
+    pub author: Option<String>,
+    pub description: Option<String>,
+    pub requires_voom: Option<String>,
+    pub requires_tools: Vec<String>,
+    pub test_fixtures: Vec<String>,
+    pub extends_chain: Vec<String>,
 }
 
 /// Compiled configuration block.
@@ -152,7 +168,26 @@ pub struct CompiledPhase {
     pub skip_when: Option<CompiledCondition>,
     pub run_if: Option<CompiledRunIf>,
     pub on_error: ErrorStrategy,
+    pub composition: CompiledPhaseComposition,
     pub operations: Vec<CompiledOperation>,
+}
+
+/// Compiled phase provenance for policy composition.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct CompiledPhaseComposition {
+    pub kind: PhaseCompositionKind,
+    pub source: Option<String>,
+    pub added_operations: usize,
+}
+
+/// How a compiled phase was produced during policy composition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PhaseCompositionKind {
+    Local,
+    Inherited,
+    Extended,
+    Overridden,
 }
 
 /// Compiled `run_if` trigger.

--- a/crates/voom-dsl/src/compiled.rs
+++ b/crates/voom-dsl/src/compiled.rs
@@ -75,6 +75,7 @@ impl<'de> Deserialize<'de> for CompiledRegex {
 #[non_exhaustive]
 pub struct CompiledPolicy {
     pub name: String,
+    #[serde(default)]
     pub metadata: CompiledMetadata,
     pub config: CompiledConfig,
     pub phases: Vec<CompiledPhase>,
@@ -168,6 +169,7 @@ pub struct CompiledPhase {
     pub skip_when: Option<CompiledCondition>,
     pub run_if: Option<CompiledRunIf>,
     pub on_error: ErrorStrategy,
+    #[serde(default)]
     pub composition: CompiledPhaseComposition,
     pub operations: Vec<CompiledOperation>,
 }
@@ -177,8 +179,25 @@ pub struct CompiledPhase {
 #[non_exhaustive]
 pub struct CompiledPhaseComposition {
     pub kind: PhaseCompositionKind,
+    /// The policy source that supplied the inherited parent phase.
+    ///
+    /// `Inherited` and `Extended` point at the parent policy source. `Overridden`
+    /// points at the source that replaced the parent phase. `Local` has no source.
     pub source: Option<String>,
+    /// Number of child operations appended to an inherited phase during `extend`.
+    ///
+    /// This is non-zero only for `Extended` phases.
     pub added_operations: usize,
+}
+
+impl Default for CompiledPhaseComposition {
+    fn default() -> Self {
+        Self {
+            kind: PhaseCompositionKind::Local,
+            source: None,
+            added_operations: 0,
+        }
+    }
 }
 
 /// How a compiled phase was produced during policy composition.

--- a/crates/voom-dsl/src/compiler.rs
+++ b/crates/voom-dsl/src/compiler.rs
@@ -11,20 +11,22 @@ use std::collections::{HashMap, HashSet};
 
 use crate::compiled::{
     ClearActionsSettings, CompiledAction, CompiledCompareOp, CompiledCondition,
-    CompiledConditional, CompiledConfig, CompiledDefault, CompiledFilter, CompiledOperation,
-    CompiledPhase, CompiledPolicy, CompiledRegex, CompiledRule, CompiledRunIf, CompiledSynthesize,
-    CompiledTranscodeSettings, CompiledValueOrField, DefaultStrategy, ErrorStrategy,
-    LoudnessNormalization, LoudnessPreset, RulesMode, RunIfTrigger, SynthLanguage, SynthPosition,
-    TrackTarget, TranscodeChannels,
+    CompiledConditional, CompiledConfig, CompiledDefault, CompiledFilter, CompiledMetadata,
+    CompiledOperation, CompiledPhase, CompiledPhaseComposition, CompiledPolicy, CompiledRegex,
+    CompiledRule, CompiledRunIf, CompiledSynthesize, CompiledTranscodeSettings,
+    CompiledValueOrField, DefaultStrategy, ErrorStrategy, LoudnessNormalization, LoudnessPreset,
+    PhaseCompositionKind, RulesMode, RunIfTrigger, SynthLanguage, SynthPosition, TrackTarget,
+    TranscodeChannels,
 };
 use voom_domain::plan::{CropSettings, SampleStrategy, TranscodeFallback};
 use voom_domain::utils::codecs;
 
 use crate::ast::{
-    ActionNode, CompareOp, ConditionNode, ConfigNode, ErrorStrategyNode, FilterNode,
+    ActionNode, CompareOp, ConditionNode, ConfigNode, ErrorStrategyNode, FilterNode, MetadataNode,
     NormalizeSetting, OperationNode, PhaseNode, PolicyAst, RunIfTriggerNode, SynthSetting, Value,
     ValueOrField, VerifyMode, WhenNode,
 };
+use crate::composition::{PhaseComposition, ResolvedPolicyAst};
 use crate::errors::DslError;
 
 /// Safely convert an f64 to u32, returning None for negative, fractional, or out-of-range values.
@@ -40,21 +42,64 @@ fn safe_u32(n: f64) -> Option<u32> {
 
 /// Compile a pre-parsed and validated AST into a [`CompiledPolicy`].
 pub(crate) fn compile_ast(ast: &PolicyAst) -> std::result::Result<CompiledPolicy, DslError> {
+    compile_ast_with_composition(ast, Vec::new(), &HashMap::new())
+}
+
+/// Compile a composition-resolved AST into a [`CompiledPolicy`].
+pub(crate) fn compile_resolved_ast(
+    resolved: &ResolvedPolicyAst,
+) -> std::result::Result<CompiledPolicy, DslError> {
+    compile_ast_with_composition(
+        &resolved.ast,
+        resolved.extends_chain.clone(),
+        &resolved.phase_sources,
+    )
+}
+
+fn compile_ast_with_composition(
+    ast: &PolicyAst,
+    extends_chain: Vec<String>,
+    phase_sources: &HashMap<String, PhaseComposition>,
+) -> std::result::Result<CompiledPolicy, DslError> {
+    let metadata = compile_metadata(ast.metadata.as_ref(), extends_chain);
     let config = compile_config(ast.config.as_ref());
     let phases: Vec<CompiledPhase> = ast
         .phases
         .iter()
-        .map(compile_phase)
+        .map(|phase| compile_phase(phase, phase_sources.get(&phase.name)))
         .collect::<std::result::Result<_, _>>()?;
     let phase_order = topological_sort(ast)?;
 
     Ok(CompiledPolicy::new(
         ast.name.clone(),
+        metadata,
         config,
         phases,
         phase_order,
         String::new(),
     ))
+}
+
+fn compile_metadata(
+    metadata: Option<&MetadataNode>,
+    extends_chain: Vec<String>,
+) -> CompiledMetadata {
+    let Some(metadata) = metadata else {
+        return CompiledMetadata {
+            extends_chain,
+            ..CompiledMetadata::default()
+        };
+    };
+
+    CompiledMetadata {
+        version: metadata.version.clone(),
+        author: metadata.author.clone(),
+        description: metadata.description.clone(),
+        requires_voom: metadata.requires_voom.clone(),
+        requires_tools: metadata.requires_tools.clone().unwrap_or_default(),
+        test_fixtures: metadata.test_fixtures.clone().unwrap_or_default(),
+        extends_chain,
+    }
 }
 
 fn compile_config(config: Option<&ConfigNode>) -> CompiledConfig {
@@ -97,7 +142,10 @@ pub(crate) fn parse_default_strategy(value: &str) -> Option<DefaultStrategy> {
     }
 }
 
-fn compile_phase(phase: &PhaseNode) -> std::result::Result<CompiledPhase, DslError> {
+fn compile_phase(
+    phase: &PhaseNode,
+    composition: Option<&PhaseComposition>,
+) -> std::result::Result<CompiledPhase, DslError> {
     if phase.extend {
         return Err(DslError::compile(format!(
             "phase \"{}\" uses extend but policy composition was not resolved",
@@ -131,8 +179,37 @@ fn compile_phase(phase: &PhaseNode) -> std::result::Result<CompiledPhase, DslErr
             .on_error
             .map(compile_error_strategy)
             .unwrap_or(ErrorStrategy::Abort),
+        composition: compile_phase_composition(composition),
         operations,
     })
+}
+
+fn compile_phase_composition(composition: Option<&PhaseComposition>) -> CompiledPhaseComposition {
+    match composition {
+        None | Some(PhaseComposition::Local) => CompiledPhaseComposition {
+            kind: PhaseCompositionKind::Local,
+            source: None,
+            added_operations: 0,
+        },
+        Some(PhaseComposition::Inherited { source }) => CompiledPhaseComposition {
+            kind: PhaseCompositionKind::Inherited,
+            source: Some(source.clone()),
+            added_operations: 0,
+        },
+        Some(PhaseComposition::Extended {
+            source,
+            added_operations,
+        }) => CompiledPhaseComposition {
+            kind: PhaseCompositionKind::Extended,
+            source: Some(source.clone()),
+            added_operations: *added_operations,
+        },
+        Some(PhaseComposition::Overridden { source }) => CompiledPhaseComposition {
+            kind: PhaseCompositionKind::Overridden,
+            source: Some(source.clone()),
+            added_operations: 0,
+        },
+    }
 }
 
 fn compile_error_strategy(strategy: ErrorStrategyNode) -> ErrorStrategy {

--- a/crates/voom-dsl/src/compiler.rs
+++ b/crates/voom-dsl/src/compiler.rs
@@ -124,7 +124,7 @@ fn compile_phase(phase: &PhaseNode) -> std::result::Result<CompiledPhase, DslErr
 
     Ok(CompiledPhase {
         name: phase.name.clone(),
-        depends_on: phase.depends_on.clone(),
+        depends_on: phase.depends_on.clone().unwrap_or_default(),
         skip_when,
         run_if,
         on_error: phase
@@ -799,7 +799,7 @@ fn topological_sort(ast: &PolicyAst) -> std::result::Result<Vec<String>, DslErro
     for phase in &ast.phases {
         adj.entry(phase.name.as_str()).or_default();
         in_degree.entry(phase.name.as_str()).or_insert(0);
-        for dep in &phase.depends_on {
+        for dep in phase.depends_on.as_deref().unwrap_or(&[]) {
             adj.entry(dep.as_str())
                 .or_default()
                 .push(phase.name.as_str());
@@ -838,6 +838,8 @@ fn topological_sort(ast: &PolicyAst) -> std::result::Result<Vec<String>, DslErro
         let has_unknown_dep = stuck.iter().any(|&name| {
             ast.phases.iter().find(|p| p.name == name).is_some_and(|p| {
                 p.depends_on
+                    .as_deref()
+                    .unwrap_or(&[])
                     .iter()
                     .any(|d| !phase_names.contains(d.as_str()))
             })

--- a/crates/voom-dsl/src/compiler.rs
+++ b/crates/voom-dsl/src/compiler.rs
@@ -98,6 +98,13 @@ pub(crate) fn parse_default_strategy(value: &str) -> Option<DefaultStrategy> {
 }
 
 fn compile_phase(phase: &PhaseNode) -> std::result::Result<CompiledPhase, DslError> {
+    if phase.extend {
+        return Err(DslError::compile(format!(
+            "phase \"{}\" uses extend but policy composition was not resolved",
+            phase.name
+        )));
+    }
+
     let skip_when = phase
         .skip_when
         .as_ref()

--- a/crates/voom-dsl/src/composition.rs
+++ b/crates/voom-dsl/src/composition.rs
@@ -1,0 +1,334 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use crate::ast::{ExtendsSource, MetadataNode, PhaseNode, PolicyAst};
+use crate::bundled_policy;
+use crate::errors::{DslError, DslPipelineError};
+use crate::parse_policy;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum PolicySourceId {
+    Inline,
+    Bundled(String),
+    File(PathBuf),
+}
+
+#[derive(Debug, Clone)]
+pub struct ResolvedPolicyAst {
+    pub ast: PolicyAst,
+    pub source_id: PolicySourceId,
+    pub extends_chain: Vec<String>,
+    pub phase_sources: HashMap<String, PhaseComposition>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum PhaseComposition {
+    Local,
+    Inherited {
+        source: String,
+    },
+    Extended {
+        source: String,
+        added_operations: usize,
+    },
+    Overridden {
+        source: String,
+    },
+}
+
+pub(crate) fn resolve_policy_file(path: &Path) -> Result<ResolvedPolicyAst, DslPipelineError> {
+    let canonical = canonicalize_existing_path(path)?;
+    let mut stack = Vec::new();
+    resolve_file_path(&canonical, &mut stack)
+}
+
+pub(crate) fn resolve_policy_with_bundled(
+    source: &str,
+) -> Result<ResolvedPolicyAst, DslPipelineError> {
+    let ast = parse_policy(source).map_err(DslPipelineError::Parse)?;
+    resolve_ast(ast, PolicySourceId::Inline, None, &mut Vec::new())
+}
+
+fn resolve_file_path(
+    path: &Path,
+    stack: &mut Vec<PolicySourceId>,
+) -> Result<ResolvedPolicyAst, DslPipelineError> {
+    let source_id = PolicySourceId::File(path.to_path_buf());
+    push_source(source_id.clone(), stack)?;
+    let source = std::fs::read_to_string(path).map_err(|err| {
+        DslPipelineError::Compile(DslError::compile(format!(
+            "failed to read policy file {}: {err}",
+            path.display()
+        )))
+    })?;
+    let ast = parse_policy(&source).map_err(DslPipelineError::Parse)?;
+    let base_dir = path.parent().map(Path::to_path_buf);
+    let resolved = resolve_ast(ast, source_id, base_dir.as_deref(), stack);
+    stack.pop();
+    resolved
+}
+
+fn resolve_bundled_policy(
+    name: &str,
+    stack: &mut Vec<PolicySourceId>,
+) -> Result<ResolvedPolicyAst, DslPipelineError> {
+    let source_id = PolicySourceId::Bundled(name.to_owned());
+    push_source(source_id.clone(), stack)?;
+    let source = bundled_policy(name).ok_or_else(|| {
+        DslPipelineError::Compile(DslError::compile(format!(
+            "unknown bundled policy \"{name}\""
+        )))
+    })?;
+    let ast = parse_policy(source).map_err(DslPipelineError::Parse)?;
+    let resolved = resolve_ast(ast, source_id, None, stack);
+    stack.pop();
+    resolved
+}
+
+fn resolve_ast(
+    mut ast: PolicyAst,
+    source_id: PolicySourceId,
+    base_dir: Option<&Path>,
+    stack: &mut Vec<PolicySourceId>,
+) -> Result<ResolvedPolicyAst, DslPipelineError> {
+    let Some(extends) = ast.extends.take() else {
+        return Ok(ResolvedPolicyAst {
+            ast,
+            source_id,
+            extends_chain: Vec::new(),
+            phase_sources: HashMap::new(),
+        });
+    };
+
+    let parent = match extends {
+        ExtendsSource::Bundled(name) => {
+            if name.contains("://") {
+                return Err(DslPipelineError::Compile(DslError::compile(format!(
+                    "unsupported policy extends URI \"{name}\"; only file:// URIs and bundled policy names are supported"
+                ))));
+            }
+            resolve_bundled_policy(&name, stack)?
+        }
+        ExtendsSource::File(uri) => {
+            let path = resolve_file_uri(&uri, base_dir)?;
+            resolve_file_path(&path, stack)?
+        }
+    };
+
+    merge_policy(parent, ast, source_id)
+}
+
+fn merge_policy(
+    parent: ResolvedPolicyAst,
+    mut child: PolicyAst,
+    source_id: PolicySourceId,
+) -> Result<ResolvedPolicyAst, DslPipelineError> {
+    let child_source = source_label(&source_id);
+    child.extends = None;
+    let parent_ast = parent.ast;
+    let parent_name = parent_ast.name.clone();
+    let parent_phase_sources = parent.phase_sources;
+    let mut child_phases = child.phases;
+    let mut consumed_child_phases = vec![false; child_phases.len()];
+
+    let mut phase_sources = HashMap::new();
+    let mut phases = Vec::new();
+
+    for parent_phase in parent_ast.phases {
+        let parent_phase_name = parent_phase.name.clone();
+        let parent_source = parent_phase_sources
+            .get(&parent_phase_name)
+            .map(phase_source_label)
+            .unwrap_or_else(|| parent_name.clone());
+
+        let child_phase_index = child_phases
+            .iter()
+            .enumerate()
+            .find(|(index, phase)| {
+                !consumed_child_phases[*index] && phase.name == parent_phase_name
+            })
+            .map(|(index, _phase)| index);
+
+        if let Some(index) = child_phase_index {
+            consumed_child_phases[index] = true;
+            let child_phase = child_phases[index].clone();
+            if child_phase.extend {
+                let added_operations = child_phase.operations.len();
+                phases.push(extend_phase(parent_phase, child_phase));
+                phase_sources.insert(
+                    parent_phase_name,
+                    PhaseComposition::Extended {
+                        source: parent_source,
+                        added_operations,
+                    },
+                );
+            } else {
+                phases.push(clear_extend(child_phase));
+                phase_sources.insert(
+                    parent_phase_name,
+                    PhaseComposition::Overridden {
+                        source: child_source.clone(),
+                    },
+                );
+            }
+        } else {
+            phases.push(clear_extend(parent_phase));
+            phase_sources.insert(
+                parent_phase_name,
+                PhaseComposition::Inherited {
+                    source: parent_source,
+                },
+            );
+        }
+    }
+
+    for (index, phase) in child_phases.drain(..).enumerate() {
+        if consumed_child_phases[index] {
+            continue;
+        }
+        let name = phase.name.clone();
+        if phase.extend {
+            return Err(DslPipelineError::Compile(DslError::compile(format!(
+                "phase \"{name}\" uses extend but no parent phase exists"
+            ))));
+        }
+        phases.push(clear_extend(phase));
+        phase_sources.insert(name, PhaseComposition::Local);
+    }
+
+    let ast = PolicyAst {
+        name: child.name,
+        extends: None,
+        metadata: merge_metadata(parent_ast.metadata, child.metadata),
+        config: child.config.or(parent_ast.config),
+        phases,
+        span: child.span,
+    };
+
+    let mut extends_chain = parent.extends_chain;
+    extends_chain.push(source_label(&parent.source_id));
+
+    Ok(ResolvedPolicyAst {
+        ast,
+        source_id,
+        extends_chain,
+        phase_sources,
+    })
+}
+
+fn extend_phase(mut parent: PhaseNode, child: PhaseNode) -> PhaseNode {
+    parent.extend = false;
+    if child.skip_when.is_some() {
+        parent.skip_when = child.skip_when;
+    }
+    if !child.depends_on.is_empty() {
+        parent.depends_on = child.depends_on;
+    }
+    if child.run_if.is_some() {
+        parent.run_if = child.run_if;
+    }
+    if child.on_error.is_some() {
+        parent.on_error = child.on_error;
+    }
+    parent.operations.extend(child.operations);
+    parent
+}
+
+fn clear_extend(mut phase: PhaseNode) -> PhaseNode {
+    phase.extend = false;
+    phase
+}
+
+fn merge_metadata(
+    parent: Option<MetadataNode>,
+    child: Option<MetadataNode>,
+) -> Option<MetadataNode> {
+    match (parent, child) {
+        (None, None) => None,
+        (Some(metadata), None) | (None, Some(metadata)) => Some(metadata),
+        (Some(parent), Some(child)) => Some(MetadataNode {
+            version: child.version.or(parent.version),
+            author: child.author.or(parent.author),
+            description: child.description.or(parent.description),
+            requires_voom: child.requires_voom.or(parent.requires_voom),
+            requires_tools: if child.requires_tools.is_empty() {
+                parent.requires_tools
+            } else {
+                child.requires_tools
+            },
+            test_fixtures: if child.test_fixtures.is_empty() {
+                parent.test_fixtures
+            } else {
+                child.test_fixtures
+            },
+            span: child.span,
+        }),
+    }
+}
+
+fn resolve_file_uri(uri: &str, base_dir: Option<&Path>) -> Result<PathBuf, DslPipelineError> {
+    let path = uri.strip_prefix("file://").ok_or_else(|| {
+        DslPipelineError::Compile(DslError::compile(format!(
+            "unsupported policy extends URI \"{uri}\"; only file:// URIs and bundled policy names are supported"
+        )))
+    })?;
+    if path.is_empty() {
+        return Err(DslPipelineError::Compile(DslError::compile(
+            "file:// policy extends URI must include a path",
+        )));
+    }
+
+    let path = Path::new(path);
+    let path = if path.is_absolute() {
+        path.to_path_buf()
+    } else if let Some(base_dir) = base_dir {
+        base_dir.join(path)
+    } else {
+        return Err(DslPipelineError::Compile(DslError::compile(
+            "file:// policy extends requires compile_policy_file(path)",
+        )));
+    };
+    canonicalize_existing_path(&path)
+}
+
+fn canonicalize_existing_path(path: &Path) -> Result<PathBuf, DslPipelineError> {
+    std::fs::canonicalize(path).map_err(|err| {
+        DslPipelineError::Compile(DslError::compile(format!(
+            "failed to resolve policy file {}: {err}",
+            path.display()
+        )))
+    })
+}
+
+fn push_source(
+    source_id: PolicySourceId,
+    stack: &mut Vec<PolicySourceId>,
+) -> Result<(), DslPipelineError> {
+    if let Some(index) = stack.iter().position(|source| source == &source_id) {
+        let mut chain: Vec<String> = stack[index..].iter().map(source_label).collect();
+        chain.push(source_label(&source_id));
+        return Err(DslPipelineError::Compile(DslError::compile(format!(
+            "cyclic policy extends: {}",
+            chain.join(" -> ")
+        ))));
+    }
+    stack.push(source_id);
+    Ok(())
+}
+
+fn phase_source_label(composition: &PhaseComposition) -> String {
+    match composition {
+        PhaseComposition::Local => "local".to_owned(),
+        PhaseComposition::Inherited { source }
+        | PhaseComposition::Extended { source, .. }
+        | PhaseComposition::Overridden { source } => source.clone(),
+    }
+}
+
+fn source_label(source_id: &PolicySourceId) -> String {
+    match source_id {
+        PolicySourceId::Inline => "inline".to_owned(),
+        PolicySourceId::Bundled(name) => name.clone(),
+        PolicySourceId::File(path) => path.display().to_string(),
+    }
+}

--- a/crates/voom-dsl/src/composition.rs
+++ b/crates/voom-dsl/src/composition.rs
@@ -221,7 +221,7 @@ fn extend_phase(mut parent: PhaseNode, child: PhaseNode) -> PhaseNode {
     if child.skip_when.is_some() {
         parent.skip_when = child.skip_when;
     }
-    if !child.depends_on.is_empty() {
+    if child.depends_on.is_some() {
         parent.depends_on = child.depends_on;
     }
     if child.run_if.is_some() {

--- a/crates/voom-dsl/src/composition.rs
+++ b/crates/voom-dsl/src/composition.rs
@@ -251,16 +251,8 @@ fn merge_metadata(
             author: child.author.or(parent.author),
             description: child.description.or(parent.description),
             requires_voom: child.requires_voom.or(parent.requires_voom),
-            requires_tools: if child.requires_tools.is_empty() {
-                parent.requires_tools
-            } else {
-                child.requires_tools
-            },
-            test_fixtures: if child.test_fixtures.is_empty() {
-                parent.test_fixtures
-            } else {
-                child.test_fixtures
-            },
+            requires_tools: child.requires_tools.or(parent.requires_tools),
+            test_fixtures: child.test_fixtures.or(parent.test_fixtures),
             span: child.span,
         }),
     }
@@ -330,5 +322,55 @@ fn source_label(source_id: &PolicySourceId) -> String {
         PolicySourceId::Inline => "inline".to_owned(),
         PolicySourceId::Bundled(name) => name.clone(),
         PolicySourceId::File(path) => path.display().to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::composition::resolve_policy_with_bundled;
+
+    #[test]
+    fn explicit_empty_metadata_list_clears_parent_value() {
+        let resolved = resolve_policy_with_bundled(
+            r#"policy "child" extends "anime-base" {
+                metadata {
+                    requires_tools: []
+                }
+
+                phase subtitles {
+                    keep subtitles
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let metadata = resolved.ast.metadata.unwrap();
+        assert_eq!(metadata.requires_tools, Some(Vec::new()));
+    }
+
+    #[test]
+    fn omitted_metadata_list_inherits_parent_value() {
+        let resolved = resolve_policy_with_bundled(
+            r#"policy "child" extends "anime-base" {
+                metadata {
+                    version: "1.1.0"
+                }
+
+                phase subtitles {
+                    keep subtitles
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let metadata = resolved.ast.metadata.unwrap();
+        assert_eq!(
+            metadata.requires_tools,
+            Some(vec![
+                "ffmpeg".to_owned(),
+                "mkvmerge".to_owned(),
+                "mkvextract".to_owned()
+            ])
+        );
     }
 }

--- a/crates/voom-dsl/src/composition.rs
+++ b/crates/voom-dsl/src/composition.rs
@@ -36,21 +36,34 @@ pub(crate) enum PhaseComposition {
     },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AllowFiles {
+    Yes,
+    No,
+}
+
 pub(crate) fn resolve_policy_file(path: &Path) -> Result<ResolvedPolicyAst, DslPipelineError> {
     let canonical = canonicalize_existing_path(path)?;
     let mut stack = Vec::new();
-    resolve_file_path(&canonical, &mut stack)
+    resolve_file_path(&canonical, AllowFiles::Yes, &mut stack)
 }
 
 pub(crate) fn resolve_policy_with_bundled(
     source: &str,
 ) -> Result<ResolvedPolicyAst, DslPipelineError> {
     let ast = parse_policy(source).map_err(DslPipelineError::Parse)?;
-    resolve_ast(ast, PolicySourceId::Inline, None, &mut Vec::new())
+    resolve_ast(
+        ast,
+        PolicySourceId::Inline,
+        None,
+        AllowFiles::No,
+        &mut Vec::new(),
+    )
 }
 
 fn resolve_file_path(
     path: &Path,
+    allow_files: AllowFiles,
     stack: &mut Vec<PolicySourceId>,
 ) -> Result<ResolvedPolicyAst, DslPipelineError> {
     let source_id = PolicySourceId::File(path.to_path_buf());
@@ -63,13 +76,14 @@ fn resolve_file_path(
     })?;
     let ast = parse_policy(&source).map_err(DslPipelineError::Parse)?;
     let base_dir = path.parent().map(Path::to_path_buf);
-    let resolved = resolve_ast(ast, source_id, base_dir.as_deref(), stack);
+    let resolved = resolve_ast(ast, source_id, base_dir.as_deref(), allow_files, stack);
     stack.pop();
     resolved
 }
 
 fn resolve_bundled_policy(
     name: &str,
+    allow_files: AllowFiles,
     stack: &mut Vec<PolicySourceId>,
 ) -> Result<ResolvedPolicyAst, DslPipelineError> {
     let source_id = PolicySourceId::Bundled(name.to_owned());
@@ -80,7 +94,7 @@ fn resolve_bundled_policy(
         )))
     })?;
     let ast = parse_policy(source).map_err(DslPipelineError::Parse)?;
-    let resolved = resolve_ast(ast, source_id, None, stack);
+    let resolved = resolve_ast(ast, source_id, None, allow_files, stack);
     stack.pop();
     resolved
 }
@@ -89,6 +103,7 @@ fn resolve_ast(
     mut ast: PolicyAst,
     source_id: PolicySourceId,
     base_dir: Option<&Path>,
+    allow_files: AllowFiles,
     stack: &mut Vec<PolicySourceId>,
 ) -> Result<ResolvedPolicyAst, DslPipelineError> {
     let Some(extends) = ast.extends.take() else {
@@ -108,16 +123,16 @@ fn resolve_ast(
                     "unsupported policy extends URI \"{name}\"; only file:// URIs and bundled policy names are supported"
                 ))));
             }
-            resolve_bundled_policy(&name, stack)?
+            resolve_bundled_policy(&name, allow_files, stack)?
         }
         ExtendsSource::File(uri) => {
-            if source_id == PolicySourceId::Inline {
+            if allow_files == AllowFiles::No {
                 return Err(DslPipelineError::Compile(DslError::compile(
                     "file:// policy extends requires compile_policy_file(path)",
                 )));
             }
             let path = resolve_file_uri(&uri, base_dir)?;
-            resolve_file_path(&path, stack)?
+            resolve_file_path(&path, allow_files, stack)?
         }
     };
 
@@ -343,7 +358,10 @@ fn source_label(source_id: &PolicySourceId) -> String {
 
 #[cfg(test)]
 mod tests {
-    use crate::composition::resolve_policy_with_bundled;
+    use crate::composition::{
+        AllowFiles, PolicySourceId, resolve_ast, resolve_policy_with_bundled,
+    };
+    use crate::parse_policy;
 
     #[test]
     fn explicit_empty_metadata_list_clears_parent_value() {
@@ -388,5 +406,29 @@ mod tests {
                 "mkvextract".to_owned()
             ])
         );
+    }
+
+    #[test]
+    fn file_extends_are_rejected_when_source_is_not_inline_but_files_are_disabled() {
+        let ast = parse_policy(
+            r#"policy "bundled-child" extends "file:///tmp/base.voom" {
+                phase subtitles {
+                    keep subtitles
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let err = resolve_ast(
+            ast,
+            PolicySourceId::Bundled("bundled-child".to_owned()),
+            None,
+            AllowFiles::No,
+            &mut Vec::new(),
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(err.contains("file:// policy extends requires compile_policy_file(path)"));
     }
 }

--- a/crates/voom-dsl/src/composition.rs
+++ b/crates/voom-dsl/src/composition.rs
@@ -157,7 +157,6 @@ fn merge_policy(
     let child_source = source_label(&source_id);
     child.extends = None;
     let parent_ast = parent.ast;
-    let parent_name = parent_ast.name.clone();
     let parent_phase_sources = parent.phase_sources;
     let mut child_phases = child.phases;
     let mut consumed_child_phases = vec![false; child_phases.len()];
@@ -167,10 +166,10 @@ fn merge_policy(
 
     for parent_phase in parent_ast.phases {
         let parent_phase_name = parent_phase.name.clone();
-        let parent_source = parent_phase_sources
-            .get(&parent_phase_name)
-            .map(phase_source_label)
-            .unwrap_or_else(|| parent_name.clone());
+        let parent_source = parent_phase_sources.get(&parent_phase_name).map_or_else(
+            || source_label(&parent.source_id),
+            |composition| phase_source_label(composition, &parent.source_id),
+        );
 
         let child_phase_index = child_phases
             .iter()
@@ -339,9 +338,9 @@ fn push_source(
     Ok(())
 }
 
-fn phase_source_label(composition: &PhaseComposition) -> String {
+fn phase_source_label(composition: &PhaseComposition, parent_source_id: &PolicySourceId) -> String {
     match composition {
-        PhaseComposition::Local => "local".to_owned(),
+        PhaseComposition::Local => source_label(parent_source_id),
         PhaseComposition::Inherited { source }
         | PhaseComposition::Extended { source, .. }
         | PhaseComposition::Overridden { source } => source.clone(),

--- a/crates/voom-dsl/src/composition.rs
+++ b/crates/voom-dsl/src/composition.rs
@@ -111,6 +111,11 @@ fn resolve_ast(
             resolve_bundled_policy(&name, stack)?
         }
         ExtendsSource::File(uri) => {
+            if source_id == PolicySourceId::Inline {
+                return Err(DslPipelineError::Compile(DslError::compile(
+                    "file:// policy extends requires compile_policy_file(path)",
+                )));
+            }
             let path = resolve_file_uri(&uri, base_dir)?;
             resolve_file_path(&path, stack)?
         }

--- a/crates/voom-dsl/src/composition.rs
+++ b/crates/voom-dsl/src/composition.rs
@@ -92,6 +92,7 @@ fn resolve_ast(
     stack: &mut Vec<PolicySourceId>,
 ) -> Result<ResolvedPolicyAst, DslPipelineError> {
     let Some(extends) = ast.extends.take() else {
+        reject_unresolved_phase_extends(&ast)?;
         return Ok(ResolvedPolicyAst {
             ast,
             source_id,
@@ -116,6 +117,16 @@ fn resolve_ast(
     };
 
     merge_policy(parent, ast, source_id)
+}
+
+fn reject_unresolved_phase_extends(ast: &PolicyAst) -> Result<(), DslPipelineError> {
+    if let Some(phase) = ast.phases.iter().find(|phase| phase.extend) {
+        return Err(DslPipelineError::Compile(DslError::compile(format!(
+            "phase \"{}\" uses extend but policy composition was not resolved",
+            phase.name
+        ))));
+    }
+    Ok(())
 }
 
 fn merge_policy(

--- a/crates/voom-dsl/src/composition.rs
+++ b/crates/voom-dsl/src/composition.rs
@@ -7,22 +7,22 @@ use crate::errors::{DslError, DslPipelineError};
 use crate::parse_policy;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum PolicySourceId {
+pub(crate) enum PolicySourceId {
     Inline,
     Bundled(String),
     File(PathBuf),
 }
 
 #[derive(Debug, Clone)]
-pub struct ResolvedPolicyAst {
-    pub ast: PolicyAst,
-    pub source_id: PolicySourceId,
-    pub extends_chain: Vec<String>,
-    pub phase_sources: HashMap<String, PhaseComposition>,
+pub(crate) struct ResolvedPolicyAst {
+    pub(crate) ast: PolicyAst,
+    pub(crate) source_id: PolicySourceId,
+    pub(crate) extends_chain: Vec<String>,
+    pub(crate) phase_sources: HashMap<String, PhaseComposition>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub enum PhaseComposition {
+pub(crate) enum PhaseComposition {
     Local,
     Inherited {
         source: String,

--- a/crates/voom-dsl/src/formatter.rs
+++ b/crates/voom-dsl/src/formatter.rs
@@ -97,11 +97,12 @@ fn format_metadata(metadata: &MetadataNode, out: &mut String, level: usize) {
     }
     if !metadata.requires_tools.is_empty() {
         indent(out, level + 1);
-        let _ = writeln!(
-            out,
-            "requires_tools: [{}]",
-            metadata.requires_tools.join(", ")
-        );
+        let tools: Vec<String> = metadata
+            .requires_tools
+            .iter()
+            .map(|tool| format!("\"{}\"", escape_string(tool)))
+            .collect();
+        let _ = writeln!(out, "requires_tools: [{}]", tools.join(", "));
     }
     if !metadata.test_fixtures.is_empty() {
         indent(out, level + 1);

--- a/crates/voom-dsl/src/formatter.rs
+++ b/crates/voom-dsl/src/formatter.rs
@@ -167,9 +167,9 @@ fn format_phase(phase: &PhaseNode, out: &mut String, level: usize) {
         out.push_str("extend\n");
     }
 
-    if !phase.depends_on.is_empty() {
+    if let Some(depends_on) = &phase.depends_on {
         indent(out, level + 1);
-        let _ = writeln!(out, "depends_on: [{}]", phase.depends_on.join(", "));
+        let _ = writeln!(out, "depends_on: [{}]", depends_on.join(", "));
     }
 
     if let Some(skip_when) = &phase.skip_when {
@@ -1137,7 +1137,7 @@ mod tests {
             name: name.into(),
             extend: false,
             skip_when: None,
-            depends_on: vec![],
+            depends_on: None,
             run_if: None,
             on_error: None,
             operations: vec![],
@@ -1153,7 +1153,7 @@ mod tests {
     #[test]
     fn format_phase_depends_on_indents_one_deeper() {
         let mut phase = empty_phase("build");
-        phase.depends_on = vec!["init".into()];
+        phase.depends_on = Some(vec!["init".into()]);
         let mut out = String::new();
         format_phase(&phase, &mut out, 1);
         assert!(

--- a/crates/voom-dsl/src/formatter.rs
+++ b/crates/voom-dsl/src/formatter.rs
@@ -6,8 +6,9 @@
 use std::fmt::Write;
 
 use crate::ast::{
-    ActionNode, CompareOp, ConditionNode, ConfigNode, FilterNode, OperationNode, PhaseNode,
-    PolicyAst, RuleNode, SynthSetting, TrackQueryNode, Value, ValueOrField, WhenNode,
+    ActionNode, CompareOp, ConditionNode, ConfigNode, ExtendsSource, FilterNode, MetadataNode,
+    OperationNode, PhaseNode, PolicyAst, RuleNode, SynthSetting, TrackQueryNode, Value,
+    ValueOrField, WhenNode,
 };
 
 /// Format a [`PolicyAst`] into a pretty-printed source string.
@@ -30,14 +31,29 @@ use crate::ast::{
 #[must_use]
 pub fn format_policy(ast: &PolicyAst) -> String {
     let mut out = String::new();
-    let _ = writeln!(out, "policy \"{}\" {{", escape_string(&ast.name));
+    let _ = write!(out, "policy \"{}\"", escape_string(&ast.name));
+    if let Some(extends) = &ast.extends {
+        let _ = write!(
+            out,
+            " extends \"{}\"",
+            escape_string(extends_source(extends))
+        );
+    }
+    out.push_str(" {\n");
+
+    if let Some(metadata) = &ast.metadata {
+        format_metadata(metadata, &mut out, 1);
+    }
 
     if let Some(config) = &ast.config {
+        if ast.metadata.is_some() {
+            out.push('\n');
+        }
         format_config(config, &mut out, 1);
     }
 
     for (i, phase) in ast.phases.iter().enumerate() {
-        if i > 0 || ast.config.is_some() {
+        if i > 0 || ast.config.is_some() || ast.metadata.is_some() {
             out.push('\n');
         }
         format_phase(phase, &mut out, 1);
@@ -47,10 +63,58 @@ pub fn format_policy(ast: &PolicyAst) -> String {
     out
 }
 
+fn extends_source(source: &ExtendsSource) -> &str {
+    match source {
+        ExtendsSource::Bundled(value) | ExtendsSource::File(value) => value,
+    }
+}
+
 fn indent(out: &mut String, level: usize) {
     for _ in 0..level {
         out.push_str("  ");
     }
+}
+
+fn format_metadata(metadata: &MetadataNode, out: &mut String, level: usize) {
+    indent(out, level);
+    out.push_str("metadata {\n");
+
+    if let Some(version) = &metadata.version {
+        indent(out, level + 1);
+        let _ = writeln!(out, "version: \"{}\"", escape_string(version));
+    }
+    if let Some(author) = &metadata.author {
+        indent(out, level + 1);
+        let _ = writeln!(out, "author: \"{}\"", escape_string(author));
+    }
+    if let Some(description) = &metadata.description {
+        indent(out, level + 1);
+        let _ = writeln!(out, "description: \"{}\"", escape_string(description));
+    }
+    if let Some(requires_voom) = &metadata.requires_voom {
+        indent(out, level + 1);
+        let _ = writeln!(out, "requires_voom: \"{}\"", escape_string(requires_voom));
+    }
+    if !metadata.requires_tools.is_empty() {
+        indent(out, level + 1);
+        let _ = writeln!(
+            out,
+            "requires_tools: [{}]",
+            metadata.requires_tools.join(", ")
+        );
+    }
+    if !metadata.test_fixtures.is_empty() {
+        indent(out, level + 1);
+        let fixtures: Vec<String> = metadata
+            .test_fixtures
+            .iter()
+            .map(|fixture| format!("\"{}\"", escape_string(fixture)))
+            .collect();
+        let _ = writeln!(out, "test_fixtures: [{}]", fixtures.join(", "));
+    }
+
+    indent(out, level);
+    out.push_str("}\n");
 }
 
 fn format_config(config: &ConfigNode, out: &mut String, level: usize) {
@@ -98,6 +162,11 @@ fn format_config(config: &ConfigNode, out: &mut String, level: usize) {
 fn format_phase(phase: &PhaseNode, out: &mut String, level: usize) {
     indent(out, level);
     let _ = writeln!(out, "phase {} {{", phase.name);
+
+    if phase.extend {
+        indent(out, level + 1);
+        out.push_str("extend\n");
+    }
 
     if !phase.depends_on.is_empty() {
         indent(out, level + 1);
@@ -1067,6 +1136,7 @@ mod tests {
     fn empty_phase(name: &str) -> PhaseNode {
         PhaseNode {
             name: name.into(),
+            extend: false,
             skip_when: None,
             depends_on: vec![],
             run_if: None,

--- a/crates/voom-dsl/src/formatter.rs
+++ b/crates/voom-dsl/src/formatter.rs
@@ -95,19 +95,17 @@ fn format_metadata(metadata: &MetadataNode, out: &mut String, level: usize) {
         indent(out, level + 1);
         let _ = writeln!(out, "requires_voom: \"{}\"", escape_string(requires_voom));
     }
-    if !metadata.requires_tools.is_empty() {
+    if let Some(requires_tools) = &metadata.requires_tools {
         indent(out, level + 1);
-        let tools: Vec<String> = metadata
-            .requires_tools
+        let tools: Vec<String> = requires_tools
             .iter()
             .map(|tool| format!("\"{}\"", escape_string(tool)))
             .collect();
         let _ = writeln!(out, "requires_tools: [{}]", tools.join(", "));
     }
-    if !metadata.test_fixtures.is_empty() {
+    if let Some(test_fixtures) = &metadata.test_fixtures {
         indent(out, level + 1);
-        let fixtures: Vec<String> = metadata
-            .test_fixtures
+        let fixtures: Vec<String> = test_fixtures
             .iter()
             .map(|fixture| format!("\"{}\"", escape_string(fixture)))
             .collect();

--- a/crates/voom-dsl/src/grammar.pest
+++ b/crates/voom-dsl/src/grammar.pest
@@ -4,7 +4,19 @@
 WHITESPACE = _{ " " | "\t" | NEWLINE }
 COMMENT    = _{ "//" ~ (!NEWLINE ~ ANY)* }
 
-policy = { SOI ~ "policy" ~ string ~ "{" ~ config? ~ phase+ ~ "}" ~ EOI }
+policy = { SOI ~ "policy" ~ string ~ extends_clause? ~ "{" ~ metadata? ~ config? ~ phase+ ~ "}" ~ EOI }
+extends_clause = { "extends" ~ string }
+
+// Metadata block
+metadata = { "metadata" ~ "{" ~ metadata_item* ~ "}" }
+metadata_item = {
+    "version" ~ ":" ~ string
+  | "author" ~ ":" ~ string
+  | "description" ~ ":" ~ string
+  | "requires_voom" ~ ":" ~ string
+  | "requires_tools" ~ ":" ~ list
+  | "test_fixtures" ~ ":" ~ list
+}
 
 // Config block
 config = { "config" ~ "{" ~ config_item* ~ "}" }
@@ -17,7 +29,8 @@ config_item = {
 lang_target = { "audio" | "subtitle" }
 
 // Phase block
-phase = { "phase" ~ ident ~ "{" ~ phase_item* ~ "}" }
+phase = { "phase" ~ ident ~ "{" ~ phase_extend? ~ phase_item* ~ "}" }
+phase_extend = { "extend" }
 phase_item = {
     skip_when | depends_on | run_if | on_error
   | clear_tags_op | set_tag_op | delete_tag_op

--- a/crates/voom-dsl/src/lib.rs
+++ b/crates/voom-dsl/src/lib.rs
@@ -20,6 +20,7 @@
 //! ```
 
 pub mod ast;
+pub mod bundled;
 pub mod compiled;
 pub mod compiler;
 pub mod errors;
@@ -36,6 +37,7 @@ pub use ast::{
     PhaseNode, PolicyAst, RuleNode, RunIfNode, RunIfTriggerNode, Span, SpannedOperation,
     SynthSetting, TrackQueryNode, TrackRefNode, Value, ValueOrField, WhenNode,
 };
+pub use bundled::{bundled_policy, bundled_policy_names};
 pub use compiled::CompiledPolicy;
 pub use errors::{DslError, DslPipelineError, DslWarning, ValidationErrors};
 pub use formatter::format_policy;

--- a/crates/voom-dsl/src/lib.rs
+++ b/crates/voom-dsl/src/lib.rs
@@ -95,20 +95,25 @@ pub fn compile_policy(source: &str) -> Result<CompiledPolicy, DslPipelineError> 
 /// or [`DslPipelineError::Compile`] if inheritance cannot be resolved or compiled.
 pub fn compile_policy_with_bundled(source: &str) -> Result<CompiledPolicy, DslPipelineError> {
     let resolved = composition::resolve_policy_with_bundled(source)?;
-    compile_resolved_policy(resolved)
+    compile_resolved_policy(resolved, Some(source))
 }
 
 fn compile_resolved_policy(
     resolved: composition::ResolvedPolicyAst,
+    standalone_source: Option<&str>,
 ) -> Result<CompiledPolicy, DslPipelineError> {
     validate(&resolved.ast).map_err(DslPipelineError::Validation)?;
     let mut policy =
         compiler::compile_resolved_ast(&resolved).map_err(DslPipelineError::Compile)?;
-    let resolved_source = format_policy(&resolved.ast);
-    policy.source_hash = format!(
-        "{:016x}",
-        xxhash_rust::xxh3::xxh3_64(resolved_source.as_bytes())
-    );
+    let source = if let Some(source) = standalone_source
+        && resolved.extends_chain.is_empty()
+        && resolved.phase_sources.is_empty()
+    {
+        std::borrow::Cow::Borrowed(source)
+    } else {
+        std::borrow::Cow::Owned(format_policy(&resolved.ast))
+    };
+    policy.source_hash = format!("{:016x}", xxhash_rust::xxh3::xxh3_64(source.as_bytes()));
     Ok(policy)
 }
 
@@ -121,5 +126,15 @@ fn compile_resolved_policy(
 /// or [`DslPipelineError::Compile`] if inheritance cannot be resolved or compiled.
 pub fn compile_policy_file(path: &std::path::Path) -> Result<CompiledPolicy, DslPipelineError> {
     let resolved = composition::resolve_policy_file(path)?;
-    compile_resolved_policy(resolved)
+    let source = if resolved.extends_chain.is_empty() && resolved.phase_sources.is_empty() {
+        Some(std::fs::read_to_string(path).map_err(|err| {
+            DslPipelineError::Compile(DslError::compile(format!(
+                "failed to read policy file {}: {err}",
+                path.display()
+            )))
+        })?)
+    } else {
+        None
+    };
+    compile_resolved_policy(resolved, source.as_deref())
 }

--- a/crates/voom-dsl/src/lib.rs
+++ b/crates/voom-dsl/src/lib.rs
@@ -95,6 +95,12 @@ pub fn compile_policy(source: &str) -> Result<CompiledPolicy, DslPipelineError> 
 /// or [`DslPipelineError::Compile`] if inheritance cannot be resolved or compiled.
 pub fn compile_policy_with_bundled(source: &str) -> Result<CompiledPolicy, DslPipelineError> {
     let resolved = composition::resolve_policy_with_bundled(source)?;
+    compile_resolved_policy(resolved)
+}
+
+fn compile_resolved_policy(
+    resolved: composition::ResolvedPolicyAst,
+) -> Result<CompiledPolicy, DslPipelineError> {
     validate(&resolved.ast).map_err(DslPipelineError::Validation)?;
     let mut policy =
         compiler::compile_resolved_ast(&resolved).map_err(DslPipelineError::Compile)?;
@@ -115,13 +121,5 @@ pub fn compile_policy_with_bundled(source: &str) -> Result<CompiledPolicy, DslPi
 /// or [`DslPipelineError::Compile`] if inheritance cannot be resolved or compiled.
 pub fn compile_policy_file(path: &std::path::Path) -> Result<CompiledPolicy, DslPipelineError> {
     let resolved = composition::resolve_policy_file(path)?;
-    validate(&resolved.ast).map_err(DslPipelineError::Validation)?;
-    let mut policy =
-        compiler::compile_resolved_ast(&resolved).map_err(DslPipelineError::Compile)?;
-    let resolved_source = format_policy(&resolved.ast);
-    policy.source_hash = format!(
-        "{:016x}",
-        xxhash_rust::xxh3::xxh3_64(resolved_source.as_bytes())
-    );
-    Ok(policy)
+    compile_resolved_policy(resolved)
 }

--- a/crates/voom-dsl/src/lib.rs
+++ b/crates/voom-dsl/src/lib.rs
@@ -39,7 +39,9 @@ pub use ast::{
     SynthSetting, TrackQueryNode, TrackRefNode, Value, ValueOrField, WhenNode,
 };
 pub use bundled::{bundled_policy, bundled_policy_names};
-pub use compiled::CompiledPolicy;
+pub use compiled::{
+    CompiledMetadata, CompiledPhaseComposition, CompiledPolicy, PhaseCompositionKind,
+};
 pub use errors::{DslError, DslPipelineError, DslWarning, ValidationErrors};
 pub use formatter::format_policy;
 pub use parser::parse_policy;
@@ -94,7 +96,8 @@ pub fn compile_policy(source: &str) -> Result<CompiledPolicy, DslPipelineError> 
 pub fn compile_policy_with_bundled(source: &str) -> Result<CompiledPolicy, DslPipelineError> {
     let resolved = composition::resolve_policy_with_bundled(source)?;
     validate(&resolved.ast).map_err(DslPipelineError::Validation)?;
-    let mut policy = compiler::compile_ast(&resolved.ast).map_err(DslPipelineError::Compile)?;
+    let mut policy =
+        compiler::compile_resolved_ast(&resolved).map_err(DslPipelineError::Compile)?;
     let resolved_source = format_policy(&resolved.ast);
     policy.source_hash = format!(
         "{:016x}",
@@ -113,7 +116,8 @@ pub fn compile_policy_with_bundled(source: &str) -> Result<CompiledPolicy, DslPi
 pub fn compile_policy_file(path: &std::path::Path) -> Result<CompiledPolicy, DslPipelineError> {
     let resolved = composition::resolve_policy_file(path)?;
     validate(&resolved.ast).map_err(DslPipelineError::Validation)?;
-    let mut policy = compiler::compile_ast(&resolved.ast).map_err(DslPipelineError::Compile)?;
+    let mut policy =
+        compiler::compile_resolved_ast(&resolved).map_err(DslPipelineError::Compile)?;
     let resolved_source = format_policy(&resolved.ast);
     policy.source_hash = format!(
         "{:016x}",

--- a/crates/voom-dsl/src/lib.rs
+++ b/crates/voom-dsl/src/lib.rs
@@ -23,6 +23,7 @@ pub mod ast;
 pub mod bundled;
 pub mod compiled;
 pub mod compiler;
+pub mod composition;
 pub mod errors;
 pub mod formatter;
 pub mod parser;
@@ -39,6 +40,7 @@ pub use ast::{
 };
 pub use bundled::{bundled_policy, bundled_policy_names};
 pub use compiled::CompiledPolicy;
+pub use composition::{PhaseComposition, PolicySourceId, ResolvedPolicyAst};
 pub use errors::{DslError, DslPipelineError, DslWarning, ValidationErrors};
 pub use formatter::format_policy;
 pub use parser::parse_policy;
@@ -70,8 +72,51 @@ pub use validator::{validate, validate_with_warnings};
 /// ```
 pub fn compile_policy(source: &str) -> Result<CompiledPolicy, DslPipelineError> {
     let ast = parse_policy(source).map_err(DslPipelineError::Parse)?;
+    if let Some(ast::ExtendsSource::File(_)) = &ast.extends {
+        return Err(DslPipelineError::Compile(DslError::compile(
+            "file:// policy extends requires compile_policy_file(path)",
+        )));
+    }
     validate(&ast).map_err(DslPipelineError::Validation)?;
     let mut policy = compiler::compile_ast(&ast).map_err(DslPipelineError::Compile)?;
     policy.source_hash = format!("{:016x}", xxhash_rust::xxh3::xxh3_64(source.as_bytes()));
+    Ok(policy)
+}
+
+/// Resolve bundled policy inheritance before validation and compilation.
+///
+/// Use this for in-memory policy sources that may extend bundled policies.
+///
+/// # Errors
+///
+/// Returns [`DslPipelineError::Parse`] if any policy source cannot be parsed,
+/// [`DslPipelineError::Validation`] if the merged AST fails semantic validation,
+/// or [`DslPipelineError::Compile`] if inheritance cannot be resolved or compiled.
+pub fn compile_policy_with_bundled(source: &str) -> Result<CompiledPolicy, DslPipelineError> {
+    let resolved = composition::resolve_policy_with_bundled(source)?;
+    validate(&resolved.ast).map_err(DslPipelineError::Validation)?;
+    let mut policy = compiler::compile_ast(&resolved.ast).map_err(DslPipelineError::Compile)?;
+    policy.source_hash = format!("{:016x}", xxhash_rust::xxh3::xxh3_64(source.as_bytes()));
+    Ok(policy)
+}
+
+/// Resolve file-relative policy inheritance before validation and compilation.
+///
+/// # Errors
+///
+/// Returns [`DslPipelineError::Parse`] if any policy source cannot be parsed,
+/// [`DslPipelineError::Validation`] if the merged AST fails semantic validation,
+/// or [`DslPipelineError::Compile`] if inheritance cannot be resolved or compiled.
+pub fn compile_policy_file(path: &std::path::Path) -> Result<CompiledPolicy, DslPipelineError> {
+    let source = std::fs::read(path).map_err(|err| {
+        DslPipelineError::Compile(DslError::compile(format!(
+            "failed to read policy file {}: {err}",
+            path.display()
+        )))
+    })?;
+    let resolved = composition::resolve_policy_file(path)?;
+    validate(&resolved.ast).map_err(DslPipelineError::Validation)?;
+    let mut policy = compiler::compile_ast(&resolved.ast).map_err(DslPipelineError::Compile)?;
+    policy.source_hash = format!("{:016x}", xxhash_rust::xxh3::xxh3_64(&source));
     Ok(policy)
 }

--- a/crates/voom-dsl/src/lib.rs
+++ b/crates/voom-dsl/src/lib.rs
@@ -72,9 +72,9 @@ pub use validator::{validate, validate_with_warnings};
 /// ```
 pub fn compile_policy(source: &str) -> Result<CompiledPolicy, DslPipelineError> {
     let ast = parse_policy(source).map_err(DslPipelineError::Parse)?;
-    if let Some(ast::ExtendsSource::File(_)) = &ast.extends {
+    if ast.extends.is_some() {
         return Err(DslPipelineError::Compile(DslError::compile(
-            "file:// policy extends requires compile_policy_file(path)",
+            "policy extends requires composition resolution; use compile_policy_with_bundled(source) or compile_policy_file(path)",
         )));
     }
     validate(&ast).map_err(DslPipelineError::Validation)?;
@@ -96,7 +96,11 @@ pub fn compile_policy_with_bundled(source: &str) -> Result<CompiledPolicy, DslPi
     let resolved = composition::resolve_policy_with_bundled(source)?;
     validate(&resolved.ast).map_err(DslPipelineError::Validation)?;
     let mut policy = compiler::compile_ast(&resolved.ast).map_err(DslPipelineError::Compile)?;
-    policy.source_hash = format!("{:016x}", xxhash_rust::xxh3::xxh3_64(source.as_bytes()));
+    let resolved_source = format_policy(&resolved.ast);
+    policy.source_hash = format!(
+        "{:016x}",
+        xxhash_rust::xxh3::xxh3_64(resolved_source.as_bytes())
+    );
     Ok(policy)
 }
 
@@ -108,15 +112,13 @@ pub fn compile_policy_with_bundled(source: &str) -> Result<CompiledPolicy, DslPi
 /// [`DslPipelineError::Validation`] if the merged AST fails semantic validation,
 /// or [`DslPipelineError::Compile`] if inheritance cannot be resolved or compiled.
 pub fn compile_policy_file(path: &std::path::Path) -> Result<CompiledPolicy, DslPipelineError> {
-    let source = std::fs::read(path).map_err(|err| {
-        DslPipelineError::Compile(DslError::compile(format!(
-            "failed to read policy file {}: {err}",
-            path.display()
-        )))
-    })?;
     let resolved = composition::resolve_policy_file(path)?;
     validate(&resolved.ast).map_err(DslPipelineError::Validation)?;
     let mut policy = compiler::compile_ast(&resolved.ast).map_err(DslPipelineError::Compile)?;
-    policy.source_hash = format!("{:016x}", xxhash_rust::xxh3::xxh3_64(&source));
+    let resolved_source = format_policy(&resolved.ast);
+    policy.source_hash = format!(
+        "{:016x}",
+        xxhash_rust::xxh3::xxh3_64(resolved_source.as_bytes())
+    );
     Ok(policy)
 }

--- a/crates/voom-dsl/src/lib.rs
+++ b/crates/voom-dsl/src/lib.rs
@@ -23,7 +23,7 @@ pub mod ast;
 pub mod bundled;
 pub mod compiled;
 pub mod compiler;
-pub mod composition;
+mod composition;
 pub mod errors;
 pub mod formatter;
 pub mod parser;
@@ -40,7 +40,6 @@ pub use ast::{
 };
 pub use bundled::{bundled_policy, bundled_policy_names};
 pub use compiled::CompiledPolicy;
-pub use composition::{PhaseComposition, PolicySourceId, ResolvedPolicyAst};
 pub use errors::{DslError, DslPipelineError, DslWarning, ValidationErrors};
 pub use formatter::format_policy;
 pub use parser::parse_policy;

--- a/crates/voom-dsl/src/parser.rs
+++ b/crates/voom-dsl/src/parser.rs
@@ -145,8 +145,8 @@ fn build_metadata(pair: Pair<'_, Rule>) -> Result<MetadataNode> {
     let mut author = None;
     let mut description = None;
     let mut requires_voom = None;
-    let mut requires_tools = Vec::new();
-    let mut test_fixtures = Vec::new();
+    let mut requires_tools = None;
+    let mut test_fixtures = None;
 
     for item in pair.into_inner() {
         if item.as_rule() != Rule::metadata_item {
@@ -188,14 +188,14 @@ fn build_metadata(pair: Pair<'_, Rule>) -> Result<MetadataNode> {
                     .into_inner()
                     .find(|p| p.as_rule() == Rule::list)
                     .unwrap();
-                requires_tools = build_list(list_pair);
+                requires_tools = Some(build_list(list_pair));
             }
             "test_fixtures" => {
                 let list_pair = item
                     .into_inner()
                     .find(|p| p.as_rule() == Rule::list)
                     .unwrap();
-                test_fixtures = build_list(list_pair);
+                test_fixtures = Some(build_list(list_pair));
             }
             other => {
                 let (line, col) = item.as_span().start_pos().line_col();

--- a/crates/voom-dsl/src/parser.rs
+++ b/crates/voom-dsl/src/parser.rs
@@ -304,7 +304,7 @@ fn build_phase(pair: Pair<'_, Rule>) -> Result<PhaseNode> {
     let name = inner.next().unwrap().as_str().to_string();
 
     let mut skip_when = None;
-    let mut depends_on = Vec::new();
+    let mut depends_on = None;
     let mut run_if = None;
     let mut on_error = None;
     let mut operations = Vec::new();
@@ -326,7 +326,7 @@ fn build_phase(pair: Pair<'_, Rule>) -> Result<PhaseNode> {
             }
             Rule::depends_on => {
                 let list = child.into_inner().next().unwrap();
-                depends_on = build_list(list);
+                depends_on = Some(build_list(list));
             }
             Rule::run_if => {
                 // Grammar: "run_if" ~ ident ~ "." ~ run_if_trigger

--- a/crates/voom-dsl/src/parser.rs
+++ b/crates/voom-dsl/src/parser.rs
@@ -13,10 +13,10 @@ use pest::iterators::Pair;
 use pest_derive::Parser;
 
 use crate::ast::{
-    ActionNode, CompareOp, ConditionNode, ConfigNode, ErrorStrategyNode, FilterNode,
-    NormalizeSetting, OperationNode, PhaseNode, PolicyAst, RuleNode, RunIfNode, RunIfTriggerNode,
-    Span, SpannedOperation, SynthSetting, TrackQueryNode, TrackRefNode, Value, ValueOrField,
-    VerifyMode, WhenNode,
+    ActionNode, CompareOp, ConditionNode, ConfigNode, ErrorStrategyNode, ExtendsSource, FilterNode,
+    MetadataNode, NormalizeSetting, OperationNode, PhaseNode, PolicyAst, RuleNode, RunIfNode,
+    RunIfTriggerNode, Span, SpannedOperation, SynthSetting, TrackQueryNode, TrackRefNode, Value,
+    ValueOrField, VerifyMode, WhenNode,
 };
 use crate::errors::{DslError, Result};
 
@@ -96,11 +96,15 @@ fn build_policy(pair: Pair<'_, Rule>) -> Result<PolicyAst> {
     let name_pair = inner.next().unwrap();
     let name = parse_string_value(&name_pair);
 
+    let mut extends = None;
+    let mut metadata = None;
     let mut config = None;
     let mut phases = Vec::new();
 
     for item in inner {
         match item.as_rule() {
+            Rule::extends_clause => extends = Some(build_extends(item)),
+            Rule::metadata => metadata = Some(build_metadata(item)?),
             Rule::config => config = Some(build_config(item)?),
             Rule::phase => phases.push(build_phase(item)?),
             Rule::EOI => {}
@@ -117,8 +121,100 @@ fn build_policy(pair: Pair<'_, Rule>) -> Result<PolicyAst> {
 
     Ok(PolicyAst {
         name,
+        extends,
+        metadata,
         config,
         phases,
+        span,
+    })
+}
+
+fn build_extends(pair: Pair<'_, Rule>) -> ExtendsSource {
+    let source_pair = pair.into_inner().next().unwrap();
+    let source = parse_string_value(&source_pair);
+    if source.starts_with("file://") {
+        ExtendsSource::File(source)
+    } else {
+        ExtendsSource::Bundled(source)
+    }
+}
+
+fn build_metadata(pair: Pair<'_, Rule>) -> Result<MetadataNode> {
+    let span = span_from_pair(&pair);
+    let mut version = None;
+    let mut author = None;
+    let mut description = None;
+    let mut requires_voom = None;
+    let mut requires_tools = Vec::new();
+    let mut test_fixtures = Vec::new();
+
+    for item in pair.into_inner() {
+        if item.as_rule() != Rule::metadata_item {
+            continue;
+        }
+        let text = item.as_str().trim();
+        let keyword = leading_keyword(text);
+        match keyword {
+            "version" => {
+                let string_pair = item
+                    .into_inner()
+                    .find(|p| p.as_rule() == Rule::string)
+                    .unwrap();
+                version = Some(parse_string_value(&string_pair));
+            }
+            "author" => {
+                let string_pair = item
+                    .into_inner()
+                    .find(|p| p.as_rule() == Rule::string)
+                    .unwrap();
+                author = Some(parse_string_value(&string_pair));
+            }
+            "description" => {
+                let string_pair = item
+                    .into_inner()
+                    .find(|p| p.as_rule() == Rule::string)
+                    .unwrap();
+                description = Some(parse_string_value(&string_pair));
+            }
+            "requires_voom" => {
+                let string_pair = item
+                    .into_inner()
+                    .find(|p| p.as_rule() == Rule::string)
+                    .unwrap();
+                requires_voom = Some(parse_string_value(&string_pair));
+            }
+            "requires_tools" => {
+                let list_pair = item
+                    .into_inner()
+                    .find(|p| p.as_rule() == Rule::list)
+                    .unwrap();
+                requires_tools = build_list(list_pair);
+            }
+            "test_fixtures" => {
+                let list_pair = item
+                    .into_inner()
+                    .find(|p| p.as_rule() == Rule::list)
+                    .unwrap();
+                test_fixtures = build_list(list_pair);
+            }
+            other => {
+                let (line, col) = item.as_span().start_pos().line_col();
+                return Err(DslError::build(
+                    line,
+                    col,
+                    format!("unexpected metadata keyword: {other}"),
+                ));
+            }
+        }
+    }
+
+    Ok(MetadataNode {
+        version,
+        author,
+        description,
+        requires_voom,
+        requires_tools,
+        test_fixtures,
         span,
     })
 }
@@ -212,8 +308,13 @@ fn build_phase(pair: Pair<'_, Rule>) -> Result<PhaseNode> {
     let mut run_if = None;
     let mut on_error = None;
     let mut operations = Vec::new();
+    let mut extend = false;
 
     for item in inner {
+        if item.as_rule() == Rule::phase_extend {
+            extend = true;
+            continue;
+        }
         if item.as_rule() != Rule::phase_item {
             continue;
         }
@@ -357,6 +458,7 @@ fn build_phase(pair: Pair<'_, Rule>) -> Result<PhaseNode> {
 
     Ok(PhaseNode {
         name,
+        extend,
         skip_when,
         depends_on,
         run_if,

--- a/crates/voom-dsl/src/parser.rs
+++ b/crates/voom-dsl/src/parser.rs
@@ -139,6 +139,22 @@ fn build_extends(pair: Pair<'_, Rule>) -> ExtendsSource {
     }
 }
 
+fn metadata_string_value(item: Pair<'_, Rule>) -> String {
+    let string_pair = item
+        .into_inner()
+        .find(|pair| pair.as_rule() == Rule::string)
+        .unwrap();
+    parse_string_value(&string_pair)
+}
+
+fn metadata_list_value(item: Pair<'_, Rule>) -> Vec<String> {
+    let list_pair = item
+        .into_inner()
+        .find(|pair| pair.as_rule() == Rule::list)
+        .unwrap();
+    build_list(list_pair)
+}
+
 fn build_metadata(pair: Pair<'_, Rule>) -> Result<MetadataNode> {
     let span = span_from_pair(&pair);
     let mut version = None;
@@ -155,48 +171,12 @@ fn build_metadata(pair: Pair<'_, Rule>) -> Result<MetadataNode> {
         let text = item.as_str().trim();
         let keyword = leading_keyword(text);
         match keyword {
-            "version" => {
-                let string_pair = item
-                    .into_inner()
-                    .find(|p| p.as_rule() == Rule::string)
-                    .unwrap();
-                version = Some(parse_string_value(&string_pair));
-            }
-            "author" => {
-                let string_pair = item
-                    .into_inner()
-                    .find(|p| p.as_rule() == Rule::string)
-                    .unwrap();
-                author = Some(parse_string_value(&string_pair));
-            }
-            "description" => {
-                let string_pair = item
-                    .into_inner()
-                    .find(|p| p.as_rule() == Rule::string)
-                    .unwrap();
-                description = Some(parse_string_value(&string_pair));
-            }
-            "requires_voom" => {
-                let string_pair = item
-                    .into_inner()
-                    .find(|p| p.as_rule() == Rule::string)
-                    .unwrap();
-                requires_voom = Some(parse_string_value(&string_pair));
-            }
-            "requires_tools" => {
-                let list_pair = item
-                    .into_inner()
-                    .find(|p| p.as_rule() == Rule::list)
-                    .unwrap();
-                requires_tools = Some(build_list(list_pair));
-            }
-            "test_fixtures" => {
-                let list_pair = item
-                    .into_inner()
-                    .find(|p| p.as_rule() == Rule::list)
-                    .unwrap();
-                test_fixtures = Some(build_list(list_pair));
-            }
+            "version" => version = Some(metadata_string_value(item)),
+            "author" => author = Some(metadata_string_value(item)),
+            "description" => description = Some(metadata_string_value(item)),
+            "requires_voom" => requires_voom = Some(metadata_string_value(item)),
+            "requires_tools" => requires_tools = Some(metadata_list_value(item)),
+            "test_fixtures" => test_fixtures = Some(metadata_list_value(item)),
             other => {
                 let (line, col) = item.as_span().start_pos().line_col();
                 return Err(DslError::build(

--- a/crates/voom-dsl/src/testing/strategies.rs
+++ b/crates/voom-dsl/src/testing/strategies.rs
@@ -614,8 +614,8 @@ fn phase_strategy() -> impl Strategy<Value = PhaseNode> {
     (
         ident_strategy(),
         proptest::option::of(condition_strategy()),
-        // depends_on: list of phase idents.
-        vec(ident_strategy(), 0..=2),
+        // depends_on: omitted or explicitly present list of phase idents.
+        proptest::option::of(vec(ident_strategy(), 0..=2)),
         proptest::option::of(
             (ident_strategy(), run_if_trigger)
                 .prop_map(|(phase, trigger)| RunIfNode { phase, trigger }),

--- a/crates/voom-dsl/src/testing/strategies.rs
+++ b/crates/voom-dsl/src/testing/strategies.rs
@@ -625,6 +625,7 @@ fn phase_strategy() -> impl Strategy<Value = PhaseNode> {
         .prop_map(
             |(name, skip_when, depends_on, run_if, operations)| PhaseNode {
                 name,
+                extend: false,
                 skip_when,
                 depends_on,
                 run_if,
@@ -659,6 +660,8 @@ pub fn policy_ast_strategy() -> impl Strategy<Value = PolicyAst> {
     )
         .prop_map(|(name, config, phases)| PolicyAst {
             name,
+            extends: None,
+            metadata: None,
             config,
             phases,
             span: dummy_span(),

--- a/crates/voom-dsl/src/validator.rs
+++ b/crates/voom-dsl/src/validator.rs
@@ -3329,6 +3329,7 @@ mod tests {
             .collect();
         PhaseNode {
             name: name.into(),
+            extend: false,
             skip_when: None,
             depends_on: vec![],
             run_if: None,

--- a/crates/voom-dsl/src/validator.rs
+++ b/crates/voom-dsl/src/validator.rs
@@ -123,7 +123,7 @@ fn validate_phase_references(ast: &PolicyAst, errors: &mut Vec<DslError>) {
     let phase_names: HashSet<&str> = ast.phases.iter().map(|p| p.name.as_str()).collect();
 
     for phase in &ast.phases {
-        for dep in &phase.depends_on {
+        for dep in phase.depends_on.as_deref().unwrap_or(&[]) {
             if !phase_names.contains(dep.as_str()) {
                 errors.push(DslError::validation(
                     phase.span.line,
@@ -164,6 +164,8 @@ fn validate_cycle_detection(ast: &PolicyAst, errors: &mut Vec<DslError>) {
     for phase in &ast.phases {
         let deps: Vec<&str> = phase
             .depends_on
+            .as_deref()
+            .unwrap_or(&[])
             .iter()
             .map(std::string::String::as_str)
             .collect();
@@ -250,7 +252,7 @@ fn validate_reachability(ast: &PolicyAst, errors: &mut Vec<DslError>) {
 
     // Roots: phases with no depends_on
     for phase in &ast.phases {
-        if phase.depends_on.is_empty() {
+        if phase.depends_on.as_deref().unwrap_or(&[]).is_empty() {
             reachable.insert(phase.name.as_str());
         }
     }
@@ -265,6 +267,8 @@ fn validate_reachability(ast: &PolicyAst, errors: &mut Vec<DslError>) {
             }
             let all_deps_reachable = phase
                 .depends_on
+                .as_deref()
+                .unwrap_or(&[])
                 .iter()
                 .all(|d| !phase_names.contains(d.as_str()) || reachable.contains(d.as_str()));
             if all_deps_reachable {
@@ -3342,7 +3346,7 @@ mod tests {
             name: name.into(),
             extend: false,
             skip_when: None,
-            depends_on: vec![],
+            depends_on: None,
             run_if: None,
             on_error: None,
             operations,

--- a/crates/voom-dsl/src/validator.rs
+++ b/crates/voom-dsl/src/validator.rs
@@ -291,6 +291,17 @@ fn validate_phase(
     errors: &mut Vec<DslError>,
     warnings: &mut Vec<DslWarning>,
 ) {
+    if phase.extend {
+        errors.push(DslError::validation(
+            phase.span.line,
+            phase.span.col,
+            format!(
+                "phase \"{}\" uses extend but policy composition was not resolved",
+                phase.name
+            ),
+        ));
+    }
+
     if let Some(skip_when) = &phase.skip_when {
         validate_condition(
             skip_when,

--- a/crates/voom-dsl/tests/composition.rs
+++ b/crates/voom-dsl/tests/composition.rs
@@ -31,6 +31,55 @@ fn bundled_extends_inherits_missing_phases() {
 }
 
 #[test]
+fn metadata_is_compiled_with_extends_chain() {
+    let policy = compile_policy_with_bundled(
+        r#"policy "child" extends "anime-base" {
+            metadata {
+                version: "2.0.0"
+                author: "user@example.com"
+            }
+            phase subtitles { keep subtitles where lang == eng }
+        }"#,
+    )
+    .unwrap();
+
+    assert_eq!(policy.metadata.version.as_deref(), Some("2.0.0"));
+    assert_eq!(policy.metadata.author.as_deref(), Some("user@example.com"));
+    assert_eq!(policy.metadata.extends_chain, ["anime-base"]);
+}
+
+#[test]
+fn phase_composition_is_serialized_for_describe() {
+    let policy = compile_policy_with_bundled(
+        r#"policy "child" extends "anime-base" {
+            phase audio { extend keep audio where lang == eng }
+            phase subtitles { keep subtitles where lang == eng }
+        }"#,
+    )
+    .unwrap();
+
+    let audio = policy
+        .phases
+        .iter()
+        .find(|phase| phase.name == "audio")
+        .unwrap();
+    let subtitles = policy
+        .phases
+        .iter()
+        .find(|phase| phase.name == "subtitles")
+        .unwrap();
+
+    assert!(matches!(
+        audio.composition.kind,
+        voom_dsl::compiled::PhaseCompositionKind::Extended
+    ));
+    assert!(matches!(
+        subtitles.composition.kind,
+        voom_dsl::compiled::PhaseCompositionKind::Overridden
+    ));
+}
+
+#[test]
 fn phase_extend_appends_operations_and_inherits_controls() {
     let policy = compile_policy_with_bundled(
         r#"policy "child" extends "anime-base" {

--- a/crates/voom-dsl/tests/composition.rs
+++ b/crates/voom-dsl/tests/composition.rs
@@ -1,7 +1,7 @@
 use std::fs;
 
 use tempfile::tempdir;
-use voom_dsl::{compile_policy_file, compile_policy_with_bundled};
+use voom_dsl::{compile_policy, compile_policy_file, compile_policy_with_bundled};
 
 #[test]
 fn bundled_extends_inherits_missing_phases() {
@@ -52,6 +52,27 @@ fn phase_extend_appends_operations_and_inherits_controls() {
         .unwrap();
     assert_eq!(audio.depends_on, ["containerize"]);
     assert!(audio.operations.len() > 1);
+}
+
+#[test]
+fn phase_extend_can_clear_inherited_dependencies() {
+    let policy = compile_policy_with_bundled(
+        r#"policy "child" extends "anime-base" {
+            phase audio {
+                extend
+                depends_on: []
+                keep audio where lang == jpn
+            }
+        }"#,
+    )
+    .unwrap();
+
+    let audio = policy
+        .phases
+        .iter()
+        .find(|phase| phase.name == "audio")
+        .unwrap();
+    assert!(audio.depends_on.is_empty());
 }
 
 #[test]
@@ -114,4 +135,81 @@ fn extending_unknown_phase_is_rejected() {
     .to_string();
 
     assert!(err.contains("phase \"missing\" uses extend but no parent phase exists"));
+}
+
+#[test]
+fn compile_policy_rejects_unresolved_bundled_extends() {
+    let err = compile_policy(
+        r#"policy "child" extends "anime-base" {
+            phase subtitles {
+                keep subtitles
+            }
+        }"#,
+    )
+    .unwrap_err()
+    .to_string();
+
+    assert!(err.contains("policy extends requires composition resolution"));
+    assert!(err.contains("compile_policy_with_bundled(source)"));
+}
+
+#[test]
+fn unsupported_extends_scheme_is_rejected() {
+    let err = compile_policy_with_bundled(
+        r#"policy "child" extends "registry://x" {
+            phase subtitles {
+                keep subtitles
+            }
+        }"#,
+    )
+    .unwrap_err()
+    .to_string();
+
+    assert!(err.contains("unsupported policy extends URI \"registry://x\""));
+}
+
+#[test]
+fn empty_file_extends_uri_is_rejected() {
+    let err = compile_policy_with_bundled(
+        r#"policy "child" extends "file://" {
+            phase subtitles {
+                keep subtitles
+            }
+        }"#,
+    )
+    .unwrap_err()
+    .to_string();
+
+    assert!(err.contains("file:// policy extends URI must include a path"));
+}
+
+#[test]
+fn composed_source_hash_reflects_resolved_parent_behavior() {
+    let dir = tempdir().unwrap();
+    let first = dir.path().join("first");
+    let second = dir.path().join("second");
+    fs::create_dir(&first).unwrap();
+    fs::create_dir(&second).unwrap();
+    fs::write(
+        first.join("base.voom"),
+        r#"policy "base" { phase base { container mkv } }"#,
+    )
+    .unwrap();
+    fs::write(
+        second.join("base.voom"),
+        r#"policy "base" { phase base { container mp4 } }"#,
+    )
+    .unwrap();
+    let child_source = r#"policy "child" extends "file://./base.voom" {
+        phase child { keep audio }
+    }"#;
+    let first_child = first.join("child.voom");
+    let second_child = second.join("child.voom");
+    fs::write(&first_child, child_source).unwrap();
+    fs::write(&second_child, child_source).unwrap();
+
+    let first_policy = compile_policy_file(&first_child).unwrap();
+    let second_policy = compile_policy_file(&second_child).unwrap();
+
+    assert_ne!(first_policy.source_hash, second_policy.source_hash);
 }

--- a/crates/voom-dsl/tests/composition.rs
+++ b/crates/voom-dsl/tests/composition.rs
@@ -138,6 +138,36 @@ fn extending_unknown_phase_is_rejected() {
 }
 
 #[test]
+fn inherited_root_policy_with_unresolved_phase_extend_is_rejected() {
+    let dir = tempdir().unwrap();
+    let base = dir.path().join("base.voom");
+    let child = dir.path().join("child.voom");
+    fs::write(
+        &base,
+        r#"policy "base" {
+            phase base {
+                extend
+                keep audio
+            }
+        }"#,
+    )
+    .unwrap();
+    fs::write(
+        &child,
+        r#"policy "child" extends "file://./base.voom" {
+            phase child {
+                keep subtitles
+            }
+        }"#,
+    )
+    .unwrap();
+
+    let err = compile_policy_file(&child).unwrap_err().to_string();
+
+    assert!(err.contains("phase \"base\" uses extend but policy composition was not resolved"));
+}
+
+#[test]
 fn compile_policy_rejects_unresolved_bundled_extends() {
     let err = compile_policy(
         r#"policy "child" extends "anime-base" {

--- a/crates/voom-dsl/tests/composition.rs
+++ b/crates/voom-dsl/tests/composition.rs
@@ -1,0 +1,117 @@
+use std::fs;
+
+use tempfile::tempdir;
+use voom_dsl::{compile_policy_file, compile_policy_with_bundled};
+
+#[test]
+fn bundled_extends_inherits_missing_phases() {
+    let policy = compile_policy_with_bundled(
+        r#"policy "child" extends "anime-base" {
+            phase subtitles {
+                keep subtitles where lang == eng
+            }
+        }"#,
+    )
+    .unwrap();
+
+    assert!(
+        policy
+            .phases
+            .iter()
+            .any(|phase| phase.name == "containerize")
+    );
+    assert!(policy.phases.iter().any(|phase| phase.name == "audio"));
+    let subtitles = policy
+        .phases
+        .iter()
+        .find(|phase| phase.name == "subtitles")
+        .unwrap();
+    assert_eq!(subtitles.operations.len(), 1);
+}
+
+#[test]
+fn phase_extend_appends_operations_and_inherits_controls() {
+    let policy = compile_policy_with_bundled(
+        r#"policy "child" extends "anime-base" {
+            phase audio {
+                extend
+                synthesize "AAC Stereo" {
+                    codec: aac
+                    channels: stereo
+                    source: prefer(channels >= 6)
+                }
+            }
+        }"#,
+    )
+    .unwrap();
+
+    let audio = policy
+        .phases
+        .iter()
+        .find(|phase| phase.name == "audio")
+        .unwrap();
+    assert_eq!(audio.depends_on, ["containerize"]);
+    assert!(audio.operations.len() > 1);
+}
+
+#[test]
+fn file_extends_resolves_relative_to_child_file() {
+    let dir = tempdir().unwrap();
+    fs::create_dir(dir.path().join("shared")).unwrap();
+    fs::write(
+        dir.path().join("shared/base.voom"),
+        r#"policy "base" { phase base { container mkv } }"#,
+    )
+    .unwrap();
+    let child = dir.path().join("child.voom");
+    fs::write(
+        &child,
+        r#"policy "child" extends "file://./shared/base.voom" {
+            phase child { depends_on: [base] keep audio }
+        }"#,
+    )
+    .unwrap();
+
+    let policy = compile_policy_file(&child).unwrap();
+
+    assert_eq!(policy.phase_order, ["base", "child"]);
+}
+
+#[test]
+fn cyclic_extends_reports_chain() {
+    let dir = tempdir().unwrap();
+    let a = dir.path().join("a.voom");
+    let b = dir.path().join("b.voom");
+    fs::write(
+        &a,
+        r#"policy "a" extends "file://./b.voom" { phase a { container mkv } }"#,
+    )
+    .unwrap();
+    fs::write(
+        &b,
+        r#"policy "b" extends "file://./a.voom" { phase b { container mkv } }"#,
+    )
+    .unwrap();
+
+    let err = compile_policy_file(&a).unwrap_err().to_string();
+
+    assert!(err.contains("cyclic policy extends"));
+    assert!(err.contains("a.voom"));
+    assert!(err.contains("b.voom"));
+}
+
+#[test]
+fn extending_unknown_phase_is_rejected() {
+    let err = compile_policy_with_bundled(
+        r#"policy "child" extends "anime-base" {
+            phase missing {
+                extend
+                keep audio
+            }
+        }"#,
+    )
+    .unwrap_err()
+    .to_string();
+
+    assert!(err.contains("phase \"missing\" uses extend but no parent phase exists"));
+}

--- a/crates/voom-dsl/tests/composition.rs
+++ b/crates/voom-dsl/tests/composition.rs
@@ -1,7 +1,8 @@
 use std::fs;
 
+use serde_json::json;
 use tempfile::tempdir;
-use voom_dsl::compiled::{CompiledOperation, TrackTarget};
+use voom_dsl::compiled::{CompiledOperation, CompiledPolicy, TrackTarget};
 use voom_dsl::{compile_policy, compile_policy_file, compile_policy_with_bundled};
 
 #[test]
@@ -58,25 +59,70 @@ fn phase_composition_is_serialized_for_describe() {
     )
     .unwrap();
 
-    let audio = policy
-        .phases
-        .iter()
-        .find(|phase| phase.name == "audio")
-        .unwrap();
-    let subtitles = policy
-        .phases
-        .iter()
-        .find(|phase| phase.name == "subtitles")
-        .unwrap();
+    let value = serde_json::to_value(&policy).unwrap();
+    assert_phase_composition_json(&value, "containerize", "Inherited", Some("anime-base"), 0);
+    assert_phase_composition_json(&value, "audio", "Extended", Some("anime-base"), 1);
+    assert_phase_composition_json(&value, "subtitles", "Overridden", Some("inline"), 0);
 
-    assert!(matches!(
-        audio.composition.kind,
-        voom_dsl::compiled::PhaseCompositionKind::Extended
-    ));
-    assert!(matches!(
-        subtitles.composition.kind,
-        voom_dsl::compiled::PhaseCompositionKind::Overridden
-    ));
+    let local_policy = compile_policy(
+        r#"policy "standalone" {
+            phase local { keep audio }
+        }"#,
+    )
+    .unwrap();
+    let local_value = serde_json::to_value(&local_policy).unwrap();
+    assert_phase_composition_json(&local_value, "local", "Local", None, 0);
+}
+
+#[test]
+fn old_compiled_json_defaults_metadata_and_phase_composition() {
+    let policy: CompiledPolicy = serde_json::from_value(json!({
+        "name": "legacy",
+        "config": {
+            "audio_languages": [],
+            "subtitle_languages": [],
+            "on_error": "Abort",
+            "commentary_patterns": [],
+            "keep_backups": false
+        },
+        "phases": [{
+            "name": "local",
+            "depends_on": [],
+            "skip_when": null,
+            "run_if": null,
+            "on_error": "Abort",
+            "operations": []
+        }],
+        "phase_order": ["local"],
+        "source_hash": "abc"
+    }))
+    .unwrap();
+
+    assert!(policy.metadata.extends_chain.is_empty());
+    let phase = policy.phases.first().unwrap();
+    assert_eq!(
+        phase.composition.kind,
+        voom_dsl::compiled::PhaseCompositionKind::Local
+    );
+    assert_eq!(phase.composition.source, None);
+    assert_eq!(phase.composition.added_operations, 0);
+}
+
+fn assert_phase_composition_json(
+    policy: &serde_json::Value,
+    name: &str,
+    kind: &str,
+    source: Option<&str>,
+    added_operations: usize,
+) {
+    let phases = policy["phases"].as_array().unwrap();
+    let phase = phases
+        .iter()
+        .find(|phase| phase["name"] == name)
+        .unwrap_or_else(|| panic!("missing phase {name}"));
+    assert_eq!(phase["composition"]["kind"], kind);
+    assert_eq!(phase["composition"]["source"], json!(source));
+    assert_eq!(phase["composition"]["added_operations"], added_operations);
 }
 
 #[test]

--- a/crates/voom-dsl/tests/composition.rs
+++ b/crates/voom-dsl/tests/composition.rs
@@ -1,6 +1,7 @@
 use std::fs;
 
 use tempfile::tempdir;
+use voom_dsl::compiled::{CompiledOperation, TrackTarget};
 use voom_dsl::{compile_policy, compile_policy_file, compile_policy_with_bundled};
 
 #[test]
@@ -51,7 +52,22 @@ fn phase_extend_appends_operations_and_inherits_controls() {
         .find(|phase| phase.name == "audio")
         .unwrap();
     assert_eq!(audio.depends_on, ["containerize"]);
-    assert!(audio.operations.len() > 1);
+    assert_eq!(audio.operations.len(), 3);
+    assert!(matches!(
+        audio.operations[0],
+        CompiledOperation::Keep {
+            target: TrackTarget::Audio,
+            ..
+        }
+    ));
+    assert!(matches!(
+        audio.operations[1],
+        CompiledOperation::SetDefaults(_)
+    ));
+    let CompiledOperation::Synthesize(synthesize) = &audio.operations[2] else {
+        panic!("expected appended synthesize operation");
+    };
+    assert_eq!(synthesize.name, "AAC Stereo");
 }
 
 #[test]
@@ -184,6 +200,22 @@ fn compile_policy_rejects_unresolved_bundled_extends() {
 }
 
 #[test]
+fn compile_policy_rejects_unresolved_file_extends() {
+    let err = compile_policy(
+        r#"policy "child" extends "file://./base.voom" {
+            phase subtitles {
+                keep subtitles
+            }
+        }"#,
+    )
+    .unwrap_err()
+    .to_string();
+
+    assert!(err.contains("policy extends requires composition resolution"));
+    assert!(err.contains("compile_policy_file(path)"));
+}
+
+#[test]
 fn unsupported_extends_scheme_is_rejected() {
     let err = compile_policy_with_bundled(
         r#"policy "child" extends "registry://x" {
@@ -199,6 +231,28 @@ fn unsupported_extends_scheme_is_rejected() {
 }
 
 #[test]
+fn compile_policy_with_bundled_rejects_absolute_file_extends() {
+    let dir = tempdir().unwrap();
+    let base = dir.path().join("base.voom");
+    fs::write(&base, r#"this file should not be parsed"#).unwrap();
+    let source = format!(
+        r#"policy "child" extends "file://{}" {{
+            phase subtitles {{
+                keep subtitles
+            }}
+        }}"#,
+        base.display()
+    );
+
+    let err = compile_policy_with_bundled(&source)
+        .unwrap_err()
+        .to_string();
+
+    assert!(err.contains("file:// policy extends requires compile_policy_file(path)"));
+    assert!(!err.contains("parse error"));
+}
+
+#[test]
 fn empty_file_extends_uri_is_rejected() {
     let err = compile_policy_with_bundled(
         r#"policy "child" extends "file://" {
@@ -210,7 +264,7 @@ fn empty_file_extends_uri_is_rejected() {
     .unwrap_err()
     .to_string();
 
-    assert!(err.contains("file:// policy extends URI must include a path"));
+    assert!(err.contains("file:// policy extends requires compile_policy_file(path)"));
 }
 
 #[test]

--- a/crates/voom-dsl/tests/composition.rs
+++ b/crates/voom-dsl/tests/composition.rs
@@ -2,7 +2,7 @@ use std::fs;
 
 use serde_json::json;
 use tempfile::tempdir;
-use voom_dsl::compiled::{CompiledOperation, CompiledPolicy, TrackTarget};
+use voom_dsl::compiled::{CompiledOperation, CompiledPolicy, PhaseCompositionKind, TrackTarget};
 use voom_dsl::{compile_policy, compile_policy_file, compile_policy_with_bundled};
 
 #[test]
@@ -207,6 +207,43 @@ fn file_extends_resolves_relative_to_child_file() {
     let policy = compile_policy_file(&child).unwrap();
 
     assert_eq!(policy.phase_order, ["base", "child"]);
+}
+
+#[test]
+fn inherited_intermediate_local_phase_uses_intermediate_source() {
+    let dir = tempdir().unwrap();
+    let base = dir.path().join("base.voom");
+    let middle = dir.path().join("middle.voom");
+    let child = dir.path().join("child.voom");
+    fs::write(&base, r#"policy "base" { phase a { container mkv } }"#).unwrap();
+    fs::write(
+        &middle,
+        r#"policy "middle" extends "file://./base.voom" {
+            phase b { depends_on: [a] keep audio }
+        }"#,
+    )
+    .unwrap();
+    fs::write(
+        &child,
+        r#"policy "child" extends "file://./middle.voom" {
+            phase c { depends_on: [b] keep subtitles }
+        }"#,
+    )
+    .unwrap();
+
+    let policy = compile_policy_file(&child).unwrap();
+
+    let middle_source = fs::canonicalize(&middle).unwrap().display().to_string();
+    let phase = policy
+        .phases
+        .iter()
+        .find(|phase| phase.name == "b")
+        .unwrap();
+    assert_eq!(phase.composition.kind, PhaseCompositionKind::Inherited);
+    assert_eq!(
+        phase.composition.source.as_deref(),
+        Some(middle_source.as_str())
+    );
 }
 
 #[test]

--- a/crates/voom-dsl/tests/composition.rs
+++ b/crates/voom-dsl/tests/composition.rs
@@ -429,3 +429,27 @@ fn composed_source_hash_reflects_resolved_parent_behavior() {
 
     assert_ne!(first_policy.source_hash, second_policy.source_hash);
 }
+
+#[test]
+fn bundled_and_file_composition_use_same_resolved_hash_pipeline() {
+    let dir = tempdir().unwrap();
+    let child = dir.path().join("child.voom");
+    fs::write(
+        &child,
+        r#"policy "child" extends "anime-base" {
+            phase audio { extend keep audio where lang == eng }
+        }"#,
+    )
+    .unwrap();
+
+    let inline = compile_policy_with_bundled(
+        r#"policy "child" extends "anime-base" {
+            phase audio { extend keep audio where lang == eng }
+        }"#,
+    )
+    .unwrap();
+    let file = compile_policy_file(&child).unwrap();
+
+    assert_eq!(inline.source_hash, file.source_hash);
+    assert_eq!(inline.phase_order, file.phase_order);
+}

--- a/crates/voom-dsl/tests/composition.rs
+++ b/crates/voom-dsl/tests/composition.rs
@@ -431,6 +431,19 @@ fn composed_source_hash_reflects_resolved_parent_behavior() {
 }
 
 #[test]
+fn standalone_file_policy_hash_matches_raw_source_hash() {
+    let dir = tempdir().unwrap();
+    let source = include_str!("../../../docs/examples/minimal.voom");
+    let path = dir.path().join("minimal.voom");
+    fs::write(&path, source).unwrap();
+
+    let inline_policy = compile_policy(source).unwrap();
+    let file_policy = compile_policy_file(&path).unwrap();
+
+    assert_eq!(file_policy.source_hash, inline_policy.source_hash);
+}
+
+#[test]
 fn bundled_and_file_composition_use_same_resolved_hash_pipeline() {
     let dir = tempdir().unwrap();
     let child = dir.path().join("child.voom");

--- a/crates/voom-dsl/tests/parser_snapshots.rs
+++ b/crates/voom-dsl/tests/parser_snapshots.rs
@@ -1,5 +1,5 @@
 use insta::assert_yaml_snapshot;
-use voom_dsl::parse_policy;
+use voom_dsl::{compile_policy_with_bundled, parse_policy};
 
 #[test]
 fn snapshot_minimal_policy() {
@@ -336,6 +336,15 @@ fn example_anime_collection_parses() {
     let ast = parse_policy(input).unwrap();
     assert_eq!(ast.name, "anime-collection");
     assert_eq!(ast.phases.len(), 5);
+}
+
+#[test]
+fn example_composed_anime_parses_and_validates() {
+    let input = include_str!("../../../docs/examples/composed-anime.voom");
+    let policy = compile_policy_with_bundled(input).unwrap();
+    assert_eq!(policy.name, "composed-anime");
+    assert_eq!(policy.metadata.extends_chain, ["anime-base"]);
+    assert_eq!(policy.phase_order, ["containerize", "audio", "subtitles"]);
 }
 
 #[test]

--- a/crates/voom-dsl/tests/parser_snapshots.rs
+++ b/crates/voom-dsl/tests/parser_snapshots.rs
@@ -71,6 +71,20 @@ fn format_preserves_policy_composition_syntax() {
 }
 
 #[test]
+fn format_quotes_path_like_metadata_requires_tools() {
+    let input = r#"policy "child" {
+        metadata { requires_tools: ["tools/ffmpeg"] }
+        phase audio { keep audio }
+    }"#;
+    let ast = parse_policy(input).unwrap();
+    let formatted = voom_dsl::format_policy(&ast);
+
+    assert!(formatted.contains(r#"requires_tools: ["tools/ffmpeg"]"#));
+    let reparsed = parse_policy(&formatted).unwrap();
+    assert_eq!(voom_dsl::format_policy(&reparsed), formatted);
+}
+
+#[test]
 fn snapshot_keep_remove_operations() {
     let input = r#"policy "track-ops" {
         phase normalize {

--- a/crates/voom-dsl/tests/parser_snapshots.rs
+++ b/crates/voom-dsl/tests/parser_snapshots.rs
@@ -1,5 +1,5 @@
 use insta::assert_yaml_snapshot;
-use voom_dsl::{compile_policy_with_bundled, parse_policy};
+use voom_dsl::{PhaseCompositionKind, compile_policy_with_bundled, parse_policy};
 
 #[test]
 fn snapshot_minimal_policy() {
@@ -345,6 +345,26 @@ fn example_composed_anime_parses_and_validates() {
     assert_eq!(policy.name, "composed-anime");
     assert_eq!(policy.metadata.extends_chain, ["anime-base"]);
     assert_eq!(policy.phase_order, ["containerize", "audio", "subtitles"]);
+    let phase = |name: &str| {
+        policy
+            .phases
+            .iter()
+            .find(|phase| phase.name == name)
+            .unwrap_or_else(|| panic!("missing compiled phase {name:?}"))
+    };
+    assert_eq!(
+        phase("containerize").composition.kind,
+        PhaseCompositionKind::Inherited
+    );
+    assert_eq!(
+        phase("audio").composition.kind,
+        PhaseCompositionKind::Extended
+    );
+    assert_eq!(phase("audio").composition.added_operations, 1);
+    assert_eq!(
+        phase("subtitles").composition.kind,
+        PhaseCompositionKind::Overridden
+    );
 }
 
 #[test]

--- a/crates/voom-dsl/tests/parser_snapshots.rs
+++ b/crates/voom-dsl/tests/parser_snapshots.rs
@@ -30,6 +30,47 @@ fn snapshot_config_block() {
 }
 
 #[test]
+fn snapshot_policy_extends_and_phase_extend() {
+    let input = r#"policy "my-anime" extends "anime-base" {
+        metadata {
+            version: "1.2.0"
+            author: "user@example.com"
+            description: "Archive-quality anime preservation"
+            requires_voom: ">=0.5.0"
+            requires_tools: [ffmpeg, mkvmerge, mkvextract]
+            test_fixtures: ["fixtures/anime/"]
+        }
+
+        phase audio {
+            extend
+            synthesize "AC3 5.1" {
+                codec: ac3
+                channels: 5.1
+                source: prefer(channels >= 5.1 and lang == jpn)
+            }
+        }
+    }"#;
+    let ast = parse_policy(input).unwrap();
+    assert_yaml_snapshot!(ast);
+}
+
+#[test]
+fn format_preserves_policy_composition_syntax() {
+    let input = r#"policy "child" extends "file://./base.voom" {
+        metadata { version: "1.0.0" }
+        phase audio { extend keep audio where lang == eng }
+    }"#;
+    let ast = parse_policy(input).unwrap();
+    let formatted = voom_dsl::format_policy(&ast);
+
+    assert!(formatted.contains("policy \"child\" extends \"file://./base.voom\""));
+    assert!(formatted.contains("metadata {"));
+    assert!(formatted.contains("extend"));
+    let reparsed = parse_policy(&formatted).unwrap();
+    assert_eq!(voom_dsl::format_policy(&reparsed), formatted);
+}
+
+#[test]
 fn snapshot_keep_remove_operations() {
     let input = r#"policy "track-ops" {
         phase normalize {

--- a/crates/voom-dsl/tests/snapshots/parser_snapshots__complex_filter_and_or.snap
+++ b/crates/voom-dsl/tests/snapshots/parser_snapshots__complex_filter_and_or.snap
@@ -10,7 +10,7 @@ phases:
   - name: norm
     extend: false
     skip_when: ~
-    depends_on: []
+    depends_on: ~
     run_if: ~
     on_error: ~
     operations:

--- a/crates/voom-dsl/tests/snapshots/parser_snapshots__complex_filter_and_or.snap
+++ b/crates/voom-dsl/tests/snapshots/parser_snapshots__complex_filter_and_or.snap
@@ -3,9 +3,12 @@ source: crates/voom-dsl/tests/parser_snapshots.rs
 expression: ast
 ---
 name: filters
+extends: ~
+metadata: ~
 config: ~
 phases:
   - name: norm
+    extend: false
     skip_when: ~
     depends_on: []
     run_if: ~

--- a/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_actions_block.snap
+++ b/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_actions_block.snap
@@ -3,9 +3,12 @@ source: crates/voom-dsl/tests/parser_snapshots.rs
 expression: ast
 ---
 name: actions
+extends: ~
+metadata: ~
 config: ~
 phases:
   - name: normalize
+    extend: false
     skip_when: ~
     depends_on: []
     run_if: ~

--- a/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_actions_block.snap
+++ b/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_actions_block.snap
@@ -10,7 +10,7 @@ phases:
   - name: normalize
     extend: false
     skip_when: ~
-    depends_on: []
+    depends_on: ~
     run_if: ~
     on_error: ~
     operations:

--- a/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_config_block.snap
+++ b/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_config_block.snap
@@ -3,6 +3,8 @@ source: crates/voom-dsl/tests/parser_snapshots.rs
 expression: ast
 ---
 name: with-config
+extends: ~
+metadata: ~
 config:
   audio_languages:
     - eng
@@ -22,6 +24,7 @@ config:
     col: 9
 phases:
   - name: init
+    extend: false
     skip_when: ~
     depends_on: []
     run_if: ~

--- a/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_config_block.snap
+++ b/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_config_block.snap
@@ -26,7 +26,7 @@ phases:
   - name: init
     extend: false
     skip_when: ~
-    depends_on: []
+    depends_on: ~
     run_if: ~
     on_error: ~
     operations:

--- a/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_container_metadata.snap
+++ b/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_container_metadata.snap
@@ -10,7 +10,7 @@ phases:
   - name: clean
     extend: false
     skip_when: ~
-    depends_on: []
+    depends_on: ~
     run_if: ~
     on_error: ~
     operations:

--- a/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_container_metadata.snap
+++ b/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_container_metadata.snap
@@ -1,12 +1,14 @@
 ---
 source: crates/voom-dsl/tests/parser_snapshots.rs
-assertion_line: 221
 expression: ast
 ---
 name: clean-convert
+extends: ~
+metadata: ~
 config: ~
 phases:
   - name: clean
+    extend: false
     skip_when: ~
     depends_on: []
     run_if: ~
@@ -49,6 +51,7 @@ phases:
       line: 2
       col: 3
   - name: metadata
+    extend: false
     skip_when: ~
     depends_on:
       - clean

--- a/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_depends_on_and_run_if.snap
+++ b/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_depends_on_and_run_if.snap
@@ -3,9 +3,12 @@ source: crates/voom-dsl/tests/parser_snapshots.rs
 expression: ast
 ---
 name: deps
+extends: ~
+metadata: ~
 config: ~
 phases:
   - name: first
+    extend: false
     skip_when: ~
     depends_on: []
     run_if: ~
@@ -24,6 +27,7 @@ phases:
       line: 2
       col: 9
   - name: second
+    extend: false
     skip_when: ~
     depends_on:
       - first

--- a/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_depends_on_and_run_if.snap
+++ b/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_depends_on_and_run_if.snap
@@ -10,7 +10,7 @@ phases:
   - name: first
     extend: false
     skip_when: ~
-    depends_on: []
+    depends_on: ~
     run_if: ~
     on_error: ~
     operations:

--- a/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_keep_remove_operations.snap
+++ b/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_keep_remove_operations.snap
@@ -10,7 +10,7 @@ phases:
   - name: normalize
     extend: false
     skip_when: ~
-    depends_on: []
+    depends_on: ~
     run_if: ~
     on_error: ~
     operations:

--- a/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_keep_remove_operations.snap
+++ b/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_keep_remove_operations.snap
@@ -3,9 +3,12 @@ source: crates/voom-dsl/tests/parser_snapshots.rs
 expression: ast
 ---
 name: track-ops
+extends: ~
+metadata: ~
 config: ~
 phases:
   - name: normalize
+    extend: false
     skip_when: ~
     depends_on: []
     run_if: ~

--- a/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_metadata_phase.snap
+++ b/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_metadata_phase.snap
@@ -1,12 +1,14 @@
 ---
 source: crates/voom-dsl/tests/parser_snapshots.rs
-assertion_line: 172
 expression: ast
 ---
 name: metadata
+extends: ~
+metadata: ~
 config: ~
 phases:
   - name: metadata
+    extend: false
     skip_when: ~
     depends_on: []
     run_if: ~

--- a/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_metadata_phase.snap
+++ b/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_metadata_phase.snap
@@ -10,7 +10,7 @@ phases:
   - name: metadata
     extend: false
     skip_when: ~
-    depends_on: []
+    depends_on: ~
     run_if: ~
     on_error: ~
     operations:

--- a/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_minimal_policy.snap
+++ b/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_minimal_policy.snap
@@ -10,7 +10,7 @@ phases:
   - name: init
     extend: false
     skip_when: ~
-    depends_on: []
+    depends_on: ~
     run_if: ~
     on_error: ~
     operations:

--- a/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_minimal_policy.snap
+++ b/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_minimal_policy.snap
@@ -3,9 +3,12 @@ source: crates/voom-dsl/tests/parser_snapshots.rs
 expression: ast
 ---
 name: minimal
+extends: ~
+metadata: ~
 config: ~
 phases:
   - name: init
+    extend: false
     skip_when: ~
     depends_on: []
     run_if: ~

--- a/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_order_and_defaults.snap
+++ b/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_order_and_defaults.snap
@@ -10,7 +10,7 @@ phases:
   - name: normalize
     extend: false
     skip_when: ~
-    depends_on: []
+    depends_on: ~
     run_if: ~
     on_error: ~
     operations:

--- a/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_order_and_defaults.snap
+++ b/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_order_and_defaults.snap
@@ -3,9 +3,12 @@ source: crates/voom-dsl/tests/parser_snapshots.rs
 expression: ast
 ---
 name: ordering
+extends: ~
+metadata: ~
 config: ~
 phases:
   - name: normalize
+    extend: false
     skip_when: ~
     depends_on: []
     run_if: ~

--- a/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_policy_extends_and_phase_extend.snap
+++ b/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_policy_extends_and_phase_extend.snap
@@ -1,0 +1,63 @@
+---
+source: crates/voom-dsl/tests/parser_snapshots.rs
+expression: ast
+---
+name: my-anime
+extends:
+  Bundled: anime-base
+metadata:
+  version: 1.2.0
+  author: user@example.com
+  description: Archive-quality anime preservation
+  requires_voom: ">=0.5.0"
+  requires_tools:
+    - ffmpeg
+    - mkvmerge
+    - mkvextract
+  test_fixtures:
+    - fixtures/anime/
+  span:
+    start: 49
+    end: 342
+    line: 2
+    col: 9
+config: ~
+phases:
+  - name: audio
+    extend: true
+    skip_when: ~
+    depends_on: []
+    run_if: ~
+    on_error: ~
+    operations:
+      - node:
+          Synthesize:
+            name: AC3 5.1
+            settings:
+              - Codec: ac3
+              - Channels:
+                  Number:
+                    - 5.1
+                    - "5.1"
+              - Source:
+                  And:
+                    - Channels:
+                        - Ge
+                        - 5.1
+                    - LangIn:
+                        - jpn
+        span:
+          start: 397
+          end: 554
+          line: 13
+          col: 13
+    span:
+      start: 352
+      end: 564
+      line: 11
+      col: 9
+span:
+  start: 0
+  end: 570
+  line: 1
+  col: 1

--- a/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_policy_extends_and_phase_extend.snap
+++ b/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_policy_extends_and_phase_extend.snap
@@ -26,7 +26,7 @@ phases:
   - name: audio
     extend: true
     skip_when: ~
-    depends_on: []
+    depends_on: ~
     run_if: ~
     on_error: ~
     operations:

--- a/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_production_normalize.snap
+++ b/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_production_normalize.snap
@@ -1,9 +1,10 @@
 ---
 source: crates/voom-dsl/tests/parser_snapshots.rs
-assertion_line: 179
 expression: ast
 ---
 name: production-normalize
+extends: ~
+metadata: ~
 config:
   audio_languages:
     - eng
@@ -24,6 +25,7 @@ config:
     col: 3
 phases:
   - name: containerize
+    extend: false
     skip_when: ~
     depends_on: []
     run_if: ~
@@ -42,6 +44,7 @@ phases:
       line: 10
       col: 3
   - name: normalize
+    extend: false
     skip_when: ~
     depends_on:
       - containerize
@@ -144,6 +147,7 @@ phases:
       line: 15
       col: 3
   - name: transcode
+    extend: false
     skip_when:
       FieldCompare:
         - - video
@@ -201,6 +205,7 @@ phases:
       line: 46
       col: 3
   - name: audio_compat
+    extend: false
     skip_when: ~
     depends_on:
       - normalize
@@ -247,6 +252,7 @@ phases:
       line: 63
       col: 3
   - name: validate
+    extend: false
     skip_when: ~
     depends_on:
       - transcode
@@ -310,6 +316,7 @@ phases:
       line: 79
       col: 3
   - name: metadata
+    extend: false
     skip_when: ~
     depends_on: []
     run_if: ~

--- a/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_production_normalize.snap
+++ b/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_production_normalize.snap
@@ -27,7 +27,7 @@ phases:
   - name: containerize
     extend: false
     skip_when: ~
-    depends_on: []
+    depends_on: ~
     run_if: ~
     on_error: ~
     operations:
@@ -156,7 +156,7 @@ phases:
         - List:
             - Ident: hevc
             - Ident: h265
-    depends_on: []
+    depends_on: ~
     run_if: ~
     on_error: ~
     operations:
@@ -318,7 +318,7 @@ phases:
   - name: metadata
     extend: false
     skip_when: ~
-    depends_on: []
+    depends_on: ~
     run_if: ~
     on_error: ~
     operations:

--- a/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_rules_block.snap
+++ b/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_rules_block.snap
@@ -10,7 +10,7 @@ phases:
   - name: validate
     extend: false
     skip_when: ~
-    depends_on: []
+    depends_on: ~
     run_if: ~
     on_error: ~
     operations:

--- a/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_rules_block.snap
+++ b/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_rules_block.snap
@@ -1,12 +1,14 @@
 ---
 source: crates/voom-dsl/tests/parser_snapshots.rs
-assertion_line: 144
 expression: ast
 ---
 name: rules
+extends: ~
+metadata: ~
 config: ~
 phases:
   - name: validate
+    extend: false
     skip_when: ~
     depends_on: []
     run_if: ~

--- a/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_speech_language_filter_example.snap
+++ b/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_speech_language_filter_example.snap
@@ -22,7 +22,7 @@ phases:
   - name: keep-english
     extend: false
     skip_when: ~
-    depends_on: []
+    depends_on: ~
     run_if: ~
     on_error: ~
     operations:

--- a/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_speech_language_filter_example.snap
+++ b/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_speech_language_filter_example.snap
@@ -3,6 +3,8 @@ source: crates/voom-dsl/tests/parser_snapshots.rs
 expression: ast
 ---
 name: speech-language-filter
+extends: ~
+metadata: ~
 config:
   audio_languages:
     - eng
@@ -18,6 +20,7 @@ config:
     col: 3
 phases:
   - name: keep-english
+    extend: false
     skip_when: ~
     depends_on: []
     run_if: ~
@@ -42,6 +45,7 @@ phases:
       line: 16
       col: 3
   - name: validate
+    extend: false
     skip_when: ~
     depends_on:
       - keep-english

--- a/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_speech_transcription_check_example.snap
+++ b/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_speech_transcription_check_example.snap
@@ -23,7 +23,7 @@ phases:
   - name: classify-speech
     extend: false
     skip_when: ~
-    depends_on: []
+    depends_on: ~
     run_if: ~
     on_error: ~
     operations:

--- a/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_speech_transcription_check_example.snap
+++ b/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_speech_transcription_check_example.snap
@@ -3,6 +3,8 @@ source: crates/voom-dsl/tests/parser_snapshots.rs
 expression: ast
 ---
 name: speech-transcription-check
+extends: ~
+metadata: ~
 config:
   audio_languages:
     - eng
@@ -19,6 +21,7 @@ config:
     col: 3
 phases:
   - name: classify-speech
+    extend: false
     skip_when: ~
     depends_on: []
     run_if: ~
@@ -97,6 +100,7 @@ phases:
       line: 13
       col: 3
   - name: validate
+    extend: false
     skip_when: ~
     depends_on:
       - classify-speech

--- a/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_synthesize.snap
+++ b/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_synthesize.snap
@@ -10,7 +10,7 @@ phases:
   - name: audio_compat
     extend: false
     skip_when: ~
-    depends_on: []
+    depends_on: ~
     run_if: ~
     on_error: ~
     operations:

--- a/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_synthesize.snap
+++ b/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_synthesize.snap
@@ -3,9 +3,12 @@ source: crates/voom-dsl/tests/parser_snapshots.rs
 expression: ast
 ---
 name: synth
+extends: ~
+metadata: ~
 config: ~
 phases:
   - name: audio_compat
+    extend: false
     skip_when: ~
     depends_on: []
     run_if: ~

--- a/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_transcode.snap
+++ b/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_transcode.snap
@@ -17,7 +17,7 @@ phases:
         - List:
             - Ident: hevc
             - Ident: h265
-    depends_on: []
+    depends_on: ~
     run_if: ~
     on_error: ~
     operations:

--- a/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_transcode.snap
+++ b/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_transcode.snap
@@ -3,9 +3,12 @@ source: crates/voom-dsl/tests/parser_snapshots.rs
 expression: ast
 ---
 name: transcode
+extends: ~
+metadata: ~
 config: ~
 phases:
   - name: tc
+    extend: false
     skip_when:
       FieldCompare:
         - - video

--- a/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_when_block.snap
+++ b/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_when_block.snap
@@ -10,7 +10,7 @@ phases:
   - name: validate
     extend: false
     skip_when: ~
-    depends_on: []
+    depends_on: ~
     run_if: ~
     on_error: ~
     operations:

--- a/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_when_block.snap
+++ b/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_when_block.snap
@@ -1,12 +1,14 @@
 ---
 source: crates/voom-dsl/tests/parser_snapshots.rs
-assertion_line: 127
 expression: ast
 ---
 name: when
+extends: ~
+metadata: ~
 config: ~
 phases:
   - name: validate
+    extend: false
     skip_when: ~
     depends_on: []
     run_if: ~

--- a/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_when_else_block.snap
+++ b/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_when_else_block.snap
@@ -10,7 +10,7 @@ phases:
   - name: validate
     extend: false
     skip_when: ~
-    depends_on: []
+    depends_on: ~
     run_if: ~
     on_error: ~
     operations:

--- a/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_when_else_block.snap
+++ b/crates/voom-dsl/tests/snapshots/parser_snapshots__snapshot_when_else_block.snap
@@ -1,12 +1,14 @@
 ---
 source: crates/voom-dsl/tests/parser_snapshots.rs
-assertion_line: 214
 expression: ast
 ---
 name: when-else
+extends: ~
+metadata: ~
 config: ~
 phases:
   - name: validate
+    extend: false
     skip_when: ~
     depends_on: []
     run_if: ~

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -203,7 +203,9 @@ The default human output shows the policy name, resolved `extends` chain,
 metadata version when present, effective phase order, and one row per phase with
 its composition source. Inherited phases are shown as inherited from the parent,
 extended phases include the parent source and number of appended operations, and
-overridden phases show the inline child source.
+overridden phases show the child source that replaced the parent phase. For
+file-loaded policies this is the child policy path; for in-memory compilation it
+may be `inline`.
 
 JSON output is intended for tooling. It includes stable top-level fields:
 `policy`, `extends_chain`, `metadata`, `phase_order`, and `phases`. Each phase

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -191,6 +191,25 @@ Show the compiled form of a policy.
 voom policy show <FILE> [--format table|json]
 ```
 
+#### `voom policy describe`
+
+Describe resolved policy composition and provenance.
+
+```
+voom policy describe <FILE> [--format table|json]
+```
+
+The default human output shows the policy name, resolved `extends` chain,
+metadata version when present, effective phase order, and one row per phase with
+its composition source. Inherited phases are shown as inherited from the parent,
+extended phases include the parent source and number of appended operations, and
+overridden phases show the inline child source.
+
+JSON output is intended for tooling. It includes stable top-level fields:
+`policy`, `extends_chain`, `metadata`, `phase_order`, and `phases`. Each phase
+entry includes `name` and `composition`, where `composition` contains `kind`,
+`source`, and `added_operations`.
+
 #### `voom policy format`
 
 Auto-format a policy file in place.
@@ -222,6 +241,8 @@ voom policy validate my-policy.voom
 voom policy validate my-policy.voom --format json
 voom policy format my-policy.voom
 voom policy show my-policy.voom --format json
+voom policy describe my-policy.voom
+voom policy describe my-policy.voom --format json
 voom policy diff old-policy.voom new-policy.voom
 voom policy test docs/examples/tests --format json
 ```

--- a/docs/dsl-reference.md
+++ b/docs/dsl-reference.md
@@ -156,7 +156,7 @@ Compiled policies include provenance fields for composition-aware tooling:
 |-------|-------------|
 | `metadata.extends_chain` | Ordered parent chain used to compose the policy |
 | `phase.composition.kind` | `Local`, `Inherited`, `Extended`, or `Overridden` |
-| `phase.composition.source` | Parent name/path, `inline` for overrides, or omitted for local phases |
+| `phase.composition.source` | Parent name/path for inherited and extended phases, the child source for overridden phases, or omitted for local phases |
 | `phase.composition.added_operations` | Number of child operations appended by an extended phase |
 
 ## Config Block

--- a/docs/dsl-reference.md
+++ b/docs/dsl-reference.md
@@ -21,6 +21,17 @@ policy "<name>" {
 }
 ```
 
+Policies can also compose from a parent policy:
+
+```
+policy "<name>" extends "<parent>" {
+  phase <name> {
+    extend
+    ...
+  }
+}
+```
+
 ### Example
 
 ```
@@ -41,6 +52,112 @@ policy "my-normalize" {
   }
 }
 ```
+
+## Policy Metadata
+
+The optional `metadata` block records human-readable and tooling metadata. These
+fields are surfaced by compiled policies and by `voom policy describe`.
+
+```
+metadata {
+  version: "1.0.0"
+  author: "user@example.com"
+  description: "Human-readable policy purpose"
+  requires_voom: ">=0.5.0"
+  requires_tools: [ffmpeg, mkvmerge]
+  test_fixtures: ["fixtures/anime/"]
+}
+```
+
+| Setting | Type | Description |
+|---------|------|-------------|
+| `version` | string | Policy version |
+| `author` | string | Policy author or owner |
+| `description` | string | Human-readable purpose or description |
+| `requires_voom` | string | Required VOOM version constraint |
+| `requires_tools` | list | External tool identifiers required by the policy |
+| `test_fixtures` | list of strings | Test fixture paths associated with the policy |
+
+## Policy Composition
+
+`extends` composes a child policy from a parent before validation and
+compilation. The child can inherit parent phases, append operations to a parent
+phase, or replace a parent phase with a local definition.
+
+### Parent Sources
+
+Bundled parent names can be used directly:
+
+```
+policy "my-anime" extends "anime-base" {
+  phase subtitles {
+    keep subtitles where lang == eng
+  }
+}
+```
+
+Current bundled policy names are:
+
+| Name |
+|------|
+| `archival` |
+| `space-saver` |
+| `mobile-friendly` |
+| `anime-base` |
+| `passthrough-audit` |
+
+Local parent files use `file://` URIs:
+
+```
+policy "child" extends "file://./base.voom" {
+  phase child {
+    keep audio
+  }
+}
+```
+
+When compiling or loading from a file, relative `file://` paths resolve relative
+to the child policy file. Absolute `file://` paths are only available through
+file-based loading. In-memory bundled compilation does not load local files.
+
+Remote sources are out of scope right now. Registry, GitHub, HTTP(S), and other
+remote parent references are unsupported.
+
+### Phase Inheritance
+
+Parent phases missing from the child are inherited unchanged. If a child defines
+a phase with the same name and does not use `extend`, the child phase replaces
+the inherited phase.
+
+Use `extend` as the first statement in a child phase to append local operations
+to the inherited phase:
+
+```
+phase audio {
+  extend
+  synthesize "AAC Stereo" {
+    codec: aac
+    channels: stereo
+    source: prefer(lang == eng)
+  }
+}
+```
+
+An extended phase inherits the parent phase controls and operations, then appends
+the child operations. Child phase controls such as `depends_on`, `skip when`,
+`run_if`, and `on_error` can be restated to replace the inherited controls. For
+example, `depends_on: []` clears inherited dependencies.
+
+### Composition Metadata
+
+Compiled policies include provenance fields for composition-aware tooling:
+
+| Field | Description |
+|-------|-------------|
+| `metadata.extends_chain` | Ordered parent chain used to compose the policy |
+| `phase.composition.kind` | `Local`, `Inherited`, `Extended`, or `Overridden` |
+| `phase.composition.source` | Parent name/path, `inline` for overrides, or omitted for local phases |
+| `phase.composition.added_operations` | Number of child operations appended by an extended phase |
 
 ## Config Block
 
@@ -664,7 +781,10 @@ Source (.voom)
 ### Programmatic API
 
 ```rust
-use voom_dsl::{parse_policy, validate, compile, compile_ast, format_policy};
+use voom_dsl::{
+    compile_policy, compile_policy_file, compile_policy_with_bundled,
+    format_policy, parse_policy, validate,
+};
 
 // Parse source to AST
 let ast = parse_policy(source)?;
@@ -672,10 +792,14 @@ let ast = parse_policy(source)?;
 // Validate semantics (returns Result<(), ValidationErrors>)
 validate(&ast)?;
 
-// Compile to domain types (parse + validate + compile in one step)
-let compiled = compile(source)?;
-// or compile from an existing AST
-let compiled = compile_ast(&ast)?;
+// Compile a standalone policy to domain types (parse + validate + compile)
+let compiled = compile_policy(source)?;
+
+// Resolve bundled extends such as `extends "anime-base"`
+let compiled = compile_policy_with_bundled(source)?;
+
+// Resolve file:// extends relative to the policy file
+let compiled = compile_policy_file(std::path::Path::new("policies/child.voom"))?;
 
 // Format/pretty-print (takes &PolicyAst, returns String)
 let formatted = format_policy(&ast);

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -17,6 +17,13 @@ Multi-language anime library with Japanese/English handling. Forced subtitle det
 
 **Plugins used:** all native + sonarr-metadata (WASM)
 
+### [composed-anime.voom](composed-anime.voom)
+Composition example that extends bundled `anime-base`, appends AAC stereo
+synthesis to the inherited `audio` phase, and replaces the inherited
+`subtitles` phase with English/undefined subtitle handling.
+
+**Plugins used:** ffmpeg-executor, mkvtoolnix-executor
+
 ### [transcode-hevc.voom](transcode-hevc.voom)
 HEVC transcoding pipeline with hardware acceleration. `skip when` with field access, video/audio transcode settings, auto-crop tuning, `synthesize` with all options (codec, channels, source, bitrate, skip_if_exists, create_if, title, language, position), `run_if` conditional phases.
 
@@ -134,6 +141,9 @@ Comprehensive reference exercising **every DSL construct**. Not intended for pro
 | Feature | Examples |
 |---------|----------|
 | `config` block | movie-library, anime, transcode, metadata, strict, full, speech-language-filter, speech-transcription-check |
+| `extends` policy composition | composed-anime |
+| phase `extend` | composed-anime |
+| phase replacement through composition | composed-anime |
 | `depends_on` | all except minimal |
 | `skip when` | transcode, full |
 | `run_if` (modified/completed) | anime, transcode, strict, full |
@@ -146,7 +156,7 @@ Comprehensive reference exercising **every DSL construct**. Not intended for pro
 | `transcode` (video/audio) | transcode, containerize-then-transcode, hw-nvenc-hevc, transcode-video-drop-attachments, metadata-stable-transcode, preflight-archive, preflight-size-gate, hdr-archival, hdr-sdr-mobile, full |
 | `preserve_hdr` / `tonemap` | hdr-archival, hdr10plus-preserve, dolby-vision-rpu, hdr-sdr-mobile |
 | `crop: auto` | transcode |
-| `synthesize` | transcode, full |
+| `synthesize` | transcode, composed-anime, full |
 | `when` / `else` | anime, metadata, full |
 | `rules first` | metadata, full |
 | `rules all` | anime, full, speech-transcription-check |

--- a/docs/examples/composed-anime.voom
+++ b/docs/examples/composed-anime.voom
@@ -1,0 +1,42 @@
+// Composed anime policy.
+//
+// Extends the bundled anime-base policy, appends an AAC stereo compatibility
+// audio track, and replaces the inherited subtitle handling with an
+// English/undefined-language subtitle policy.
+
+policy "composed-anime" extends "anime-base" {
+  metadata {
+    version: "1.0.0"
+    description: "Anime policy composed from anime-base with AAC stereo and English subtitles"
+    requires_tools: [ffmpeg, mkvmerge, mkvextract]
+  }
+
+  phase audio {
+    extend
+
+    synthesize "AAC Stereo" {
+      codec: aac
+      channels: stereo
+      source: prefer(lang in [jpn, eng, und] and not commentary)
+      bitrate: "192k"
+      skip_if_exists {
+        codec == aac and channels == 2 and lang in [jpn, eng, und] and not commentary
+      }
+      title: "Stereo (AAC)"
+      language: inherit
+      position: after_source
+    }
+  }
+
+  phase subtitles {
+    depends_on: [audio]
+
+    keep subtitles where lang in [eng, und] and not commentary
+    remove subtitles where title contains "auto-generated"
+    remove attachments where not font
+
+    defaults {
+      subtitle: first
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add policy-level composition with bundled and file-based parent policies.
- Track compiled provenance metadata and expose it through `voom policy describe`.
- Add CLI/DSL coverage plus docs and a composed anime example.
- Apply simplification follow-ups for shared compilation, bundled registry, and parser metadata extraction.

## Test Plan
- [x] cargo test -p voom-dsl
- [x] cargo test -p voom-cli --test cli_tests policy_
- [x] cargo fmt --check
- [x] cargo clippy -p voom-dsl -p voom-cli --all-targets --all-features -- -D warnings

Closes #209