### PR TITLE
refactor: decompose scan-session functions in SqliteStore and InMemoryStore

### DIFF
--- a/crates/voom-domain/src/test_support.rs
+++ b/crates/voom-domain/src/test_support.rs
@@ -205,6 +205,17 @@ impl Default for InMemoryStore {
     }
 }
 
+/// A move-pair detected during `finish_scan_session`: an active row that
+/// wasn't seen this session whose `expected_hash` matches a New-this-session
+/// row's `content_hash`. The candidate is the row to keep (relocated to
+/// `new_path`); the new row at `new_path` will be deleted in favor of it.
+struct MovePair {
+    candidate_id: Uuid,
+    new_id: Uuid,
+    old_path: PathBuf,
+    new_path: PathBuf,
+}
+
 // Private helpers for ingest_discovered_file. Kept in a dedicated impl
 // block so they sit alongside the dispatcher without disturbing the
 // builder block above or the trait impls below.
@@ -388,6 +399,155 @@ impl InMemoryStore {
             file_id: new_id,
             needs_introspection: true,
         })
+    }
+
+    /// Validate session is in_progress, bump heartbeat, return cloned roots.
+    /// Releases the sessions lock before returning.
+    fn finish_validate_session(
+        &self,
+        session: crate::transition::ScanSessionId,
+    ) -> Result<Vec<std::path::PathBuf>> {
+        let mut sessions = self.sessions.lock();
+        let row = sessions.get_mut(&session).ok_or_else(|| {
+            crate::errors::VoomError::Other(format!("unknown scan session {session}").into())
+        })?;
+        if row.status != crate::transition::ScanSessionStatus::InProgress {
+            return Err(crate::errors::VoomError::Other(
+                format!(
+                    "scan session {session} is not in_progress (status: {:?})",
+                    row.status,
+                )
+                .into(),
+            ));
+        }
+        row.last_heartbeat_at = chrono::Utc::now();
+        Ok(row.roots.clone())
+    }
+
+    /// Collect `MovePair` records by scanning the in-memory `files` map.
+    /// Acquires `new_in_session` (released immediately), then `last_seen` and
+    /// `files` together; all locks released before returning.
+    fn finish_collect_move_pairs(
+        &self,
+        session: crate::transition::ScanSessionId,
+        roots: &[std::path::PathBuf],
+    ) -> Vec<MovePair> {
+        let new_ids: std::collections::HashSet<Uuid> = self
+            .new_in_session
+            .lock()
+            .get(&session)
+            .cloned()
+            .unwrap_or_default();
+
+        let last_seen = self.last_seen.lock();
+        let files = self.files.lock();
+
+        let new_by_hash: HashMap<String, (Uuid, std::path::PathBuf, u64)> = files
+            .iter()
+            .filter(|(id, _)| new_ids.contains(id))
+            .filter_map(|(id, f)| {
+                f.content_hash
+                    .as_ref()
+                    .map(|h| (h.clone(), (*id, f.path.clone(), f.size)))
+            })
+            .collect();
+
+        files
+            .values()
+            .filter(|f| {
+                f.status == FileStatus::Active
+                    && is_under_any(&f.path, roots)
+                    && last_seen.get(&f.path) != Some(&session)
+                    && f.expected_hash.is_some()
+            })
+            .filter_map(|f| {
+                let hash = f.expected_hash.as_deref()?;
+                let (new_id, new_path, _) = new_by_hash.get(hash)?;
+                Some(MovePair {
+                    candidate_id: f.id,
+                    new_id: *new_id,
+                    old_path: f.path.clone(),
+                    new_path: new_path.clone(),
+                })
+            })
+            .collect()
+    }
+
+    /// Apply the collected move pairs: delete the New row, update the
+    /// candidate to the new path, record a move transition, update
+    /// last_seen. Returns the number of promotions applied. Acquires
+    /// `files` (read), `files` (mutate), `last_seen`, and `transitions`
+    /// per iteration; each lock is released before the next is acquired.
+    fn finish_apply_move_promotions(
+        &self,
+        session: crate::transition::ScanSessionId,
+        move_pairs: &[MovePair],
+    ) -> u32 {
+        let mut promoted_moves = 0u32;
+        for pair in move_pairs {
+            let (new_size, new_hash) = {
+                let files = self.files.lock();
+                match files.get(&pair.new_id) {
+                    Some(f) => (f.size, f.content_hash.clone()),
+                    None => continue,
+                }
+            };
+
+            self.files.lock().remove(&pair.new_id);
+
+            {
+                let mut files = self.files.lock();
+                if let Some(candidate) = files.get_mut(&pair.candidate_id) {
+                    candidate.path = pair.new_path.clone();
+                    candidate.size = new_size;
+                    candidate.content_hash = new_hash.clone();
+                    candidate.status = FileStatus::Active;
+                }
+            }
+
+            self.last_seen.lock().insert(pair.new_path.clone(), session);
+
+            let move_tx = FileTransition::new(
+                pair.candidate_id,
+                pair.new_path.clone(),
+                new_hash.unwrap_or_default(),
+                new_size,
+                TransitionSource::Discovery,
+            )
+            .with_from_path(pair.old_path.clone())
+            .with_detail("detected_move");
+            self.transitions.lock().push(move_tx);
+
+            promoted_moves += 1;
+        }
+        promoted_moves
+    }
+
+    /// Missing pass: mark every active file under roots that wasn't seen
+    /// this session as missing. Returns the count. Acquires `last_seen`
+    /// then `files` in that order; both released before returning.
+    fn finish_mark_missing(
+        &self,
+        session: crate::transition::ScanSessionId,
+        roots: &[std::path::PathBuf],
+    ) -> u32 {
+        let last_seen = self.last_seen.lock();
+        let mut files = self.files.lock();
+        let mut count = 0u32;
+        for f in files.values_mut() {
+            if f.status != FileStatus::Active {
+                continue;
+            }
+            if !is_under_any(&f.path, roots) {
+                continue;
+            }
+            if last_seen.get(&f.path) == Some(&session) {
+                continue;
+            }
+            f.status = FileStatus::Missing;
+            count += 1;
+        }
+        count
     }
 }
 
