### PR TITLE
feat(scan): streaming discovery + bounded ffprobe concurrency (#359)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1415,6 +1415,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2041,6 +2047,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -3748,6 +3764,7 @@ dependencies = [
  "fs2",
  "indicatif",
  "insta",
+ "num_cpus",
  "parking_lot",
  "predicates",
  "rand 0.10.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 
 # Synchronization
+num_cpus = "1"
 parking_lot = "0.12"
 
 # Text matching

--- a/crates/voom-cli/Cargo.toml
+++ b/crates/voom-cli/Cargo.toml
@@ -65,7 +65,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 
 # Concurrency
-num_cpus = "1"
+num_cpus.workspace = true
 parking_lot.workspace = true
 rayon.workspace = true
 

--- a/crates/voom-cli/Cargo.toml
+++ b/crates/voom-cli/Cargo.toml
@@ -65,6 +65,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 
 # Concurrency
+num_cpus = "1"
 parking_lot.workspace = true
 rayon.workspace = true
 

--- a/crates/voom-cli/src/cli.rs
+++ b/crates/voom-cli/src/cli.rs
@@ -131,6 +131,11 @@ pub struct ScanArgs {
     #[arg(short, long, default_value_t = 0)]
     pub workers: usize,
 
+    /// Number of parallel workers for ffprobe introspection. Default 0 = auto
+    /// (min(num_cpus, sqlite_pool_size - 2), floor 1).
+    #[arg(long, default_value_t = 0)]
+    pub probe_workers: usize,
+
     /// Skip content hashing
     #[arg(long)]
     pub no_hash: bool,
@@ -1179,6 +1184,26 @@ mod tests {
         match cli.command {
             Commands::Scan(args) => assert!(matches!(args.format, Some(OutputFormat::Plain))),
             _ => panic!("expected Scan"),
+        }
+    }
+
+    #[test]
+    fn test_scan_args_probe_workers_defaults_to_zero() {
+        let args = Cli::try_parse_from(["voom", "scan", "/tmp"]).unwrap();
+        if let Commands::Scan(scan) = args.command {
+            assert_eq!(scan.probe_workers, 0);
+        } else {
+            panic!("expected Scan command");
+        }
+    }
+
+    #[test]
+    fn test_scan_args_probe_workers_explicit() {
+        let args = Cli::try_parse_from(["voom", "scan", "/tmp", "--probe-workers", "3"]).unwrap();
+        if let Commands::Scan(scan) = args.command {
+            assert_eq!(scan.probe_workers, 3);
+        } else {
+            panic!("expected Scan command");
         }
     }
 

--- a/crates/voom-cli/src/commands/scan/mod.rs
+++ b/crates/voom-cli/src/commands/scan/mod.rs
@@ -886,6 +886,93 @@ mod streaming_tests {
             "discovery error must not allow finish_scan_session to run"
         );
     }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn probe_channel_close_cancels_session_does_not_mark_missing() {
+        // Regression: if the probe stage dies (drops rx_probe) while
+        // ingest still has events to forward, tx_probe.blocking_send
+        // fails. Without the fix, ingest breaks out of its recv loop
+        // and falls through to finish_scan_session — marking every
+        // unprocessed active file under the roots as Missing. With the
+        // fix, ingest cancels the pipeline token and returns Err, so
+        // with_scan_session cancels the session instead.
+        let bed = make_bed();
+
+        // Seed a row that would be marked Missing by finish_scan_session
+        // if it runs (it's in the DB under the scan root but we never
+        // send a discovery event for it). This is the canary: if
+        // finish_scan_session ran, this row becomes Missing.
+        let canary_path = bed.media_dir.path().join("canary.mkv");
+        let mut canary = MediaFile::new(canary_path.clone())
+            .with_container(Container::Mkv)
+            .with_tracks(vec![Track::new(0, TrackType::Video, "h264".into())]);
+        canary.size = 9;
+        canary.content_hash = Some("abcdef0123456789".into());
+        canary.expected_hash = canary.content_hash.clone();
+        bed.store.upsert_file(&canary).expect("canary upsert");
+
+        // Set up tx_probe with its receiver dropped immediately.
+        // When ingest tries to forward a NEW file to the probe stage,
+        // blocking_send will return Err because the receiver is closed.
+        let (tx_disc, rx_disc) = tokio::sync::mpsc::channel(4);
+        let (tx_probe, rx_probe) = tokio::sync::mpsc::channel(4);
+        drop(rx_probe);
+
+        let token = tokio_util::sync::CancellationToken::new();
+        let paths = vec![bed.media_dir.path().to_path_buf()];
+
+        let ingest_fut = tokio::spawn(super::pipeline::run_ingest_for_test(
+            bed.store.clone(),
+            bed.kernel.clone(),
+            paths,
+            rx_disc,
+            tx_probe,
+            token.clone(),
+        ));
+
+        // Send an event for a path that is NOT in the DB — ingest will
+        // call ingest_discovered_file, get IngestDecision::New
+        // (needs_introspection: true), and try to forward to probe.
+        // Since rx_probe is dropped, blocking_send returns Err.
+        let new_path = bed.media_dir.path().join("new_file.mkv");
+        tx_disc
+            .send(voom_domain::events::FileDiscoveredEvent::new(
+                new_path.clone(),
+                42,
+                Some("ffffffffffffffff".into()),
+            ))
+            .await
+            .expect("send disc event");
+        drop(tx_disc); // close so ingest's recv loop terminates
+
+        let result = ingest_fut.await.expect("join ingest");
+
+        // The ingest task must have returned Err.
+        assert!(
+            result.is_err(),
+            "ingest must return Err on probe channel close"
+        );
+        // The pipeline cancellation token must be set.
+        assert!(
+            token.is_cancelled(),
+            "ingest must cancel the pipeline token on probe channel close"
+        );
+
+        // The canary file MUST still be Active — finish_scan_session
+        // must NOT have run (which would have marked it Missing since
+        // no discovery event was sent for it in this session).
+        let row = bed
+            .store
+            .file_by_path(&canary_path)
+            .expect("file_by_path ok")
+            .expect("canary row still present");
+        assert_ne!(
+            row.status,
+            FileStatus::Missing,
+            "probe-channel-close must not cause finish_scan_session to \
+             mark unprocessed files as missing"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/voom-cli/src/commands/scan/mod.rs
+++ b/crates/voom-cli/src/commands/scan/mod.rs
@@ -973,6 +973,83 @@ mod streaming_tests {
              mark unprocessed files as missing"
         );
     }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn closed_probe_channel_with_cancelled_token_is_not_an_error() {
+        // Regression: previously, ingest reported "probe stage closed its
+        // receiver unexpectedly" whenever tx_probe.blocking_send failed —
+        // even when the channel was closed because cancellation was already
+        // in flight. Now we check token.is_cancelled() first and route
+        // cancelled flows through the clean cancellation path (session ends
+        // Cancelled, no files marked Missing, ingest returns Ok).
+        let bed = make_bed();
+
+        // Seed a canary so we can verify finish_scan_session did NOT run.
+        // If finish_scan_session ran it would mark this row Missing (since
+        // no discovery event is sent for it during the scan).
+        let canary_path = bed.media_dir.path().join("canary.mkv");
+        let mut canary = MediaFile::new(canary_path.clone())
+            .with_container(Container::Mkv)
+            .with_tracks(vec![Track::new(0, TrackType::Video, "h264".into())]);
+        canary.size = 9;
+        canary.content_hash = Some("abcdef0123456789".into());
+        canary.expected_hash = canary.content_hash.clone();
+        bed.store.upsert_file(&canary).expect("seed canary");
+
+        let (tx_disc, rx_disc) = tokio::sync::mpsc::channel(4);
+        let (tx_probe, rx_probe) = tokio::sync::mpsc::channel(4);
+        drop(rx_probe); // simulate probe-already-exited
+
+        let token = tokio_util::sync::CancellationToken::new();
+        token.cancel(); // pre-cancel: the external request that caused probe to exit
+
+        let paths = vec![bed.media_dir.path().to_path_buf()];
+
+        let ingest_fut = tokio::spawn(super::pipeline::run_ingest_for_test(
+            bed.store.clone(),
+            bed.kernel.clone(),
+            paths,
+            rx_disc,
+            tx_probe,
+            token.clone(),
+        ));
+
+        // Send one event for a path NOT in the DB — ingest decides New and
+        // tries to forward to probe. blocking_send fails (rx_probe dropped),
+        // but the token is already cancelled, so this must be treated as a
+        // clean cancellation, NOT a fatal probe-stage failure.
+        let new_path = bed.media_dir.path().join("new_file.mkv");
+        tx_disc
+            .send(voom_domain::events::FileDiscoveredEvent::new(
+                new_path,
+                42,
+                Some("ffffffffffffffff".into()),
+            ))
+            .await
+            .expect("send disc event");
+        drop(tx_disc);
+
+        let result = ingest_fut.await.expect("join ingest");
+
+        // Cancellation must NOT be reported as a probe failure.
+        assert!(
+            result.is_ok(),
+            "ingest must return Ok when probe close coincides with cancellation; got: {:?}",
+            result.err()
+        );
+
+        // Canary must remain Active — finish_scan_session must not have run.
+        let row = bed
+            .store
+            .file_by_path(&canary_path)
+            .expect("file_by_path ok")
+            .expect("canary present");
+        assert_ne!(
+            row.status,
+            FileStatus::Missing,
+            "cancelled scan must not mark files missing"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/voom-cli/src/commands/scan/mod.rs
+++ b/crates/voom-cli/src/commands/scan/mod.rs
@@ -1,7 +1,4 @@
-use std::collections::HashSet;
-use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use crate::app;
@@ -10,11 +7,10 @@ use crate::config;
 use crate::output;
 use crate::paths::resolve_paths;
 use crate::progress::{DiscoveryProgress, ProbeProgress};
-use anyhow::{Context, Result};
+use anyhow::Result;
 use console::style;
-use indicatif::HumanDuration;
+use indicatif::{HumanDuration, MultiProgress};
 use tokio_util::sync::CancellationToken;
-use voom_domain::bad_file::BadFileSource;
 use voom_domain::events::{Event, FileDiscoveredEvent, ScanCompleteEvent};
 use voom_domain::storage::StorageTrait;
 use voom_domain::verification::{VerificationMode, VerificationOutcome, VerificationRecord};
@@ -26,9 +22,9 @@ mod pipeline;
 
 /// Run the scan command.
 ///
-/// Discovery and introspection are driven directly for deterministic progress
-/// reporting, but all events are also published through the kernel's event bus
-/// so that subscribers (sqlite-store, WASM plugins) receive them.
+/// Discovery, ingest, and introspection run as three concurrent streaming
+/// stages. All events are published through the kernel's event bus so that
+/// subscribers (sqlite-store, WASM plugins) receive them.
 pub async fn run(args: ScanArgs, quiet: bool, token: CancellationToken) -> Result<()> {
     let config = config::load_config()?;
     let app::BootstrapResult { kernel, store, .. } = app::bootstrap_kernel_with_store(&config)?;
@@ -47,69 +43,117 @@ pub async fn run(args: ScanArgs, quiet: bool, token: CancellationToken) -> Resul
             eprintln!("{} {}", style("Scanning").bold(), path_list.join(", "));
         }
 
-        let (mut all_events, orphans, disc_errors) =
-            run_discovery(&args, &paths, hash_files, quiet, &kernel, store.clone())?;
+        let mp = MultiProgress::new();
+        let discovery_progress = if quiet {
+            DiscoveryProgress::hidden()
+        } else {
+            DiscoveryProgress::new_in(&mp)
+        };
+        let probe_progress = if quiet {
+            ProbeProgress::hidden_dynamic()
+        } else {
+            ProbeProgress::new_dynamic_in(&mp)
+        };
 
-        // Deduplicate by path: overlapping scan roots can produce the same path
-        // multiple times. Doing this here keeps the dispatch, summary,
-        // introspection, verification, and JSON output paths all
-        // single-counted. The session API's IngestDecision::Duplicate is now
-        // defense in depth for the hash path.
-        {
-            let mut seen = HashSet::new();
-            all_events.retain(|e| seen.insert(e.path.clone()));
-        }
+        let outcome = pipeline::run_streaming_pipeline(
+            &args,
+            &paths,
+            hash_files,
+            store.clone(),
+            kernel.clone(),
+            config.ffprobe_path().map(|s| s.to_owned()),
+            config.animation_detection_mode(),
+            discovery_progress,
+            probe_progress,
+            token.clone(),
+        )
+        .await?;
 
-        if all_events.is_empty() {
-            handle_empty_scan(&*store, &paths, hash_files, orphans, quiet, args.format)?;
+        if outcome.files_discovered == 0 {
+            if !quiet && outcome.missing > 0 {
+                print_missing_count(outcome.missing);
+            }
+            if !quiet {
+                if outcome.orphans > 0 {
+                    eprintln!(
+                        "{} ({} orphaned temp {} skipped)",
+                        style("No media files found.").yellow(),
+                        outcome.orphans,
+                        if outcome.orphans == 1 {
+                            "file"
+                        } else {
+                            "files"
+                        },
+                    );
+                } else {
+                    eprintln!("{}", style("No media files found.").yellow());
+                }
+            }
+            if matches!(args.format, Some(crate::cli::OutputFormat::Json)) {
+                #[allow(clippy::print_stdout)]
+                {
+                    println!("[]");
+                }
+            }
             return Ok(());
         }
 
         if !quiet {
             print_discovery_summary(
-                all_events.len(),
+                outcome.files_discovered as usize,
                 start.elapsed(),
                 hash_files,
-                orphans,
-                disc_errors,
+                outcome.orphans,
+                outcome.discovery_errors,
             );
         }
 
-        let reconcile_outcome =
-            drive_session_ingest(&*store, &all_events, &paths, hash_files, quiet, &kernel)?;
-        let needs_introspection = reconcile_outcome.needs_introspection;
-        let needs_introspection_refs: Vec<&FileDiscoveredEvent> =
-            needs_introspection.iter().collect();
-        let (introspected, errors) = run_introspection(
-            &needs_introspection_refs,
-            &kernel,
-            config.ffprobe_path(),
-            config.animation_detection_mode(),
-            &token,
-            quiet,
-        )
-        .await;
+        if !quiet {
+            if outcome.missing > 0 {
+                print_missing_count(outcome.missing);
+            }
+            if outcome.moved > 0 {
+                eprintln!(
+                    "  {} {} files moved/renamed",
+                    style("Moved").dim(),
+                    outcome.moved,
+                );
+            }
+            if outcome.external_changes > 0 {
+                eprintln!(
+                    "  {} {} files changed externally",
+                    style("Changed").dim(),
+                    outcome.external_changes,
+                );
+            }
+        }
 
-        let formatted_results = args.format.map(|fmt| (fmt, format_results(&all_events)));
         print_scan_summary(
-            all_events.len(),
-            introspected,
-            errors,
+            outcome.files_discovered as usize,
+            outcome.files_introspected,
+            outcome.errors(),
             start.elapsed(),
             token.is_cancelled(),
             quiet,
-            formatted_results,
         );
 
         if token.is_cancelled() {
+            if let Some(format) = args.format {
+                output::format_scan_results(&outcome.formatted, format);
+            }
             return Ok(());
         }
 
         purge_stale_records(&*store, config.pruning.retention_days, quiet);
 
-        // Optional quick-verification pass after introspection. Discovery itself
-        // is not blocked by this — verifications run as a separate fan-out only
-        // once the discovery + introspection phases have completed.
+        // Build FileDiscoveredEvent stubs for the verify helper.
+        let all_events: Vec<FileDiscoveredEvent> = outcome
+            .formatted
+            .iter()
+            .map(|(path, size, hash)| FileDiscoveredEvent::new(path.clone(), *size, hash.clone()))
+            .collect();
+
+        // Optional quick-verification pass after introspection.
         let verifier_cfg = read_verifier_config(&config);
         let should_verify = args.verify || verifier_cfg.verify_on_scan;
         if should_verify {
@@ -123,7 +167,6 @@ pub async fn run(args: ScanArgs, quiet: bool, token: CancellationToken) -> Resul
             );
         }
 
-        // Protected from cancelled runs by the early return above (line 91).
         // `ScanComplete` carries both files_discovered and files_introspected and
         // is the single lifecycle event for a full scan. We deliberately do NOT
         // dispatch `IntrospectComplete` here — that event is reserved for
@@ -131,12 +174,12 @@ pub async fn run(args: ScanArgs, quiet: bool, token: CancellationToken) -> Resul
         // both would cause subscribers like the report plugin to capture two
         // back-to-back snapshots (see issue #153).
         kernel.dispatch(Event::ScanComplete(ScanCompleteEvent::new(
-            all_events.len() as u64,
-            introspected,
+            outcome.files_discovered,
+            outcome.files_introspected,
         )));
 
         if let Some(format) = args.format {
-            output::format_scan_results(&format_results(&all_events), format);
+            output::format_scan_results(&outcome.formatted, format);
         }
 
         Ok(())
@@ -146,229 +189,6 @@ pub async fn run(args: ScanArgs, quiet: bool, token: CancellationToken) -> Resul
     crate::retention::maybe_run_after_cli(store, &config.retention, Some(kernel));
 
     primary_result
-}
-
-/// Outcome of driving the session-based ingest flow.
-struct ReconcileOutcome {
-    needs_introspection: Vec<FileDiscoveredEvent>,
-}
-
-/// Drive the scan-session lifecycle (begin → ingest each → finish) over
-/// discovered events, dispatching `FileDiscovered` on the bus and collecting
-/// the set of events that need introspection. On error mid-loop, cancels the
-/// session so no file is marked missing.
-fn drive_session_ingest(
-    store: &dyn voom_domain::storage::StorageTrait,
-    events: &[FileDiscoveredEvent],
-    paths: &[PathBuf],
-    hash_files: bool,
-    quiet: bool,
-    kernel: &Arc<voom_kernel::Kernel>,
-) -> anyhow::Result<ReconcileOutcome> {
-    use voom_domain::storage::with_scan_session;
-    use voom_domain::transition::{DiscoveredFile, IngestDecision, ScanFinishOutcome};
-
-    let mut needs_introspection: Vec<FileDiscoveredEvent> = Vec::new();
-
-    if !hash_files {
-        // --no-hash path: dispatch events + path-only missing-mark.
-        let discovered: Vec<PathBuf> = events.iter().map(|e| e.path.clone()).collect();
-        let missing = store
-            .mark_missing_paths(&discovered, paths)
-            .context("path-only reconciliation failed")?;
-        if !quiet && missing > 0 {
-            print_missing_count(missing);
-        }
-        for event in events {
-            kernel.dispatch(Event::FileDiscovered(event.clone()));
-        }
-        needs_introspection = events.to_vec();
-        return Ok(ReconcileOutcome {
-            needs_introspection,
-        });
-    }
-
-    let mut moved = 0u32;
-    let mut external_changes = 0u32;
-
-    let finish: ScanFinishOutcome = with_scan_session(
-        store,
-        paths,
-        |session| -> anyhow::Result<ScanFinishOutcome> {
-            for event in events {
-                // Dispatch before ingest so bus subscribers see every event even if
-                // ingest later errors and aborts the loop.
-                kernel.dispatch(Event::FileDiscovered(event.clone()));
-
-                let Some(hash) = event.content_hash.clone() else {
-                    continue;
-                };
-                let df = DiscoveredFile::new(event.path.clone(), event.size, hash);
-                let decision = store
-                    .ingest_discovered_file(session, &df)
-                    .context("ingest_discovered_file failed")?;
-                match &decision {
-                    IngestDecision::Moved { .. } => moved += 1,
-                    IngestDecision::ExternallyChanged { .. } => external_changes += 1,
-                    _ => {}
-                }
-                if decision.needs_introspection_path(&event.path).is_some() {
-                    needs_introspection.push(event.clone());
-                }
-            }
-            let finish = store
-                .finish_scan_session(session)
-                .context("finish_scan_session failed")?;
-            Ok(finish)
-        },
-    )?;
-
-    // Promoted moves were counted as New during ingestion; correct the total.
-    moved += finish.promoted_moves;
-    if !quiet {
-        if finish.missing > 0 {
-            print_missing_count(finish.missing);
-        }
-        if moved > 0 {
-            eprintln!("  {} {} files moved/renamed", style("Moved").dim(), moved,);
-        }
-        if external_changes > 0 {
-            eprintln!(
-                "  {} {} files changed externally",
-                style("Changed").dim(),
-                external_changes,
-            );
-        }
-    }
-    Ok(ReconcileOutcome {
-        needs_introspection,
-    })
-}
-
-/// Run filesystem discovery across all paths, returning events and counters.
-fn run_discovery(
-    args: &ScanArgs,
-    paths: &[PathBuf],
-    hash_files: bool,
-    quiet: bool,
-    kernel: &Arc<voom_kernel::Kernel>,
-    store: Arc<dyn voom_domain::storage::StorageTrait>,
-) -> Result<(Vec<FileDiscoveredEvent>, u64, u64)> {
-    let discovery = voom_discovery::DiscoveryPlugin::new();
-    let progress = if quiet {
-        DiscoveryProgress::hidden()
-    } else {
-        DiscoveryProgress::new()
-    };
-    let orphan_count = Arc::new(AtomicU64::new(0));
-    let discovery_errors = Arc::new(AtomicU64::new(0));
-    let cumulative_discovered = Arc::new(AtomicU64::new(0));
-    let processing_base = Arc::new(AtomicU64::new(0));
-    let mut all_events = Vec::new();
-
-    for path in paths {
-        progress.reset_to_spinner();
-
-        let progress_clone = progress.clone();
-        let orphan_clone = orphan_count.clone();
-        let errors_clone = discovery_errors.clone();
-        let kernel_clone = kernel.clone();
-        let cum_disc = cumulative_discovered.clone();
-        let proc_base = processing_base.clone();
-        let pre_scan = cumulative_discovered.load(Ordering::Relaxed);
-
-        let mut options = voom_discovery::ScanOptions::new(path.clone());
-        options.recursive = args.recursive;
-        options.hash_files = hash_files;
-        options.workers = args.workers;
-        options.fingerprint_lookup = Some(crate::introspect::fingerprint_lookup(store.clone()));
-        options.on_progress = Some(Box::new(move |progress| match progress {
-            voom_discovery::ScanProgress::Discovered { count: _, path } => {
-                let cumulative = cum_disc.fetch_add(1, Ordering::Relaxed) + 1;
-                let cumulative = usize::try_from(cumulative).unwrap_or(usize::MAX);
-                progress_clone.on_discovered(cumulative, &path);
-            }
-            voom_discovery::ScanProgress::Processing {
-                current,
-                total,
-                path,
-            } => {
-                let base = proc_base.load(Ordering::Relaxed);
-                let base = usize::try_from(base).unwrap_or(usize::MAX);
-                let action = if hash_files { "Hashing" } else { "Processing" };
-                progress_clone.on_processing(base + current, base + total, &path, action);
-            }
-            voom_discovery::ScanProgress::OrphanedTempFiles { count } => {
-                orphan_clone.fetch_add(count as u64, Ordering::Relaxed);
-            }
-            voom_discovery::ScanProgress::HashReused { .. } => {}
-        }));
-        options.on_error = Some(Box::new(move |path, size, error| {
-            tracing::warn!(path = %path.display(), error = %error, "discovery error");
-            errors_clone.fetch_add(1, Ordering::Relaxed);
-            crate::introspect::dispatch_failure(
-                &kernel_clone,
-                path,
-                size,
-                None,
-                &error,
-                BadFileSource::Discovery,
-            );
-        }));
-
-        let events = discovery.scan(&options).context("filesystem scan failed")?;
-
-        let dir_discovered = cumulative_discovered.load(Ordering::Relaxed) - pre_scan;
-        processing_base.fetch_add(dir_discovered, Ordering::Relaxed);
-        all_events.extend(events);
-    }
-
-    progress.finish();
-
-    let orphans = orphan_count.load(Ordering::Relaxed);
-    let errors = discovery_errors.load(Ordering::Relaxed);
-    Ok((all_events, orphans, errors))
-}
-
-/// Handle the case where discovery found no files. Runs reconciliation
-/// to mark previously known files as missing, then prints output.
-fn handle_empty_scan(
-    store: &dyn voom_domain::storage::StorageTrait,
-    paths: &[PathBuf],
-    hash_files: bool,
-    orphans: u64,
-    quiet: bool,
-    format: Option<crate::cli::OutputFormat>,
-) -> Result<()> {
-    if hash_files {
-        let result = store.reconcile_discovered_files(&[], paths)?;
-        if !quiet && result.missing > 0 {
-            print_missing_count(result.missing);
-        }
-    } else {
-        let missing = store.mark_missing_paths(&[], paths)?;
-        if !quiet && missing > 0 {
-            print_missing_count(missing);
-        }
-    }
-
-    if !quiet {
-        if orphans > 0 {
-            eprintln!(
-                "{} ({} orphaned temp {} skipped)",
-                style("No media files found.").yellow(),
-                orphans,
-                if orphans == 1 { "file" } else { "files" },
-            );
-        } else {
-            eprintln!("{}", style("No media files found.").yellow());
-        }
-    }
-
-    if matches!(format, Some(crate::cli::OutputFormat::Json)) {
-        println!("[]");
-    }
-    Ok(())
 }
 
 /// Print the discovery/hashing summary line.
@@ -423,67 +243,12 @@ fn print_discovery_summary(
     }
 }
 
-/// Run ffprobe introspection on files. Returns (introspected, errors) counts.
-async fn run_introspection(
-    events: &[&FileDiscoveredEvent],
-    kernel: &Arc<voom_kernel::Kernel>,
-    ffprobe_path: Option<&str>,
-    animation_mode: voom_ffprobe_introspector::parser::AnimationDetectionMode,
-    token: &CancellationToken,
-    quiet: bool,
-) -> (u64, u64) {
-    let probe = if quiet {
-        ProbeProgress::hidden(events.len())
-    } else {
-        ProbeProgress::new(events.len())
-    };
-    let mut introspected = 0u64;
-    let mut errors = 0u64;
-
-    for (i, event) in events.iter().enumerate() {
-        if token.is_cancelled() {
-            break;
-        }
-        probe.on_file(i + 1, &event.path);
-
-        match crate::introspect::introspect_file(
-            event.path.clone(),
-            event.size,
-            event.content_hash.clone(),
-            kernel,
-            ffprobe_path,
-            animation_mode,
-        )
-        .await
-        {
-            Ok(_file) => introspected += 1,
-            Err(e) => {
-                tracing::warn!(
-                    path = %event.path.display(),
-                    error = %e,
-                    "introspection failed"
-                );
-                errors += 1;
-            }
-        }
-        probe.inc();
-    }
-
-    probe.finish();
-    (introspected, errors)
-}
-
-type FormattedScanResults = (
-    crate::cli::OutputFormat,
-    Vec<(PathBuf, u64, Option<String>)>,
-);
-
 /// Print the final scan summary (completion or interruption).
 ///
-/// Takes primitive counts plus an optional pre-built `(format, results)`
-/// pair instead of borrowing the events slice. This keeps tainted data
-/// from CodeQL's `rust/cleartext-logging` flow analysis out of the
-/// logging sink — the print sites see only `usize`/`u64`/`Duration`.
+/// Takes primitive counts plus elapsed time instead of borrowing the events
+/// slice. This keeps tainted data from CodeQL's `rust/cleartext-logging` flow
+/// analysis out of the logging sink — the print sites see only
+/// `usize`/`u64`/`Duration`.
 fn print_scan_summary(
     total_files: usize,
     introspected: u64,
@@ -491,7 +256,6 @@ fn print_scan_summary(
     elapsed: Duration,
     cancelled: bool,
     quiet: bool,
-    formatted_results: Option<FormattedScanResults>,
 ) {
     let total = total_files as u64;
     let error_suffix = if errors > 0 {
@@ -511,9 +275,6 @@ fn print_scan_summary(
                 error_suffix,
                 HumanDuration(elapsed),
             );
-        }
-        if let Some((fmt, results)) = formatted_results {
-            output::format_scan_results(&results, fmt);
         }
         return;
     }
@@ -560,13 +321,6 @@ fn print_missing_count(count: u32) {
         style("Missing").dim(),
         count
     );
-}
-
-fn format_results(events: &[FileDiscoveredEvent]) -> Vec<(PathBuf, u64, Option<String>)> {
-    events
-        .iter()
-        .map(|e| (e.path.clone(), e.size, e.content_hash.clone()))
-        .collect()
 }
 
 /// Read `[plugin.verifier]` from the loaded `AppConfig`, falling back to defaults.

--- a/crates/voom-cli/src/commands/scan/mod.rs
+++ b/crates/voom-cli/src/commands/scan/mod.rs
@@ -753,6 +753,64 @@ mod streaming_tests {
         assert_eq!(outcome.files_introspected, 0);
         assert_eq!(outcome.probe_errors, 2);
     }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn discovery_error_does_not_mark_unprocessed_files_missing() {
+        // Seed an active row whose path lives under media_dir.
+        // Then run the pipeline against a nonexistent subdirectory so that
+        // scan_streaming returns Err immediately (the discovery plugin returns
+        // Err when options.root doesn't exist).
+        //
+        // Without the pipeline_cancel fix: discovery errors, tx_disc is dropped
+        // normally, ingest's recv loop returns None, the post-loop check sees
+        // token.is_cancelled() == false, and finish_scan_session runs — marking
+        // the seeded file missing.
+        //
+        // With the fix: disc_join.is_err() triggers pipeline_cancel.cancel(),
+        // ingest's post-loop check sees token.is_cancelled() == true, runs
+        // cancel_scan_session, and the seeded file stays Active.
+        let bed = make_bed();
+        let seeded_path = bed.media_dir.path().join("untouched.mkv");
+        let mut seeded = MediaFile::new(seeded_path.clone())
+            .with_container(Container::Mkv)
+            .with_tracks(vec![Track::new(0, TrackType::Video, "h264".into())]);
+        seeded.size = 9;
+        seeded.content_hash = Some("abcdef0123456789".into());
+        seeded.expected_hash = seeded.content_hash.clone();
+        bed.store.upsert_file(&seeded).expect("seed upsert");
+
+        // Scan a path that does NOT exist — this makes scan_streaming return Err.
+        let nonexistent = bed.media_dir.path().join("nonexistent-subdir");
+        let args = args_with(2, false);
+        let result = pipeline::run_streaming_pipeline(
+            &args,
+            &[nonexistent],
+            true, // hash_files
+            bed.store.clone(),
+            bed.kernel.clone(),
+            None,
+            voom_ffprobe_introspector::parser::AnimationDetectionMode::Off,
+            crate::progress::DiscoveryProgress::hidden(),
+            crate::progress::ProbeProgress::hidden_dynamic(),
+            CancellationToken::new(),
+        )
+        .await;
+
+        // The pipeline must propagate the discovery error.
+        assert!(result.is_err(), "pipeline should propagate discovery error");
+
+        // The seeded file must remain Active — NOT marked Missing.
+        let row = bed
+            .store
+            .file_by_path(&seeded_path)
+            .expect("file_by_path ok")
+            .expect("seed still present");
+        assert_eq!(
+            row.status,
+            FileStatus::Active,
+            "discovery error must not cause unprocessed files to be marked missing"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/voom-cli/src/commands/scan/mod.rs
+++ b/crates/voom-cli/src/commands/scan/mod.rs
@@ -22,6 +22,8 @@ use voom_verifier::VerifierConfig;
 
 use crate::commands::verify::{QuickVerifyTarget, run_quick_pass};
 
+mod pipeline;
+
 /// Run the scan command.
 ///
 /// Discovery and introspection are driven directly for deterministic progress

--- a/crates/voom-cli/src/commands/scan/mod.rs
+++ b/crates/voom-cli/src/commands/scan/mod.rs
@@ -974,51 +974,107 @@ mod streaming_tests {
         );
     }
 
-    #[tokio::test(flavor = "multi_thread")]
-    async fn closed_probe_channel_with_cancelled_token_is_not_an_error() {
-        // Regression: previously, ingest reported "probe stage closed its
-        // receiver unexpectedly" whenever tx_probe.blocking_send failed —
-        // even when the channel was closed because cancellation was already
-        // in flight. Now we check token.is_cancelled() first and route
-        // cancelled flows through the clean cancellation path (session ends
-        // Cancelled, no files marked Missing, ingest returns Ok).
-        let bed = make_bed();
+    /// Test plugin that cancels a `CancellationToken` whenever it observes
+    /// a `FileDiscovered` event. Used to deterministically trigger the
+    /// race the cancel-vs-probe-death fix addresses.
+    struct CancelOnFileDiscovered {
+        token: tokio_util::sync::CancellationToken,
+    }
 
-        // Seed a canary so we can verify finish_scan_session did NOT run.
-        // If finish_scan_session ran it would mark this row Missing (since
-        // no discovery event is sent for it during the scan).
-        let canary_path = bed.media_dir.path().join("canary.mkv");
+    impl voom_kernel::Plugin for CancelOnFileDiscovered {
+        fn name(&self) -> &str {
+            "cancel-on-file-discovered"
+        }
+        fn version(&self) -> &str {
+            "0.0.0"
+        }
+        fn capabilities(&self) -> &[voom_domain::capabilities::Capability] {
+            &[]
+        }
+        fn handles(&self, event_type: &str) -> bool {
+            event_type == voom_domain::events::Event::FILE_DISCOVERED
+        }
+        fn on_event(
+            &self,
+            event: &voom_domain::events::Event,
+        ) -> voom_domain::errors::Result<Option<voom_domain::events::EventResult>> {
+            if matches!(event, voom_domain::events::Event::FileDiscovered(_)) {
+                self.token.cancel();
+            }
+            Ok(None)
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn cancellation_between_top_check_and_probe_send_is_not_an_error() {
+        // Regression for the cancel-vs-probe-death race the previous
+        // test couldn't trigger:
+        //
+        // 1. Top-of-loop `if token.is_cancelled()` → false (we haven't
+        //    cancelled yet).
+        // 2. Body proceeds, calls kernel.dispatch(FileDiscovered).
+        // 3. A registered plugin synchronously cancels the token from
+        //    its on_event handler.
+        // 4. blocking_send fails because rx_probe is closed.
+        // 5. The fix's new `if token.is_cancelled()` check fires and
+        //    routes through the clean cancellation path → Ok.
+        //
+        // Without the fix, step 5 would unconditionally treat the
+        // failed send as a probe-stage fault and return Err — even
+        // though the cancellation is what closed the channel.
+
+        let db_dir = tempfile::tempdir().expect("temp db dir");
+        let db_path = db_dir.path().join("voom.db");
+        let store: Arc<dyn voom_domain::storage::StorageTrait> =
+            Arc::new(voom_sqlite_store::store::SqliteStore::open(&db_path).expect("open store"));
+        let media_dir = tempfile::tempdir().expect("temp media dir");
+
+        let token = CancellationToken::new();
+
+        let mut kernel = voom_kernel::Kernel::new();
+        kernel
+            .register_plugin(
+                Arc::new(CancelOnFileDiscovered {
+                    token: token.clone(),
+                }),
+                10,
+            )
+            .expect("register cancel plugin");
+        let kernel = Arc::new(kernel);
+
+        // Seed a canary row so we can verify finish_scan_session did
+        // NOT run.
+        let canary_path = media_dir.path().join("canary.mkv");
         let mut canary = MediaFile::new(canary_path.clone())
             .with_container(Container::Mkv)
             .with_tracks(vec![Track::new(0, TrackType::Video, "h264".into())]);
         canary.size = 9;
         canary.content_hash = Some("abcdef0123456789".into());
         canary.expected_hash = canary.content_hash.clone();
-        bed.store.upsert_file(&canary).expect("seed canary");
+        store.upsert_file(&canary).expect("seed canary");
 
+        // Pre-close rx_probe so blocking_send is guaranteed to fail.
         let (tx_disc, rx_disc) = tokio::sync::mpsc::channel(4);
         let (tx_probe, rx_probe) = tokio::sync::mpsc::channel(4);
-        drop(rx_probe); // simulate probe-already-exited
+        drop(rx_probe);
 
-        let token = tokio_util::sync::CancellationToken::new();
-        token.cancel(); // pre-cancel: the external request that caused probe to exit
-
-        let paths = vec![bed.media_dir.path().to_path_buf()];
+        let paths = vec![media_dir.path().to_path_buf()];
 
         let ingest_fut = tokio::spawn(super::pipeline::run_ingest_for_test(
-            bed.store.clone(),
-            bed.kernel.clone(),
+            store.clone(),
+            kernel.clone(),
             paths,
             rx_disc,
             tx_probe,
             token.clone(),
         ));
 
-        // Send one event for a path NOT in the DB — ingest decides New and
-        // tries to forward to probe. blocking_send fails (rx_probe dropped),
-        // but the token is already cancelled, so this must be treated as a
-        // clean cancellation, NOT a fatal probe-stage failure.
-        let new_path = bed.media_dir.path().join("new_file.mkv");
+        // Send one event for a path NOT in the DB. ingest's flow:
+        //   recv → top-check passes → ingest_discovered_file (New) →
+        //   kernel.dispatch(FileDiscovered) → our plugin cancels the
+        //   token → blocking_send fails → fix's is_cancelled check
+        //   sees true → return Ok.
+        let new_path = media_dir.path().join("new_file.mkv");
         tx_disc
             .send(voom_domain::events::FileDiscoveredEvent::new(
                 new_path,
@@ -1031,24 +1087,21 @@ mod streaming_tests {
 
         let result = ingest_fut.await.expect("join ingest");
 
-        // Cancellation must NOT be reported as a probe failure.
+        // The cancel happened mid-iteration via the plugin, so the
+        // close of tx_probe must NOT be reported as a probe-stage
+        // failure.
         assert!(
             result.is_ok(),
-            "ingest must return Ok when probe close coincides with cancellation; got: {:?}",
+            "cancellation occurring mid-iteration must not be \
+             reported as a probe-stage failure; got: {:?}",
             result.err()
         );
-
-        // Canary must remain Active — finish_scan_session must not have run.
-        let row = bed
-            .store
+        // The canary row must remain Active.
+        let row = store
             .file_by_path(&canary_path)
             .expect("file_by_path ok")
             .expect("canary present");
-        assert_ne!(
-            row.status,
-            FileStatus::Missing,
-            "cancelled scan must not mark files missing"
-        );
+        assert_ne!(row.status, FileStatus::Missing);
     }
 }
 

--- a/crates/voom-cli/src/commands/scan/mod.rs
+++ b/crates/voom-cli/src/commands/scan/mod.rs
@@ -811,6 +811,81 @@ mod streaming_tests {
             "discovery error must not cause unprocessed files to be marked missing"
         );
     }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn mid_scan_discovery_error_does_not_mark_processed_roots_files_missing() {
+        // Race regression: when discovery succeeds on root 1 (sending events
+        // to ingest) then errors on root 2 (nonexistent), the ingest task sees
+        // tx_disc close. Without per-stage cancel-on-err, ingest's post-loop
+        // check observes token.is_cancelled() == false (the orchestrator hasn't
+        // awaited disc_join yet), so it calls finish_scan_session — which marks
+        // any active file under any scanned root that wasn't seen this session
+        // as Missing. With the fix, discovery cancels the token BEFORE dropping
+        // tx_disc, so ingest's post-loop check correctly cancels the session.
+        let bed = make_bed();
+        let root1_dir = tempfile::tempdir().expect("root1 temp dir");
+        let root1 = std::fs::canonicalize(root1_dir.path()).expect("canonicalize root1");
+        let seeded_path = root1.join("seed.mkv");
+        std::fs::write(&seeded_path, b"unused").expect("write seed");
+
+        // Seed an Active row whose path is under root1 but with a hash that
+        // does NOT match the on-disk file's actual hash — this forces an
+        // ExternallyChanged decision, ensuring ingest processes the file
+        // before the discovery error on root2 fires.
+        let mut seeded = MediaFile::new(seeded_path.clone())
+            .with_container(Container::Mkv)
+            .with_tracks(vec![Track::new(0, TrackType::Video, "h264".into())]);
+        seeded.size = 6;
+        seeded.content_hash = Some("deadbeefdeadbeef".into());
+        seeded.expected_hash = seeded.content_hash.clone();
+        bed.store.upsert_file(&seeded).expect("seed upsert");
+
+        // Also seed an Active row under root1 for a file that does NOT exist
+        // on disk. Without the fix this row would be marked Missing.
+        let absent_path = root1.join("absent.mkv");
+        let mut absent = MediaFile::new(absent_path.clone())
+            .with_container(Container::Mkv)
+            .with_tracks(vec![Track::new(0, TrackType::Video, "h264".into())]);
+        absent.size = 100;
+        absent.content_hash = Some("absentabsentabse".into());
+        absent.expected_hash = absent.content_hash.clone();
+        bed.store.upsert_file(&absent).expect("seed absent");
+
+        let nonexistent_root = bed.media_dir.path().join("does-not-exist");
+
+        let args = args_with(2, false);
+        let result = pipeline::run_streaming_pipeline(
+            &args,
+            &[root1.clone(), nonexistent_root],
+            true, // hash_files
+            bed.store.clone(),
+            bed.kernel.clone(),
+            None,
+            voom_ffprobe_introspector::parser::AnimationDetectionMode::Off,
+            crate::progress::DiscoveryProgress::hidden(),
+            crate::progress::ProbeProgress::hidden_dynamic(),
+            CancellationToken::new(),
+        )
+        .await;
+
+        assert!(
+            result.is_err(),
+            "pipeline should propagate the discovery error"
+        );
+
+        // The absent file MUST still be Active. Without the cancel-on-err fix,
+        // ingest's post-loop check would let finish_scan_session mark it Missing.
+        let row = bed
+            .store
+            .file_by_path(&absent_path)
+            .expect("file_by_path ok")
+            .expect("absent row still present");
+        assert_eq!(
+            row.status,
+            FileStatus::Active,
+            "discovery error must not allow finish_scan_session to run"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/voom-cli/src/commands/scan/mod.rs
+++ b/crates/voom-cli/src/commands/scan/mod.rs
@@ -70,6 +70,11 @@ pub async fn run(args: ScanArgs, quiet: bool, token: CancellationToken) -> Resul
         .await?;
 
         if outcome.files_discovered == 0 {
+            // Missing-file reconciliation already ran INSIDE the pipeline
+            // (finish_scan_session for the hashed path, mark_missing_paths
+            // for --no-hash). outcome.missing / outcome.orphans are
+            // authoritative — do NOT re-run reconciliation here. A second
+            // session would clobber the count from the first.
             if !quiet && outcome.missing > 0 {
                 print_missing_count(outcome.missing);
             }

--- a/crates/voom-cli/src/commands/scan/mod.rs
+++ b/crates/voom-cli/src/commands/scan/mod.rs
@@ -492,6 +492,270 @@ fn print_verify_summary(records: &[VerificationRecord]) {
 }
 
 #[cfg(test)]
+mod streaming_tests {
+    use super::pipeline::{self, PipelineOutcome};
+    use std::sync::Arc;
+    use tempfile::TempDir;
+    use tokio_util::sync::CancellationToken;
+    use voom_domain::media::{Container, MediaFile, Track, TrackType};
+    use voom_domain::storage::StorageTrait;
+    use voom_domain::transition::FileStatus;
+
+    struct Bed {
+        _db_dir: TempDir,
+        media_dir: TempDir,
+        store: Arc<dyn StorageTrait>,
+        kernel: Arc<voom_kernel::Kernel>,
+    }
+
+    fn make_bed() -> Bed {
+        let db_dir = tempfile::tempdir().expect("temp db dir");
+        let db_path = db_dir.path().join("voom.db");
+        let store: Arc<dyn StorageTrait> =
+            Arc::new(voom_sqlite_store::store::SqliteStore::open(&db_path).expect("open store"));
+        let kernel = Arc::new(voom_kernel::Kernel::new());
+        let media_dir = tempfile::tempdir().expect("temp media dir");
+        Bed {
+            _db_dir: db_dir,
+            media_dir,
+            store,
+            kernel,
+        }
+    }
+
+    fn args_with(probe_workers: usize, no_hash: bool) -> crate::cli::ScanArgs {
+        crate::cli::ScanArgs {
+            paths: vec![],
+            recursive: true,
+            workers: 0,
+            probe_workers,
+            no_hash,
+            verify: false,
+            format: None,
+        }
+    }
+
+    async fn run_for(
+        bed: &Bed,
+        probe_workers: usize,
+        hash_files: bool,
+        ffprobe_path: Option<String>,
+        token: CancellationToken,
+    ) -> anyhow::Result<PipelineOutcome> {
+        let args = args_with(probe_workers, !hash_files);
+        pipeline::run_streaming_pipeline(
+            &args,
+            &[bed.media_dir.path().to_path_buf()],
+            hash_files,
+            bed.store.clone(),
+            bed.kernel.clone(),
+            ffprobe_path,
+            voom_ffprobe_introspector::parser::AnimationDetectionMode::Off,
+            crate::progress::DiscoveryProgress::hidden(),
+            crate::progress::ProbeProgress::hidden_dynamic(),
+            token,
+        )
+        .await
+    }
+
+    fn write_media(root: &std::path::Path, names: &[&str]) {
+        for n in names {
+            std::fs::write(root.join(n), b"fake-media-data").unwrap();
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn empty_scan_returns_zero_counts_and_no_missing() {
+        let bed = make_bed();
+        let outcome = run_for(&bed, 2, true, None, CancellationToken::new())
+            .await
+            .expect("pipeline ok");
+        assert_eq!(outcome.files_discovered, 0);
+        assert_eq!(outcome.files_introspected, 0);
+        assert_eq!(outcome.errors(), 0);
+        assert_eq!(outcome.missing, 0);
+        assert_eq!(outcome.orphans, 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn empty_scan_does_not_re_run_reconciliation() {
+        // Regression: previously, handle_empty_scan ran a second
+        // reconcile_discovered_files after the pipeline already finished a
+        // session — clobbering the missing count and double-running
+        // missing-file detection.
+        let bed = make_bed();
+        let seeded_path = bed.media_dir.path().join("vanished.mkv");
+        let mut seeded = MediaFile::new(seeded_path.clone())
+            .with_container(Container::Mkv)
+            .with_tracks(vec![Track::new(0, TrackType::Video, "h264".into())]);
+        seeded.size = 9;
+        seeded.content_hash = Some("abcdef0123456789".into());
+        seeded.expected_hash = seeded.content_hash.clone();
+        bed.store.upsert_file(&seeded).expect("seed upsert");
+
+        let outcome = run_for(&bed, 2, true, None, CancellationToken::new())
+            .await
+            .expect("pipeline ok");
+        assert_eq!(outcome.files_discovered, 0);
+        assert_eq!(
+            outcome.missing, 1,
+            "first session must report the missing file"
+        );
+
+        // The seeded row should now be Missing in the DB.
+        let row = bed
+            .store
+            .file_by_path(&seeded_path)
+            .expect("file_by_path ok")
+            .expect("row still in DB");
+        assert_eq!(row.status, FileStatus::Missing);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn cancelled_scan_does_not_mark_missing() {
+        let bed = make_bed();
+        let seeded_path = bed.media_dir.path().join("seed.mkv");
+        let mut seeded = MediaFile::new(seeded_path.clone())
+            .with_container(Container::Mkv)
+            .with_tracks(vec![Track::new(0, TrackType::Video, "h264".into())]);
+        seeded.size = 9;
+        seeded.content_hash = Some("abcdef0123456789".into());
+        seeded.expected_hash = seeded.content_hash.clone();
+        bed.store.upsert_file(&seeded).expect("seed upsert");
+
+        let token = CancellationToken::new();
+        token.cancel();
+        let outcome = run_for(&bed, 2, true, None, token)
+            .await
+            .expect("pipeline ok");
+        assert_eq!(outcome.missing, 0, "cancelled scan must not mark missing");
+
+        let row = bed
+            .store
+            .file_by_path(&seeded_path)
+            .expect("file_by_path ok")
+            .expect("seed still present");
+        assert_eq!(row.status, FileStatus::Active);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn introspection_failures_are_counted() {
+        let bed = make_bed();
+        write_media(bed.media_dir.path(), &["a.mkv", "b.mkv", "c.mkv"]);
+
+        let outcome = run_for(
+            &bed,
+            2,
+            true,
+            Some("/this/path/does/not/exist/ffprobe".to_string()),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("pipeline ok");
+
+        assert_eq!(outcome.files_discovered, 3);
+        assert_eq!(outcome.files_introspected, 0);
+        assert_eq!(outcome.probe_errors, 3);
+        assert_eq!(outcome.discovery_errors, 0);
+        assert_eq!(outcome.errors(), 3);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn cache_hits_skip_probe_entirely() {
+        let bed = make_bed();
+        let file_path = bed.media_dir.path().join("cached.mkv");
+        std::fs::write(&file_path, b"cached-content").unwrap();
+        // Canonicalize so the stored path matches what the discovery scanner
+        // emits (it calls normalize_path → fs::canonicalize, which on macOS
+        // expands /var → /private/var).
+        let canonical_path = std::fs::canonicalize(&file_path).unwrap_or(file_path);
+        let on_disk_size = std::fs::metadata(&canonical_path).unwrap().len();
+        let actual_hash = voom_discovery::hash_file(&canonical_path).expect("hash");
+
+        let mut seeded = MediaFile::new(canonical_path.clone())
+            .with_container(Container::Mkv)
+            .with_tracks(vec![Track::new(0, TrackType::Video, "h264".into())]);
+        seeded.size = on_disk_size;
+        seeded.content_hash = Some(actual_hash.clone());
+        seeded.expected_hash = Some(actual_hash);
+        bed.store.upsert_file(&seeded).expect("seed upsert");
+
+        // Broken ffprobe path: any probe invocation would bump probe_errors.
+        let outcome = run_for(
+            &bed,
+            2,
+            true,
+            Some("/this/path/does/not/exist/ffprobe".to_string()),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("pipeline ok");
+
+        assert_eq!(outcome.files_discovered, 1);
+        assert_eq!(
+            outcome.files_introspected, 0,
+            "cache hit should skip ffprobe"
+        );
+        assert_eq!(
+            outcome.probe_errors, 0,
+            "ffprobe must not have been invoked"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn session_finalisation_visible_after_pipeline_returns() {
+        let bed = make_bed();
+        write_media(bed.media_dir.path(), &["x.mkv", "y.mkv"]);
+
+        let outcome = run_for(
+            &bed,
+            2,
+            true,
+            Some("/no/such/ffprobe".to_string()),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("pipeline ok");
+        assert_eq!(outcome.files_discovered, 2);
+
+        // The scanner canonicalizes paths (normalize_path → fs::canonicalize),
+        // so rows are stored under the real path. Canonicalize the lookup path
+        // to match on macOS where /var is a symlink to /private/var.
+        let canonical_dir = std::fs::canonicalize(bed.media_dir.path())
+            .unwrap_or_else(|_| bed.media_dir.path().to_path_buf());
+        for name in ["x.mkv", "y.mkv"] {
+            let p = canonical_dir.join(name);
+            let row = bed
+                .store
+                .file_by_path(&p)
+                .expect("file_by_path ok")
+                .expect("row present after drain");
+            assert_eq!(row.status, FileStatus::Active);
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn no_hash_mode_streams_through_probe() {
+        let bed = make_bed();
+        write_media(bed.media_dir.path(), &["a.mkv", "b.mkv"]);
+
+        let outcome = run_for(
+            &bed,
+            2,
+            false, // --no-hash
+            Some("/no/such/ffprobe".to_string()),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("pipeline ok");
+
+        assert_eq!(outcome.files_discovered, 2);
+        assert_eq!(outcome.files_introspected, 0);
+        assert_eq!(outcome.probe_errors, 2);
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use std::path::PathBuf;

--- a/crates/voom-cli/src/commands/scan/pipeline.rs
+++ b/crates/voom-cli/src/commands/scan/pipeline.rs
@@ -489,10 +489,35 @@ fn spawn_probe_stage(
             });
         }
 
-        // Drain remaining workers.
-        while set.join_next().await.is_some() {}
+        // Drain remaining workers. A panicked probe task would otherwise be
+        // silently lost — we'd miss both the error count AND the progress
+        // bar increment, leaving the total stuck below the discovered count.
+        while let Some(joined) = set.join_next().await {
+            handle_probe_join_result(&joined, &probe_errors, &progress);
+        }
         Ok(())
     })
+}
+
+/// Account for a probe-task `JoinResult`. Non-panicked completions
+/// already updated counters and the progress bar inside the spawned task;
+/// only panics need attention here. Cancellation is treated as a warning for
+/// accounting purposes (rare — JoinSet tasks are not normally cancelled
+/// individually).
+fn handle_probe_join_result(
+    joined: &Result<(), tokio::task::JoinError>,
+    probe_errors: &Arc<AtomicU64>,
+    progress: &crate::progress::ProbeProgress,
+) {
+    if let Err(e) = joined {
+        if e.is_panic() {
+            tracing::error!(error = %e, "probe task panicked");
+            probe_errors.fetch_add(1, Ordering::Relaxed);
+            progress.inc();
+        } else {
+            tracing::warn!(error = %e, "probe task cancelled");
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/voom-cli/src/commands/scan/pipeline.rs
+++ b/crates/voom-cli/src/commands/scan/pipeline.rs
@@ -1,0 +1,66 @@
+//! Streaming scan pipeline: discovery → ingest → bounded probe pool.
+
+/// Default SQLite connection pool size. Mirrors
+/// `voom_sqlite_store::store::SqliteStoreConfig::default().pool_size`.
+/// Hard-coded here to avoid a circular dep on the store crate's config type.
+// TODO(#359): remove once wired into the streaming pipeline (Task 6)
+#[allow(dead_code)]
+const DEFAULT_SQLITE_POOL: usize = 8;
+
+/// Slots we reserve out of the pool for non-probe work (one writer reacting
+/// to events, one ad-hoc reader). Anything below this is unsafe — probes
+/// would deadlock against the bus.
+// TODO(#359): remove once wired into the streaming pipeline (Task 6)
+#[allow(dead_code)]
+const RESERVED_POOL_SLOTS: usize = 2;
+
+/// Pick the introspection worker count when `--probe-workers` is `0`.
+///
+/// Returns `min(num_cpus, pool_size - reserved)` with a floor of `1`.
+// TODO(#359): remove once wired into the streaming pipeline (Task 6)
+#[allow(dead_code)]
+#[must_use]
+pub(crate) fn auto_probe_workers(num_cpus: usize, pool_size: usize) -> usize {
+    let cap = pool_size.saturating_sub(RESERVED_POOL_SLOTS);
+    num_cpus.min(cap).max(1)
+}
+
+/// Resolve the effective probe worker count from the CLI flag.
+// TODO(#359): remove once wired into the streaming pipeline (Task 6)
+#[allow(dead_code)]
+#[must_use]
+pub(crate) fn resolve_probe_workers(flag: usize) -> usize {
+    if flag == 0 {
+        auto_probe_workers(num_cpus::get(), DEFAULT_SQLITE_POOL)
+    } else {
+        flag
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auto_probe_workers_caps_at_pool_minus_reserved() {
+        assert_eq!(auto_probe_workers(16, 8), 6);
+    }
+
+    #[test]
+    fn auto_probe_workers_uses_cpus_when_pool_is_generous() {
+        assert_eq!(auto_probe_workers(4, 32), 4);
+    }
+
+    #[test]
+    fn auto_probe_workers_floor_is_one() {
+        assert_eq!(auto_probe_workers(0, 0), 1);
+        assert_eq!(auto_probe_workers(1, 2), 1);
+        assert_eq!(auto_probe_workers(1, 1), 1);
+    }
+
+    #[test]
+    fn resolve_probe_workers_explicit_flag_wins() {
+        assert_eq!(resolve_probe_workers(3), 3);
+        assert_eq!(resolve_probe_workers(1), 1);
+    }
+}

--- a/crates/voom-cli/src/commands/scan/pipeline.rs
+++ b/crates/voom-cli/src/commands/scan/pipeline.rs
@@ -378,10 +378,15 @@ fn spawn_ingest_stage(
                 kernel.dispatch(Event::FileDiscovered(event.clone()));
                 probe_progress.add_pending(1);
                 if let Err(e) = tx_probe.blocking_send(event) {
-                    // Probe stage closed its receiver — it has died (panic or
-                    // early exit). Cancel the pipeline token so siblings stop,
-                    // and return Err so the caller does not proceed to
-                    // mark_missing_paths on a partial scan.
+                    if token.is_cancelled() {
+                        // Cancellation was already requested; the channel close
+                        // is its expected consequence (probe exited its recv
+                        // loop due to token cancellation). Stop ingesting
+                        // cleanly. The post-loop `if token.is_cancelled()`
+                        // check will skip mark_missing_paths.
+                        break;
+                    }
+                    // Token was NOT cancelled — probe died unexpectedly. Fatal.
                     token.cancel();
                     return Err(anyhow::anyhow!(
                         "probe stage closed its receiver unexpectedly: {e}"
@@ -458,11 +463,24 @@ fn spawn_ingest_stage(
                             // probe so the file still gets introspected.
                             probe_progress.add_pending(1);
                             if let Err(e) = tx_probe.blocking_send(event) {
-                                // Probe stage closed its receiver — it has died
-                                // (panic or early exit). Cancel the pipeline token
-                                // so siblings stop, and return Err so
-                                // with_scan_session calls cancel_scan_session
-                                // instead of finish_scan_session.
+                                if token.is_cancelled() {
+                                    // Probe closed its receiver because
+                                    // cancellation was already requested
+                                    // (external Ctrl-C, or a sibling stage
+                                    // errored and cancelled the child token).
+                                    // The channel close is the expected
+                                    // downstream consequence, NOT a probe-stage
+                                    // fault. Route through the same path the
+                                    // in-loop cancellation check uses so the
+                                    // session ends Cancelled and no files are
+                                    // marked missing.
+                                    store
+                                        .cancel_scan_session(session)
+                                        .context("cancel_scan_session failed")?;
+                                    return Ok(ScanFinishOutcome::default());
+                                }
+                                // Token was NOT cancelled — probe died
+                                // unexpectedly. Fatal.
                                 token.cancel();
                                 return Err(anyhow::anyhow!(
                                     "probe stage closed its receiver unexpectedly: {e}"
@@ -482,11 +500,24 @@ fn spawn_ingest_stage(
                         if decision.needs_introspection_path(&event.path).is_some() {
                             probe_progress.add_pending(1);
                             if let Err(e) = tx_probe.blocking_send(event) {
-                                // Probe stage closed its receiver — it has died
-                                // (panic or early exit). Cancel the pipeline token
-                                // so siblings stop, and return Err so
-                                // with_scan_session calls cancel_scan_session
-                                // instead of finish_scan_session.
+                                if token.is_cancelled() {
+                                    // Probe closed its receiver because
+                                    // cancellation was already requested
+                                    // (external Ctrl-C, or a sibling stage
+                                    // errored and cancelled the child token).
+                                    // The channel close is the expected
+                                    // downstream consequence, NOT a probe-stage
+                                    // fault. Route through the same path the
+                                    // in-loop cancellation check uses so the
+                                    // session ends Cancelled and no files are
+                                    // marked missing.
+                                    store
+                                        .cancel_scan_session(session)
+                                        .context("cancel_scan_session failed")?;
+                                    return Ok(ScanFinishOutcome::default());
+                                }
+                                // Token was NOT cancelled — probe died
+                                // unexpectedly. Fatal.
                                 token.cancel();
                                 return Err(anyhow::anyhow!(
                                     "probe stage closed its receiver unexpectedly: {e}"

--- a/crates/voom-cli/src/commands/scan/pipeline.rs
+++ b/crates/voom-cli/src/commands/scan/pipeline.rs
@@ -78,6 +78,13 @@ impl PipelineOutcome {
 /// roughly `probe_workers * CHANNEL_DEPTH_PER_WORKER`.
 const CHANNEL_DEPTH_PER_WORKER: usize = 4;
 
+/// How often the streaming ingest stage refreshes its scan-session
+/// heartbeat. Must be comfortably below
+/// [`voom_domain::transition::STALE_SESSION_SECS`] (60s) so a sluggish
+/// directory walk can't accidentally let the session look stale to a
+/// concurrent `voom scan`. 20s gives a 3x safety margin.
+const HEARTBEAT_INTERVAL_SECS: u64 = 20;
+
 /// Drive the full streaming pipeline. Returns the outcome counters used by
 /// the caller for the final summary and `ScanComplete` dispatch.
 ///
@@ -411,6 +418,12 @@ fn spawn_ingest_stage(
                 store.as_ref(),
                 &paths,
                 |session| -> Result<ScanFinishOutcome> {
+                    // Drive a periodic heartbeat so a slow initial directory walk
+                    // (>STALE_SESSION_SECS) can't make this session look stale to a
+                    // concurrent `voom scan`. The handle's drop guard ensures the
+                    // heartbeat task is cancelled even on panic / early return.
+                    let _heartbeat = spawn_heartbeat_task(store.clone(), session);
+
                     while let Some(event) = rx_disc.blocking_recv() {
                         if token.is_cancelled() {
                             // Explicitly cancel the session to leave it in
@@ -600,6 +613,57 @@ fn handle_probe_join_result(
             tracing::warn!(error = %e, "probe task cancelled");
         }
     }
+}
+
+/// RAII handle for the periodic scan-session heartbeat task. Drop = cancel.
+struct HeartbeatHandle {
+    cancel: CancellationToken,
+}
+
+impl Drop for HeartbeatHandle {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+    }
+}
+
+/// Spawn a tokio task that calls `heartbeat_scan_session(session)` every
+/// `HEARTBEAT_INTERVAL_SECS` until the returned handle is dropped.
+///
+/// Errors from the storage call are logged at `warn` and not propagated —
+/// a missed heartbeat will at worst cause a concurrent scan to view this
+/// session as stale. The fix in that case is operator-visible (the next
+/// `begin_scan_session` log message will name the auto-cancellation),
+/// not a silent data corruption.
+#[must_use = "dropping the handle stops the heartbeat task"]
+fn spawn_heartbeat_task(
+    store: Arc<dyn StorageTrait>,
+    session: voom_domain::transition::ScanSessionId,
+) -> HeartbeatHandle {
+    let cancel = CancellationToken::new();
+    let cancel_for_task = cancel.clone();
+    tokio::spawn(async move {
+        let mut interval =
+            tokio::time::interval(std::time::Duration::from_secs(HEARTBEAT_INTERVAL_SECS));
+        // Skip the immediate tick: ingest_discovered_file already bumps
+        // the heartbeat on each ingest, so the first heartbeat from this
+        // task should only fire if we sit idle for HEARTBEAT_INTERVAL_SECS.
+        interval.tick().await;
+        loop {
+            tokio::select! {
+                () = cancel_for_task.cancelled() => break,
+                _ = interval.tick() => {
+                    if let Err(e) = store.heartbeat_scan_session(session) {
+                        tracing::warn!(
+                            session = %session,
+                            error = %e,
+                            "scan session heartbeat failed; continuing"
+                        );
+                    }
+                }
+            }
+        }
+    });
+    HeartbeatHandle { cancel }
 }
 
 #[cfg(test)]

--- a/crates/voom-cli/src/commands/scan/pipeline.rs
+++ b/crates/voom-cli/src/commands/scan/pipeline.rs
@@ -3,22 +3,16 @@
 /// Default SQLite connection pool size. Mirrors
 /// `voom_sqlite_store::store::SqliteStoreConfig::default().pool_size`.
 /// Hard-coded here to avoid a circular dep on the store crate's config type.
-// TODO(#359): remove once wired into the streaming pipeline (Task 6)
-#[allow(dead_code)]
 const DEFAULT_SQLITE_POOL: usize = 8;
 
 /// Slots we reserve out of the pool for non-probe work (one writer reacting
 /// to events, one ad-hoc reader). Anything below this is unsafe — probes
 /// would deadlock against the bus.
-// TODO(#359): remove once wired into the streaming pipeline (Task 6)
-#[allow(dead_code)]
 const RESERVED_POOL_SLOTS: usize = 2;
 
 /// Pick the introspection worker count when `--probe-workers` is `0`.
 ///
 /// Returns `min(num_cpus, pool_size - reserved)` with a floor of `1`.
-// TODO(#359): remove once wired into the streaming pipeline (Task 6)
-#[allow(dead_code)]
 #[must_use]
 pub(crate) fn auto_probe_workers(num_cpus: usize, pool_size: usize) -> usize {
     let cap = pool_size.saturating_sub(RESERVED_POOL_SLOTS);
@@ -26,8 +20,6 @@ pub(crate) fn auto_probe_workers(num_cpus: usize, pool_size: usize) -> usize {
 }
 
 /// Resolve the effective probe worker count from the CLI flag.
-// TODO(#359): remove once wired into the streaming pipeline (Task 6)
-#[allow(dead_code)]
 #[must_use]
 pub(crate) fn resolve_probe_workers(flag: usize) -> usize {
     if flag == 0 {
@@ -35,6 +27,472 @@ pub(crate) fn resolve_probe_workers(flag: usize) -> usize {
     } else {
         flag
     }
+}
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use anyhow::{Context, Result};
+use tokio::sync::{Semaphore, mpsc};
+use tokio::task::JoinSet;
+use tokio_util::sync::CancellationToken;
+use voom_domain::bad_file::BadFileSource;
+use voom_domain::events::{Event, FileDiscoveredEvent};
+use voom_domain::storage::{StorageTrait, with_scan_session};
+use voom_domain::transition::{DiscoveredFile, IngestDecision, ScanFinishOutcome};
+
+use crate::cli::ScanArgs;
+use crate::introspect;
+use crate::progress::{DiscoveryProgress, ProbeProgress};
+
+/// Output of the streaming pipeline. Fields mirror the counters that
+/// `print_scan_summary`, `print_discovery_summary`, and `ScanComplete` need.
+pub(crate) struct PipelineOutcome {
+    pub files_discovered: u64,
+    pub files_introspected: u64,
+    /// Errors raised by the discovery / hashing stage (walk failures, open
+    /// failures, etc.). Reported in the discovery summary line.
+    pub discovery_errors: u64,
+    /// Errors raised by the ffprobe stage. Reported in the final summary line.
+    pub probe_errors: u64,
+    pub moved: u32,
+    pub external_changes: u32,
+    pub missing: u32,
+    /// Voom-temp files skipped during discovery. Reported in the discovery
+    /// summary line (parity with the pre-streaming behaviour).
+    pub orphans: u64,
+    /// `(path, size, content_hash)` tuples for `--format` output.
+    pub formatted: Vec<(PathBuf, u64, Option<String>)>,
+}
+
+impl PipelineOutcome {
+    /// Sum of discovery + probe errors for the final scan-summary line.
+    #[must_use]
+    pub fn errors(&self) -> u64 {
+        self.discovery_errors.saturating_add(self.probe_errors)
+    }
+}
+
+/// Channel capacity multiplier — bounds peak in-memory queue depth to
+/// roughly `probe_workers * CHANNEL_DEPTH_PER_WORKER`.
+const CHANNEL_DEPTH_PER_WORKER: usize = 4;
+
+/// Drive the full streaming pipeline. Returns the outcome counters used by
+/// the caller for the final summary and `ScanComplete` dispatch.
+///
+/// `ffprobe_path` / `animation_mode` are passed in directly (rather than
+/// pulled from `config` inside this fn) so tests can call it without
+/// going through `app::bootstrap_kernel_with_store`.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn run_streaming_pipeline(
+    args: &ScanArgs,
+    paths: &[PathBuf],
+    hash_files: bool,
+    store: Arc<dyn StorageTrait>,
+    kernel: Arc<voom_kernel::Kernel>,
+    ffprobe_path: Option<String>,
+    animation_mode: voom_ffprobe_introspector::parser::AnimationDetectionMode,
+    discovery_progress: DiscoveryProgress,
+    probe_progress: ProbeProgress,
+    token: CancellationToken,
+) -> Result<PipelineOutcome> {
+    let probe_workers = resolve_probe_workers(args.probe_workers);
+    let channel_depth = probe_workers * CHANNEL_DEPTH_PER_WORKER;
+
+    let (tx_disc, rx_disc) = mpsc::channel::<FileDiscoveredEvent>(channel_depth);
+    let (tx_probe, rx_probe) = mpsc::channel::<FileDiscoveredEvent>(channel_depth);
+
+    // Shared counters. Discovery and probe errors stay separate so the
+    // existing per-stage summary lines keep their meaning.
+    let introspected = Arc::new(AtomicU64::new(0));
+    let probe_errors = Arc::new(AtomicU64::new(0));
+    let orphans = Arc::new(AtomicU64::new(0));
+
+    let discovery_handle = spawn_discovery_stage(
+        args,
+        paths,
+        hash_files,
+        store.clone(),
+        kernel.clone(),
+        discovery_progress.clone(),
+        tx_disc,
+        token.clone(),
+        orphans.clone(),
+    );
+
+    let ingest_handle = spawn_ingest_stage(
+        store,
+        kernel.clone(),
+        paths.to_vec(),
+        hash_files,
+        rx_disc,
+        tx_probe,
+        probe_progress.clone(),
+        token.clone(),
+    );
+
+    let probe_handle = spawn_probe_stage(
+        rx_probe,
+        kernel,
+        ffprobe_path,
+        animation_mode,
+        probe_workers,
+        probe_progress.clone(),
+        token.clone(),
+        introspected.clone(),
+        probe_errors.clone(),
+    );
+
+    // Wait for all three stages. If any errors, propagate.
+    let disc_result = discovery_handle
+        .await
+        .context("discovery task join failed")?;
+    let ingest_result = ingest_handle.await.context("ingest task join failed")?;
+    let probe_result = probe_handle.await.context("probe task join failed")?;
+
+    let discovery_errors = disc_result?;
+    let (finish_outcome, formatted, files_discovered) = ingest_result?;
+    probe_result?;
+
+    discovery_progress.finish();
+    probe_progress.finish();
+
+    let mut moved = finish_outcome.moved_from_ingest;
+    moved += finish_outcome.scan_finish.promoted_moves;
+
+    Ok(PipelineOutcome {
+        files_discovered,
+        files_introspected: introspected.load(Ordering::Relaxed),
+        discovery_errors,
+        probe_errors: probe_errors.load(Ordering::Relaxed),
+        moved,
+        external_changes: finish_outcome.external_changes,
+        missing: finish_outcome.scan_finish.missing,
+        orphans: orphans.load(Ordering::Relaxed),
+        formatted,
+    })
+}
+
+/// Bundle of session-related counts returned by the ingest task.
+struct IngestSummary {
+    scan_finish: ScanFinishOutcome,
+    moved_from_ingest: u32,
+    external_changes: u32,
+}
+
+#[allow(clippy::too_many_arguments)]
+fn spawn_discovery_stage(
+    args: &ScanArgs,
+    paths: &[PathBuf],
+    hash_files: bool,
+    store: Arc<dyn StorageTrait>,
+    kernel: Arc<voom_kernel::Kernel>,
+    progress: DiscoveryProgress,
+    tx_disc: mpsc::Sender<FileDiscoveredEvent>,
+    token: CancellationToken,
+    orphans: Arc<AtomicU64>,
+) -> tokio::task::JoinHandle<Result<u64>> {
+    let workers = args.workers;
+    let recursive = args.recursive;
+    let paths = paths.to_vec();
+    tokio::task::spawn_blocking(move || -> Result<u64> {
+        let discovery = voom_discovery::DiscoveryPlugin::new();
+        let cumulative_discovered = Arc::new(AtomicU64::new(0));
+        let processing_base = Arc::new(AtomicU64::new(0));
+        // Local counter for discovery-time errors (open / hash / walk
+        // failures). Returned via the JoinHandle's Ok value.
+        let discovery_errors = Arc::new(AtomicU64::new(0));
+
+        for path in &paths {
+            if token.is_cancelled() {
+                break;
+            }
+            progress.reset_to_spinner();
+            let pre = cumulative_discovered.load(Ordering::Relaxed);
+
+            let mut options = voom_discovery::ScanOptions::new(path.clone());
+            options.recursive = recursive;
+            options.hash_files = hash_files;
+            options.workers = workers;
+            options.fingerprint_lookup = Some(crate::introspect::fingerprint_lookup(store.clone()));
+
+            let progress_clone = progress.clone();
+            let cum_disc = cumulative_discovered.clone();
+            let proc_base = processing_base.clone();
+            let orphans_progress = orphans.clone();
+            let hash_for_progress = hash_files;
+            options.on_progress = Some(Box::new(move |p| match p {
+                voom_discovery::ScanProgress::Discovered { count: _, path } => {
+                    let n = cum_disc.fetch_add(1, Ordering::Relaxed) + 1;
+                    let n = usize::try_from(n).unwrap_or(usize::MAX);
+                    progress_clone.on_discovered(n, &path);
+                }
+                voom_discovery::ScanProgress::Processing {
+                    current,
+                    total,
+                    path,
+                } => {
+                    let base = proc_base.load(Ordering::Relaxed);
+                    let base = usize::try_from(base).unwrap_or(usize::MAX);
+                    let action = if hash_for_progress {
+                        "Hashing"
+                    } else {
+                        "Processing"
+                    };
+                    progress_clone.on_processing(base + current, base + total, &path, action);
+                }
+                voom_discovery::ScanProgress::OrphanedTempFiles { count } => {
+                    // Capture orphan-temp count so the discovery summary line
+                    // can report it (parity with the pre-streaming behaviour).
+                    orphans_progress.fetch_add(count as u64, Ordering::Relaxed);
+                }
+                voom_discovery::ScanProgress::HashReused { .. } => {}
+            }));
+
+            let kernel_clone = kernel.clone();
+            let errors_clone = discovery_errors.clone();
+            options.on_error = Some(Box::new(move |path, size, error| {
+                tracing::warn!(path = %path.display(), error = %error, "discovery error");
+                errors_clone.fetch_add(1, Ordering::Relaxed);
+                crate::introspect::dispatch_failure(
+                    &kernel_clone,
+                    path,
+                    size,
+                    None,
+                    &error,
+                    BadFileSource::Discovery,
+                );
+            }));
+
+            let token_inner = token.clone();
+            let tx_inner = tx_disc.clone();
+            let on_event: voom_discovery::EventSink = Box::new(move |event| {
+                if token_inner.is_cancelled() {
+                    return;
+                }
+                // blocking_send blocks the current rayon worker until the
+                // ingest stage drains. This is the backpressure mechanism.
+                let _ = tx_inner.blocking_send(event);
+            });
+
+            discovery
+                .scan_streaming(&options, on_event)
+                .with_context(|| format!("filesystem scan failed for {}", path.display()))?;
+
+            let dir_count = cumulative_discovered.load(Ordering::Relaxed) - pre;
+            processing_base.fetch_add(dir_count, Ordering::Relaxed);
+        }
+
+        // Closing tx_disc signals the ingest stage that discovery is done.
+        drop(tx_disc);
+
+        Ok(discovery_errors.load(Ordering::Relaxed))
+    })
+}
+
+/// Ingest-stage output: session summary, formatted results, and discovered count.
+type IngestOutput = (IngestSummary, Vec<(PathBuf, u64, Option<String>)>, u64);
+
+#[allow(clippy::too_many_arguments)]
+fn spawn_ingest_stage(
+    store: Arc<dyn StorageTrait>,
+    kernel: Arc<voom_kernel::Kernel>,
+    paths: Vec<PathBuf>,
+    hash_files: bool,
+    mut rx_disc: mpsc::Receiver<FileDiscoveredEvent>,
+    tx_probe: mpsc::Sender<FileDiscoveredEvent>,
+    probe_progress: ProbeProgress,
+    token: CancellationToken,
+) -> tokio::task::JoinHandle<Result<IngestOutput>> {
+    tokio::task::spawn_blocking(move || -> Result<_> {
+        use std::collections::HashSet;
+
+        let mut formatted: Vec<(PathBuf, u64, Option<String>)> = Vec::new();
+        let mut files_discovered: u64 = 0;
+
+        if !hash_files {
+            // --no-hash path: no session, collect paths for missing-mark.
+            let mut seen: HashSet<PathBuf> = HashSet::new();
+            while let Some(event) = rx_disc.blocking_recv() {
+                if token.is_cancelled() {
+                    break;
+                }
+                if !seen.insert(event.path.clone()) {
+                    continue;
+                }
+                files_discovered += 1;
+                formatted.push((event.path.clone(), event.size, event.content_hash.clone()));
+                kernel.dispatch(Event::FileDiscovered(event.clone()));
+                probe_progress.add_pending(1);
+                if tx_probe.blocking_send(event).is_err() {
+                    break;
+                }
+            }
+            drop(tx_probe);
+
+            let discovered_paths: Vec<PathBuf> =
+                formatted.iter().map(|(p, _, _)| p.clone()).collect();
+            let missing = if token.is_cancelled() {
+                0
+            } else {
+                store
+                    .mark_missing_paths(&discovered_paths, &paths)
+                    .context("path-only reconciliation failed")?
+            };
+            let scan_finish = ScanFinishOutcome::new(missing, 0);
+            return Ok((
+                IngestSummary {
+                    scan_finish,
+                    moved_from_ingest: 0,
+                    external_changes: 0,
+                },
+                formatted,
+                files_discovered,
+            ));
+        }
+
+        // Hashed path: session-based ingest.
+        let mut moved: u32 = 0;
+        let mut external_changes: u32 = 0;
+        let mut seen: HashSet<PathBuf> = HashSet::new();
+
+        let session_outcome: ScanFinishOutcome = with_scan_session(
+            store.as_ref(),
+            &paths,
+            |session| -> Result<ScanFinishOutcome> {
+                while let Some(event) = rx_disc.blocking_recv() {
+                    if token.is_cancelled() {
+                        // Explicitly cancel the session to leave it in
+                        // Cancelled state (no missing-file marking), then
+                        // return an Ok sentinel so the outer with_scan_session
+                        // doesn't double-cancel.
+                        store
+                            .cancel_scan_session(session)
+                            .context("cancel_scan_session failed")?;
+                        return Ok(ScanFinishOutcome::default());
+                    }
+                    if !seen.insert(event.path.clone()) {
+                        continue;
+                    }
+                    files_discovered += 1;
+                    formatted.push((event.path.clone(), event.size, event.content_hash.clone()));
+                    kernel.dispatch(Event::FileDiscovered(event.clone()));
+
+                    let Some(hash) = event.content_hash.clone() else {
+                        // No hash → can't ingest into the session; forward to
+                        // probe so the file still gets introspected.
+                        probe_progress.add_pending(1);
+                        if tx_probe.blocking_send(event).is_err() {
+                            break;
+                        }
+                        continue;
+                    };
+                    let df = DiscoveredFile::new(event.path.clone(), event.size, hash);
+                    let decision = store
+                        .ingest_discovered_file(session, &df)
+                        .context("ingest_discovered_file failed")?;
+                    match &decision {
+                        IngestDecision::Moved { .. } => moved += 1,
+                        IngestDecision::ExternallyChanged { .. } => external_changes += 1,
+                        _ => {}
+                    }
+                    if decision.needs_introspection_path(&event.path).is_some() {
+                        probe_progress.add_pending(1);
+                        if tx_probe.blocking_send(event).is_err() {
+                            break;
+                        }
+                    }
+                }
+                drop(tx_probe);
+                let finish = store
+                    .finish_scan_session(session)
+                    .context("finish_scan_session failed")?;
+                Ok(finish)
+            },
+        )?;
+
+        Ok((
+            IngestSummary {
+                scan_finish: session_outcome,
+                moved_from_ingest: moved,
+                external_changes,
+            },
+            formatted,
+            files_discovered,
+        ))
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn spawn_probe_stage(
+    mut rx_probe: mpsc::Receiver<FileDiscoveredEvent>,
+    kernel: Arc<voom_kernel::Kernel>,
+    ffprobe_path: Option<String>,
+    animation_mode: voom_ffprobe_introspector::parser::AnimationDetectionMode,
+    probe_workers: usize,
+    progress: ProbeProgress,
+    token: CancellationToken,
+    introspected: Arc<AtomicU64>,
+    probe_errors: Arc<AtomicU64>,
+) -> tokio::task::JoinHandle<Result<()>> {
+    tokio::spawn(async move {
+        let sem = Arc::new(Semaphore::new(probe_workers));
+        let mut set: JoinSet<()> = JoinSet::new();
+
+        while let Some(event) = rx_probe.recv().await {
+            if token.is_cancelled() {
+                break;
+            }
+            let permit = sem
+                .clone()
+                .acquire_owned()
+                .await
+                .context("probe semaphore closed unexpectedly")?;
+            let kernel_inner = kernel.clone();
+            let introspected = introspected.clone();
+            let probe_errors = probe_errors.clone();
+            let progress_inner = progress.clone();
+            let ffprobe_path = ffprobe_path.clone();
+            let token_inner = token.clone();
+            set.spawn(async move {
+                let _permit = permit;
+                if token_inner.is_cancelled() {
+                    progress_inner.inc();
+                    return;
+                }
+                let path_for_progress = event.path.clone();
+                progress_inner.on_file(0, &path_for_progress);
+                match introspect::introspect_file(
+                    event.path.clone(),
+                    event.size,
+                    event.content_hash.clone(),
+                    &kernel_inner,
+                    ffprobe_path.as_deref(),
+                    animation_mode,
+                )
+                .await
+                {
+                    Ok(_) => {
+                        introspected.fetch_add(1, Ordering::Relaxed);
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            path = %event.path.display(),
+                            error = %e,
+                            "introspection failed"
+                        );
+                        probe_errors.fetch_add(1, Ordering::Relaxed);
+                    }
+                }
+                progress_inner.inc();
+            });
+        }
+
+        // Drain remaining workers.
+        while set.join_next().await.is_some() {}
+        Ok(())
+    })
 }
 
 #[cfg(test)]

--- a/crates/voom-cli/src/commands/scan/pipeline.rs
+++ b/crates/voom-cli/src/commands/scan/pipeline.rs
@@ -378,15 +378,10 @@ fn spawn_ingest_stage(
                 kernel.dispatch(Event::FileDiscovered(event.clone()));
                 probe_progress.add_pending(1);
                 if let Err(e) = tx_probe.blocking_send(event) {
-                    if token.is_cancelled() {
-                        // Cancellation was already requested; the channel close
-                        // is its expected consequence (probe exited its recv
-                        // loop due to token cancellation). Stop ingesting
-                        // cleanly. The post-loop `if token.is_cancelled()`
-                        // check will skip mark_missing_paths.
-                        break;
-                    }
-                    // Token was NOT cancelled — probe died unexpectedly. Fatal.
+                    // Probe stage closed its receiver — it has died (panic or
+                    // early exit). Cancel the pipeline token so siblings stop,
+                    // and return Err so the caller does not proceed to
+                    // mark_missing_paths on a partial scan.
                     token.cancel();
                     return Err(anyhow::anyhow!(
                         "probe stage closed its receiver unexpectedly: {e}"
@@ -463,24 +458,11 @@ fn spawn_ingest_stage(
                             // probe so the file still gets introspected.
                             probe_progress.add_pending(1);
                             if let Err(e) = tx_probe.blocking_send(event) {
-                                if token.is_cancelled() {
-                                    // Probe closed its receiver because
-                                    // cancellation was already requested
-                                    // (external Ctrl-C, or a sibling stage
-                                    // errored and cancelled the child token).
-                                    // The channel close is the expected
-                                    // downstream consequence, NOT a probe-stage
-                                    // fault. Route through the same path the
-                                    // in-loop cancellation check uses so the
-                                    // session ends Cancelled and no files are
-                                    // marked missing.
-                                    store
-                                        .cancel_scan_session(session)
-                                        .context("cancel_scan_session failed")?;
-                                    return Ok(ScanFinishOutcome::default());
-                                }
-                                // Token was NOT cancelled — probe died
-                                // unexpectedly. Fatal.
+                                // Probe stage closed its receiver — it has died
+                                // (panic or early exit). Cancel the pipeline token
+                                // so siblings stop, and return Err so
+                                // with_scan_session calls cancel_scan_session
+                                // instead of finish_scan_session.
                                 token.cancel();
                                 return Err(anyhow::anyhow!(
                                     "probe stage closed its receiver unexpectedly: {e}"
@@ -500,24 +482,11 @@ fn spawn_ingest_stage(
                         if decision.needs_introspection_path(&event.path).is_some() {
                             probe_progress.add_pending(1);
                             if let Err(e) = tx_probe.blocking_send(event) {
-                                if token.is_cancelled() {
-                                    // Probe closed its receiver because
-                                    // cancellation was already requested
-                                    // (external Ctrl-C, or a sibling stage
-                                    // errored and cancelled the child token).
-                                    // The channel close is the expected
-                                    // downstream consequence, NOT a probe-stage
-                                    // fault. Route through the same path the
-                                    // in-loop cancellation check uses so the
-                                    // session ends Cancelled and no files are
-                                    // marked missing.
-                                    store
-                                        .cancel_scan_session(session)
-                                        .context("cancel_scan_session failed")?;
-                                    return Ok(ScanFinishOutcome::default());
-                                }
-                                // Token was NOT cancelled — probe died
-                                // unexpectedly. Fatal.
+                                // Probe stage closed its receiver — it has died
+                                // (panic or early exit). Cancel the pipeline token
+                                // so siblings stop, and return Err so
+                                // with_scan_session calls cancel_scan_session
+                                // instead of finish_scan_session.
                                 token.cancel();
                                 return Err(anyhow::anyhow!(
                                     "probe stage closed its receiver unexpectedly: {e}"

--- a/crates/voom-cli/src/commands/scan/pipeline.rs
+++ b/crates/voom-cli/src/commands/scan/pipeline.rs
@@ -109,6 +109,13 @@ pub(crate) async fn run_streaming_pipeline(
     let probe_errors = Arc::new(AtomicU64::new(0));
     let orphans = Arc::new(AtomicU64::new(0));
 
+    // Pipeline-internal cancellation token. When any stage errors, we cancel
+    // this token so sibling stages observe the failure and clean up promptly
+    // (e.g., ingest runs cancel_scan_session instead of finish_scan_session).
+    // It is a child of the external `token` so external cancellation also
+    // propagates automatically.
+    let pipeline_cancel = token.child_token();
+
     let discovery_handle = spawn_discovery_stage(
         args,
         paths,
@@ -117,7 +124,7 @@ pub(crate) async fn run_streaming_pipeline(
         kernel.clone(),
         discovery_progress.clone(),
         tx_disc,
-        token.clone(),
+        pipeline_cancel.clone(),
         orphans.clone(),
     );
 
@@ -129,7 +136,7 @@ pub(crate) async fn run_streaming_pipeline(
         rx_disc,
         tx_probe,
         probe_progress.clone(),
-        token.clone(),
+        pipeline_cancel.clone(),
     );
 
     let probe_handle = spawn_probe_stage(
@@ -139,24 +146,44 @@ pub(crate) async fn run_streaming_pipeline(
         animation_mode,
         probe_workers,
         probe_progress.clone(),
-        token.clone(),
+        pipeline_cancel.clone(),
         introspected.clone(),
         probe_errors.clone(),
     );
 
-    // Wait for all three stages. If any errors, propagate.
-    let disc_result = discovery_handle
-        .await
-        .context("discovery task join failed")?;
-    let ingest_result = ingest_handle.await.context("ingest task join failed")?;
-    let probe_result = probe_handle.await.context("probe task join failed")?;
+    // Await all three stages unconditionally before propagating any error so
+    // that:
+    //   - the scan session always ends in a terminal state (Finished or
+    //     Cancelled), never InProgress
+    //   - progress bars always finish() before we return
+    //   - probe tasks always drain
+    //
+    // After each await, if the result indicates failure (join error OR the
+    // task's own Err), cancel the internal token so sibling stages observe
+    // the failure and take the cancel path rather than the finish path.
+    let disc_join = discovery_handle.await;
+    if disc_join.as_ref().map_or(true, |r| r.is_err()) {
+        pipeline_cancel.cancel();
+    }
 
-    let discovery_errors = disc_result?;
-    let (finish_outcome, formatted, files_discovered) = ingest_result?;
-    probe_result?;
+    let ingest_join = ingest_handle.await;
+    if ingest_join.as_ref().map_or(true, |r| r.is_err()) {
+        pipeline_cancel.cancel();
+    }
 
+    let probe_join = probe_handle.await;
+
+    // Finish progress bars before propagating errors so they never hang.
     discovery_progress.finish();
     probe_progress.finish();
+
+    // Propagate errors in source order: discovery → ingest → probe.
+    // The `??` idiom: outer `?` propagates the JoinError (after .context()),
+    // inner `?` propagates the task's own Err.
+    let discovery_errors = disc_join.context("discovery task join failed")??;
+    let (finish_outcome, formatted, files_discovered) =
+        ingest_join.context("ingest task join failed")??;
+    probe_join.context("probe task join failed")??;
 
     let mut moved = finish_outcome.moved_from_ingest;
     moved += finish_outcome.scan_finish.promoted_moves;
@@ -460,6 +487,14 @@ fn spawn_probe_stage(
                 .acquire_owned()
                 .await
                 .context("probe semaphore closed unexpectedly")?;
+            // Drain any tasks that completed since the last poll. This is what
+            // keeps the JoinSet bounded by `probe_workers` rather than by the
+            // total number of files scanned. The Semaphore prevents
+            // oversubscription; the opportunistic drain prevents JoinHandle
+            // accumulation.
+            while let Some(joined) = set.try_join_next() {
+                handle_probe_join_result(&joined, &probe_errors, &progress);
+            }
             let kernel_inner = kernel.clone();
             let introspected = introspected.clone();
             let probe_errors = probe_errors.clone();

--- a/crates/voom-cli/src/commands/scan/pipeline.rs
+++ b/crates/voom-cli/src/commands/scan/pipeline.rs
@@ -689,6 +689,35 @@ fn spawn_heartbeat_task(
     HeartbeatHandle { cancel }
 }
 
+/// Test-only handle into the ingest stage's hashed-path body. Used by the
+/// `streaming_tests` module to assert that closing `tx_probe` (simulating
+/// a dead probe stage) causes the session to be cancelled rather than
+/// finalised. Not part of the public pipeline API.
+#[cfg(test)]
+pub(crate) async fn run_ingest_for_test(
+    store: Arc<dyn StorageTrait>,
+    kernel: Arc<voom_kernel::Kernel>,
+    paths: Vec<PathBuf>,
+    rx_disc: tokio::sync::mpsc::Receiver<FileDiscoveredEvent>,
+    tx_probe: tokio::sync::mpsc::Sender<FileDiscoveredEvent>,
+    token: CancellationToken,
+) -> Result<()> {
+    // Mirrors spawn_ingest_stage's spawn_blocking call but returns a
+    // simplified Result so tests can assert .is_err() / .is_ok().
+    let handle = spawn_ingest_stage(
+        store,
+        kernel,
+        paths,
+        true, // hash_files — only the hashed path has the probe-close issue
+        rx_disc,
+        tx_probe,
+        crate::progress::ProbeProgress::hidden_dynamic(),
+        token,
+    );
+    handle.await.context("ingest task join failed")??;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -714,5 +743,21 @@ mod tests {
     fn resolve_probe_workers_explicit_flag_wins() {
         assert_eq!(resolve_probe_workers(3), 3);
         assert_eq!(resolve_probe_workers(1), 1);
+    }
+
+    // Verify tokio's mpsc channel behavior: blocking_send to a channel
+    // whose receiver was dropped should return Err immediately.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn blocking_send_to_dropped_receiver_returns_err() {
+        let (tx, rx) = tokio::sync::mpsc::channel::<u32>(4);
+        drop(rx);
+        // spawn_blocking because blocking_send must not be called on async thread
+        let result = tokio::task::spawn_blocking(move || tx.blocking_send(42))
+            .await
+            .expect("join");
+        assert!(
+            result.is_err(),
+            "blocking_send must Err when receiver dropped"
+        );
     }
 }

--- a/crates/voom-cli/src/commands/scan/pipeline.rs
+++ b/crates/voom-cli/src/commands/scan/pipeline.rs
@@ -231,90 +231,108 @@ fn spawn_discovery_stage(
         // failures). Returned via the JoinHandle's Ok value.
         let discovery_errors = Arc::new(AtomicU64::new(0));
 
-        for path in &paths {
-            if token.is_cancelled() {
-                break;
+        // Wrap the scan loop so we can inspect the result BEFORE dropping
+        // tx_disc. On Err, we cancel the pipeline token first; that ensures
+        // ingest's post-loop cancellation check observes the cancellation when
+        // blocking_recv() returns None — closing the race where ingest would
+        // otherwise call finish_scan_session and mark files Missing.
+        let run_scan = || -> Result<u64> {
+            for path in &paths {
+                if token.is_cancelled() {
+                    break;
+                }
+                progress.reset_to_spinner();
+                let pre = cumulative_discovered.load(Ordering::Relaxed);
+
+                let mut options = voom_discovery::ScanOptions::new(path.clone());
+                options.recursive = recursive;
+                options.hash_files = hash_files;
+                options.workers = workers;
+                options.fingerprint_lookup =
+                    Some(crate::introspect::fingerprint_lookup(store.clone()));
+
+                let progress_clone = progress.clone();
+                let cum_disc = cumulative_discovered.clone();
+                let proc_base = processing_base.clone();
+                let orphans_progress = orphans.clone();
+                let hash_for_progress = hash_files;
+                options.on_progress = Some(Box::new(move |p| match p {
+                    voom_discovery::ScanProgress::Discovered { count: _, path } => {
+                        let n = cum_disc.fetch_add(1, Ordering::Relaxed) + 1;
+                        let n = usize::try_from(n).unwrap_or(usize::MAX);
+                        progress_clone.on_discovered(n, &path);
+                    }
+                    voom_discovery::ScanProgress::Processing {
+                        current,
+                        total,
+                        path,
+                    } => {
+                        let base = proc_base.load(Ordering::Relaxed);
+                        let base = usize::try_from(base).unwrap_or(usize::MAX);
+                        let action = if hash_for_progress {
+                            "Hashing"
+                        } else {
+                            "Processing"
+                        };
+                        progress_clone.on_processing(base + current, base + total, &path, action);
+                    }
+                    voom_discovery::ScanProgress::OrphanedTempFiles { count } => {
+                        // Capture orphan-temp count so the discovery summary line
+                        // can report it (parity with the pre-streaming behaviour).
+                        orphans_progress.fetch_add(count as u64, Ordering::Relaxed);
+                    }
+                    voom_discovery::ScanProgress::HashReused { .. } => {}
+                }));
+
+                let kernel_clone = kernel.clone();
+                let errors_clone = discovery_errors.clone();
+                options.on_error = Some(Box::new(move |path, size, error| {
+                    tracing::warn!(path = %path.display(), error = %error, "discovery error");
+                    errors_clone.fetch_add(1, Ordering::Relaxed);
+                    crate::introspect::dispatch_failure(
+                        &kernel_clone,
+                        path,
+                        size,
+                        None,
+                        &error,
+                        BadFileSource::Discovery,
+                    );
+                }));
+
+                let token_inner = token.clone();
+                let tx_inner = tx_disc.clone();
+                let on_event: voom_discovery::EventSink = Box::new(move |event| {
+                    if token_inner.is_cancelled() {
+                        return;
+                    }
+                    // blocking_send blocks the current rayon worker until the
+                    // ingest stage drains. This is the backpressure mechanism.
+                    let _ = tx_inner.blocking_send(event);
+                });
+
+                discovery
+                    .scan_streaming(&options, on_event)
+                    .with_context(|| format!("filesystem scan failed for {}", path.display()))?;
+
+                let dir_count = cumulative_discovered.load(Ordering::Relaxed) - pre;
+                processing_base.fetch_add(dir_count, Ordering::Relaxed);
             }
-            progress.reset_to_spinner();
-            let pre = cumulative_discovered.load(Ordering::Relaxed);
 
-            let mut options = voom_discovery::ScanOptions::new(path.clone());
-            options.recursive = recursive;
-            options.hash_files = hash_files;
-            options.workers = workers;
-            options.fingerprint_lookup = Some(crate::introspect::fingerprint_lookup(store.clone()));
+            Ok(discovery_errors.load(Ordering::Relaxed))
+        };
+        let result = run_scan();
 
-            let progress_clone = progress.clone();
-            let cum_disc = cumulative_discovered.clone();
-            let proc_base = processing_base.clone();
-            let orphans_progress = orphans.clone();
-            let hash_for_progress = hash_files;
-            options.on_progress = Some(Box::new(move |p| match p {
-                voom_discovery::ScanProgress::Discovered { count: _, path } => {
-                    let n = cum_disc.fetch_add(1, Ordering::Relaxed) + 1;
-                    let n = usize::try_from(n).unwrap_or(usize::MAX);
-                    progress_clone.on_discovered(n, &path);
-                }
-                voom_discovery::ScanProgress::Processing {
-                    current,
-                    total,
-                    path,
-                } => {
-                    let base = proc_base.load(Ordering::Relaxed);
-                    let base = usize::try_from(base).unwrap_or(usize::MAX);
-                    let action = if hash_for_progress {
-                        "Hashing"
-                    } else {
-                        "Processing"
-                    };
-                    progress_clone.on_processing(base + current, base + total, &path, action);
-                }
-                voom_discovery::ScanProgress::OrphanedTempFiles { count } => {
-                    // Capture orphan-temp count so the discovery summary line
-                    // can report it (parity with the pre-streaming behaviour).
-                    orphans_progress.fetch_add(count as u64, Ordering::Relaxed);
-                }
-                voom_discovery::ScanProgress::HashReused { .. } => {}
-            }));
-
-            let kernel_clone = kernel.clone();
-            let errors_clone = discovery_errors.clone();
-            options.on_error = Some(Box::new(move |path, size, error| {
-                tracing::warn!(path = %path.display(), error = %error, "discovery error");
-                errors_clone.fetch_add(1, Ordering::Relaxed);
-                crate::introspect::dispatch_failure(
-                    &kernel_clone,
-                    path,
-                    size,
-                    None,
-                    &error,
-                    BadFileSource::Discovery,
-                );
-            }));
-
-            let token_inner = token.clone();
-            let tx_inner = tx_disc.clone();
-            let on_event: voom_discovery::EventSink = Box::new(move |event| {
-                if token_inner.is_cancelled() {
-                    return;
-                }
-                // blocking_send blocks the current rayon worker until the
-                // ingest stage drains. This is the backpressure mechanism.
-                let _ = tx_inner.blocking_send(event);
-            });
-
-            discovery
-                .scan_streaming(&options, on_event)
-                .with_context(|| format!("filesystem scan failed for {}", path.display()))?;
-
-            let dir_count = cumulative_discovered.load(Ordering::Relaxed) - pre;
-            processing_base.fetch_add(dir_count, Ordering::Relaxed);
+        // Cancel BEFORE dropping tx_disc so ingest's post-loop cancellation
+        // check observes the token as cancelled when blocking_recv() returns
+        // None. CancellationToken::cancel() carries Release semantics; the
+        // channel close that follows establishes the happens-before edge to
+        // ingest's blocking_recv returning None.
+        if result.is_err() {
+            token.cancel();
         }
-
-        // Closing tx_disc signals the ingest stage that discovery is done.
+        // Explicit drop makes the ordering visible at the call site.
         drop(tx_disc);
-
-        Ok(discovery_errors.load(Ordering::Relaxed))
+        result
     })
 }
 
@@ -384,71 +402,89 @@ fn spawn_ingest_stage(
         let mut external_changes: u32 = 0;
         let mut seen: HashSet<PathBuf> = HashSet::new();
 
-        let session_outcome: ScanFinishOutcome = with_scan_session(
-            store.as_ref(),
-            &paths,
-            |session| -> Result<ScanFinishOutcome> {
-                while let Some(event) = rx_disc.blocking_recv() {
+        // Wrap with_scan_session in a named closure so we can inspect the
+        // result BEFORE tx_probe's implicit drop at closure end. On Err,
+        // cancel the pipeline token first so that the probe stage's post-recv
+        // check observes the cancellation when rx_probe returns None.
+        let run_ingest = || -> Result<ScanFinishOutcome> {
+            with_scan_session(
+                store.as_ref(),
+                &paths,
+                |session| -> Result<ScanFinishOutcome> {
+                    while let Some(event) = rx_disc.blocking_recv() {
+                        if token.is_cancelled() {
+                            // Explicitly cancel the session to leave it in
+                            // Cancelled state (no missing-file marking), then
+                            // return an Ok sentinel so the outer with_scan_session
+                            // doesn't double-cancel.
+                            store
+                                .cancel_scan_session(session)
+                                .context("cancel_scan_session failed")?;
+                            return Ok(ScanFinishOutcome::default());
+                        }
+                        if !seen.insert(event.path.clone()) {
+                            continue;
+                        }
+                        files_discovered += 1;
+                        formatted.push((
+                            event.path.clone(),
+                            event.size,
+                            event.content_hash.clone(),
+                        ));
+                        kernel.dispatch(Event::FileDiscovered(event.clone()));
+
+                        let Some(hash) = event.content_hash.clone() else {
+                            // No hash → can't ingest into the session; forward to
+                            // probe so the file still gets introspected.
+                            probe_progress.add_pending(1);
+                            if tx_probe.blocking_send(event).is_err() {
+                                break;
+                            }
+                            continue;
+                        };
+                        let df = DiscoveredFile::new(event.path.clone(), event.size, hash);
+                        let decision = store
+                            .ingest_discovered_file(session, &df)
+                            .context("ingest_discovered_file failed")?;
+                        match &decision {
+                            IngestDecision::Moved { .. } => moved += 1,
+                            IngestDecision::ExternallyChanged { .. } => external_changes += 1,
+                            _ => {}
+                        }
+                        if decision.needs_introspection_path(&event.path).is_some() {
+                            probe_progress.add_pending(1);
+                            if tx_probe.blocking_send(event).is_err() {
+                                break;
+                            }
+                        }
+                    }
+                    drop(tx_probe);
+                    // Re-check cancellation after the receive loop drains. If
+                    // discovery cancelled the token BEFORE dropping tx_disc
+                    // (the per-stage cancel-on-err fix), this check will see
+                    // is_cancelled() == true and avoid finish_scan_session.
                     if token.is_cancelled() {
-                        // Explicitly cancel the session to leave it in
-                        // Cancelled state (no missing-file marking), then
-                        // return an Ok sentinel so the outer with_scan_session
-                        // doesn't double-cancel.
                         store
                             .cancel_scan_session(session)
-                            .context("cancel_scan_session failed")?;
+                            .context("cancel_scan_session (post-loop) failed")?;
                         return Ok(ScanFinishOutcome::default());
                     }
-                    if !seen.insert(event.path.clone()) {
-                        continue;
-                    }
-                    files_discovered += 1;
-                    formatted.push((event.path.clone(), event.size, event.content_hash.clone()));
-                    kernel.dispatch(Event::FileDiscovered(event.clone()));
+                    let finish = store
+                        .finish_scan_session(session)
+                        .context("finish_scan_session failed")?;
+                    Ok(finish)
+                },
+            )
+        };
+        let ingest_result = run_ingest();
 
-                    let Some(hash) = event.content_hash.clone() else {
-                        // No hash → can't ingest into the session; forward to
-                        // probe so the file still gets introspected.
-                        probe_progress.add_pending(1);
-                        if tx_probe.blocking_send(event).is_err() {
-                            break;
-                        }
-                        continue;
-                    };
-                    let df = DiscoveredFile::new(event.path.clone(), event.size, hash);
-                    let decision = store
-                        .ingest_discovered_file(session, &df)
-                        .context("ingest_discovered_file failed")?;
-                    match &decision {
-                        IngestDecision::Moved { .. } => moved += 1,
-                        IngestDecision::ExternallyChanged { .. } => external_changes += 1,
-                        _ => {}
-                    }
-                    if decision.needs_introspection_path(&event.path).is_some() {
-                        probe_progress.add_pending(1);
-                        if tx_probe.blocking_send(event).is_err() {
-                            break;
-                        }
-                    }
-                }
-                drop(tx_probe);
-                // Re-check cancellation after the receive loop drains. If
-                // discovery was cancelled before sending any events, the loop
-                // body never runs, so the in-loop check is never reached. We
-                // must cancel the session here too to avoid marking every
-                // known file as missing.
-                if token.is_cancelled() {
-                    store
-                        .cancel_scan_session(session)
-                        .context("cancel_scan_session (post-loop) failed")?;
-                    return Ok(ScanFinishOutcome::default());
-                }
-                let finish = store
-                    .finish_scan_session(session)
-                    .context("finish_scan_session failed")?;
-                Ok(finish)
-            },
-        )?;
+        // Cancel BEFORE the closure's captured locals (including any remaining
+        // tx_probe handle) are dropped, so the probe stage observes the
+        // cancellation when rx_probe returns None.
+        if ingest_result.is_err() {
+            token.cancel();
+        }
+        let session_outcome = ingest_result?;
 
         Ok((
             IngestSummary {

--- a/crates/voom-cli/src/commands/scan/pipeline.rs
+++ b/crates/voom-cli/src/commands/scan/pipeline.rs
@@ -377,8 +377,15 @@ fn spawn_ingest_stage(
                 formatted.push((event.path.clone(), event.size, event.content_hash.clone()));
                 kernel.dispatch(Event::FileDiscovered(event.clone()));
                 probe_progress.add_pending(1);
-                if tx_probe.blocking_send(event).is_err() {
-                    break;
+                if let Err(e) = tx_probe.blocking_send(event) {
+                    // Probe stage closed its receiver — it has died (panic or
+                    // early exit). Cancel the pipeline token so siblings stop,
+                    // and return Err so the caller does not proceed to
+                    // mark_missing_paths on a partial scan.
+                    token.cancel();
+                    return Err(anyhow::anyhow!(
+                        "probe stage closed its receiver unexpectedly: {e}"
+                    ));
                 }
             }
             drop(tx_probe);
@@ -450,8 +457,16 @@ fn spawn_ingest_stage(
                             // No hash → can't ingest into the session; forward to
                             // probe so the file still gets introspected.
                             probe_progress.add_pending(1);
-                            if tx_probe.blocking_send(event).is_err() {
-                                break;
+                            if let Err(e) = tx_probe.blocking_send(event) {
+                                // Probe stage closed its receiver — it has died
+                                // (panic or early exit). Cancel the pipeline token
+                                // so siblings stop, and return Err so
+                                // with_scan_session calls cancel_scan_session
+                                // instead of finish_scan_session.
+                                token.cancel();
+                                return Err(anyhow::anyhow!(
+                                    "probe stage closed its receiver unexpectedly: {e}"
+                                ));
                             }
                             continue;
                         };
@@ -466,8 +481,16 @@ fn spawn_ingest_stage(
                         }
                         if decision.needs_introspection_path(&event.path).is_some() {
                             probe_progress.add_pending(1);
-                            if tx_probe.blocking_send(event).is_err() {
-                                break;
+                            if let Err(e) = tx_probe.blocking_send(event) {
+                                // Probe stage closed its receiver — it has died
+                                // (panic or early exit). Cancel the pipeline token
+                                // so siblings stop, and return Err so
+                                // with_scan_session calls cancel_scan_session
+                                // instead of finish_scan_session.
+                                token.cancel();
+                                return Err(anyhow::anyhow!(
+                                    "probe stage closed its receiver unexpectedly: {e}"
+                                ));
                             }
                         }
                     }

--- a/crates/voom-cli/src/commands/scan/pipeline.rs
+++ b/crates/voom-cli/src/commands/scan/pipeline.rs
@@ -405,6 +405,17 @@ fn spawn_ingest_stage(
                     }
                 }
                 drop(tx_probe);
+                // Re-check cancellation after the receive loop drains. If
+                // discovery was cancelled before sending any events, the loop
+                // body never runs, so the in-loop check is never reached. We
+                // must cancel the session here too to avoid marking every
+                // known file as missing.
+                if token.is_cancelled() {
+                    store
+                        .cancel_scan_session(session)
+                        .context("cancel_scan_session (post-loop) failed")?;
+                    return Ok(ScanFinishOutcome::default());
+                }
                 let finish = store
                     .finish_scan_session(session)
                     .context("finish_scan_session failed")?;

--- a/crates/voom-cli/src/commands/scan/pipeline.rs
+++ b/crates/voom-cli/src/commands/scan/pipeline.rs
@@ -657,6 +657,22 @@ impl Drop for HeartbeatHandle {
 /// session as stale. The fix in that case is operator-visible (the next
 /// `begin_scan_session` log message will name the auto-cancellation),
 /// not a silent data corruption.
+///
+/// # Testing
+///
+/// The heartbeat task spins on a 20s interval — too slow for fast unit
+/// tests. We rely instead on:
+/// 1. Storage-level unit tests in `voom-sqlite-store` that verify
+///    `heartbeat_scan_session` updates `last_heartbeat_at` and is silent
+///    on non-in_progress sessions.
+/// 2. Manual smoke verification: run `voom scan` on a large library
+///    (>60s wall clock) and confirm `last_heartbeat_at` advances by
+///    inspecting the DB.
+///
+/// A future enhancement could plumb `HEARTBEAT_INTERVAL_SECS` through as
+/// a parameter (or `#[cfg(test)]`-gated function) to enable a faster
+/// test, but the current trade-off is reasonable given the unit-test
+/// coverage above.
 #[must_use = "dropping the handle stops the heartbeat task"]
 fn spawn_heartbeat_task(
     store: Arc<dyn StorageTrait>,

--- a/crates/voom-cli/src/progress.rs
+++ b/crates/voom-cli/src/progress.rs
@@ -176,37 +176,6 @@ pub struct ProbeProgress {
 }
 
 impl ProbeProgress {
-    /// Create a new introspection progress bar with a fixed total.
-    ///
-    /// Used by commands that collect all files before probing (e.g. a future
-    /// `process --re-introspect` mode). The streaming scan uses
-    /// [`Self::new_dynamic_in`] instead.
-    #[allow(dead_code)] // retained for future serial-introspection callers
-    pub fn new(total: usize) -> Self {
-        let pb = ProgressBar::new(total as u64);
-        pb.set_style(bar_style());
-        pb.enable_steady_tick(TICK_INTERVAL);
-        pb.set_message("Probing...");
-        Self {
-            pb,
-            start: Instant::now(),
-            total,
-        }
-    }
-
-    /// Create a hidden (no-op) progress bar with a fixed total.
-    ///
-    /// Used by commands that collect all files before probing. The streaming
-    /// scan uses [`Self::hidden_dynamic`] instead.
-    #[allow(dead_code)] // retained for future serial-introspection callers
-    pub fn hidden(total: usize) -> Self {
-        Self {
-            pb: ProgressBar::hidden(),
-            start: Instant::now(),
-            total,
-        }
-    }
-
     /// Create a probe progress bar with an *initial* total of zero.
     /// The total is grown via [`Self::add_pending`] as work is enqueued.
     /// Suitable for streaming mode where the caller doesn't know the final

--- a/crates/voom-cli/src/progress.rs
+++ b/crates/voom-cli/src/progress.rs
@@ -155,6 +155,7 @@ impl DiscoveryProgress {
 }
 
 /// Determinate progress bar for introspection (probing) loops.
+#[derive(Clone)]
 pub struct ProbeProgress {
     pb: ProgressBar,
     start: Instant,
@@ -182,6 +183,54 @@ impl ProbeProgress {
             start: Instant::now(),
             total,
         }
+    }
+
+    /// Create a probe progress bar with an *initial* total of zero.
+    /// The total is grown via [`Self::add_pending`] as work is enqueued.
+    /// Suitable for streaming mode where the caller doesn't know the final
+    /// total until discovery completes.
+    // Dead code until Task 6 wires the streaming pipeline into the scan command.
+    #[allow(dead_code)]
+    pub fn new_dynamic() -> Self {
+        let pb = ProgressBar::new(0);
+        pb.set_style(bar_style());
+        pb.enable_steady_tick(TICK_INTERVAL);
+        pb.set_message("Probing...");
+        Self {
+            pb,
+            start: Instant::now(),
+            total: 0,
+        }
+    }
+
+    /// Hidden no-op equivalent of [`Self::new_dynamic`].
+    // Dead code until Task 6 wires the streaming pipeline into the scan command.
+    #[allow(dead_code)]
+    pub fn hidden_dynamic() -> Self {
+        Self {
+            pb: ProgressBar::hidden(),
+            start: Instant::now(),
+            total: 0,
+        }
+    }
+
+    /// Increase the bar's total by `n`. Safe to call from any thread.
+    // Dead code until Task 6 wires the streaming pipeline into the scan command.
+    #[allow(dead_code)]
+    pub fn add_pending(&self, n: u64) {
+        self.pb.inc_length(n);
+    }
+
+    /// Current bar length (for tests).
+    #[cfg(test)]
+    pub(crate) fn length(&self) -> u64 {
+        self.pb.length().unwrap_or(0)
+    }
+
+    /// Current bar position (for tests).
+    #[cfg(test)]
+    pub(crate) fn position(&self) -> u64 {
+        self.pb.position()
     }
 
     /// Update progress for the current file being probed.
@@ -686,6 +735,29 @@ mod tests {
 
         let estimate = state.estimate();
         assert!(estimate.eta.unwrap_or_default() >= Duration::from_secs(50));
+    }
+
+    #[test]
+    fn test_probe_progress_dynamic_total_starts_at_zero() {
+        let pb = ProbeProgress::new_dynamic();
+        assert_eq!(pb.length(), 0);
+    }
+
+    #[test]
+    fn test_probe_progress_add_pending_grows_total() {
+        let pb = ProbeProgress::new_dynamic();
+        pb.add_pending(3);
+        assert_eq!(pb.length(), 3);
+        pb.add_pending(2);
+        assert_eq!(pb.length(), 5);
+    }
+
+    #[test]
+    fn test_probe_progress_inc_position() {
+        let pb = ProbeProgress::new_dynamic();
+        pb.add_pending(2);
+        pb.inc();
+        assert_eq!(pb.position(), 1);
     }
 
     #[test]

--- a/crates/voom-cli/src/progress.rs
+++ b/crates/voom-cli/src/progress.rs
@@ -109,6 +109,19 @@ impl DiscoveryProgress {
         }
     }
 
+    /// Like [`Self::new`] but attached to a shared `MultiProgress` so the
+    /// bar coexists with other bars (e.g. the probe bar in streaming mode).
+    pub fn new_in(mp: &indicatif::MultiProgress) -> Self {
+        let pb = mp.add(ProgressBar::new_spinner());
+        pb.set_style(spinner_style());
+        pb.enable_steady_tick(TICK_INTERVAL);
+        Self {
+            pb,
+            start: Instant::now(),
+            transitioned: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
     /// Reset from bar back to spinner for a new discovery phase.
     ///
     /// Called between directories so the progress bar doesn't show stale
@@ -163,7 +176,12 @@ pub struct ProbeProgress {
 }
 
 impl ProbeProgress {
-    /// Create a new introspection progress bar.
+    /// Create a new introspection progress bar with a fixed total.
+    ///
+    /// Used by commands that collect all files before probing (e.g. a future
+    /// `process --re-introspect` mode). The streaming scan uses
+    /// [`Self::new_dynamic_in`] instead.
+    #[allow(dead_code)] // retained for future serial-introspection callers
     pub fn new(total: usize) -> Self {
         let pb = ProgressBar::new(total as u64);
         pb.set_style(bar_style());
@@ -176,7 +194,11 @@ impl ProbeProgress {
         }
     }
 
-    /// Create a hidden (no-op) progress bar for quiet/scripted mode.
+    /// Create a hidden (no-op) progress bar with a fixed total.
+    ///
+    /// Used by commands that collect all files before probing. The streaming
+    /// scan uses [`Self::hidden_dynamic`] instead.
+    #[allow(dead_code)] // retained for future serial-introspection callers
     pub fn hidden(total: usize) -> Self {
         Self {
             pb: ProgressBar::hidden(),
@@ -189,8 +211,10 @@ impl ProbeProgress {
     /// The total is grown via [`Self::add_pending`] as work is enqueued.
     /// Suitable for streaming mode where the caller doesn't know the final
     /// total until discovery completes.
-    // Dead code until Task 6 wires the streaming pipeline into the scan command.
-    #[allow(dead_code)]
+    ///
+    /// Production code uses [`Self::new_dynamic_in`] (attached to a
+    /// `MultiProgress`). This variant is used in tests and standalone contexts.
+    #[allow(dead_code)] // used in tests; production callers use new_dynamic_in
     pub fn new_dynamic() -> Self {
         let pb = ProgressBar::new(0);
         pb.set_style(bar_style());
@@ -204,8 +228,6 @@ impl ProbeProgress {
     }
 
     /// Hidden no-op equivalent of [`Self::new_dynamic`].
-    // Dead code until Task 6 wires the streaming pipeline into the scan command.
-    #[allow(dead_code)]
     pub fn hidden_dynamic() -> Self {
         Self {
             pb: ProgressBar::hidden(),
@@ -214,9 +236,20 @@ impl ProbeProgress {
         }
     }
 
+    /// Like [`Self::new_dynamic`] but attached to a shared `MultiProgress`.
+    pub fn new_dynamic_in(mp: &indicatif::MultiProgress) -> Self {
+        let pb = mp.add(ProgressBar::new(0));
+        pb.set_style(bar_style());
+        pb.enable_steady_tick(TICK_INTERVAL);
+        pb.set_message("Probing...");
+        Self {
+            pb,
+            start: Instant::now(),
+            total: 0,
+        }
+    }
+
     /// Increase the bar's total by `n`. Safe to call from any thread.
-    // Dead code until Task 6 wires the streaming pipeline into the scan command.
-    #[allow(dead_code)]
     pub fn add_pending(&self, n: u64) {
         self.pb.inc_length(n);
     }

--- a/crates/voom-domain/src/storage.rs
+++ b/crates/voom-domain/src/storage.rs
@@ -232,6 +232,19 @@ pub trait FileStorage: Send + Sync {
     /// when scan errors out mid-way.
     fn cancel_scan_session(&self, session: crate::transition::ScanSessionId) -> Result<()>;
 
+    /// Bump the `last_heartbeat_at` for an in-progress scan session.
+    ///
+    /// Backends with stale-session auto-cancellation (see
+    /// [`crate::transition::STALE_SESSION_SECS`]) must override this; the
+    /// default is a no-op for backends without such a timeout.
+    ///
+    /// Implementations MUST NOT modify a session that is not currently
+    /// `InProgress`. A bump on a finished/cancelled session is silently
+    /// ignored (returns `Ok(())`).
+    fn heartbeat_scan_session(&self, _session: crate::transition::ScanSessionId) -> Result<()> {
+        Ok(())
+    }
+
     /// Update the expected hash for a file (set after a successful voom operation).
     fn update_expected_hash(&self, id: &Uuid, hash: &str) -> Result<()>;
     /// Update the `files.status` column for the given file id. Used by the

--- a/crates/voom-domain/src/test_support.rs
+++ b/crates/voom-domain/src/test_support.rs
@@ -1921,3 +1921,19 @@ mod transcode_outcome_storage_tests {
         assert_eq!(latest.id, Uuid::from_u128(2));
     }
 }
+
+#[cfg(test)]
+mod heartbeat_tests {
+    use super::*;
+
+    #[test]
+    fn in_memory_store_heartbeat_is_a_no_op() {
+        use crate::storage::FileStorage;
+        let store = InMemoryStore::default();
+        let session = store
+            .begin_scan_session(&[std::path::PathBuf::from("/m")])
+            .expect("begin session");
+        // Default impl is a no-op — must return Ok without observable side effect.
+        store.heartbeat_scan_session(session).expect("heartbeat ok");
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -286,6 +286,21 @@ See `docs/superpowers/specs/2026-05-11-scan-sessions-design.md`,
 `docs/superpowers/specs/2026-05-11-scan-session-hardening-design.md`, and
 issue #358 for the full specification.
 
+### Scan pipeline (streaming, phase 2)
+
+`voom scan` runs three cooperating stages: a discovery task that walks the
+filesystem (via `voom-discovery::scan_directory_streaming`), an ingest task
+that holds the active scan session and writes per-file rows as events
+arrive, and a bounded pool of ffprobe workers (sized by `--probe-workers`,
+default = `min(num_cpus, sqlite_pool_size - 2)` with a floor of 1).
+Backpressure flows from the probe pool through ingest back to discovery,
+so memory usage stays bounded even on libraries with tens of thousands of
+files. Cancellation is honoured at every stage; cancelled sessions never
+mark files missing.
+
+See `docs/superpowers/specs/2026-05-11-issue-359-scan-streaming-phase-2-design.md`
+for the full design.
+
 ## Data Flow
 
 ```

--- a/plugins/discovery/src/lib.rs
+++ b/plugins/discovery/src/lib.rs
@@ -2,8 +2,10 @@
 
 pub mod scanner;
 
+pub use scanner::EventSink;
 pub use scanner::hash_file;
 pub use scanner::normalize_path;
+pub use scanner::scan_directory_streaming;
 
 use voom_domain::capabilities::Capability;
 use voom_domain::errors::Result;
@@ -120,6 +122,15 @@ impl DiscoveryPlugin {
     /// Scan a directory for media files and return discovery events.
     pub fn scan(&self, options: &ScanOptions) -> Result<Vec<FileDiscoveredEvent>> {
         scanner::scan_directory(options)
+    }
+
+    /// Streaming scan. See [`scanner::scan_directory_streaming`].
+    pub fn scan_streaming(
+        &self,
+        options: &ScanOptions,
+        on_event: scanner::EventSink,
+    ) -> Result<()> {
+        scanner::scan_directory_streaming(options, on_event)
     }
 }
 

--- a/plugins/discovery/src/scanner.rs
+++ b/plugins/discovery/src/scanner.rs
@@ -256,8 +256,19 @@ fn report_walk_errors(options: &ScanOptions, walk_errors: &[DiscoveryWalkError])
     }
 }
 
-/// Scan a directory for media files.
-pub fn scan_directory(options: &ScanOptions) -> Result<Vec<FileDiscoveredEvent>> {
+/// Callback invoked once per successfully built `FileDiscoveredEvent`.
+///
+/// The callback may be invoked from multiple rayon worker threads concurrently
+/// and must be `Send + Sync`. Implementations that need ordering or
+/// serialization (e.g. an mpsc sender that returns errors) should handle
+/// it themselves.
+pub type EventSink = Box<dyn Fn(FileDiscoveredEvent) + Send + Sync>;
+
+/// Streaming variant of [`scan_directory`]. Emits each `FileDiscoveredEvent`
+/// via `on_event` as soon as its content hash is computed, rather than
+/// collecting into a `Vec`. Order is rayon-dependent — callers that need a
+/// deterministic order should sort downstream.
+pub fn scan_directory_streaming(options: &ScanOptions, on_event: EventSink) -> Result<()> {
     if !options.root.exists() {
         return Err(VoomError::Io(std::io::Error::new(
             std::io::ErrorKind::NotFound,
@@ -271,15 +282,13 @@ pub fn scan_directory(options: &ScanOptions) -> Result<Vec<FileDiscoveredEvent>>
     tracing::info!(
         root = %options.root.display(),
         count = media_paths.len(),
-        "discovered media files"
+        "discovered media files (streaming)"
     );
 
     let total = media_paths.len();
     let processed = Arc::new(AtomicUsize::new(0));
     let fd_sem = Arc::new(FdSemaphore::new(MAX_CONCURRENT_FDS));
 
-    // Process files in parallel using rayon, with a semaphore to limit
-    // concurrent open file descriptors during hashing.
     let process_file = |(path, walk_size): &(PathBuf, u64)| {
         let _guard = fd_sem.guard();
         let result = build_event(
@@ -297,37 +306,54 @@ pub fn scan_directory(options: &ScanOptions) -> Result<Vec<FileDiscoveredEvent>>
                 path: path.clone(),
             });
         }
-        result
-    };
-
-    let events: Vec<Result<FileDiscoveredEvent>> = if options.workers > 0 {
-        let pool = rayon::ThreadPoolBuilder::new()
-            .num_threads(options.workers)
-            .build()
-            .map_err(|e| VoomError::Other(Box::new(e)))?;
-        pool.install(|| media_paths.par_iter().map(process_file).collect())
-    } else {
-        media_paths.par_iter().map(process_file).collect()
-    };
-
-    // Collect results, reporting errors via callback (or logging as fallback)
-    let mut discovered = Vec::with_capacity(events.len());
-    for (result, (path, walk_size)) in events.into_iter().zip(media_paths.iter()) {
         match result {
-            Ok(event) => discovered.push(event),
+            Ok(event) => on_event(event),
             Err(e) => {
                 if let Some(ref cb) = options.on_error {
                     cb(path.clone(), *walk_size, e.to_string());
                 } else {
-                    tracing::warn!(error = %e, "failed to process file during discovery");
+                    tracing::warn!(
+                        error = %e,
+                        "failed to process file during streaming discovery"
+                    );
                 }
             }
         }
+    };
+
+    if options.workers > 0 {
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(options.workers)
+            .build()
+            .map_err(|e| VoomError::Other(Box::new(e)))?;
+        pool.install(|| media_paths.par_iter().for_each(process_file));
+    } else {
+        media_paths.par_iter().for_each(process_file);
     }
 
-    // Sort by path for deterministic output
-    discovered.sort_by(|a, b| a.path.cmp(&b.path));
+    Ok(())
+}
 
+/// Scan a directory for media files. Returns all discovered events in
+/// deterministic path order. Kept for callers (e.g. `voom process`) that
+/// expect a fully-collected list.
+pub fn scan_directory(options: &ScanOptions) -> Result<Vec<FileDiscoveredEvent>> {
+    let collected: Arc<Mutex<Vec<FileDiscoveredEvent>>> = Arc::new(Mutex::new(Vec::new()));
+    let collected_clone = collected.clone();
+    scan_directory_streaming(
+        options,
+        Box::new(move |event| {
+            collected_clone
+                .lock()
+                .expect("scan_directory event sink lock poisoned")
+                .push(event);
+        }),
+    )?;
+    let mut discovered = Arc::try_unwrap(collected)
+        .expect("scan_directory: Arc still has other owners after streaming completed")
+        .into_inner()
+        .expect("scan_directory event sink lock poisoned");
+    discovered.sort_by(|a, b| a.path.cmp(&b.path));
     Ok(discovered)
 }
 
@@ -650,5 +676,74 @@ mod tests {
         assert_eq!(errors[0].0, missing);
         assert_eq!(errors[0].1, 0);
         assert_eq!(errors[0].2, "permission denied");
+    }
+
+    #[test]
+    fn test_scan_directory_streaming_emits_per_file() {
+        use std::sync::Arc;
+        use std::sync::Mutex;
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.mkv"), b"alpha").unwrap();
+        std::fs::write(dir.path().join("b.mp4"), b"beta").unwrap();
+        std::fs::write(dir.path().join("c.avi"), b"gamma").unwrap();
+
+        let emitted: Arc<Mutex<Vec<FileDiscoveredEvent>>> = Arc::new(Mutex::new(Vec::new()));
+        let emitted_clone = emitted.clone();
+
+        let options = ScanOptions::new(dir.path());
+        scan_directory_streaming(
+            &options,
+            Box::new(move |event| {
+                emitted_clone.lock().unwrap().push(event);
+            }),
+        )
+        .unwrap();
+
+        let events = emitted.lock().unwrap();
+        assert_eq!(events.len(), 3);
+        // All three files should be present (order is rayon-dependent in
+        // streaming mode — no deterministic sort).
+        let names: std::collections::HashSet<_> = events
+            .iter()
+            .filter_map(|e| e.path.file_name().map(|n| n.to_string_lossy().into_owned()))
+            .collect();
+        assert!(names.contains("a.mkv"));
+        assert!(names.contains("b.mp4"));
+        assert!(names.contains("c.avi"));
+    }
+
+    #[test]
+    fn test_scan_directory_streaming_reports_errors_via_options() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("real.mkv"), b"real").unwrap();
+
+        let errors = Arc::new(AtomicUsize::new(0));
+        let errors_clone = errors.clone();
+
+        let mut options = ScanOptions::new(dir.path());
+        options.on_error = Some(Box::new(move |_path, _size, _msg| {
+            errors_clone.fetch_add(1, Ordering::Relaxed);
+        }));
+
+        // Sanity: with a healthy directory, no errors fire.
+        scan_directory_streaming(&options, Box::new(|_| {})).unwrap();
+        assert_eq!(errors.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn test_scan_directory_still_returns_vec_after_refactor() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.mkv"), b"alpha").unwrap();
+        std::fs::write(dir.path().join("b.mp4"), b"beta").unwrap();
+
+        let options = ScanOptions::new(dir.path());
+        let events = scan_directory(&options).unwrap();
+        assert_eq!(events.len(), 2);
+        // Existing API guarantees deterministic path ordering.
+        assert!(events[0].path < events[1].path);
     }
 }

--- a/plugins/sqlite-store/src/store/file_storage.rs
+++ b/plugins/sqlite-store/src/store/file_storage.rs
@@ -756,6 +756,25 @@ impl FileStorage for SqliteStore {
         .map_err(storage_err("failed to cancel scan session"))?;
         Ok(())
     }
+
+    fn heartbeat_scan_session(
+        &self,
+        session: voom_domain::transition::ScanSessionId,
+    ) -> voom_domain::errors::Result<()> {
+        let conn = self.conn()?;
+        let now = format_datetime(&Utc::now());
+        let session_str = session.to_string();
+        // Gate on status = 'in_progress' so a stale heartbeat task that
+        // races against finish/cancel cannot accidentally revive a session.
+        conn.execute(
+            "UPDATE scan_sessions \
+             SET last_heartbeat_at = ?1 \
+             WHERE id = ?2 AND status = 'in_progress'",
+            params![now, session_str],
+        )
+        .map_err(storage_err("failed to bump scan session heartbeat"))?;
+        Ok(())
+    }
 }
 
 /// Bundles the per-call common context for ingest helpers. Avoids
@@ -4023,5 +4042,87 @@ mod tests {
             )
             .unwrap();
         assert_eq!(ext_count, 0, "no external transition should exist");
+    }
+
+    #[test]
+    fn heartbeat_scan_session_bumps_last_heartbeat_at_for_in_progress() {
+        use std::path::PathBuf;
+        use voom_domain::storage::FileStorage;
+
+        let store = SqliteStore::in_memory().expect("in-memory");
+        let session = store
+            .begin_scan_session(&[PathBuf::from("/m")])
+            .expect("begin");
+        let session_str = session.to_string();
+
+        // Force last_heartbeat_at into the distant past so we can prove
+        // the bump moved it forward.
+        let conn = store.conn().expect("conn");
+        conn.execute(
+            "UPDATE scan_sessions SET last_heartbeat_at = '1970-01-01T00:00:00Z' WHERE id = ?1",
+            rusqlite::params![&session_str],
+        )
+        .expect("force-set heartbeat");
+
+        store.heartbeat_scan_session(session).expect("heartbeat ok");
+
+        let now: String = conn
+            .query_row(
+                "SELECT last_heartbeat_at FROM scan_sessions WHERE id = ?1",
+                rusqlite::params![&session_str],
+                |row| row.get(0),
+            )
+            .expect("query");
+        assert_ne!(
+            now, "1970-01-01T00:00:00Z",
+            "heartbeat should have been moved off epoch"
+        );
+        // Sanity: parses as a real RFC3339 timestamp.
+        chrono::DateTime::parse_from_rfc3339(&now).expect("parse new heartbeat as RFC3339");
+    }
+
+    #[test]
+    fn heartbeat_scan_session_is_silent_for_non_in_progress_sessions() {
+        use std::path::PathBuf;
+        use voom_domain::storage::FileStorage;
+
+        let store = SqliteStore::in_memory().expect("in-memory");
+        let session = store
+            .begin_scan_session(&[PathBuf::from("/m")])
+            .expect("begin");
+        // Cancel it.
+        store.cancel_scan_session(session).expect("cancel");
+
+        let session_str = session.to_string();
+        let conn = store.conn().expect("conn");
+
+        // Note the heartbeat value AFTER cancel.
+        let before: String = conn
+            .query_row(
+                "SELECT last_heartbeat_at FROM scan_sessions WHERE id = ?1",
+                rusqlite::params![&session_str],
+                |row| row.get(0),
+            )
+            .expect("query");
+
+        // Sleep briefly so a successful bump would produce a different timestamp.
+        std::thread::sleep(std::time::Duration::from_millis(20));
+
+        store
+            .heartbeat_scan_session(session)
+            .expect("heartbeat ok on cancelled session");
+
+        let after: String = conn
+            .query_row(
+                "SELECT last_heartbeat_at FROM scan_sessions WHERE id = ?1",
+                rusqlite::params![&session_str],
+                |row| row.get(0),
+            )
+            .expect("query");
+
+        assert_eq!(
+            before, after,
+            "heartbeat must NOT bump non-in_progress sessions"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Adds a streaming pipeline to `voom scan`: discovery, per-file scan-session ingest, and bounded ffprobe workers all run concurrently with backpressure (discovery → ingest → probe).
- New `--probe-workers <N>` flag. Default `0` = auto (`min(num_cpus, sqlite_pool_size - 2)`, floor 1; 6 on the default 8-conn pool).
- Cancellation is observed at every stage; cancelled sessions end as `Cancelled` and never mark files missing (covered by regression test).
- Discovery summary, probe progress, and missing/orphan counts continue to be reported accurately; the empty-scan branch was the stop-time-review regression target and is now locked by a dedicated test.

Closes #359.

## Architecture

```text
discovery (spawn_blocking, rayon)
  └── mpsc<FileDiscoveredEvent> (depth = probe_workers * 4)
       └── ingest (spawn_blocking, holds scan session)
            └── mpsc<FileDiscoveredEvent> (depth = probe_workers * 4)
                 └── probe pool (JoinSet + Semaphore(probe_workers))
                      └── introspect_file → FileIntrospected events
```

Spec: `docs/superpowers/specs/2026-05-11-issue-359-scan-streaming-phase-2-design.md`.

## Test plan

- [x] `cargo test --workspace` — all targets pass
- [x] `cargo test -p voom-cli --features functional -- --test-threads=4` — 128 functional tests pass
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — zero warnings
- [x] `cargo fmt --all` — clean
- [x] Smoke scan against fake media with `--probe-workers 3` — pipeline runs cleanly, accurate error counts, no panics
- [x] 7 inline streaming tests cover: empty scan, double-session regression, cancellation safety, probe-failure counting, cache-hit bypass, post-drain DB visibility, --no-hash mode

## Notable cleanups along the way

- `ProbeProgress::new` / `::hidden` removed — pre-streaming dead code after the pipeline replaced `run_introspection`.
- Probe-task panic accounting added — `JoinSet::join_next` previously swallowed panics, leaving the bar stuck below total.
- Pre-cancellation race in ingest stage fixed (post-loop cancel check). Caught by `cancelled_scan_does_not_mark_missing` while writing tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)