### PR TITLE
refactor: share scan-session lifecycle via with_scan_session (#365)

### DIFF
--- a/crates/voom-cli/src/commands/scan.rs
+++ b/crates/voom-cli/src/commands/scan.rs
@@ -163,12 +163,13 @@ fn drive_session_ingest(
     quiet: bool,
     kernel: &Arc<voom_kernel::Kernel>,
 ) -> anyhow::Result<ReconcileOutcome> {
-    use voom_domain::transition::{DiscoveredFile, IngestDecision};
+    use voom_domain::storage::with_scan_session;
+    use voom_domain::transition::{DiscoveredFile, IngestDecision, ScanFinishOutcome};
 
     let mut needs_introspection: Vec<FileDiscoveredEvent> = Vec::new();
 
     if !hash_files {
-        // --no-hash path: dispatch events + path-only missing-mark
+        // --no-hash path: dispatch events + path-only missing-mark.
         let discovered: Vec<PathBuf> = events.iter().map(|e| e.path.clone()).collect();
         let missing = store
             .mark_missing_paths(&discovered, paths)
@@ -185,59 +186,42 @@ fn drive_session_ingest(
         });
     }
 
-    let session = store
-        .begin_scan_session(paths)
-        .context("failed to begin scan session")?;
-
     let mut moved = 0u32;
     let mut external_changes = 0u32;
 
-    // Wrap ingest + finish so any error routes through the cancel path below
-    // and the session is never left in_progress.
-    let combined_result: anyhow::Result<voom_domain::transition::ScanFinishOutcome> = (|| {
-        for event in events {
-            // Dispatch before ingest so bus subscribers see every event even if
-            // ingest later errors and aborts the loop.
-            kernel.dispatch(Event::FileDiscovered(event.clone()));
+    let finish: ScanFinishOutcome = with_scan_session(
+        store,
+        paths,
+        |session| -> anyhow::Result<ScanFinishOutcome> {
+            for event in events {
+                // Dispatch before ingest so bus subscribers see every event even if
+                // ingest later errors and aborts the loop.
+                kernel.dispatch(Event::FileDiscovered(event.clone()));
 
-            let Some(hash) = event.content_hash.clone() else {
-                continue;
-            };
-            let df = DiscoveredFile::new(event.path.clone(), event.size, hash);
-            let decision = store
-                .ingest_discovered_file(session, &df)
-                .context("ingest_discovered_file failed")?;
-            match &decision {
-                IngestDecision::Moved { .. } => moved += 1,
-                IngestDecision::ExternallyChanged { .. } => external_changes += 1,
-                _ => {}
+                let Some(hash) = event.content_hash.clone() else {
+                    continue;
+                };
+                let df = DiscoveredFile::new(event.path.clone(), event.size, hash);
+                let decision = store
+                    .ingest_discovered_file(session, &df)
+                    .context("ingest_discovered_file failed")?;
+                match &decision {
+                    IngestDecision::Moved { .. } => moved += 1,
+                    IngestDecision::ExternallyChanged { .. } => external_changes += 1,
+                    _ => {}
+                }
+                if decision.needs_introspection_path(&event.path).is_some() {
+                    needs_introspection.push(event.clone());
+                }
             }
-            if decision.needs_introspection_path(&event.path).is_some() {
-                needs_introspection.push(event.clone());
-            }
-        }
-        let finish = store
-            .finish_scan_session(session)
-            .context("finish_scan_session failed")?;
-        Ok(finish)
-    })();
+            let finish = store
+                .finish_scan_session(session)
+                .context("finish_scan_session failed")?;
+            Ok(finish)
+        },
+    )?;
 
-    let finish = match combined_result {
-        Ok(f) => f,
-        Err(e) => {
-            if let Err(cancel_err) = store.cancel_scan_session(session) {
-                tracing::warn!(
-                    session = %session,
-                    ingest_error = %e,
-                    cancel_error = %cancel_err,
-                    "failed to cancel scan session after ingest error",
-                );
-            }
-            return Err(e);
-        }
-    };
-
-    // Promoted moves were counted as New during ingestion; correct both totals.
+    // Promoted moves were counted as New during ingestion; correct the total.
     moved += finish.promoted_moves;
     if !quiet {
         if finish.missing > 0 {

--- a/crates/voom-domain/src/storage.rs
+++ b/crates/voom-domain/src/storage.rs
@@ -157,7 +157,38 @@ pub trait FileStorage: Send + Sync {
         &self,
         discovered: &[DiscoveredFile],
         scanned_dirs: &[PathBuf],
-    ) -> Result<ReconcileResult>;
+    ) -> Result<ReconcileResult> {
+        use crate::transition::IngestDecision;
+
+        let mut result = ReconcileResult::default();
+
+        with_scan_session(self, scanned_dirs, |session| -> Result<()> {
+            for df in discovered {
+                let decision = self.ingest_discovered_file(session, df)?;
+                match &decision {
+                    IngestDecision::New { .. } => result.new_files += 1,
+                    IngestDecision::Unchanged { .. } => result.unchanged += 1,
+                    IngestDecision::ExternallyChanged { .. } => result.external_changes += 1,
+                    IngestDecision::Moved { .. } => result.moved += 1,
+                    IngestDecision::Duplicate { .. } => {
+                        // Silently drop — preserves the prior `HashSet`-based
+                        // dedup semantics on the input list.
+                    }
+                }
+                if let Some(p) = decision.needs_introspection_path(&df.path) {
+                    result.needs_introspection.push(p);
+                }
+            }
+            let finish = self.finish_scan_session(session)?;
+            result.missing = finish.missing;
+            // Promoted moves were counted as New during ingestion; reclassify.
+            result.new_files = result.new_files.saturating_sub(finish.promoted_moves);
+            result.moved += finish.promoted_moves;
+            Ok(())
+        })?;
+
+        Ok(result)
+    }
     /// Mark active files under `scanned_dirs` as missing if their path is not
     /// in `discovered_paths`. This is a path-only operation — no hash needed.
     fn mark_missing_paths(

--- a/crates/voom-domain/src/storage.rs
+++ b/crates/voom-domain/src/storage.rs
@@ -276,7 +276,7 @@ pub trait FileStorage: Send + Sync {
 /// original error.
 pub fn with_scan_session<S, F, T, E>(
     store: &S,
-    roots: &[std::path::PathBuf],
+    roots: &[PathBuf],
     body: F,
 ) -> std::result::Result<T, E>
 where

--- a/crates/voom-domain/src/storage.rs
+++ b/crates/voom-domain/src/storage.rs
@@ -256,6 +256,51 @@ pub trait FileStorage: Send + Sync {
     fn predecessor_id_of(&self, successor_id: &Uuid) -> Result<Option<Uuid>>;
 }
 
+/// Drive a scan session: call `begin_scan_session`, run `body`, and on
+/// error from `body` best-effort `cancel_scan_session` so the session is
+/// not left `InProgress` to block the next begin.
+///
+/// The body is responsible for calling `finish_scan_session` itself —
+/// finish returns a [`crate::transition::ScanFinishOutcome`] that callers
+/// usually need to thread back into their result, and embedding the
+/// finish call here would force a single return shape on every caller.
+///
+/// Generic over the body's error type via [`From<VoomError>`] so callers
+/// using `anyhow::Error` (CLI) and callers using `VoomError` directly
+/// (trait default impls) can share the same helper.
+///
+/// # Errors
+/// Returns the error from `begin_scan_session` (converted via `From`) or
+/// propagates the error from `body`. A failure inside
+/// `cancel_scan_session` is logged at `warn` but does not mask the
+/// original error.
+pub fn with_scan_session<S, F, T, E>(
+    store: &S,
+    roots: &[std::path::PathBuf],
+    body: F,
+) -> std::result::Result<T, E>
+where
+    S: FileStorage + ?Sized,
+    F: FnOnce(crate::transition::ScanSessionId) -> std::result::Result<T, E>,
+    E: From<crate::errors::VoomError> + std::fmt::Display,
+{
+    let session = store.begin_scan_session(roots)?;
+    match body(session) {
+        Ok(value) => Ok(value),
+        Err(e) => {
+            if let Err(cancel_err) = store.cancel_scan_session(session) {
+                tracing::warn!(
+                    session = %session,
+                    ingest_error = %e,
+                    cancel_error = %cancel_err,
+                    "failed to cancel scan session after ingest error",
+                );
+            }
+            Err(e)
+        }
+    }
+}
+
 /// Job queue operations.
 ///
 /// # Errors

--- a/crates/voom-domain/src/test_support.rs
+++ b/crates/voom-domain/src/test_support.rs
@@ -32,8 +32,7 @@ use crate::storage::{
 };
 use crate::transcode::TranscodeOutcome;
 use crate::transition::{
-    DiscoveredFile, FileStatus, FileTransition, ReconcileResult, STALE_SESSION_SECS,
-    TransitionSource, is_under_any,
+    DiscoveredFile, FileStatus, FileTransition, STALE_SESSION_SECS, TransitionSource, is_under_any,
 };
 use crate::verification::{
     IntegritySummary, IntegritySummaryInput, VerificationFilters, VerificationMode,
@@ -633,53 +632,6 @@ impl FileStorage for InMemoryStore {
         let before = files.len();
         files.retain(|_, f| f.status != FileStatus::Missing);
         Ok((before - files.len()) as u64)
-    }
-
-    fn reconcile_discovered_files(
-        &self,
-        discovered: &[DiscoveredFile],
-        scanned_dirs: &[std::path::PathBuf],
-    ) -> Result<ReconcileResult> {
-        use crate::transition::IngestDecision;
-
-        let session = self.begin_scan_session(scanned_dirs)?;
-        let mut result = ReconcileResult::default();
-
-        let outcome: Result<()> = (|| {
-            for df in discovered {
-                let decision = self.ingest_discovered_file(session, df)?;
-                match &decision {
-                    IngestDecision::New { .. } => result.new_files += 1,
-                    IngestDecision::Unchanged { .. } => result.unchanged += 1,
-                    IngestDecision::ExternallyChanged { .. } => result.external_changes += 1,
-                    IngestDecision::Moved { .. } => result.moved += 1,
-                    IngestDecision::Duplicate { .. } => {}
-                }
-                if let Some(p) = decision.needs_introspection_path(&df.path) {
-                    result.needs_introspection.push(p);
-                }
-            }
-            let finish = self.finish_scan_session(session)?;
-            result.missing = finish.missing;
-            result.new_files = result.new_files.saturating_sub(finish.promoted_moves);
-            result.moved += finish.promoted_moves;
-            Ok(())
-        })();
-
-        match outcome {
-            Ok(()) => Ok(result),
-            Err(e) => {
-                if let Err(cancel_err) = self.cancel_scan_session(session) {
-                    tracing::warn!(
-                        session = %session,
-                        ingest_error = %e,
-                        cancel_error = %cancel_err,
-                        "failed to cancel scan session after ingest error",
-                    );
-                }
-                Err(e)
-            }
-        }
     }
 
     fn update_expected_hash(&self, id: &Uuid, hash: &str) -> Result<()> {

--- a/plugins/sqlite-store/src/store/file_storage.rs
+++ b/plugins/sqlite-store/src/store/file_storage.rs
@@ -9,8 +9,8 @@ use voom_domain::errors::Result;
 use voom_domain::media::{MediaFile, StoredFingerprint, Track};
 use voom_domain::storage::{FileFilters, FileStorage};
 use voom_domain::transition::{
-    DiscoveredFile, FileStatus, FileTransition, IngestDecision, ReconcileResult,
-    STALE_SESSION_SECS, ScanFinishOutcome, ScanSessionStatus, TransitionSource, is_under_any,
+    DiscoveredFile, FileStatus, FileTransition, IngestDecision, STALE_SESSION_SECS,
+    ScanFinishOutcome, ScanSessionStatus, TransitionSource, is_under_any,
 };
 
 use super::{
@@ -353,60 +353,6 @@ impl FileStorage for SqliteStore {
             )
             .map_err(storage_err("failed to purge missing files"))?;
         Ok(deleted as u64)
-    }
-
-    fn reconcile_discovered_files(
-        &self,
-        discovered: &[DiscoveredFile],
-        scanned_dirs: &[PathBuf],
-    ) -> Result<ReconcileResult> {
-        let session = self.begin_scan_session(scanned_dirs)?;
-        let mut result = ReconcileResult::default();
-
-        // Single closure so any `?` on ingest/finish error routes through
-        // the cancel path below.
-        let outcome: Result<()> = (|| {
-            for df in discovered {
-                let decision = self.ingest_discovered_file(session, df)?;
-                match &decision {
-                    IngestDecision::New { .. } => result.new_files += 1,
-                    IngestDecision::Unchanged { .. } => result.unchanged += 1,
-                    IngestDecision::ExternallyChanged { .. } => result.external_changes += 1,
-                    IngestDecision::Moved { .. } => result.moved += 1,
-                    IngestDecision::Duplicate { .. } => {
-                        // Silently drop — preserves today's `HashSet`-based
-                        // dedup semantics on the input list.
-                    }
-                }
-                if let Some(p) = decision.needs_introspection_path(&df.path) {
-                    result.needs_introspection.push(p);
-                }
-            }
-            let finish = self.finish_scan_session(session)?;
-            result.missing = finish.missing;
-            // Promoted moves: each was counted as New during ingestion, so decrement
-            // new_files and increment moved to reflect the retroactive reclassification.
-            result.new_files = result.new_files.saturating_sub(finish.promoted_moves);
-            result.moved += finish.promoted_moves;
-            Ok(())
-        })();
-
-        match outcome {
-            Ok(()) => Ok(result),
-            Err(e) => {
-                // Best-effort: cancel the session so it doesn't linger as
-                // in_progress and block the next begin.
-                if let Err(cancel_err) = self.cancel_scan_session(session) {
-                    tracing::warn!(
-                        session = %session,
-                        ingest_error = %e,
-                        cancel_error = %cancel_err,
-                        "failed to cancel scan session after ingest error",
-                    );
-                }
-                Err(e)
-            }
-        }
     }
 
     fn update_expected_hash(&self, id: &Uuid, hash: &str) -> Result<()> {


### PR DESCRIPTION
Closes #365.

## Summary
- Add `voom_domain::storage::with_scan_session`, a free function that wraps the `begin_scan_session` + body + cancel-on-error pattern. Generic over body error type via `From<VoomError>` so both `anyhow::Error` and `VoomError` callers reuse it.
- Promote `FileStorage::reconcile_discovered_files` from a required method to a default trait method built on `with_scan_session`. Drop the duplicate overrides in `SqliteStore` and `InMemoryStore`.
- Refactor `voom-cli`'s `drive_session_ingest` to use the helper while keeping the per-event `FileDiscovered` dispatch ordering (acceptance criterion from the issue).

Net: +113 / -155 across 4 files. The three near-identical copies of the scan-session lifecycle collapse to one.

## Test Plan
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --workspace` passes
- [x] `cargo test -p voom-cli --features functional -- --test-threads=4` — 128 + 1 + 4 tests pass
- [x] CLI still dispatches `FileDiscovered` before each ingest call (verified in code at `crates/voom-cli/src/commands/scan.rs:199`)