@@ -697,134 +857,11 @@ impl FileStorage for InMemoryStore {
     ) -> Result<crate::transition::ScanFinishOutcome> {
         use crate::transition::ScanFinishOutcome;
 
-        // Step 1: validate session status and clone roots, then release sessions
-        // before acquiring last_seen and files (preserves documented lock order).
-        let roots = {
-            let mut sessions = self.sessions.lock();
-            let row = sessions.get_mut(&session).ok_or_else(|| {
-                crate::errors::VoomError::Other(format!("unknown scan session {session}").into())
-            })?;
-            if row.status != crate::transition::ScanSessionStatus::InProgress {
-                return Err(crate::errors::VoomError::Other(
-                    format!(
-                        "scan session {session} is not in_progress (status: {:?})",
-                        row.status,
-                    )
-                    .into(),
-                ));
-            }
-            row.last_heartbeat_at = chrono::Utc::now();
-            row.roots.clone()
-        };
+        let roots = self.finish_validate_session(session)?;
+        let move_pairs = self.finish_collect_move_pairs(session, &roots);
+        let promoted_moves = self.finish_apply_move_promotions(session, &move_pairs);
+        let missing = self.finish_mark_missing(session, &roots);
 
-        // Step 2: collect the New-this-session IDs (released before acquiring other locks).
-        let new_ids: std::collections::HashSet<Uuid> = self
-            .new_in_session
-            .lock()
-            .get(&session)
-            .cloned()
-            .unwrap_or_default();
-
-        // Step 3: identify move pairs (read-only pass; releases all locks when done).
-        // A move pair is (candidate_id, new_id, old_path, new_path):
-        //   candidate = active file under roots not seen this session with expected_hash
-        //   new_id    = a New-this-session file whose content_hash == candidate.expected_hash
-        let move_pairs: Vec<(Uuid, Uuid, std::path::PathBuf, std::path::PathBuf)> = {
-            let last_seen = self.last_seen.lock();
-            let files = self.files.lock();
-
-            let new_by_hash: HashMap<String, (Uuid, std::path::PathBuf, u64)> = files
-                .iter()
-                .filter(|(id, _)| new_ids.contains(id))
-                .filter_map(|(id, f)| {
-                    f.content_hash
-                        .as_ref()
-                        .map(|h| (h.clone(), (*id, f.path.clone(), f.size)))
-                })
-                .collect();
-
-            files
-                .values()
-                .filter(|f| {
-                    f.status == FileStatus::Active
-                        && is_under_any(&f.path, &roots)
-                        && last_seen.get(&f.path) != Some(&session)
-                        && f.expected_hash.is_some()
-                })
-                .filter_map(|f| {
-                    let hash = f.expected_hash.as_deref()?;
-                    let (new_id, new_path, _) = new_by_hash.get(hash)?;
-                    Some((f.id, *new_id, f.path.clone(), new_path.clone()))
-                })
-                .collect()
-        };
-
-        // Step 4: apply promotions one by one. Each iteration acquires/releases locks.
-        let mut promoted_moves = 0u32;
-        for (candidate_id, new_id, old_path, new_path) in &move_pairs {
-            // Read the New row's data.
-            let (new_size, new_hash) = {
-                let files = self.files.lock();
-                match files.get(new_id) {
-                    Some(f) => (f.size, f.content_hash.clone()),
-                    None => continue,
-                }
-            };
-
-            // Remove the New row.
-            self.files.lock().remove(new_id);
-
-            // Update the candidate row to the new path.
-            {
-                let mut files = self.files.lock();
-                if let Some(candidate) = files.get_mut(candidate_id) {
-                    candidate.path = new_path.clone();
-                    candidate.size = new_size;
-                    candidate.content_hash = new_hash.clone();
-                    candidate.status = FileStatus::Active;
-                }
-            }
-
-            // Update last_seen so the missing pass below skips the new path.
-            self.last_seen.lock().insert(new_path.clone(), session);
-
-            // Record a move transition.
-            let move_tx = FileTransition::new(
-                *candidate_id,
-                new_path.clone(),
-                new_hash.unwrap_or_default(),
-                new_size,
-                TransitionSource::Discovery,
-            )
-            .with_from_path(old_path.clone())
-            .with_detail("detected_move");
-            self.transitions.lock().push(move_tx);
-
-            promoted_moves += 1;
-        }
-
-        // Step 5: missing pass (last_seen then files, in order).
-        let missing = {
-            let last_seen = self.last_seen.lock();
-            let mut files = self.files.lock();
-            let mut count = 0u32;
-            for f in files.values_mut() {
-                if f.status != FileStatus::Active {
-                    continue;
-                }
-                if !is_under_any(&f.path, &roots) {
-                    continue;
-                }
-                if last_seen.get(&f.path) == Some(&session) {
-                    continue;
-                }
-                f.status = FileStatus::Missing;
-                count += 1;
-            }
-            count
-        };
-
-        // Step 6: flip session status to Completed.
         if let Some(row) = self.sessions.lock().get_mut(&session) {
             row.status = crate::transition::ScanSessionStatus::Completed;
             row.last_heartbeat_at = chrono::Utc::now();

--- a/crates/voom-domain/src/test_support.rs
+++ b/crates/voom-domain/src/test_support.rs
@@ -10,7 +10,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-use parking_lot::Mutex;
+use parking_lot::{Mutex, MutexGuard};
 use uuid::Uuid;
 
 use crate::bad_file::BadFile;
@@ -202,6 +202,192 @@ impl InMemoryStore {
 impl Default for InMemoryStore {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+// Private helpers for ingest_discovered_file. Kept in a dedicated impl
+// block so they sit alongside the dispatcher without disturbing the
+// builder block above or the trait impls below.
+impl InMemoryStore {
+    /// Validate the session is `InProgress`, bump heartbeat, return the
+    /// session's roots plus a snapshot of all session statuses. Releases
+    /// the sessions lock before returning.
+    fn ingest_validate_session(
+        &self,
+        session: crate::transition::ScanSessionId,
+    ) -> Result<(
+        Vec<std::path::PathBuf>,
+        HashMap<crate::transition::ScanSessionId, crate::transition::ScanSessionStatus>,
+    )> {
+        let mut sessions = self.sessions.lock();
+        let row = sessions.get_mut(&session).ok_or_else(|| {
+            crate::errors::VoomError::Other(format!("unknown scan session {session}").into())
+        })?;
+        if row.status != crate::transition::ScanSessionStatus::InProgress {
+            return Err(crate::errors::VoomError::Other(
+                format!(
+                    "scan session {session} is not in_progress (status: {:?})",
+                    row.status,
+                )
+                .into(),
+            ));
+        }
+        row.last_heartbeat_at = chrono::Utc::now();
+        let roots = row.roots.clone();
+        let statuses: HashMap<
+            crate::transition::ScanSessionId,
+            crate::transition::ScanSessionStatus,
+        > = sessions.iter().map(|(k, v)| (*k, v.status)).collect();
+        Ok((roots, statuses))
+    }
+
+    /// Handle the three existing-row sub-branches: stub recovery (delete
+    /// the row and signal fall-through with `Ok(None)`), unchanged, or
+    /// ExternallyChanged.
+    ///
+    /// Takes ownership of the `last_seen` and `files` guards. On stub
+    /// recovery the helper removes the row from `files`, clears the entry
+    /// in `file_session_affinity`, and drops the upper guards before
+    /// returning `Ok(None)`. The dispatcher then re-acquires `last_seen`
+    /// and `files` in documented lock order before falling through to
+    /// `ingest_handle_no_row`.
+    fn ingest_handle_existing_row(
+        &self,
+        session: crate::transition::ScanSessionId,
+        file: &DiscoveredFile,
+        existing: MediaFile,
+        session_status_snapshot: &HashMap<
+            crate::transition::ScanSessionId,
+            crate::transition::ScanSessionStatus,
+        >,
+        mut last_seen: MutexGuard<
+            '_,
+            HashMap<std::path::PathBuf, crate::transition::ScanSessionId>,
+        >,
+        mut files: MutexGuard<'_, HashMap<Uuid, MediaFile>>,
+    ) -> Result<Option<crate::transition::IngestDecision>> {
+        let affinity_lookup: Option<crate::transition::ScanSessionId> = {
+            let affinity = self.file_session_affinity.lock();
+            affinity.get(&existing.id).copied()
+        };
+        let needs_recovery = match affinity_lookup {
+            Some(prior_session) => !matches!(
+                session_status_snapshot.get(&prior_session),
+                Some(crate::transition::ScanSessionStatus::Completed)
+            ),
+            None => false,
+        };
+
+        let hash_matches = existing
+            .expected_hash
+            .as_ref()
+            .is_none_or(|eh| eh == &file.content_hash);
+
+        if needs_recovery {
+            // Stub from a non-completed session — delete unconditionally
+            // (regardless of hash match), then signal fall-through to the
+            // no-row path.
+            let stub_id = existing.id;
+            files.remove(&stub_id);
+            drop(files);
+            drop(last_seen);
+            self.file_session_affinity.lock().remove(&stub_id);
+            Ok(None)
+        } else if hash_matches {
+            let mut updated = existing;
+            updated.status = FileStatus::Active;
+            if updated.expected_hash.is_none() {
+                updated.expected_hash = Some(file.content_hash.clone());
+            }
+            let id = updated.id;
+            files.insert(updated.id, updated);
+            last_seen.insert(file.path.clone(), session);
+            drop(files);
+            drop(last_seen);
+            self.file_session_affinity.lock().insert(id, session);
+            Ok(Some(crate::transition::IngestDecision::Unchanged {
+                file_id: id,
+            }))
+        } else {
+            let old_id = existing.id;
+            let mut superseded = existing;
+            superseded.status = FileStatus::Missing;
+            files.insert(old_id, superseded);
+
+            let new_id = Uuid::new_v4();
+            files.insert(new_id, fresh_active_file(new_id, file));
+            last_seen.insert(file.path.clone(), session);
+            drop(files);
+            drop(last_seen);
+            self.file_session_affinity.lock().insert(new_id, session);
+            Ok(Some(crate::transition::IngestDecision::ExternallyChanged {
+                file_id: new_id,
+                superseded: old_id,
+            }))
+        }
+    }
+
+    /// Handle the no-row path: move detection by hash+missing-status,
+    /// otherwise insert a new active row.
+    ///
+    /// Takes ownership of the `last_seen` and `files` guards and drops
+    /// them before acquiring the leaf locks `new_in_session` and
+    /// `file_session_affinity`.
+    fn ingest_handle_no_row(
+        &self,
+        session: crate::transition::ScanSessionId,
+        file: &DiscoveredFile,
+        session_roots: &[std::path::PathBuf],
+        mut last_seen: MutexGuard<
+            '_,
+            HashMap<std::path::PathBuf, crate::transition::ScanSessionId>,
+        >,
+        mut files: MutexGuard<'_, HashMap<Uuid, MediaFile>>,
+    ) -> Result<crate::transition::IngestDecision> {
+        // Move detection: constrain to session roots to avoid cross-root
+        // hash-collision false positives.
+        let move_match = files
+            .values()
+            .find(|f| {
+                f.status == FileStatus::Missing
+                    && f.expected_hash.as_deref() == Some(file.content_hash.as_str())
+                    && is_under_any(&f.path, session_roots)
+            })
+            .cloned();
+        if let Some(mut m) = move_match {
+            let from_path = m.path.clone();
+            m.path = file.path.clone();
+            m.status = FileStatus::Active;
+            m.size = file.size;
+            m.content_hash = Some(file.content_hash.clone());
+            let id = m.id;
+            files.insert(id, m);
+            last_seen.insert(file.path.clone(), session);
+            drop(files);
+            drop(last_seen);
+            self.file_session_affinity.lock().insert(id, session);
+            return Ok(crate::transition::IngestDecision::Moved {
+                file_id: id,
+                from_path,
+            });
+        }
+
+        // Truly new file.
+        let new_id = Uuid::new_v4();
+        files.insert(new_id, fresh_active_file(new_id, file));
+        last_seen.insert(file.path.clone(), session);
+        drop(files);
+        drop(last_seen);
+        self.new_in_session
+            .lock()
+            .entry(session)
+            .or_default()
+            .insert(new_id);
+        self.file_session_affinity.lock().insert(new_id, session);
+        Ok(crate::transition::IngestDecision::New {
+            file_id: new_id,
+            needs_introspection: true,
+        })
     }
 }
 
@@ -457,34 +643,10 @@ impl FileStorage for InMemoryStore {
         session: crate::transition::ScanSessionId,
         file: &crate::transition::DiscoveredFile,
     ) -> Result<crate::transition::IngestDecision> {
-        // Step 1: Acquire sessions: validate, bump heartbeat, snapshot roots + statuses.
-        // Lock is released before acquiring last_seen/files (lock order: 1→2→3→4).
-        let (session_roots, session_status_snapshot) = {
-            let mut sessions = self.sessions.lock();
-            let row = sessions.get_mut(&session).ok_or_else(|| {
-                crate::errors::VoomError::Other(format!("unknown scan session {session}").into())
-            })?;
-            if row.status != crate::transition::ScanSessionStatus::InProgress {
-                return Err(crate::errors::VoomError::Other(
-                    format!(
-                        "scan session {session} is not in_progress (status: {:?})",
-                        row.status,
-                    )
-                    .into(),
-                ));
-            }
-            row.last_heartbeat_at = chrono::Utc::now();
-            let roots = row.roots.clone();
-            // Snapshot all session statuses so we can do stub-recovery lookups
-            // without re-acquiring the sessions lock later.
-            let statuses: HashMap<
-                crate::transition::ScanSessionId,
-                crate::transition::ScanSessionStatus,
-            > = sessions.iter().map(|(k, v)| (*k, v.status)).collect();
-            (roots, statuses)
-        };
+        // Step 1: validate session, snapshot statuses (releases sessions lock).
+        let (session_roots, session_status_snapshot) = self.ingest_validate_session(session)?;
 
-        // Step 2: Acquire last_seen, do duplicate fast-path.
+        // Step 2: acquire last_seen, duplicate fast-path.
         let mut last_seen = self.last_seen.lock();
         if last_seen.get(&file.path) == Some(&session) {
             let files = self.files.lock();
@@ -504,124 +666,29 @@ impl FileStorage for InMemoryStore {
             return Ok(crate::transition::IngestDecision::Duplicate { file_id: id });
         }
 
-        // Step 3: Acquire files, do existing-row branches.
+        // Step 3: acquire files, existing-row dispatch.
         let mut files = self.files.lock();
         let existing = files.values().find(|f| f.path == file.path).cloned();
 
-        if let Some(mut existing) = existing {
-            // Look up affinity (lock order: sessions→last_seen→files→file_session_affinity).
-            // We already hold last_seen and files, so we acquire affinity now.
-            let affinity_lookup: Option<crate::transition::ScanSessionId> = {
-                let affinity = self.file_session_affinity.lock();
-                affinity.get(&existing.id).copied()
-            };
-            // Stub recovery: check whether this row was last touched by a
-            // non-completed session. If so, it's a stub from an interrupted scan.
-            let needs_recovery = match affinity_lookup {
-                Some(prior_session) => !matches!(
-                    session_status_snapshot.get(&prior_session),
-                    Some(crate::transition::ScanSessionStatus::Completed)
-                ),
-                None => false,
-            };
-
-            let hash_matches = existing
-                .expected_hash
-                .as_ref()
-                .is_none_or(|eh| eh == &file.content_hash);
-
-            if needs_recovery {
-                // Stub from a non-completed session — delete unconditionally
-                // (regardless of hash match), then fall through to the no-row path.
-                let stub_id = existing.id;
-                files.remove(&stub_id);
-                drop(files);
-                drop(last_seen);
-                self.file_session_affinity.lock().remove(&stub_id);
-                // Re-acquire locks in documented order so the no-row path proceeds normally.
-                last_seen = self.last_seen.lock();
-                files = self.files.lock();
-                // Fall through to no-row path (existing is dropped; files has no entry now).
-            } else if hash_matches {
-                // Unchanged
-                existing.status = FileStatus::Active;
-                if existing.expected_hash.is_none() {
-                    existing.expected_hash = Some(file.content_hash.clone());
-                }
-                let id = existing.id;
-                files.insert(existing.id, existing);
-                last_seen.insert(file.path.clone(), session);
-                drop(files);
-                drop(last_seen);
-                self.file_session_affinity.lock().insert(id, session);
-                return Ok(crate::transition::IngestDecision::Unchanged { file_id: id });
-            } else {
-                // !hash_matches && !needs_recovery: ExternallyChanged
-                let old_id = existing.id;
-                existing.status = FileStatus::Missing;
-                files.insert(old_id, existing);
-
-                let new_id = Uuid::new_v4();
-                files.insert(new_id, fresh_active_file(new_id, file));
-                last_seen.insert(file.path.clone(), session);
-                drop(files);
-                drop(last_seen);
-                self.file_session_affinity.lock().insert(new_id, session);
-                return Ok(crate::transition::IngestDecision::ExternallyChanged {
-                    file_id: new_id,
-                    superseded: old_id,
-                });
+        if let Some(existing) = existing {
+            if let Some(decision) = self.ingest_handle_existing_row(
+                session,
+                file,
+                existing,
+                &session_status_snapshot,
+                last_seen,
+                files,
+            )? {
+                return Ok(decision);
             }
+            // Stub recovery: helper already cleared file_session_affinity and
+            // dropped the upper guards. Re-acquire in documented order.
+            last_seen = self.last_seen.lock();
+            files = self.files.lock();
         }
 
-        // No row at this path (either never existed, or stub was just deleted above).
-        // Check for move via missing+expected_hash match.
-        // Constrain to session roots to avoid cross-root hash-collision false positives.
-        let move_match = files
-            .values()
-            .find(|f| {
-                f.status == FileStatus::Missing
-                    && f.expected_hash.as_deref() == Some(file.content_hash.as_str())
-                    && is_under_any(&f.path, &session_roots)
-            })
-            .cloned();
-        if let Some(mut m) = move_match {
-            let from_path = m.path.clone();
-            m.path = file.path.clone();
-            m.status = FileStatus::Active;
-            m.size = file.size;
-            m.content_hash = Some(file.content_hash.clone());
-            let id = m.id;
-            files.insert(id, m);
-            last_seen.insert(file.path.clone(), session);
-            drop(files);
-            drop(last_seen);
-            self.file_session_affinity.lock().insert(id, session);
-            return Ok(crate::transition::IngestDecision::Moved {
-                file_id: id,
-                from_path,
-            });
-        }
-
-        // Truly new
-        let new_id = Uuid::new_v4();
-        files.insert(new_id, fresh_active_file(new_id, file));
-        last_seen.insert(file.path.clone(), session);
-        // Release other locks before acquiring new_in_session and affinity
-        // (preserve lock order — these are both isolation-only locks).
-        drop(files);
-        drop(last_seen);
-        // Track this file ID as new in the session for move-promotion at finish time.
-        self.new_in_session
-            .lock()
-            .entry(session)
-            .or_default()
-            .insert(new_id);
-        self.file_session_affinity.lock().insert(new_id, session);
-        Ok(crate::transition::IngestDecision::New {
-            file_id: new_id,
-            needs_introspection: true,
-        })
+        // Step 4: no-row path.
+        self.ingest_handle_no_row(session, file, &session_roots, last_seen, files)
     }
 
     fn finish_scan_session(

--- a/plugins/sqlite-store/src/store/file_storage.rs
+++ b/plugins/sqlite-store/src/store/file_storage.rs
@@ -823,164 +823,9 @@ impl FileStorage for SqliteStore {
         let roots: Vec<PathBuf> = serde_json::from_str(&roots_json)
             .map_err(other_storage_err("failed to parse roots_json"))?;
 
-        // ---- MOVE PROMOTION ----
-        // Files ingested as New this session may actually be moves from an active
-        // file that's about to be marked missing. Detect these by matching
-        // content_hash (New-this-session row) against expected_hash (missing candidate).
-        // "New this session" == last_seen_session_id == this session AND created_at >= started_at.
-
-        struct MissingCandidate {
-            id: String,
-            path: String,
-            expected_hash: String,
-        }
-
-        let candidates_for_move: Vec<MissingCandidate> = {
-            let mut stmt = tx
-                .prepare(
-                    "SELECT id, path, expected_hash FROM files \
-                     WHERE status = 'active' AND path IS NOT NULL \
-                       AND expected_hash IS NOT NULL \
-                       AND (last_seen_session_id IS NULL OR last_seen_session_id != ?1)",
-                )
-                .map_err(storage_err("failed to prepare move-candidate select"))?;
-            stmt.query_map(params![&session_str], |row| {
-                Ok(MissingCandidate {
-                    id: row.get(0)?,
-                    path: row.get(1)?,
-                    expected_hash: row.get(2)?,
-                })
-            })
-            .map_err(storage_err("failed to query move candidates"))?
-            .collect::<rusqlite::Result<Vec<_>>>()
-            .map_err(storage_err("failed to collect move candidates"))?
-            .into_iter()
-            .filter(|c| is_under_any(Path::new(&c.path), &roots))
-            .collect()
-        };
-
-        let mut promoted_moves = 0u32;
-
-        for candidate in &candidates_for_move {
-            // Find a New-this-session row with content_hash matching this candidate's
-            // expected_hash. "New this session" == last_seen_session_id == this session
-            // AND created_at >= session started_at.
-            // Exclude rows that are part of a supersession chain — these are
-            // ExternallyChanged replacement rows (their id appears as superseded_by
-            // on the old row) and must not be hijacked as move targets.
-            let new_match: Option<(String, String, i64)> = tx
-                .query_row(
-                    "SELECT id, path, size FROM files \
-                     WHERE last_seen_session_id = ?1 \
-                       AND content_hash = ?2 \
-                       AND created_at >= ?3 \
-                       AND path IS NOT NULL \
-                       AND id != ?4 \
-                       AND id NOT IN (SELECT superseded_by FROM files \
-                                      WHERE superseded_by IS NOT NULL) \
-                     LIMIT 1",
-                    params![
-                        &session_str,
-                        &candidate.expected_hash,
-                        &session_started_at,
-                        &candidate.id,
-                    ],
-                    |row| {
-                        Ok((
-                            row.get::<_, String>(0)?,
-                            row.get::<_, String>(1)?,
-                            row.get::<_, i64>(2)?,
-                        ))
-                    },
-                )
-                .optional()
-                .map_err(storage_err("failed to look up move-promotion target"))?;
-
-            let Some((new_id, new_path, new_size)) = new_match else {
-                continue;
-            };
-
-            // Delete the New row's transitions so the move transition is the only record.
-            tx.execute(
-                "DELETE FROM file_transitions WHERE file_id = ?1",
-                params![&new_id],
-            )
-            .map_err(storage_err("failed to delete New row's transitions"))?;
-
-            // Delete the New row itself.
-            tx.execute("DELETE FROM files WHERE id = ?1", params![&new_id])
-                .map_err(storage_err("failed to delete New row for move promotion"))?;
-
-            // Update the candidate row to reflect the new path and keep it active.
-            let new_filename = filename_string(Path::new(&new_path));
-            tx.execute(
-                "UPDATE files SET path = ?1, filename = ?2, size = ?3, \
-                 content_hash = ?4, \
-                 status = 'active', missing_since = NULL, \
-                 last_seen_session_id = ?5, updated_at = ?6 \
-                 WHERE id = ?7",
-                params![
-                    &new_path,
-                    new_filename,
-                    new_size,
-                    &candidate.expected_hash,
-                    &session_str,
-                    &now,
-                    &candidate.id,
-                ],
-            )
-            .map_err(storage_err("failed to promote candidate to moved"))?;
-
-            // Record a Discovery transition with from_path set to signal the move.
-            let file_uuid = super::parse_uuid(&candidate.id)?;
-            let move_tx = FileTransition::new(
-                file_uuid,
-                PathBuf::from(&new_path),
-                candidate.expected_hash.clone(),
-                new_size as u64,
-                TransitionSource::Discovery,
-            )
-            .with_from_path(PathBuf::from(&candidate.path))
-            .with_detail("detected_move");
-            insert_transition_in_tx(&tx, &move_tx, &now)?;
-
-            promoted_moves += 1;
-        }
-
-        // ---- MISSING PASS ----
-        // Mark every active file under a scanned root that wasn't seen this
-        // session. The `AND status = 'active'` clause on the UPDATE guards
-        // against a race between SELECT and UPDATE. Promoted candidates already
-        // have last_seen_session_id == this session, so they're excluded here.
-        let candidates: Vec<(String, String)> = {
-            let mut stmt = tx
-                .prepare(
-                    "SELECT id, path FROM files \
-                     WHERE status = 'active' AND path IS NOT NULL \
-                       AND (last_seen_session_id IS NULL OR last_seen_session_id != ?1)",
-                )
-                .map_err(storage_err("failed to prepare missing-scan select"))?;
-            stmt.query_map(params![&session_str], |row| {
-                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-            })
-            .map_err(storage_err("failed to query missing candidates"))?
-            .collect::<rusqlite::Result<Vec<_>>>()
-            .map_err(storage_err("failed to collect missing candidates"))?
-        };
-
-        let mut missing = 0u32;
-        for (id, path) in candidates {
-            if !is_under_any(Path::new(&path), &roots) {
-                continue;
-            }
-            tx.execute(
-                "UPDATE files SET status = 'missing', missing_since = ?1, updated_at = ?1 \
-                 WHERE id = ?2 AND status = 'active'",
-                params![&now, &id],
-            )
-            .map_err(storage_err("failed to mark file missing in finish"))?;
-            missing += 1;
-        }
+        let promoted_moves =
+            promote_moves_in_tx(&tx, &session_str, &session_started_at, &roots, &now)?;
+        let missing = mark_missing_in_finish_tx(&tx, &session_str, &roots, &now)?;
 
         tx.execute(
             "UPDATE scan_sessions SET status = 'completed', finished_at = ?1, \
@@ -1339,6 +1184,193 @@ fn ingest_new_in_tx(tx: &rusqlite::Transaction<'_>, ctx: &IngestCtx<'_>) -> Resu
     insert_transition_in_tx(tx, &disc_transition, ctx.now)?;
 
     Ok(new_id)
+}
+
+/// A currently-active file row that wasn't seen in this scan session and is
+/// eligible to be promoted to a `detected_move` if a matching New-this-session
+/// row exists with the same `content_hash`.
+struct MissingCandidate {
+    id: String,
+    path: String,
+    expected_hash: String,
+}
+
+/// Promote New-this-session rows whose content_hash matches a missing
+/// candidate's expected_hash into a `detected_move`. Run during
+/// `finish_scan_session` before the missing pass so promoted candidates retain
+/// their active status.
+///
+/// Returns the number of files promoted to a moved state.
+fn promote_moves_in_tx(
+    tx: &rusqlite::Transaction<'_>,
+    session_str: &str,
+    session_started_at: &str,
+    roots: &[PathBuf],
+    now: &str,
+) -> Result<u32> {
+    let candidates_for_move: Vec<MissingCandidate> = {
+        let mut stmt = tx
+            .prepare(
+                "SELECT id, path, expected_hash FROM files \
+                 WHERE status = 'active' AND path IS NOT NULL \
+                   AND expected_hash IS NOT NULL \
+                   AND (last_seen_session_id IS NULL OR last_seen_session_id != ?1)",
+            )
+            .map_err(storage_err("failed to prepare move-candidate select"))?;
+        stmt.query_map(params![session_str], |row| {
+            Ok(MissingCandidate {
+                id: row.get(0)?,
+                path: row.get(1)?,
+                expected_hash: row.get(2)?,
+            })
+        })
+        .map_err(storage_err("failed to query move candidates"))?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(storage_err("failed to collect move candidates"))?
+        .into_iter()
+        .filter(|c| is_under_any(Path::new(&c.path), roots))
+        .collect()
+    };
+
+    let mut promoted_moves = 0u32;
+
+    for candidate in &candidates_for_move {
+        if try_promote_one_move_in_tx(tx, candidate, session_str, session_started_at, now)? {
+            promoted_moves += 1;
+        }
+    }
+
+    Ok(promoted_moves)
+}
+
+/// Attempt to promote one missing candidate to a moved row by finding a
+/// matching New-this-session row with the same `content_hash`. Returns `true`
+/// if a promotion happened, `false` if no matching target was found.
+fn try_promote_one_move_in_tx(
+    tx: &rusqlite::Transaction<'_>,
+    candidate: &MissingCandidate,
+    session_str: &str,
+    session_started_at: &str,
+    now: &str,
+) -> Result<bool> {
+    let new_match: Option<(String, String, i64)> = tx
+        .query_row(
+            "SELECT id, path, size FROM files \
+             WHERE last_seen_session_id = ?1 \
+               AND content_hash = ?2 \
+               AND created_at >= ?3 \
+               AND path IS NOT NULL \
+               AND id != ?4 \
+               AND id NOT IN (SELECT superseded_by FROM files \
+                              WHERE superseded_by IS NOT NULL) \
+             LIMIT 1",
+            params![
+                session_str,
+                &candidate.expected_hash,
+                session_started_at,
+                &candidate.id,
+            ],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, i64>(2)?,
+                ))
+            },
+        )
+        .optional()
+        .map_err(storage_err("failed to look up move-promotion target"))?;
+
+    let Some((new_id, new_path, new_size)) = new_match else {
+        return Ok(false);
+    };
+
+    tx.execute(
+        "DELETE FROM file_transitions WHERE file_id = ?1",
+        params![&new_id],
+    )
+    .map_err(storage_err("failed to delete New row's transitions"))?;
+
+    tx.execute("DELETE FROM files WHERE id = ?1", params![&new_id])
+        .map_err(storage_err("failed to delete New row for move promotion"))?;
+
+    let new_filename = filename_string(Path::new(&new_path));
+    tx.execute(
+        "UPDATE files SET path = ?1, filename = ?2, size = ?3, \
+         content_hash = ?4, \
+         status = 'active', missing_since = NULL, \
+         last_seen_session_id = ?5, updated_at = ?6 \
+         WHERE id = ?7",
+        params![
+            &new_path,
+            new_filename,
+            new_size,
+            &candidate.expected_hash,
+            session_str,
+            now,
+            &candidate.id,
+        ],
+    )
+    .map_err(storage_err("failed to promote candidate to moved"))?;
+
+    let file_uuid = super::parse_uuid(&candidate.id)?;
+    let move_tx = FileTransition::new(
+        file_uuid,
+        PathBuf::from(&new_path),
+        candidate.expected_hash.clone(),
+        new_size as u64,
+        TransitionSource::Discovery,
+    )
+    .with_from_path(PathBuf::from(&candidate.path))
+    .with_detail("detected_move");
+    insert_transition_in_tx(tx, &move_tx, now)?;
+
+    Ok(true)
+}
+
+/// Mark every active file under a scanned root that wasn't seen during this
+/// session as `missing`. The `AND status = 'active'` clause on the UPDATE
+/// guards against a race between SELECT and UPDATE. Promoted candidates
+/// already have `last_seen_session_id` == this session, so they're excluded.
+///
+/// Returns the number of files newly marked missing.
+fn mark_missing_in_finish_tx(
+    tx: &rusqlite::Transaction<'_>,
+    session_str: &str,
+    roots: &[PathBuf],
+    now: &str,
+) -> Result<u32> {
+    let candidates: Vec<(String, String)> = {
+        let mut stmt = tx
+            .prepare(
+                "SELECT id, path FROM files \
+                 WHERE status = 'active' AND path IS NOT NULL \
+                   AND (last_seen_session_id IS NULL OR last_seen_session_id != ?1)",
+            )
+            .map_err(storage_err("failed to prepare missing-scan select"))?;
+        stmt.query_map(params![session_str], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })
+        .map_err(storage_err("failed to query missing candidates"))?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(storage_err("failed to collect missing candidates"))?
+    };
+
+    let mut missing = 0u32;
+    for (id, path) in candidates {
+        if !is_under_any(Path::new(&path), roots) {
+            continue;
+        }
+        tx.execute(
+            "UPDATE files SET status = 'missing', missing_since = ?1, updated_at = ?1 \
+             WHERE id = ?2 AND status = 'active'",
+            params![now, &id],
+        )
+        .map_err(storage_err("failed to mark file missing in finish"))?;
+        missing += 1;
+    }
+
+    Ok(missing)
 }
 
 /// Parameters for [`insert_active_file_in_tx`]. Bundled into a struct so the

--- a/plugins/sqlite-store/src/store/file_storage.rs
+++ b/plugins/sqlite-store/src/store/file_storage.rs
@@ -702,67 +702,18 @@ impl FileStorage for SqliteStore {
             .transaction()
             .map_err(storage_err("failed to begin ingest transaction"))?;
 
-        // Session must be in_progress
-        let status: Option<String> = tx
-            .query_row(
-                "SELECT status FROM scan_sessions WHERE id = ?1",
-                params![&session_str],
-                |row| row.get(0),
-            )
-            .optional()
-            .map_err(storage_err("failed to look up scan session"))?;
-        match status.as_deref().and_then(ScanSessionStatus::parse) {
-            Some(ScanSessionStatus::InProgress) => {}
-            Some(other) => {
-                return Err(voom_domain::errors::VoomError::Storage {
-                    kind: voom_domain::errors::StorageErrorKind::Other,
-                    message: format!(
-                        "scan session {session_str} is not in_progress (status: {})",
-                        other.as_str()
-                    ),
-                });
-            }
-            None if status.is_some() => {
-                return Err(voom_domain::errors::VoomError::Storage {
-                    kind: voom_domain::errors::StorageErrorKind::Other,
-                    message: format!(
-                        "scan session {session_str} has unrecognized status: {}",
-                        status.as_deref().unwrap_or(""),
-                    ),
-                });
-            }
-            None => {
-                return Err(voom_domain::errors::VoomError::Storage {
-                    kind: voom_domain::errors::StorageErrorKind::NotFound,
-                    message: format!("unknown scan session {session_str}"),
-                });
-            }
-        }
+        validate_session_in_progress_in_tx(&tx, &session_str)?;
+        bump_session_heartbeat_in_tx(&tx, &session_str, &now)?;
 
-        // Bump heartbeat as part of this ingest transaction.
-        tx.execute(
-            "UPDATE scan_sessions SET last_heartbeat_at = ?1 WHERE id = ?2",
-            params![&now, &session_str],
-        )
-        .map_err(storage_err("failed to bump scan session heartbeat"))?;
+        let ctx = IngestCtx {
+            now: &now,
+            session_str: &session_str,
+            path_str: &path_str,
+            filename: &filename,
+            file,
+        };
 
-        // Look up existing row by path
-        let existing: Option<(String, Option<String>, i64, Option<String>)> = tx
-            .query_row(
-                "SELECT id, expected_hash, size, last_seen_session_id \
-                 FROM files WHERE path = ?1",
-                params![&path_str],
-                |row| {
-                    Ok((
-                        row.get::<_, String>(0)?,
-                        row.get::<_, Option<String>>(1)?,
-                        row.get::<_, i64>(2)?,
-                        row.get::<_, Option<String>>(3)?,
-                    ))
-                },
-            )
-            .optional()
-            .map_err(storage_err("failed to look up existing file"))?;
+        let existing = lookup_existing_file_in_tx(&tx, &path_str)?;
 
         if let Some((existing_id, expected_hash, existing_size, last_seen)) = existing {
             // Duplicate fast-path
@@ -773,119 +724,28 @@ impl FileStorage for SqliteStore {
                 return Ok(IngestDecision::Duplicate { file_id: file_uuid });
             }
 
-            // Stub recovery: if this row was last seen by a non-completed
-            // session (cancelled, in_progress, or unknown), it's a stub
-            // from an interrupted scan. Delete it and fall through.
-            let needs_recovery: bool = if let Some(prior) = &last_seen {
-                let prior_status: Option<String> = tx
-                    .query_row(
-                        "SELECT status FROM scan_sessions WHERE id = ?1",
-                        params![prior],
-                        |row| row.get(0),
-                    )
-                    .optional()
-                    .map_err(storage_err("failed to look up prior session status"))?;
-                !matches!(
-                    prior_status.as_deref().and_then(ScanSessionStatus::parse),
-                    Some(ScanSessionStatus::Completed)
-                )
-            } else {
-                false
-            };
-
+            let needs_recovery = prior_session_needs_recovery_in_tx(&tx, last_seen.as_deref())?;
             let hash_matches = expected_hash
                 .as_ref()
                 .is_none_or(|eh| eh == &file.content_hash);
 
             if needs_recovery {
-                // Stub from a non-completed session — delete unconditionally
-                // (regardless of hash match), then fall through to no-row path.
-                tx.execute(
-                    "UPDATE files SET superseded_by = NULL WHERE superseded_by = ?1",
-                    params![&existing_id],
-                )
-                .map_err(storage_err(
-                    "failed to clear dangling supersession during stub recovery",
-                ))?;
-                tx.execute(
-                    "DELETE FROM file_transitions WHERE file_id = ?1",
-                    params![&existing_id],
-                )
-                .map_err(storage_err("failed to delete stub transitions"))?;
-                tx.execute("DELETE FROM files WHERE id = ?1", params![&existing_id])
-                    .map_err(storage_err("failed to delete stub file row"))?;
+                recover_stub_in_tx(&tx, &existing_id)?;
+                // Fall through to no-row path.
             } else if hash_matches {
-                // Unchanged
-                tx.execute(
-                    "UPDATE files SET size = ?1, content_hash = ?2, \
-                     status = 'active', missing_since = NULL, \
-                     last_seen_session_id = ?3, \
-                     updated_at = ?4 WHERE id = ?5",
-                    params![
-                        file.size as i64,
-                        &file.content_hash,
-                        &session_str,
-                        &now,
-                        &existing_id
-                    ],
-                )
-                .map_err(storage_err("failed to update unchanged file"))?;
-
-                if expected_hash.is_none() {
-                    tx.execute(
-                        "UPDATE files SET expected_hash = ?1 WHERE id = ?2",
-                        params![&file.content_hash, &existing_id],
-                    )
-                    .map_err(storage_err("failed to backfill expected_hash"))?;
-                }
-
+                let file_uuid =
+                    ingest_unchanged_in_tx(&tx, &ctx, &existing_id, expected_hash.is_none())?;
                 tx.commit()
                     .map_err(storage_err("failed to commit unchanged ingest"))?;
-                let file_uuid = super::parse_uuid(&existing_id)?;
                 return Ok(IngestDecision::Unchanged { file_id: file_uuid });
             } else {
-                // Hash mismatch → ExternallyChanged (existing implementation).
-                let old_uuid = super::parse_uuid(&existing_id)?;
-                let new_id = Uuid::new_v4();
-
-                let ext_transition = FileTransition::new(
-                    old_uuid,
-                    file.path.clone(),
-                    file.content_hash.clone(),
-                    file.size,
-                    TransitionSource::External,
-                )
-                .with_from(expected_hash.clone(), Some(existing_size as u64));
-                insert_transition_in_tx(&tx, &ext_transition, &now)?;
-
-                tx.execute(
-                    "UPDATE files SET path = NULL, status = 'missing', \
-                     missing_since = ?1, superseded_by = ?2 WHERE id = ?3",
-                    params![&now, new_id.to_string(), &existing_id],
-                )
-                .map_err(storage_err("failed to clear old file for external change"))?;
-                insert_active_file_in_tx(
+                let (new_id, old_uuid) = ingest_externally_changed_in_tx(
                     &tx,
-                    InsertActiveFile {
-                        new_id,
-                        path_str: &path_str,
-                        filename: &filename,
-                        file,
-                        now: &now,
-                        session_str: &session_str,
-                        err_msg: "failed to insert new file for external change",
-                    },
+                    &ctx,
+                    &existing_id,
+                    expected_hash.as_deref(),
+                    existing_size,
                 )?;
-
-                let disc_transition = FileTransition::new(
-                    new_id,
-                    file.path.clone(),
-                    file.content_hash.clone(),
-                    file.size,
-                    TransitionSource::Discovery,
-                );
-                insert_transition_in_tx(&tx, &disc_transition, &now)?;
-
                 tx.commit()
                     .map_err(storage_err("failed to commit external-change ingest"))?;
                 return Ok(IngestDecision::ExternallyChanged {
@@ -895,77 +755,13 @@ impl FileStorage for SqliteStore {
             }
         }
 
-        // Control reaches here either because there was no row at this path,
-        // or because stub recovery deleted the row above. Either way, proceed
-        // to the move-detection / new-file path.
-
-        // No row at this path. Check for move: a missing file with matching
-        // expected_hash. The status='missing' filter prevents double-consumption
-        // within a session — once we reactivate a row it's no longer 'missing'.
-        // Move detection is scoped to the current session's scanned roots so a
-        // hash collision across roots can't falsely promote to Moved.
-        let session_roots: Vec<PathBuf> = {
-            let roots_json: String = tx
-                .query_row(
-                    "SELECT roots_json FROM scan_sessions WHERE id = ?1",
-                    params![&session_str],
-                    |row| row.get(0),
-                )
-                .map_err(storage_err("failed to load session roots for move lookup"))?;
-            serde_json::from_str(&roots_json)
-                .map_err(other_storage_err("failed to parse roots_json"))?
-        };
-
-        let move_match: Option<(String, String)> = {
-            let mut stmt = tx
-                .prepare(
-                    "SELECT id, path FROM files \
-                     WHERE expected_hash = ?1 AND status = 'missing' AND path IS NOT NULL",
-                )
-                .map_err(storage_err("failed to prepare move-candidate select"))?;
-            let candidates: Vec<(String, String)> = stmt
-                .query_map(params![&file.content_hash], |row| {
-                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-                })
-                .map_err(storage_err("failed to query move candidates"))?
-                .collect::<rusqlite::Result<Vec<_>>>()
-                .map_err(storage_err("failed to collect move candidates"))?;
-            candidates
-                .into_iter()
-                .find(|(_, path)| is_under_any(Path::new(path), &session_roots))
-        };
+        // No row at this path (either originally or after stub recovery).
+        // Check for move: a missing file with matching expected_hash, scoped
+        // to the current session's roots.
+        let move_match = find_move_candidate_in_tx(&tx, &session_str, &file.content_hash)?;
 
         if let Some((missing_id, prior_path)) = move_match {
-            tx.execute(
-                "UPDATE files SET path = ?1, filename = ?2, \
-                 size = ?3, content_hash = ?4, \
-                 status = 'active', missing_since = NULL, \
-                 last_seen_session_id = ?5, \
-                 updated_at = ?6 WHERE id = ?7",
-                params![
-                    &path_str,
-                    filename,
-                    file.size as i64,
-                    &file.content_hash,
-                    &session_str,
-                    &now,
-                    &missing_id,
-                ],
-            )
-            .map_err(storage_err("failed to reactivate moved file"))?;
-
-            let file_uuid = super::parse_uuid(&missing_id)?;
-            let move_transition = voom_domain::transition::FileTransition::new(
-                file_uuid,
-                file.path.clone(),
-                file.content_hash.clone(),
-                file.size,
-                voom_domain::transition::TransitionSource::Discovery,
-            )
-            .with_from_path(PathBuf::from(prior_path.clone()))
-            .with_detail("detected_move");
-            insert_transition_in_tx(&tx, &move_transition, &now)?;
-
+            let file_uuid = ingest_moved_in_tx(&tx, &ctx, &missing_id, &prior_path)?;
             tx.commit()
                 .map_err(storage_err("failed to commit moved ingest"))?;
             return Ok(IngestDecision::Moved {
@@ -974,30 +770,7 @@ impl FileStorage for SqliteStore {
             });
         }
 
-        // Truly new file
-        let new_id = Uuid::new_v4();
-        insert_active_file_in_tx(
-            &tx,
-            InsertActiveFile {
-                new_id,
-                path_str: &path_str,
-                filename: &filename,
-                file,
-                now: &now,
-                session_str: &session_str,
-                err_msg: "failed to insert new file in ingest",
-            },
-        )?;
-
-        let disc_transition = FileTransition::new(
-            new_id,
-            file.path.clone(),
-            file.content_hash.clone(),
-            file.size,
-            TransitionSource::Discovery,
-        );
-        insert_transition_in_tx(&tx, &disc_transition, &now)?;
-
+        let new_id = ingest_new_in_tx(&tx, &ctx)?;
         tx.commit()
             .map_err(storage_err("failed to commit ingest transaction"))?;
 
@@ -1237,6 +1010,335 @@ impl FileStorage for SqliteStore {
         .map_err(storage_err("failed to cancel scan session"))?;
         Ok(())
     }
+}
+
+/// Bundles the per-call common context for ingest helpers. Avoids
+/// long parameter lists and keeps each helper's signature consistent.
+struct IngestCtx<'a> {
+    now: &'a str,
+    session_str: &'a str,
+    path_str: &'a str,
+    filename: &'a str,
+    file: &'a DiscoveredFile,
+}
+
+/// Validate that the given scan session exists and is `InProgress`. Produces
+/// the same three error variants as the inline check it replaces:
+/// `Storage{Other}` for a non-`InProgress` status, `Storage{Other}` for an
+/// unrecognized status string, and `Storage{NotFound}` for an unknown session.
+fn validate_session_in_progress_in_tx(
+    tx: &rusqlite::Transaction<'_>,
+    session_str: &str,
+) -> Result<()> {
+    let status: Option<String> = tx
+        .query_row(
+            "SELECT status FROM scan_sessions WHERE id = ?1",
+            params![session_str],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(storage_err("failed to look up scan session"))?;
+    match status.as_deref().and_then(ScanSessionStatus::parse) {
+        Some(ScanSessionStatus::InProgress) => Ok(()),
+        Some(other) => Err(voom_domain::errors::VoomError::Storage {
+            kind: voom_domain::errors::StorageErrorKind::Other,
+            message: format!(
+                "scan session {session_str} is not in_progress (status: {})",
+                other.as_str()
+            ),
+        }),
+        None if status.is_some() => Err(voom_domain::errors::VoomError::Storage {
+            kind: voom_domain::errors::StorageErrorKind::Other,
+            message: format!(
+                "scan session {session_str} has unrecognized status: {}",
+                status.as_deref().unwrap_or(""),
+            ),
+        }),
+        None => Err(voom_domain::errors::VoomError::Storage {
+            kind: voom_domain::errors::StorageErrorKind::NotFound,
+            message: format!("unknown scan session {session_str}"),
+        }),
+    }
+}
+
+/// Bump the `last_heartbeat_at` of the given scan session inside the caller's
+/// transaction.
+fn bump_session_heartbeat_in_tx(
+    tx: &rusqlite::Transaction<'_>,
+    session_str: &str,
+    now: &str,
+) -> Result<()> {
+    tx.execute(
+        "UPDATE scan_sessions SET last_heartbeat_at = ?1 WHERE id = ?2",
+        params![now, session_str],
+    )
+    .map_err(storage_err("failed to bump scan session heartbeat"))?;
+    Ok(())
+}
+
+/// Existing-file lookup result: `(id, expected_hash, size, last_seen_session_id)`.
+type ExistingFileRow = (String, Option<String>, i64, Option<String>);
+
+/// Look up an existing file row by path. Returns `(id, expected_hash, size,
+/// last_seen_session_id)` if present.
+fn lookup_existing_file_in_tx(
+    tx: &rusqlite::Transaction<'_>,
+    path_str: &str,
+) -> Result<Option<ExistingFileRow>> {
+    tx.query_row(
+        "SELECT id, expected_hash, size, last_seen_session_id \
+         FROM files WHERE path = ?1",
+        params![path_str],
+        |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, Option<String>>(1)?,
+                row.get::<_, i64>(2)?,
+                row.get::<_, Option<String>>(3)?,
+            ))
+        },
+    )
+    .optional()
+    .map_err(storage_err("failed to look up existing file"))
+}
+
+/// Decide whether an existing row whose `last_seen_session_id` is `prior`
+/// represents a stub from a non-completed session and therefore needs
+/// recovery. Returns `false` if `prior` is `None`.
+fn prior_session_needs_recovery_in_tx(
+    tx: &rusqlite::Transaction<'_>,
+    prior: Option<&str>,
+) -> Result<bool> {
+    let Some(prior) = prior else {
+        return Ok(false);
+    };
+    let prior_status: Option<String> = tx
+        .query_row(
+            "SELECT status FROM scan_sessions WHERE id = ?1",
+            params![prior],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(storage_err("failed to look up prior session status"))?;
+    Ok(!matches!(
+        prior_status.as_deref().and_then(ScanSessionStatus::parse),
+        Some(ScanSessionStatus::Completed)
+    ))
+}
+
+/// Find a `missing` file with matching `expected_hash` whose previous path
+/// lies under one of the current session's scanned roots. Used by the
+/// move-detection branch of `ingest_discovered_file`.
+fn find_move_candidate_in_tx(
+    tx: &rusqlite::Transaction<'_>,
+    session_str: &str,
+    content_hash: &str,
+) -> Result<Option<(String, String)>> {
+    let roots_json: String = tx
+        .query_row(
+            "SELECT roots_json FROM scan_sessions WHERE id = ?1",
+            params![session_str],
+            |row| row.get(0),
+        )
+        .map_err(storage_err("failed to load session roots for move lookup"))?;
+    let session_roots: Vec<PathBuf> = serde_json::from_str(&roots_json)
+        .map_err(other_storage_err("failed to parse roots_json"))?;
+
+    let mut stmt = tx
+        .prepare(
+            "SELECT id, path FROM files \
+             WHERE expected_hash = ?1 AND status = 'missing' AND path IS NOT NULL",
+        )
+        .map_err(storage_err("failed to prepare move-candidate select"))?;
+    let candidates: Vec<(String, String)> = stmt
+        .query_map(params![content_hash], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })
+        .map_err(storage_err("failed to query move candidates"))?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(storage_err("failed to collect move candidates"))?;
+    Ok(candidates
+        .into_iter()
+        .find(|(_, path)| is_under_any(Path::new(path), &session_roots)))
+}
+
+/// Stub recovery: delete the dangling row + its transitions, clear any
+/// inbound supersession pointers. After this returns Ok, the caller must
+/// fall through to the no-row path (move-or-new).
+fn recover_stub_in_tx(tx: &rusqlite::Transaction<'_>, existing_id: &str) -> Result<()> {
+    tx.execute(
+        "UPDATE files SET superseded_by = NULL WHERE superseded_by = ?1",
+        params![existing_id],
+    )
+    .map_err(storage_err(
+        "failed to clear dangling supersession during stub recovery",
+    ))?;
+    tx.execute(
+        "DELETE FROM file_transitions WHERE file_id = ?1",
+        params![existing_id],
+    )
+    .map_err(storage_err("failed to delete stub transitions"))?;
+    tx.execute("DELETE FROM files WHERE id = ?1", params![existing_id])
+        .map_err(storage_err("failed to delete stub file row"))?;
+    Ok(())
+}
+
+/// Unchanged branch: bump size/hash/status/last_seen, optionally backfill
+/// expected_hash. Returns the existing row's UUID for the `IngestDecision`.
+fn ingest_unchanged_in_tx(
+    tx: &rusqlite::Transaction<'_>,
+    ctx: &IngestCtx<'_>,
+    existing_id: &str,
+    expected_hash_was_none: bool,
+) -> Result<Uuid> {
+    tx.execute(
+        "UPDATE files SET size = ?1, content_hash = ?2, \
+         status = 'active', missing_since = NULL, \
+         last_seen_session_id = ?3, \
+         updated_at = ?4 WHERE id = ?5",
+        params![
+            ctx.file.size as i64,
+            &ctx.file.content_hash,
+            ctx.session_str,
+            ctx.now,
+            existing_id,
+        ],
+    )
+    .map_err(storage_err("failed to update unchanged file"))?;
+
+    if expected_hash_was_none {
+        tx.execute(
+            "UPDATE files SET expected_hash = ?1 WHERE id = ?2",
+            params![&ctx.file.content_hash, existing_id],
+        )
+        .map_err(storage_err("failed to backfill expected_hash"))?;
+    }
+
+    super::parse_uuid(existing_id)
+}
+
+/// `ExternallyChanged` branch: insert the external-change transition,
+/// supersede the old row, insert the new active row, insert the discovery
+/// transition. Returns `(new_id, old_id)`.
+fn ingest_externally_changed_in_tx(
+    tx: &rusqlite::Transaction<'_>,
+    ctx: &IngestCtx<'_>,
+    existing_id: &str,
+    expected_hash: Option<&str>,
+    existing_size: i64,
+) -> Result<(Uuid, Uuid)> {
+    let old_uuid = super::parse_uuid(existing_id)?;
+    let new_id = Uuid::new_v4();
+
+    let ext_transition = FileTransition::new(
+        old_uuid,
+        ctx.file.path.clone(),
+        ctx.file.content_hash.clone(),
+        ctx.file.size,
+        TransitionSource::External,
+    )
+    .with_from(expected_hash.map(str::to_owned), Some(existing_size as u64));
+    insert_transition_in_tx(tx, &ext_transition, ctx.now)?;
+
+    tx.execute(
+        "UPDATE files SET path = NULL, status = 'missing', \
+         missing_since = ?1, superseded_by = ?2 WHERE id = ?3",
+        params![ctx.now, new_id.to_string(), existing_id],
+    )
+    .map_err(storage_err("failed to clear old file for external change"))?;
+    insert_active_file_in_tx(
+        tx,
+        InsertActiveFile {
+            new_id,
+            path_str: ctx.path_str,
+            filename: ctx.filename,
+            file: ctx.file,
+            now: ctx.now,
+            session_str: ctx.session_str,
+            err_msg: "failed to insert new file for external change",
+        },
+    )?;
+
+    let disc_transition = FileTransition::new(
+        new_id,
+        ctx.file.path.clone(),
+        ctx.file.content_hash.clone(),
+        ctx.file.size,
+        TransitionSource::Discovery,
+    );
+    insert_transition_in_tx(tx, &disc_transition, ctx.now)?;
+
+    Ok((new_id, old_uuid))
+}
+
+/// Moved branch: reactivate the missing row at the new path, insert a
+/// move-typed Discovery transition. Returns the reactivated row's UUID.
+fn ingest_moved_in_tx(
+    tx: &rusqlite::Transaction<'_>,
+    ctx: &IngestCtx<'_>,
+    missing_id: &str,
+    prior_path: &str,
+) -> Result<Uuid> {
+    tx.execute(
+        "UPDATE files SET path = ?1, filename = ?2, \
+         size = ?3, content_hash = ?4, \
+         status = 'active', missing_since = NULL, \
+         last_seen_session_id = ?5, \
+         updated_at = ?6 WHERE id = ?7",
+        params![
+            ctx.path_str,
+            ctx.filename,
+            ctx.file.size as i64,
+            &ctx.file.content_hash,
+            ctx.session_str,
+            ctx.now,
+            missing_id,
+        ],
+    )
+    .map_err(storage_err("failed to reactivate moved file"))?;
+
+    let file_uuid = super::parse_uuid(missing_id)?;
+    let move_transition = FileTransition::new(
+        file_uuid,
+        ctx.file.path.clone(),
+        ctx.file.content_hash.clone(),
+        ctx.file.size,
+        TransitionSource::Discovery,
+    )
+    .with_from_path(PathBuf::from(prior_path))
+    .with_detail("detected_move");
+    insert_transition_in_tx(tx, &move_transition, ctx.now)?;
+
+    Ok(file_uuid)
+}
+
+/// New-file branch: insert the active row, insert the Discovery transition.
+/// Returns the freshly allocated UUID.
+fn ingest_new_in_tx(tx: &rusqlite::Transaction<'_>, ctx: &IngestCtx<'_>) -> Result<Uuid> {
+    let new_id = Uuid::new_v4();
+    insert_active_file_in_tx(
+        tx,
+        InsertActiveFile {
+            new_id,
+            path_str: ctx.path_str,
+            filename: ctx.filename,
+            file: ctx.file,
+            now: ctx.now,
+            session_str: ctx.session_str,
+            err_msg: "failed to insert new file in ingest",
+        },
+    )?;
+
+    let disc_transition = FileTransition::new(
+        new_id,
+        ctx.file.path.clone(),
+        ctx.file.content_hash.clone(),
+        ctx.file.size,
+        TransitionSource::Discovery,
+    );
+    insert_transition_in_tx(tx, &disc_transition, ctx.now)?;
+
+    Ok(new_id)
 }
 
 /// Parameters for [`insert_active_file_in_tx`]. Bundled into a struct so the


### PR DESCRIPTION
## Summary

- Decomposes `SqliteStore::ingest_discovered_file` (319 → 92 lines) into per-branch helpers (`recover_stub_in_tx`, `ingest_unchanged_in_tx`, `ingest_externally_changed_in_tx`, `ingest_moved_in_tx`, `ingest_new_in_tx`) plus a few support helpers.
- Decomposes `SqliteStore::finish_scan_session` (214 → 59 lines) into `promote_moves_in_tx` (with a per-candidate `try_promote_one_move_in_tx` sub-helper) and `mark_missing_in_finish_tx`.
- Decomposes `InMemoryStore::ingest_discovered_file` (171 → 52 lines) into `ingest_validate_session`, `ingest_handle_existing_row`, and `ingest_handle_no_row`, preserving the documented lock-acquisition order (sessions → last_seen → files → leaf locks).
- Decomposes `InMemoryStore::finish_scan_session` (141 → 18 lines) into `finish_validate_session`, `finish_collect_move_pairs`, `finish_apply_move_promotions`, and `finish_mark_missing`; introduces a private `MovePair` struct.
- No behavior changes. All existing tests pass unchanged. The only production function in either file still over the 100-line cap is `SqliteStore::upsert_file` (135 lines), which was out of scope; tracked as #367.

Closes #364

## Test plan
- [x] `cargo test -p voom-sqlite-store` — 318 lib + 1 integration pass
- [x] `cargo test -p voom-domain` — 215 lib + 12 doctest pass
- [x] `cargo test --workspace` — exit 0
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test -p voom-cli --features functional -- --test-threads=4` — 133 functional tests pass
- [x] Verified via awk function-length sweep that no production function in `file_storage.rs` or `test_support.rs` exceeds 100 lines (except `upsert_file`, tracked in #367)