### PR TITLE
feat(process): streaming phase 3 — enqueue work as files become ready

### DIFF
--- a/crates/voom-cli/src/commands/process/mod.rs
+++ b/crates/voom-cli/src/commands/process/mod.rs
@@ -16,7 +16,6 @@ use parking_lot::Mutex;
 
 use tokio_util::sync::CancellationToken;
 
-use dispatch::dispatch_and_log;
 use pipeline::process_single_file;
 
 use crate::app;
@@ -24,8 +23,7 @@ use crate::cli::{ErrorHandling, ProcessArgs};
 use crate::config;
 use crate::paths::resolve_paths;
 use crate::policy_map::PolicyResolver;
-use crate::progress::{BatchProgress, DiscoveryProgress};
-use voom_domain::bad_file::BadFileSource;
+use crate::progress::BatchProgress;
 use voom_domain::events::{
     Event, IntrospectSessionCompletedEvent, JobCompletedEvent, JobProgressEvent, JobStartedEvent,
 };
@@ -180,6 +178,19 @@ pub async fn run(args: ProcessArgs, quiet: bool, token: CancellationToken) -> Re
             Err(e) => tracing::warn!(error = %e, "crash recovery check failed"),
         }
 
+        // Pre-load the bad-file set so the streaming ingest stage can filter
+        // inline without per-file DB lookups.
+        let bad_files: std::collections::HashSet<std::path::PathBuf> = if args.force_rescan {
+            std::collections::HashSet::new()
+        } else {
+            store
+                .list_bad_files(&voom_domain::storage::BadFileFilters::default())
+                .context("failed to list bad files")?
+                .into_iter()
+                .map(|bf| bf.path)
+                .collect()
+        };
+
         if token.is_cancelled() {
             if !plan_only && !quiet {
                 eprintln!("{}", style("Interrupted before discovery.").yellow());
@@ -187,52 +198,20 @@ pub async fn run(args: ProcessArgs, quiet: bool, token: CancellationToken) -> Re
             return Ok(());
         }
 
-        let mut events = discover_files(&paths, &args, &kernel, quiet, store.clone())?;
-        if events.is_empty() {
-            if plan_only {
-                println!("[]");
-            } else if !quiet {
-                eprintln!("{}", style("No media files found.").yellow());
-            }
-            return Ok(());
-        }
-
-        // Filter out known-bad files unless --force-rescan is set
-        if !args.force_rescan {
-            filter_bad_files(&mut events, &store, plan_only, quiet)?;
-        }
-
-        if events.is_empty() {
-            if plan_only {
-                println!("[]");
-            } else if !quiet {
-                eprintln!("{}", style("No processable files found.").yellow());
-            }
-            return Ok(());
-        }
-
-        let file_count = events.len();
-        if !plan_only && !quiet {
-            eprintln!("Found {} media files.", style(file_count).bold());
-        }
-
         let on_error = match args.on_error {
             ErrorHandling::Fail => JobErrorStrategy::Fail,
             ErrorHandling::Continue => JobErrorStrategy::Continue,
         };
 
-        if token.is_cancelled() {
-            if !quiet {
-                eprintln!("{}", style("Interrupted before processing.").yellow());
-            }
-            return Ok(());
-        }
-
         let (pool, effective_workers) = create_worker_pool(job_queue, &args, token.clone());
+        let pool = Arc::new(pool);
 
-        let reporter = build_reporter(&events, effective_workers, plan_only, quiet, kernel.clone());
+        // Build reporter with an empty event list; the pipeline calls
+        // reporter.seed_events(&events) before on_batch_start once discovery
+        // finishes.
+        let reporter: Arc<dyn ProgressReporter> =
+            build_reporter(&[], effective_workers, plan_only, quiet, kernel.clone());
 
-        let items = build_work_items(&events, args.priority_by_date);
         let all_phase_names = resolver.all_phase_names();
         let resolver = Arc::new(resolver);
         let flag_size_increase = args.flag_size_increase;
@@ -248,64 +227,104 @@ pub async fn run(args: ProcessArgs, quiet: bool, token: CancellationToken) -> Re
         let ffprobe_path: Option<String> = config.ffprobe_path().map(String::from);
         let ffprobe_path = Arc::new(ffprobe_path);
         let animation_detection_mode = config.animation_detection_mode();
-        let counters_for_summary = counters.clone();
-        let kernel_for_completion = kernel.clone();
-        let store_for_summary = store.clone();
-        let _results = pool
-            .process_batch(
-                items,
-                move |job| {
-                    let resolver = resolver.clone();
-                    let kernel = kernel.clone();
-                    let store = store.clone();
-                    let token = token_for_workers.clone();
-                    let ffprobe_path = ffprobe_path.clone();
-                    let capabilities = capabilities.clone();
-                    let plan_limiter = plan_limiter.clone();
-                    let estimate_model = estimate_model.clone();
-                    let counters = counters.clone();
-                    async move {
-                        let ctx = ProcessContext {
-                            resolver: &resolver,
-                            kernel,
-                            store,
-                            dry_run,
-                            plan_only,
-                            estimate_mode,
-                            flag_size_increase,
-                            flag_duration_shrink,
-                            force_rescan,
-                            token: &token,
-                            ffprobe_path: ffprobe_path.as_deref(),
-                            animation_detection_mode,
-                            capabilities: &capabilities,
-                            plan_limiter,
-                            confirm_savings,
-                            estimate_model,
-                            counters: &counters,
-                        };
-                        process_single_file(job, &ctx).await
-                    }
-                },
-                on_error,
-                reporter.clone(),
-            )
-            .await;
+        let kernel_for_workers = kernel.clone();
+        let store_for_workers = store.clone();
+        let capabilities_for_workers = capabilities.clone();
+        let plan_limiter_for_workers = plan_limiter.clone();
+        let counters_for_workers = counters.clone();
+
+        let processor = move |job: voom_domain::job::Job| {
+            let resolver = resolver.clone();
+            let kernel = kernel_for_workers.clone();
+            let store = store_for_workers.clone();
+            let token = token_for_workers.clone();
+            let ffprobe_path = ffprobe_path.clone();
+            let capabilities = capabilities_for_workers.clone();
+            let plan_limiter = plan_limiter_for_workers.clone();
+            let estimate_model = estimate_model.clone();
+            let counters = counters_for_workers.clone();
+            async move {
+                let ctx = ProcessContext {
+                    resolver: &resolver,
+                    kernel,
+                    store,
+                    dry_run,
+                    plan_only,
+                    estimate_mode,
+                    flag_size_increase,
+                    flag_duration_shrink,
+                    force_rescan,
+                    token: &token,
+                    ffprobe_path: ffprobe_path.as_deref(),
+                    animation_detection_mode,
+                    capabilities: &capabilities,
+                    plan_limiter,
+                    confirm_savings,
+                    estimate_model,
+                    counters: &counters,
+                };
+                process_single_file(job, &ctx).await
+            }
+        };
+
+        let outcome = pipeline_streaming::run_streaming_pipeline(
+            &args,
+            &paths,
+            kernel.clone(),
+            store.clone(),
+            pool.clone(),
+            reporter.clone(),
+            on_error,
+            bad_files,
+            processor,
+            dry_run,
+            token.clone(),
+        )
+        .await?;
+
+        if outcome.discovery_errors > 0 {
+            tracing::warn!(
+                count = outcome.discovery_errors,
+                "discovery reported errors during streaming pipeline"
+            );
+        }
+
+        if outcome.discovered == 0 {
+            if plan_only {
+                println!("[]");
+            } else if !quiet {
+                eprintln!("{}", style("No media files found.").yellow());
+            }
+            return Ok(());
+        }
+
+        if outcome.skipped_bad > 0 && !plan_only && !quiet {
+            eprintln!(
+                "Skipping {} known-bad files (use {} to re-attempt).",
+                style(outcome.skipped_bad).yellow(),
+                style("--force-rescan").bold()
+            );
+        }
+
+        let file_count = outcome.enqueued as usize;
+        if !plan_only && !quiet {
+            eprintln!("Found {} media files.", style(file_count).bold());
+        }
 
         if !token.is_cancelled() {
-            kernel_for_completion.dispatch(Event::IntrospectSessionCompleted(
+            kernel.clone().dispatch(Event::IntrospectSessionCompleted(
                 IntrospectSessionCompletedEvent::new(pool.completed_count()),
             ));
         }
 
         print_run_results(&RunResultsContext {
-            counters: &counters_for_summary,
-            store: store_for_summary.as_ref(),
+            counters: &counters,
+            store: store.as_ref(),
             plan_only,
             estimate_mode,
             quiet,
             cancelled: token.is_cancelled(),
-            pool: &pool,
+            pool: pool.as_ref(),
             file_count,
             effective_workers,
             dry_run,
@@ -322,33 +341,6 @@ pub async fn run(args: ProcessArgs, quiet: bool, token: CancellationToken) -> Re
     );
 
     primary_result
-}
-
-/// Remove known-bad files from the event list, logging how many were skipped.
-fn filter_bad_files(
-    events: &mut Vec<voom_domain::events::FileDiscoveredEvent>,
-    store: &Arc<dyn voom_domain::storage::StorageTrait>,
-    plan_only: bool,
-    quiet: bool,
-) -> Result<()> {
-    let bad_files = store
-        .list_bad_files(&voom_domain::storage::BadFileFilters::default())
-        .context("failed to list bad files")?;
-    if bad_files.is_empty() {
-        return Ok(());
-    }
-    let bad_paths: std::collections::HashSet<_> = bad_files.iter().map(|bf| &bf.path).collect();
-    let before = events.len();
-    events.retain(|e| !bad_paths.contains(&e.path));
-    let skipped = before - events.len();
-    if skipped > 0 && !plan_only && !quiet {
-        eprintln!(
-            "Skipping {} known-bad files (use {} to re-attempt).",
-            style(skipped).yellow(),
-            style("--force-rescan").bold()
-        );
-    }
-    Ok(())
 }
 
 /// Build the progress reporter stack for the processing batch.
@@ -600,117 +592,6 @@ fn print_run_header(policy_name: &str, path_display: &str, dry_run: bool, sessio
     );
 }
 
-/// Walk the filesystem and discover media files, dispatching events through the kernel.
-///
-/// Creates a standalone `DiscoveryPlugin` for direct API access (scan options,
-/// progress callbacks) that the event-bus path does not support. `FileDiscovered`
-/// events are dispatched to the kernel so that subscribers react:
-/// - sqlite-store records each file in `discovered_files`
-/// - ffprobe-introspector enqueues `JobType::Introspect` jobs
-///
-/// Introspection is still driven directly by `process_single_file` for
-/// deterministic progress reporting.
-fn discover_files(
-    paths: &[std::path::PathBuf],
-    args: &ProcessArgs,
-    kernel: &voom_kernel::Kernel,
-    quiet: bool,
-    store: Arc<dyn voom_domain::storage::StorageTrait>,
-) -> Result<Vec<voom_domain::events::FileDiscoveredEvent>> {
-    let discovery = voom_discovery::DiscoveryPlugin::new();
-    let hash_files = !args.no_backup;
-
-    let progress = if quiet {
-        DiscoveryProgress::hidden()
-    } else {
-        DiscoveryProgress::new()
-    };
-
-    let discovery_errors: Arc<Mutex<Vec<(std::path::PathBuf, u64, String)>>> =
-        Arc::new(Mutex::new(Vec::new()));
-
-    let mut all_events: Vec<voom_domain::events::FileDiscoveredEvent> = Vec::new();
-
-    // Cumulative counters so the progress bar shows totals across all
-    // directories instead of resetting per directory.
-    let cumulative_discovered = Arc::new(std::sync::atomic::AtomicU64::new(0));
-    let processing_base = Arc::new(std::sync::atomic::AtomicU64::new(0));
-
-    for path in paths {
-        // Reset bar to spinner so stale position/length from the previous
-        // directory's processing phase doesn't bleed into this discovery.
-        progress.reset_to_spinner();
-
-        let mut options = voom_discovery::ScanOptions::new(path.clone());
-        options.hash_files = hash_files;
-        options.workers = args.workers;
-        options.fingerprint_lookup = Some(crate::introspect::fingerprint_lookup(store.clone()));
-
-        let progress_clone = progress.clone();
-        let cum_disc = cumulative_discovered.clone();
-        let proc_base = processing_base.clone();
-        let pre_scan_discovered = cumulative_discovered.load(std::sync::atomic::Ordering::Relaxed);
-
-        options.on_progress = Some(Box::new(move |p| match p {
-            voom_discovery::ScanProgress::Discovered { count: _, path } => {
-                let cumulative = cum_disc.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
-                let cumulative = usize::try_from(cumulative).unwrap_or(usize::MAX);
-                progress_clone.on_discovered(cumulative, &path);
-            }
-            voom_discovery::ScanProgress::Processing {
-                current,
-                total,
-                path,
-            } => {
-                let base = proc_base.load(std::sync::atomic::Ordering::Relaxed);
-                let base = usize::try_from(base).unwrap_or(usize::MAX);
-                let action = if hash_files { "Hashing" } else { "Scanning" };
-                progress_clone.on_processing(base + current, base + total, &path, action);
-            }
-            voom_discovery::ScanProgress::OrphanedTempFiles { .. } => {}
-            voom_discovery::ScanProgress::HashReused { .. } => {}
-        }));
-
-        let errors_clone = discovery_errors.clone();
-        options.on_error = Some(Box::new(move |path, size, error| {
-            tracing::warn!(path = %path.display(), error = %error, "discovery error");
-            errors_clone.lock().push((path, size, error));
-        }));
-
-        let events = discovery.scan(&options).context("filesystem scan failed")?;
-
-        let dir_discovered =
-            cumulative_discovered.load(std::sync::atomic::Ordering::Relaxed) - pre_scan_discovered;
-        processing_base.fetch_add(dir_discovered, std::sync::atomic::Ordering::Relaxed);
-
-        all_events.extend(events);
-    }
-
-    progress.finish();
-
-    let mut seen = std::collections::HashSet::new();
-    all_events.retain(|e| seen.insert(e.path.clone()));
-
-    for event in &all_events {
-        dispatch_and_log(kernel, Event::FileDiscovered(event.clone()));
-    }
-
-    for (path, size, error) in discovery_errors.lock().drain(..) {
-        crate::introspect::dispatch_failure(
-            kernel,
-            path,
-            size,
-            None,
-            &error,
-            BadFileSource::Discovery,
-        );
-    }
-
-    Ok(all_events)
-}
-
-use crate::introspect::DiscoveredFilePayload;
-
 /// Compute job priority based on file modification date.
 ///
 /// More recently modified files get higher priority (lower number).
@@ -739,32 +620,6 @@ pub(super) fn compute_file_date_priority(path: &std::path::Path) -> i32 {
     } else {
         200
     }
-}
-
-/// Build work items from discovery events for the worker pool.
-fn build_work_items(
-    events: &[voom_domain::events::FileDiscoveredEvent],
-    priority_by_date: bool,
-) -> Vec<voom_job_manager::worker::WorkItem<DiscoveredFilePayload>> {
-    events
-        .iter()
-        .map(|evt| {
-            let priority = if priority_by_date {
-                compute_file_date_priority(&evt.path)
-            } else {
-                100
-            };
-            voom_job_manager::worker::WorkItem::new(
-                voom_domain::job::JobType::Process,
-                priority,
-                Some(DiscoveredFilePayload {
-                    path: evt.path.to_string_lossy().into_owned(),
-                    size: evt.size,
-                    content_hash: evt.content_hash.clone(),
-                }),
-            )
-        })
-        .collect()
 }
 
 /// Set up the worker pool using the provided job queue.
@@ -1023,6 +878,7 @@ mod tests {
     use voom_domain::media::MediaFile;
     use voom_domain::plan::{ActionParams, OperationType, Plan, PlannedAction, TranscodeSettings};
 
+    use super::dispatch::dispatch_and_log;
     use super::pipeline::execute_single_plan;
     use super::plan_outcome::PlanOutcome;
     use super::safeguards::{check_disk_space, check_duration_shrink, check_size_increase};

--- a/crates/voom-cli/src/commands/process/mod.rs
+++ b/crates/voom-cli/src/commands/process/mod.rs
@@ -1,6 +1,7 @@
 mod audio_language;
 mod dispatch;
 mod pipeline;
+mod pipeline_streaming;
 mod plan_outcome;
 mod safeguards;
 mod transitions;
@@ -717,7 +718,7 @@ use crate::introspect::DiscoveredFilePayload;
 /// - Modified within 30 days: 50
 /// - Modified within 1 year: 100
 /// - Older or metadata unavailable: 200
-fn compute_file_date_priority(path: &std::path::Path) -> i32 {
+pub(super) fn compute_file_date_priority(path: &std::path::Path) -> i32 {
     const SECS_PER_DAY: u64 = 86_400;
     let Ok(metadata) = std::fs::metadata(path) else {
         return 200;

--- a/crates/voom-cli/src/commands/process/mod.rs
+++ b/crates/voom-cli/src/commands/process/mod.rs
@@ -277,7 +277,8 @@ pub async fn run(args: ProcessArgs, quiet: bool, token: CancellationToken) -> Re
             on_error,
             bad_files,
             processor,
-            dry_run,
+            quiet,
+            plan_only,
             token.clone(),
         )
         .await?;
@@ -290,7 +291,11 @@ pub async fn run(args: ProcessArgs, quiet: bool, token: CancellationToken) -> Re
         }
 
         if outcome.discovered == 0 {
-            if plan_only {
+            if token.is_cancelled() {
+                if !plan_only && !quiet {
+                    eprintln!("{}", style("Interrupted before processing.").yellow());
+                }
+            } else if plan_only {
                 println!("[]");
             } else if !quiet {
                 eprintln!("{}", style("No media files found.").yellow());
@@ -307,12 +312,9 @@ pub async fn run(args: ProcessArgs, quiet: bool, token: CancellationToken) -> Re
         }
 
         let file_count = outcome.enqueued as usize;
-        if !plan_only && !quiet {
-            eprintln!("Found {} media files.", style(file_count).bold());
-        }
 
         if !token.is_cancelled() {
-            kernel.clone().dispatch(Event::IntrospectSessionCompleted(
+            kernel.dispatch(Event::IntrospectSessionCompleted(
                 IntrospectSessionCompletedEvent::new(pool.completed_count()),
             ));
         }

--- a/crates/voom-cli/src/commands/process/pipeline_streaming.rs
+++ b/crates/voom-cli/src/commands/process/pipeline_streaming.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use anyhow::{Context, Result};
+use console::style;
 use parking_lot::Mutex;
 use tokio::sync::{Notify, mpsc};
 use tokio::task::JoinHandle;
@@ -89,7 +90,8 @@ pub(crate) async fn run_streaming_pipeline<F, Fut>(
     on_error: JobErrorStrategy,
     bad_files: HashSet<PathBuf>,
     processor: F,
-    _dry_run: bool,
+    quiet: bool,
+    plan_only: bool,
     token: CancellationToken,
 ) -> Result<StreamingOutcome>
 where
@@ -144,6 +146,8 @@ where
         skipped_bad.clone(),
         events_for_eta.clone(),
         reporter.clone(),
+        quiet,
+        plan_only,
     );
 
     // Drive the pool future concurrently with discovery and ingest. Awaiting
@@ -304,6 +308,8 @@ fn spawn_ingest_stage(
     skipped_bad: Arc<AtomicU64>,
     events_for_eta: Arc<Mutex<Vec<FileDiscoveredEvent>>>,
     reporter: Arc<dyn ProgressReporter>,
+    quiet: bool,
+    plan_only: bool,
 ) -> JoinHandle<Result<()>> {
     tokio::spawn(async move {
         let mut seen: HashSet<PathBuf> = HashSet::new();
@@ -371,6 +377,13 @@ fn spawn_ingest_stage(
             let events = events_for_eta.lock().clone();
             reporter.seed_events(&events);
             reporter.on_batch_start(events.len());
+
+            // Print the "Found N media files." line BEFORE workers start so the
+            // user sees discovery's final count between the spinner and the
+            // per-file progress bar, matching the pre-streaming UX.
+            if !plan_only && !quiet && !token.is_cancelled() {
+                eprintln!("Found {} media files.", style(events.len()).bold());
+            }
 
             // Sleep briefly so worker tasks reach their first `.notified()`
             // point. In production discovery takes orders of magnitude
@@ -478,6 +491,7 @@ mod tests {
                 }
             },
             true,
+            true,
             token,
         )
         .await
@@ -513,6 +527,7 @@ mod tests {
             JobErrorStrategy::Continue,
             bad,
             |_job| async { Ok(None) },
+            true,
             true,
             token,
         )

--- a/crates/voom-cli/src/commands/process/pipeline_streaming.rs
+++ b/crates/voom-cli/src/commands/process/pipeline_streaming.rs
@@ -167,8 +167,10 @@ where
     // serializing the awaits and cancelling on the first failure we mirror
     // the structure used in `scan/pipeline.rs`.
     let pool_reporter = reporter.clone();
+    let pool_for_task = pool.clone();
     let pool_handle: JoinHandle<Vec<JobResult>> = tokio::spawn(async move {
-        pool.process_stream(rx_items, execution_gate, processor, on_error, pool_reporter)
+        pool_for_task
+            .process_stream(rx_items, execution_gate, processor, on_error, pool_reporter)
             .await
     });
 
@@ -179,11 +181,17 @@ where
     let disc_join = discovery_handle.await;
     if disc_join.as_ref().map_or(true, |r| r.is_err()) {
         pipeline_cancel.cancel();
+        // Also cancel the worker pool so it exits its gate wait promptly.
+        // pipeline_cancel is a CHILD of `token`, but the pool was constructed
+        // with `token` — child cancellation alone won't reach the pool's
+        // internal token, leaving workers hung on execution_gate.notified().
+        pool.cancel();
     }
 
     let ingest_join = ingest_handle.await;
     if ingest_join.as_ref().map_or(true, |r| r.is_err()) {
         pipeline_cancel.cancel();
+        pool.cancel();
     }
 
     let pool_join = pool_handle.await;
@@ -685,6 +693,45 @@ mod tests {
             successes <= 4,
             "fail-fast should stop short of all 10 files, got {successes} successes"
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn discovery_error_does_not_hang_pool() {
+        // Discovery is given a non-existent root so scan_streaming returns
+        // Err on the first path. The pipeline must propagate that error
+        // promptly and the pool must not be left waiting on the gate.
+        let token = CancellationToken::new();
+        let (pool, store, kernel) = make_pool(token.clone());
+
+        let missing = std::path::PathBuf::from("/does/not/exist/for/streaming/test");
+        let args = make_test_args(vec![missing.clone()]);
+
+        // Race with a 5-second hard timeout — without the fix this hangs
+        // forever.
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            run_streaming_pipeline(
+                &args,
+                &args.paths,
+                kernel,
+                store,
+                pool.clone(),
+                Arc::new(NoopReporter),
+                JobErrorStrategy::Continue,
+                HashSet::new(),
+                |_job| async { Ok(None) },
+                true,
+                true,
+                token,
+            ),
+        )
+        .await;
+
+        match result {
+            Ok(Err(_)) => { /* pipeline returned an error — good */ }
+            Ok(Ok(_)) => panic!("pipeline returned Ok despite discovery error"),
+            Err(_) => panic!("pipeline hung instead of propagating the discovery error"),
+        }
     }
 
     #[tokio::test]

--- a/crates/voom-cli/src/commands/process/pipeline_streaming.rs
+++ b/crates/voom-cli/src/commands/process/pipeline_streaming.rs
@@ -1,9 +1,3 @@
-// The streaming pipeline is constructed in this task (Task 5) and wired into
-// `process::run` in the next task. Until then the public symbols below have
-// no production caller, only tests, so dead-code lints would fire under
-// `-D warnings`. The allow is removed by Task 6's commit.
-#![allow(dead_code)]
-
 //! Streaming pipeline for `voom process`: discovery → ingest → worker pool.
 //!
 //! Mirrors the layout of `scan/pipeline.rs`. The discovery stage runs
@@ -51,8 +45,15 @@ pub(crate) struct StreamingOutcome {
     /// Errors raised by the discovery walk (open / hash failures).
     pub(crate) discovery_errors: u64,
     /// Full `FileDiscoveredEvent` set fed to the reporter via `seed_events`.
+    /// Surfaced on the outcome so Task 7 integration tests can assert on the
+    /// exact event stream observed by the reporter without re-running discovery.
+    #[allow(dead_code)]
     pub(crate) events_for_eta: Vec<FileDiscoveredEvent>,
-    /// `Vec<JobResult>` returned by the worker pool.
+    /// `Vec<JobResult>` returned by the worker pool. Production callers don't
+    /// inspect this (results are aggregated through the kernel event bus and
+    /// `RunCounters`), but Task 7 integration tests verify per-job outcomes
+    /// directly off this field.
+    #[allow(dead_code)]
     pub(crate) job_results: Vec<JobResult>,
 }
 

--- a/crates/voom-cli/src/commands/process/pipeline_streaming.rs
+++ b/crates/voom-cli/src/commands/process/pipeline_streaming.rs
@@ -83,7 +83,7 @@ pub(crate) async fn run_streaming_pipeline<F, Fut>(
     paths: &[PathBuf],
     kernel: Arc<voom_kernel::Kernel>,
     store: Arc<dyn StorageTrait>,
-    pool: &WorkerPool,
+    pool: Arc<WorkerPool>,
     reporter: Arc<dyn ProgressReporter>,
     on_error: JobErrorStrategy,
     bad_files: HashSet<PathBuf>,
@@ -152,21 +152,45 @@ where
     // stage via `pipeline_cancel` — discovery cancels the token if its scan
     // errors, ingest observes the token in its receive select, and the pool's
     // workers observe their own copy via `WorkerPool::new`'s `token`.
-    let pool_future = pool.process_stream(
-        rx_items,
-        execution_gate,
-        processor,
-        on_error,
-        reporter.clone(),
-    );
-    let (disc_join, ingest_join, job_results) =
-        tokio::join!(discovery_handle, ingest_handle, pool_future);
+    //
+    // We wrap the pool future in its own `tokio::spawn` so all three stages
+    // are `JoinHandle`s. If we used `tokio::join!` directly with a bare
+    // future, a panic in the pool future would resolve `join!` only after
+    // the two `JoinHandle`s also resolved — dropping a `JoinHandle` only
+    // detaches the task, it does NOT abort it. Discovery and ingest could
+    // keep running indefinitely with `pipeline_cancel` never tripped. By
+    // serializing the awaits and cancelling on the first failure we mirror
+    // the structure used in `scan/pipeline.rs`.
+    let pool_reporter = reporter.clone();
+    let pool_handle: JoinHandle<Vec<JobResult>> = tokio::spawn(async move {
+        pool.process_stream(rx_items, execution_gate, processor, on_error, pool_reporter)
+            .await
+    });
 
-    // Propagate errors in source order: discovery → ingest. If either fails
-    // it has already cancelled `pipeline_cancel` and the ingest stage will
-    // have dropped `tx_items`, draining the pool to a clean stop.
+    // Await each handle in source order. After each await, if the result
+    // indicates failure (join error OR the task's own Err), cancel the
+    // child token so sibling stages observe the failure rather than
+    // continuing on the finish path.
+    let disc_join = discovery_handle.await;
+    if disc_join.as_ref().map_or(true, |r| r.is_err()) {
+        pipeline_cancel.cancel();
+    }
+
+    let ingest_join = ingest_handle.await;
+    if ingest_join.as_ref().map_or(true, |r| r.is_err()) {
+        pipeline_cancel.cancel();
+    }
+
+    let pool_join = pool_handle.await;
+    // No further stages remain to cancel; the pool's own `JoinError` is
+    // surfaced below via `.context()?`.
+
+    // Propagate errors in source order: discovery → ingest → pool. The
+    // `??` idiom: outer `?` propagates the JoinError (after .context()),
+    // inner `?` propagates the task's own Err.
     disc_join.context("discovery task join failed")??;
     ingest_join.context("ingest task join failed")??;
+    let job_results = pool_join.context("pool task join failed")?;
 
     let events_for_eta = Arc::try_unwrap(events_for_eta)
         .map(parking_lot::Mutex::into_inner)
@@ -248,9 +272,12 @@ fn spawn_discovery_stage(
         };
         let result = run_scan();
 
-        // Cancel BEFORE dropping tx_disc so the ingest stage's post-recv
-        // cancellation check sees the token as cancelled. Mirrors the
-        // pattern used by scan/pipeline.rs.
+        // Cancel BEFORE dropping tx_disc on error. When tx_disc is dropped,
+        // ingest's tokio::select! arm `ev = rx_disc.recv()` resolves to None,
+        // breaking the ingest loop. By cancelling first, ingest's gate-fire
+        // check at end of loop (`if !token.is_cancelled() { ... }`) observes
+        // the cancellation and skips seeding the reporter / opening the
+        // gate.
         if result.is_err() {
             token.cancel();
         }
@@ -334,11 +361,16 @@ fn spawn_ingest_stage(
         // its body with `execution_gate.notified()`) has reached the await
         // point. `notify_one` is not a workable alternative because `Notify`
         // stores at most one permit regardless of how many calls are made.
-        let events = events_for_eta.lock().clone();
-        reporter.seed_events(&events);
-        reporter.on_batch_start(events.len());
-
+        //
+        // Skip seeding the reporter and opening the gate entirely when
+        // cancelled. The partial event set collected so far is meaningless
+        // — `BatchProgress` would render a misleading total and never tick
+        // because no workers will run.
         if !token.is_cancelled() {
+            let events = events_for_eta.lock().clone();
+            reporter.seed_events(&events);
+            reporter.on_batch_start(events.len());
+
             // Sleep briefly so worker tasks reach their first `.notified()`
             // point. In production discovery takes orders of magnitude
             // longer than 10ms, so this is essentially free in the common
@@ -396,7 +428,11 @@ mod tests {
 
     fn make_pool(
         token: CancellationToken,
-    ) -> (WorkerPool, Arc<dyn StorageTrait>, Arc<voom_kernel::Kernel>) {
+    ) -> (
+        Arc<WorkerPool>,
+        Arc<dyn StorageTrait>,
+        Arc<voom_kernel::Kernel>,
+    ) {
         let store: Arc<dyn StorageTrait> =
             Arc::new(voom_domain::test_support::InMemoryStore::new());
         let job_store: Arc<dyn voom_domain::storage::JobStorage> =
@@ -405,7 +441,7 @@ mod tests {
         let mut config = WorkerPoolConfig::default();
         config.max_workers = 2;
         config.worker_prefix = "test".into();
-        let pool = WorkerPool::new(queue, config, token);
+        let pool = Arc::new(WorkerPool::new(queue, config, token));
         let kernel = Arc::new(voom_kernel::Kernel::new());
         (pool, store, kernel)
     }
@@ -429,7 +465,7 @@ mod tests {
             &args.paths,
             kernel,
             store,
-            &pool,
+            pool,
             Arc::new(NoopReporter),
             JobErrorStrategy::Continue,
             HashSet::new(),
@@ -471,7 +507,7 @@ mod tests {
             &args.paths,
             kernel,
             store,
-            &pool,
+            pool,
             Arc::new(NoopReporter),
             JobErrorStrategy::Continue,
             bad,

--- a/crates/voom-cli/src/commands/process/pipeline_streaming.rs
+++ b/crates/voom-cli/src/commands/process/pipeline_streaming.rs
@@ -538,4 +538,191 @@ mod tests {
         assert_eq!(outcome.enqueued, 1);
         assert_eq!(outcome.skipped_bad, 1);
     }
+
+    #[tokio::test]
+    async fn streaming_enqueues_during_discovery() {
+        let tmp = TempDir::new().unwrap();
+        for i in 0..20 {
+            write_fixture(tmp.path(), &format!("f{i:02}.mkv"), b"x");
+        }
+
+        let token = CancellationToken::new();
+        let (pool, store, kernel) = make_pool(token.clone());
+        let args = make_test_args(vec![tmp.path().to_path_buf()]);
+
+        let invocations = Arc::new(AtomicU64::new(0));
+        let invocations_clone = invocations.clone();
+
+        let outcome = run_streaming_pipeline(
+            &args,
+            &args.paths,
+            kernel,
+            store,
+            pool,
+            Arc::new(NoopReporter),
+            JobErrorStrategy::Continue,
+            HashSet::new(),
+            move |_job| {
+                let c = invocations_clone.clone();
+                async move {
+                    c.fetch_add(1, Ordering::SeqCst);
+                    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+                    Ok(None)
+                }
+            },
+            true,
+            true,
+            token,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome.discovered, 20);
+        assert_eq!(outcome.enqueued, 20);
+        assert!(invocations.load(Ordering::SeqCst) >= 20);
+    }
+
+    #[tokio::test]
+    async fn cancellation_during_discovery_leaves_no_pending_jobs() {
+        let tmp = TempDir::new().unwrap();
+        for i in 0..50 {
+            write_fixture(tmp.path(), &format!("f{i:02}.mkv"), b"x");
+        }
+        let token = CancellationToken::new();
+        let (pool, store, kernel) = make_pool(token.clone());
+        let args = make_test_args(vec![tmp.path().to_path_buf()]);
+
+        let token_for_cancel = token.clone();
+        let processor = move |_job: voom_domain::job::Job| {
+            let token_for_cancel = token_for_cancel.clone();
+            async move {
+                token_for_cancel.cancel();
+                Err::<Option<serde_json::Value>, String>("cancelled mid-run".into())
+            }
+        };
+
+        let pool_clone = pool.clone();
+        let _outcome = run_streaming_pipeline(
+            &args,
+            &args.paths,
+            kernel,
+            store,
+            pool,
+            Arc::new(NoopReporter),
+            JobErrorStrategy::Continue,
+            HashSet::new(),
+            processor,
+            true,
+            true,
+            token,
+        )
+        .await
+        .unwrap();
+
+        let mut filters = voom_domain::storage::JobFilters::default();
+        filters.status = Some(voom_domain::job::JobStatus::Pending);
+        let pending = pool_clone.queue().list_jobs(&filters).unwrap();
+        assert!(
+            pending.is_empty(),
+            "no jobs should remain in Pending after cancel, got {}",
+            pending.len()
+        );
+    }
+
+    #[tokio::test]
+    async fn fail_fast_with_pending_streamed_jobs() {
+        let tmp = TempDir::new().unwrap();
+        for i in 0..10 {
+            write_fixture(tmp.path(), &format!("f{i:02}.mkv"), b"x");
+        }
+        let token = CancellationToken::new();
+        let (pool, store, kernel) = make_pool(token.clone());
+        let args = make_test_args(vec![tmp.path().to_path_buf()]);
+
+        let invocations = Arc::new(AtomicU64::new(0));
+        let invocations_clone = invocations.clone();
+        let processor = move |_job: voom_domain::job::Job| {
+            let c = invocations_clone.clone();
+            async move {
+                let n = c.fetch_add(1, Ordering::SeqCst);
+                if n == 2 {
+                    Err::<Option<serde_json::Value>, String>("boom".into())
+                } else {
+                    Ok(None)
+                }
+            }
+        };
+
+        let outcome = run_streaming_pipeline(
+            &args,
+            &args.paths,
+            kernel,
+            store,
+            pool,
+            Arc::new(NoopReporter),
+            JobErrorStrategy::Fail,
+            HashSet::new(),
+            processor,
+            true,
+            true,
+            token,
+        )
+        .await
+        .unwrap();
+
+        let failures = outcome
+            .job_results
+            .iter()
+            .filter(|r| !r.is_success())
+            .count();
+        let successes = outcome
+            .job_results
+            .iter()
+            .filter(|r| r.is_success())
+            .count();
+        assert!(failures >= 1, "expected at least one failure, got 0");
+        assert!(
+            successes <= 4,
+            "fail-fast should stop short of all 10 files, got {successes} successes"
+        );
+    }
+
+    #[tokio::test]
+    async fn bounded_buffering_under_large_input() {
+        let tmp = TempDir::new().unwrap();
+        for i in 0..200 {
+            write_fixture(tmp.path(), &format!("f{i:03}.mkv"), b"x");
+        }
+        let token = CancellationToken::new();
+        let (pool, store, kernel) = make_pool(token.clone());
+        let args = make_test_args(vec![tmp.path().to_path_buf()]);
+
+        let outcome = run_streaming_pipeline(
+            &args,
+            &args.paths,
+            kernel,
+            store,
+            pool,
+            Arc::new(NoopReporter),
+            JobErrorStrategy::Continue,
+            HashSet::new(),
+            |_job| async {
+                tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+                Ok(None)
+            },
+            true,
+            true,
+            token,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome.enqueued, 200);
+        let successes = outcome
+            .job_results
+            .iter()
+            .filter(|r| r.is_success())
+            .count();
+        assert_eq!(successes, 200, "expected all 200 jobs to succeed");
+    }
 }

--- a/crates/voom-cli/src/commands/process/pipeline_streaming.rs
+++ b/crates/voom-cli/src/commands/process/pipeline_streaming.rs
@@ -1,0 +1,489 @@
+// The streaming pipeline is constructed in this task (Task 5) and wired into
+// `process::run` in the next task. Until then the public symbols below have
+// no production caller, only tests, so dead-code lints would fire under
+// `-D warnings`. The allow is removed by Task 6's commit.
+#![allow(dead_code)]
+
+//! Streaming pipeline for `voom process`: discovery → ingest → worker pool.
+//!
+//! Mirrors the layout of `scan/pipeline.rs`. The discovery stage runs
+//! `DiscoveryPlugin::scan_streaming` inside `spawn_blocking` and pushes
+//! `FileDiscoveredEvent`s into a bounded `mpsc` channel. The ingest stage
+//! filters known-bad paths, dedupes overlapping roots, dispatches
+//! `Event::FileDiscovered` through the kernel (so sqlite-store and the
+//! ffprobe-introspector see every file), and forwards a
+//! `WorkItem<DiscoveredFilePayload>` to a second bounded channel that
+//! feeds `WorkerPool::process_stream`.
+//!
+//! The "I'm done producing" signal from the ingest stage is the drop of
+//! `tx_items` — there is no separate `Notify`. The `execution_gate` is
+//! still real: workers wait on it before claiming their first job so the
+//! reporter sees the full discovery set before any work begins.
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use anyhow::{Context, Result};
+use parking_lot::Mutex;
+use tokio::sync::{Notify, mpsc};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+use voom_domain::bad_file::BadFileSource;
+use voom_domain::events::{Event, FileDiscoveredEvent};
+use voom_domain::storage::StorageTrait;
+use voom_job_manager::progress::ProgressReporter;
+use voom_job_manager::worker::{JobErrorStrategy, JobResult, WorkItem, WorkerPool};
+
+use crate::cli::ProcessArgs;
+use crate::introspect::DiscoveredFilePayload;
+
+/// Outcome of a streaming run. The fields here feed `print_run_results` and
+/// the post-pipeline summary lines in `process::run`.
+pub(crate) struct StreamingOutcome {
+    /// Total files emitted by discovery (after dedup, before bad-file filter).
+    pub(crate) discovered: u64,
+    /// Files actually enqueued (after bad-file filter).
+    pub(crate) enqueued: u64,
+    /// Files dropped by the bad-file filter.
+    pub(crate) skipped_bad: u64,
+    /// Errors raised by the discovery walk (open / hash failures).
+    pub(crate) discovery_errors: u64,
+    /// Full `FileDiscoveredEvent` set fed to the reporter via `seed_events`.
+    pub(crate) events_for_eta: Vec<FileDiscoveredEvent>,
+    /// `Vec<JobResult>` returned by the worker pool.
+    pub(crate) job_results: Vec<JobResult>,
+}
+
+/// Channel capacity per worker. Same constant as scan phase 2.
+const CHANNEL_DEPTH_PER_WORKER: usize = 4;
+
+/// Drive the full process streaming pipeline.
+///
+/// Three stages run concurrently:
+///
+/// 1. **Discovery** — `DiscoveryPlugin::scan_streaming` inside `spawn_blocking`,
+///    pushing `FileDiscoveredEvent`s into `tx_disc`.
+/// 2. **Ingest** — async task that dedupes, filters known-bad paths,
+///    dispatches `FileDiscovered` through the kernel, builds `WorkItem`s, and
+///    forwards them to `tx_items`. When `rx_disc` drains it drops `tx_items`
+///    and (for mutating runs) releases `execution_gate` so the pool can
+///    start claiming.
+/// 3. **Pool** — `WorkerPool::process_stream` drains `rx_items`, enqueues
+///    rows into the job queue, and runs workers in parallel.
+///
+/// Cancellation: a child token derived from `token`. Any stage failure
+/// cancels the child token; siblings observe and exit. All three handles
+/// are awaited unconditionally; the first error is propagated in source
+/// order (discovery → ingest).
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn run_streaming_pipeline<F, Fut>(
+    args: &ProcessArgs,
+    paths: &[PathBuf],
+    kernel: Arc<voom_kernel::Kernel>,
+    store: Arc<dyn StorageTrait>,
+    pool: &WorkerPool,
+    reporter: Arc<dyn ProgressReporter>,
+    on_error: JobErrorStrategy,
+    bad_files: HashSet<PathBuf>,
+    processor: F,
+    _dry_run: bool,
+    token: CancellationToken,
+) -> Result<StreamingOutcome>
+where
+    F: Fn(voom_domain::job::Job) -> Fut + Send + Sync + 'static,
+    Fut: std::future::Future<Output = std::result::Result<Option<serde_json::Value>, String>>
+        + Send
+        + 'static,
+{
+    let effective_workers = pool.config().effective_workers();
+    let channel_depth = effective_workers * CHANNEL_DEPTH_PER_WORKER;
+
+    let (tx_disc, rx_disc) = mpsc::channel::<FileDiscoveredEvent>(channel_depth);
+    let (tx_items, rx_items) = mpsc::channel::<WorkItem<DiscoveredFilePayload>>(channel_depth);
+
+    let execution_gate = Arc::new(Notify::new());
+    let pipeline_cancel = token.child_token();
+
+    // The gate is always fired by the ingest stage once the channel drains —
+    // this is the moment we know the full discovery set, so reporters can be
+    // seeded with deterministic totals before workers begin claiming. Workers
+    // wait on the gate (edge-triggered `notify_waiters`) so this ordering is
+    // strict: workers register first, then ingest opens the gate after
+    // `tx_items` is dropped.
+
+    let discovery_errors = Arc::new(AtomicU64::new(0));
+    let events_for_eta: Arc<Mutex<Vec<FileDiscoveredEvent>>> = Arc::new(Mutex::new(Vec::new()));
+    let enqueued = Arc::new(AtomicU64::new(0));
+    let discovered = Arc::new(AtomicU64::new(0));
+    let skipped_bad = Arc::new(AtomicU64::new(0));
+
+    let discovery_handle = spawn_discovery_stage(
+        args,
+        paths,
+        store.clone(),
+        kernel.clone(),
+        tx_disc,
+        pipeline_cancel.clone(),
+        discovery_errors.clone(),
+    );
+
+    let ingest_handle = spawn_ingest_stage(
+        kernel.clone(),
+        bad_files,
+        args.force_rescan,
+        args.priority_by_date,
+        rx_disc,
+        tx_items,
+        execution_gate.clone(),
+        pipeline_cancel.clone(),
+        discovered.clone(),
+        enqueued.clone(),
+        skipped_bad.clone(),
+        events_for_eta.clone(),
+        reporter.clone(),
+    );
+
+    // Drive the pool future concurrently with discovery and ingest. Awaiting
+    // sequentially would deadlock: ingest sends `WorkItem`s into rx_items but
+    // until `process_stream` is being polled there is no enqueuer task to
+    // drain that channel. Cross-stage cancellation is handled inside each
+    // stage via `pipeline_cancel` — discovery cancels the token if its scan
+    // errors, ingest observes the token in its receive select, and the pool's
+    // workers observe their own copy via `WorkerPool::new`'s `token`.
+    let pool_future = pool.process_stream(
+        rx_items,
+        execution_gate,
+        processor,
+        on_error,
+        reporter.clone(),
+    );
+    let (disc_join, ingest_join, job_results) =
+        tokio::join!(discovery_handle, ingest_handle, pool_future);
+
+    // Propagate errors in source order: discovery → ingest. If either fails
+    // it has already cancelled `pipeline_cancel` and the ingest stage will
+    // have dropped `tx_items`, draining the pool to a clean stop.
+    disc_join.context("discovery task join failed")??;
+    ingest_join.context("ingest task join failed")??;
+
+    let events_for_eta = Arc::try_unwrap(events_for_eta)
+        .map(parking_lot::Mutex::into_inner)
+        .unwrap_or_else(|m| m.lock().clone());
+
+    Ok(StreamingOutcome {
+        discovered: discovered.load(Ordering::Relaxed),
+        enqueued: enqueued.load(Ordering::Relaxed),
+        skipped_bad: skipped_bad.load(Ordering::Relaxed),
+        discovery_errors: discovery_errors.load(Ordering::Relaxed),
+        events_for_eta,
+        job_results,
+    })
+}
+
+// --- Discovery stage --------------------------------------------------------
+
+#[allow(clippy::too_many_arguments)]
+fn spawn_discovery_stage(
+    args: &ProcessArgs,
+    paths: &[PathBuf],
+    store: Arc<dyn StorageTrait>,
+    kernel: Arc<voom_kernel::Kernel>,
+    tx_disc: mpsc::Sender<FileDiscoveredEvent>,
+    token: CancellationToken,
+    discovery_errors: Arc<AtomicU64>,
+) -> JoinHandle<Result<()>> {
+    let workers = args.workers;
+    let hash_files = !args.no_backup;
+    let paths = paths.to_vec();
+
+    tokio::task::spawn_blocking(move || -> Result<()> {
+        let discovery = voom_discovery::DiscoveryPlugin::new();
+
+        let run_scan = || -> Result<()> {
+            for path in &paths {
+                if token.is_cancelled() {
+                    break;
+                }
+
+                let mut options = voom_discovery::ScanOptions::new(path.clone());
+                options.hash_files = hash_files;
+                options.workers = workers;
+                options.fingerprint_lookup =
+                    Some(crate::introspect::fingerprint_lookup(store.clone()));
+
+                let kernel_clone = kernel.clone();
+                let errors_clone = discovery_errors.clone();
+                options.on_error = Some(Box::new(move |path, size, error| {
+                    tracing::warn!(path = %path.display(), error = %error, "discovery error");
+                    errors_clone.fetch_add(1, Ordering::Relaxed);
+                    crate::introspect::dispatch_failure(
+                        &kernel_clone,
+                        path,
+                        size,
+                        None,
+                        &error,
+                        BadFileSource::Discovery,
+                    );
+                }));
+
+                let token_inner = token.clone();
+                let tx_inner = tx_disc.clone();
+                let on_event: voom_discovery::EventSink = Box::new(move |event| {
+                    if token_inner.is_cancelled() {
+                        return;
+                    }
+                    // blocking_send applies natural backpressure: when the
+                    // ingest channel is full this blocks the rayon worker
+                    // until the ingest stage drains.
+                    let _ = tx_inner.blocking_send(event);
+                });
+
+                discovery
+                    .scan_streaming(&options, on_event)
+                    .with_context(|| format!("filesystem scan failed for {}", path.display()))?;
+            }
+            Ok(())
+        };
+        let result = run_scan();
+
+        // Cancel BEFORE dropping tx_disc so the ingest stage's post-recv
+        // cancellation check sees the token as cancelled. Mirrors the
+        // pattern used by scan/pipeline.rs.
+        if result.is_err() {
+            token.cancel();
+        }
+        drop(tx_disc);
+        result
+    })
+}
+
+// --- Ingest stage -----------------------------------------------------------
+
+#[allow(clippy::too_many_arguments)]
+fn spawn_ingest_stage(
+    kernel: Arc<voom_kernel::Kernel>,
+    bad_files: HashSet<PathBuf>,
+    force_rescan: bool,
+    priority_by_date: bool,
+    mut rx_disc: mpsc::Receiver<FileDiscoveredEvent>,
+    tx_items: mpsc::Sender<WorkItem<DiscoveredFilePayload>>,
+    execution_gate: Arc<Notify>,
+    token: CancellationToken,
+    discovered: Arc<AtomicU64>,
+    enqueued: Arc<AtomicU64>,
+    skipped_bad: Arc<AtomicU64>,
+    events_for_eta: Arc<Mutex<Vec<FileDiscoveredEvent>>>,
+    reporter: Arc<dyn ProgressReporter>,
+) -> JoinHandle<Result<()>> {
+    tokio::spawn(async move {
+        let mut seen: HashSet<PathBuf> = HashSet::new();
+
+        loop {
+            let event = tokio::select! {
+                biased;
+                () = token.cancelled() => break,
+                ev = rx_disc.recv() => ev,
+            };
+            let Some(event) = event else { break };
+
+            if !seen.insert(event.path.clone()) {
+                continue;
+            }
+            discovered.fetch_add(1, Ordering::Relaxed);
+
+            if !force_rescan && bad_files.contains(&event.path) {
+                skipped_bad.fetch_add(1, Ordering::Relaxed);
+                continue;
+            }
+
+            events_for_eta.lock().push(event.clone());
+            super::dispatch::dispatch_and_log(&kernel, Event::FileDiscovered(event.clone()));
+
+            let priority = if priority_by_date {
+                super::compute_file_date_priority(&event.path)
+            } else {
+                100
+            };
+            let payload = DiscoveredFilePayload {
+                path: event.path.to_string_lossy().into_owned(),
+                size: event.size,
+                content_hash: event.content_hash.clone(),
+            };
+            let item = WorkItem::new(voom_domain::job::JobType::Process, priority, Some(payload));
+            if tx_items.send(item).await.is_err() {
+                // The pool's enqueuer dropped its receiver; bail out.
+                break;
+            }
+            enqueued.fetch_add(1, Ordering::Relaxed);
+        }
+
+        // Dropping tx_items signals "no more work" to the pool's enqueuer.
+        drop(tx_items);
+
+        // Seed the reporter with the full discovery set so progress bars and
+        // ETA reporters have determinate totals before workers begin. Then
+        // open the gate so workers can claim. For dry-run, mutating, and
+        // estimate flows this ordering is the same: reporters see the full
+        // set, then workers start.
+        //
+        // `Notify::notify_waiters` is edge-triggered: it only wakes waiters
+        // that have already called `.notified()`. We yield to the runtime a
+        // few times before firing so that every worker task (which starts
+        // its body with `execution_gate.notified()`) has reached the await
+        // point. `notify_one` is not a workable alternative because `Notify`
+        // stores at most one permit regardless of how many calls are made.
+        let events = events_for_eta.lock().clone();
+        reporter.seed_events(&events);
+        reporter.on_batch_start(events.len());
+
+        if !token.is_cancelled() {
+            // Sleep briefly so worker tasks reach their first `.notified()`
+            // point. In production discovery takes orders of magnitude
+            // longer than 10ms, so this is essentially free in the common
+            // case. Without it, tiny test workloads (where discovery
+            // completes in < 1ms) can lose the gate signal entirely.
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            execution_gate.notify_waiters();
+        }
+
+        Ok(())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+    use tempfile::TempDir;
+    use voom_job_manager::progress::NoopReporter;
+    use voom_job_manager::queue::JobQueue;
+    use voom_job_manager::worker::WorkerPoolConfig;
+
+    use crate::cli::{ErrorHandling, ProcessArgs};
+
+    fn write_fixture(dir: &Path, name: &str, bytes: &[u8]) -> PathBuf {
+        let p = dir.join(name);
+        std::fs::write(&p, bytes).unwrap();
+        // Match the path normalization that discovery applies so test
+        // assertions against `event.path` line up. On macOS `/var` is a
+        // symlink to `/private/var`, so the raw tempdir path and the
+        // canonicalized path differ.
+        std::fs::canonicalize(&p).unwrap_or(p)
+    }
+
+    fn make_test_args(paths: Vec<PathBuf>) -> ProcessArgs {
+        ProcessArgs {
+            paths,
+            policy: None,
+            policy_map: None,
+            dry_run: true,
+            estimate: false,
+            estimate_only: false,
+            on_error: ErrorHandling::Continue,
+            workers: 2,
+            approve: false,
+            no_backup: true,
+            force_rescan: false,
+            flag_size_increase: false,
+            flag_duration_shrink: false,
+            plan_only: false,
+            confirm_savings: None,
+            priority_by_date: false,
+        }
+    }
+
+    fn make_pool(
+        token: CancellationToken,
+    ) -> (WorkerPool, Arc<dyn StorageTrait>, Arc<voom_kernel::Kernel>) {
+        let store: Arc<dyn StorageTrait> =
+            Arc::new(voom_domain::test_support::InMemoryStore::new());
+        let job_store: Arc<dyn voom_domain::storage::JobStorage> =
+            Arc::new(voom_domain::test_support::InMemoryStore::new());
+        let queue = Arc::new(JobQueue::new(job_store));
+        let mut config = WorkerPoolConfig::default();
+        config.max_workers = 2;
+        config.worker_prefix = "test".into();
+        let pool = WorkerPool::new(queue, config, token);
+        let kernel = Arc::new(voom_kernel::Kernel::new());
+        (pool, store, kernel)
+    }
+
+    #[tokio::test]
+    async fn streaming_pipeline_enqueues_dry_run() {
+        let tmp = TempDir::new().unwrap();
+        write_fixture(tmp.path(), "a.mkv", b"a");
+        write_fixture(tmp.path(), "b.mkv", b"b");
+
+        let token = CancellationToken::new();
+        let (pool, store, kernel) = make_pool(token.clone());
+
+        let args = make_test_args(vec![tmp.path().to_path_buf()]);
+
+        let invocations = Arc::new(AtomicU64::new(0));
+        let invocations_clone = invocations.clone();
+
+        let outcome = run_streaming_pipeline(
+            &args,
+            &args.paths,
+            kernel,
+            store,
+            &pool,
+            Arc::new(NoopReporter),
+            JobErrorStrategy::Continue,
+            HashSet::new(),
+            move |_job| {
+                let c = invocations_clone.clone();
+                async move {
+                    c.fetch_add(1, Ordering::SeqCst);
+                    Ok(None)
+                }
+            },
+            true,
+            token,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome.discovered, 2);
+        assert_eq!(outcome.enqueued, 2);
+        assert_eq!(outcome.skipped_bad, 0);
+        assert_eq!(invocations.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn streaming_pipeline_filters_known_bad() {
+        let tmp = TempDir::new().unwrap();
+        let a = write_fixture(tmp.path(), "a.mkv", b"a");
+        let _b = write_fixture(tmp.path(), "b.mkv", b"b");
+
+        let mut bad = HashSet::new();
+        bad.insert(a);
+
+        let token = CancellationToken::new();
+        let (pool, store, kernel) = make_pool(token.clone());
+
+        let args = make_test_args(vec![tmp.path().to_path_buf()]);
+
+        let outcome = run_streaming_pipeline(
+            &args,
+            &args.paths,
+            kernel,
+            store,
+            &pool,
+            Arc::new(NoopReporter),
+            JobErrorStrategy::Continue,
+            bad,
+            |_job| async { Ok(None) },
+            true,
+            token,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome.discovered, 2);
+        assert_eq!(outcome.enqueued, 1);
+        assert_eq!(outcome.skipped_bad, 1);
+    }
+}

--- a/crates/voom-cli/src/progress.rs
+++ b/crates/voom-cli/src/progress.rs
@@ -88,18 +88,6 @@ pub struct DiscoveryProgress {
 }
 
 impl DiscoveryProgress {
-    /// Create a new discovery-phase progress indicator.
-    pub fn new() -> Self {
-        let pb = ProgressBar::new_spinner();
-        pb.set_style(spinner_style());
-        pb.enable_steady_tick(TICK_INTERVAL);
-        Self {
-            pb,
-            start: Instant::now(),
-            transitioned: Arc::new(AtomicBool::new(false)),
-        }
-    }
-
     /// Create a hidden (no-op) progress indicator for quiet/scripted mode.
     pub fn hidden() -> Self {
         Self {

--- a/crates/voom-cli/src/progress.rs
+++ b/crates/voom-cli/src/progress.rs
@@ -278,8 +278,10 @@ impl BatchProgress {
 
     /// Create a hidden (no-op) progress bar for quiet/scripted mode.
     pub fn hidden(files: &[FileDiscoveredEvent], workers: usize) -> Self {
+        let overall = ProgressBar::hidden();
+        overall.set_length(files.len() as u64);
         Self {
-            overall: ProgressBar::hidden(),
+            overall,
             state: Mutex::new(BatchEtaState::new(files, workers)),
         }
     }
@@ -336,6 +338,24 @@ impl ProgressReporter for BatchProgress {
 
     fn on_batch_complete(&self, _completed: u64, _failed: u64) {
         self.overall.finish_and_clear();
+    }
+
+    fn on_jobs_extended(&self, additional: usize) {
+        let new_len = self.overall.length().unwrap_or(0) + additional as u64;
+        self.overall.set_length(new_len);
+    }
+
+    fn seed_events(&self, events: &[voom_domain::events::FileDiscoveredEvent]) {
+        // Streaming mode: the pipeline calls this once, right before
+        // `on_batch_start`, with the full list of files that will be processed.
+        // Replace the internal ETA state with one seeded from those events so
+        // size-based ETA estimates work normally during the determinate phase.
+        let workers = {
+            let state = self.state.lock();
+            state.effective_workers
+        };
+        let new_state = BatchEtaState::new(events, workers);
+        *self.state.lock() = new_state;
     }
 }
 
@@ -824,5 +844,42 @@ mod tests {
 
         let estimate = state.estimate();
         assert!(estimate.eta.unwrap_or_default() < Duration::from_secs(15));
+    }
+
+    #[test]
+    fn batch_progress_seed_events_rebuilds_eta_state() {
+        use std::path::PathBuf;
+        use voom_domain::events::FileDiscoveredEvent;
+
+        // Start with zero events (the streaming-mode default).
+        let bp = BatchProgress::hidden(&[], 2);
+
+        // Seed three events after the fact.
+        let events: Vec<FileDiscoveredEvent> = (0..3)
+            .map(|i| {
+                FileDiscoveredEvent::new(
+                    PathBuf::from(format!("/tmp/f{i}.mkv")),
+                    1024 * (i + 1),
+                    None,
+                )
+            })
+            .collect();
+        bp.seed_events(&events);
+
+        // After seeding, the state must contain three queued weights.
+        let state = bp.state.lock();
+        assert_eq!(state.queued_weights.len(), 3);
+        assert_eq!(state.effective_workers, 2);
+    }
+
+    #[test]
+    fn batch_progress_on_jobs_extended_extends_total() {
+        let bp = BatchProgress::hidden(&[], 1);
+        // Length starts at zero in streaming mode.
+        assert_eq!(bp.overall.length(), Some(0));
+        bp.on_jobs_extended(5);
+        assert_eq!(bp.overall.length(), Some(5));
+        bp.on_jobs_extended(3);
+        assert_eq!(bp.overall.length(), Some(8));
     }
 }

--- a/plugins/job-manager/src/lib.rs
+++ b/plugins/job-manager/src/lib.rs
@@ -10,6 +10,7 @@
 pub mod progress;
 pub mod queue;
 pub mod worker;
+pub mod worker_stream;
 
 pub use worker::{JobErrorStrategy, JobOutcome, JobResult, WorkerPool, WorkerPoolConfig};
 

--- a/plugins/job-manager/src/progress.rs
+++ b/plugins/job-manager/src/progress.rs
@@ -25,6 +25,15 @@ pub trait ProgressReporter: Send + Sync {
 
     /// Called when all jobs in a batch are done.
     fn on_batch_complete(&self, completed: u64, failed: u64);
+
+    /// Called when more jobs become known to the pool. Used by the streaming
+    /// pool to grow the total before `on_batch_start` is issued. Default no-op.
+    fn on_jobs_extended(&self, _additional: usize) {}
+
+    /// Called once, before `on_batch_start`, when the full list of files the
+    /// reporter will see is finally known. Used by `BatchProgress` to build
+    /// size-based ETA state. Default no-op.
+    fn seed_events(&self, _events: &[voom_domain::events::FileDiscoveredEvent]) {}
 }
 
 /// Combines multiple reporters, delegating each callback to all of them.
@@ -67,6 +76,18 @@ impl ProgressReporter for CompositeReporter {
     fn on_batch_complete(&self, completed: u64, failed: u64) {
         for r in &self.reporters {
             r.on_batch_complete(completed, failed);
+        }
+    }
+
+    fn on_jobs_extended(&self, additional: usize) {
+        for r in &self.reporters {
+            r.on_jobs_extended(additional);
+        }
+    }
+
+    fn seed_events(&self, events: &[voom_domain::events::FileDiscoveredEvent]) {
+        for r in &self.reporters {
+            r.seed_events(events);
         }
     }
 }
@@ -271,5 +292,63 @@ mod tests {
             assert_eq!(r.job_completes.load(Ordering::SeqCst), 1);
             assert_eq!(r.batch_completes.load(Ordering::SeqCst), 1);
         }
+    }
+}
+
+#[cfg(test)]
+mod progress_reporter_streaming_tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    struct CountingReporter {
+        extended: AtomicU64,
+        seeded: AtomicU64,
+    }
+
+    impl CountingReporter {
+        fn new() -> Self {
+            Self {
+                extended: AtomicU64::new(0),
+                seeded: AtomicU64::new(0),
+            }
+        }
+    }
+
+    impl ProgressReporter for CountingReporter {
+        fn on_batch_start(&self, _total: usize) {}
+        fn on_job_start(&self, _job: &Job) {}
+        fn on_job_progress(&self, _id: Uuid, _progress: f64, _msg: Option<&str>) {}
+        fn on_job_complete(&self, _id: Uuid, _success: bool, _error: Option<&str>) {}
+        fn on_batch_complete(&self, _completed: u64, _failed: u64) {}
+
+        fn on_jobs_extended(&self, additional: usize) {
+            self.extended.fetch_add(additional as u64, Ordering::SeqCst);
+        }
+
+        fn seed_events(&self, events: &[voom_domain::events::FileDiscoveredEvent]) {
+            self.seeded.fetch_add(events.len() as u64, Ordering::SeqCst);
+        }
+    }
+
+    #[test]
+    fn noop_reporter_accepts_new_streaming_methods() {
+        let r = NoopReporter;
+        r.on_jobs_extended(5);
+        r.seed_events(&[]);
+    }
+
+    #[test]
+    fn composite_forwards_streaming_methods_to_children() {
+        let a = Arc::new(CountingReporter::new());
+        let b = Arc::new(CountingReporter::new());
+        let composite = CompositeReporter::new(vec![
+            a.clone() as Arc<dyn ProgressReporter>,
+            b.clone() as Arc<dyn ProgressReporter>,
+        ]);
+        composite.on_jobs_extended(3);
+        composite.seed_events(&[]);
+        assert_eq!(a.extended.load(Ordering::SeqCst), 3);
+        assert_eq!(b.extended.load(Ordering::SeqCst), 3);
     }
 }

--- a/plugins/job-manager/src/worker.rs
+++ b/plugins/job-manager/src/worker.rs
@@ -300,12 +300,12 @@ impl JobResult {
 /// up to `max_workers` concurrently. Each work item is processed by a
 /// user-provided async function.
 pub struct WorkerPool {
-    config: WorkerPoolConfig,
-    queue: Arc<JobQueue>,
-    token: CancellationToken,
-    completed_count: Arc<AtomicU64>,
-    failed_count: Arc<AtomicU64>,
-    already_claimed_count: Arc<AtomicU64>,
+    pub(crate) config: WorkerPoolConfig,
+    pub(crate) queue: Arc<JobQueue>,
+    pub(crate) token: CancellationToken,
+    pub(crate) completed_count: Arc<AtomicU64>,
+    pub(crate) failed_count: Arc<AtomicU64>,
+    pub(crate) already_claimed_count: Arc<AtomicU64>,
 }
 
 impl WorkerPool {
@@ -480,7 +480,7 @@ impl WorkerPool {
     }
 }
 
-async fn cancel_unstarted_jobs(queue: Arc<JobQueue>, job_ids: Vec<Uuid>) {
+pub(crate) async fn cancel_unstarted_jobs(queue: Arc<JobQueue>, job_ids: Vec<Uuid>) {
     if job_ids.is_empty() {
         return;
     }
@@ -509,17 +509,20 @@ async fn cancel_unstarted_jobs(queue: Arc<JobQueue>, job_ids: Vec<Uuid>) {
 }
 
 /// Shared context passed to each worker task.
-struct WorkerContext<F> {
-    queue: Arc<JobQueue>,
-    token: CancellationToken,
-    completed: Arc<AtomicU64>,
-    failed: Arc<AtomicU64>,
-    already_claimed: Arc<AtomicU64>,
-    processor: Arc<F>,
-    reporter: Arc<dyn ProgressReporter>,
-    result_tx: mpsc::Sender<JobResult>,
-    worker_id: String,
-    on_error: JobErrorStrategy,
+///
+/// All fields are owned (Arc, owned types, cheap-clone tokens). This is reused
+/// by [`worker_stream::WorkerPool::process_stream`] via [`run_one_job`].
+pub(crate) struct WorkerContext<F> {
+    pub(crate) queue: Arc<JobQueue>,
+    pub(crate) token: CancellationToken,
+    pub(crate) completed: Arc<AtomicU64>,
+    pub(crate) failed: Arc<AtomicU64>,
+    pub(crate) already_claimed: Arc<AtomicU64>,
+    pub(crate) processor: Arc<F>,
+    pub(crate) reporter: Arc<dyn ProgressReporter>,
+    pub(crate) result_tx: mpsc::Sender<JobResult>,
+    pub(crate) worker_id: String,
+    pub(crate) on_error: JobErrorStrategy,
 }
 
 /// Increment the failed counter and send a `JobResult` describing the failure.
@@ -562,7 +565,7 @@ where
 }
 
 /// Execute a single job: claim it, run the processor, and record the result.
-async fn run_one_job<F, Fut>(job_id: Uuid, ctx: WorkerContext<F>)
+pub(crate) async fn run_one_job<F, Fut>(job_id: Uuid, ctx: WorkerContext<F>)
 where
     F: Fn(voom_domain::job::Job) -> Fut + Send + Sync + 'static,
     Fut: std::future::Future<Output = std::result::Result<Option<serde_json::Value>, String>>

--- a/plugins/job-manager/src/worker.rs
+++ b/plugins/job-manager/src/worker.rs
@@ -511,7 +511,7 @@ pub(crate) async fn cancel_unstarted_jobs(queue: Arc<JobQueue>, job_ids: Vec<Uui
 /// Shared context passed to each worker task.
 ///
 /// All fields are owned (Arc, owned types, cheap-clone tokens). This is reused
-/// by [`worker_stream::WorkerPool::process_stream`] via [`run_one_job`].
+/// by [`worker_stream::WorkerPool::process_stream`] via [`run_claimed_job`].
 pub(crate) struct WorkerContext<F> {
     pub(crate) queue: Arc<JobQueue>,
     pub(crate) token: CancellationToken,
@@ -564,7 +564,7 @@ where
     .inspect_err(|e| tracing::error!(job_id = %job_id, error = %e, "job update failed"))
 }
 
-/// Execute a single job: claim it, run the processor, and record the result.
+/// Execute a single job: claim it by id, run the processor, and record the result.
 pub(crate) async fn run_one_job<F, Fut>(job_id: Uuid, ctx: WorkerContext<F>)
 where
     F: Fn(voom_domain::job::Job) -> Fut + Send + Sync + 'static,
@@ -608,12 +608,29 @@ where
         }
     };
 
+    run_claimed_job(job, ctx).await;
+}
+
+/// Execute a job that has already been claimed by this worker. Used by the
+/// streaming pool: workers call `queue.claim(worker_id)` (which honors SQLite
+/// priority ordering) and pass the returned [`voom_domain::job::Job`] here.
+///
+/// Mirrors the post-claim portion of [`run_one_job`]: cancellation re-check,
+/// processor invocation, result/error recording, and `Fail` strategy cancel.
+pub(crate) async fn run_claimed_job<F, Fut>(job: voom_domain::job::Job, ctx: WorkerContext<F>)
+where
+    F: Fn(voom_domain::job::Job) -> Fut + Send + Sync + 'static,
+    Fut: std::future::Future<Output = std::result::Result<Option<serde_json::Value>, String>>
+        + Send
+        + 'static,
+{
+    let job_id = job.id;
+
     // Re-check cancellation after claiming (closes race with JobErrorStrategy::Fail)
     if ctx.token.is_cancelled() {
         let q = ctx.queue.clone();
-        let jid = job.id;
         if let Err(e) =
-            record_job_update(job_id, "mark job as cancelled", move || q.cancel(&jid)).await
+            record_job_update(job_id, "mark job as cancelled", move || q.cancel(&job_id)).await
         {
             send_failure(&ctx, job_id, e).await;
             return;
@@ -622,7 +639,6 @@ where
         return;
     }
 
-    let job_id = job.id;
     ctx.reporter.on_job_start(&job);
 
     match (ctx.processor)(job).await {

--- a/plugins/job-manager/src/worker.rs
+++ b/plugins/job-manager/src/worker.rs
@@ -321,6 +321,12 @@ impl WorkerPool {
         }
     }
 
+    /// Read-only view of the pool's configuration.
+    #[must_use]
+    pub fn config(&self) -> &WorkerPoolConfig {
+        &self.config
+    }
+
     pub fn cancel(&self) {
         self.token.cancel();
     }

--- a/plugins/job-manager/src/worker.rs
+++ b/plugins/job-manager/src/worker.rs
@@ -327,6 +327,12 @@ impl WorkerPool {
         &self.config
     }
 
+    /// Read-only view of the pool's underlying job queue.
+    #[must_use]
+    pub fn queue(&self) -> &Arc<crate::queue::JobQueue> {
+        &self.queue
+    }
+
     pub fn cancel(&self) {
         self.token.cancel();
     }

--- a/plugins/job-manager/src/worker_stream.rs
+++ b/plugins/job-manager/src/worker_stream.rs
@@ -2,8 +2,9 @@
 //! `mpsc::Receiver`, enqueue them into the SQLite-backed `JobQueue`, and
 //! claim/process them concurrently while an `execution_gate` is held open.
 
-use std::collections::HashSet;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::cmp::Reverse;
+use std::collections::{BinaryHeap, HashSet};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -22,6 +23,12 @@ use crate::worker::{
 /// the loop only sleeps when there is genuinely no pending work.
 const CLAIM_POLL_INTERVAL: Duration = Duration::from_millis(5);
 
+/// Run-scoped pending queue entries: `(priority, seq, id)` wrapped in
+/// `Reverse` so the max-heap yields the lowest priority (and then earliest
+/// `seq`) first — matching the SQLite store's
+/// `ORDER BY priority ASC, created_at ASC`.
+type PendingHeap = BinaryHeap<Reverse<(i32, u64, Uuid)>>;
+
 /// Arguments shared across all workers in a single `process_stream` invocation.
 ///
 /// Bundled into a struct to keep `spawn_worker`'s signature within the
@@ -33,6 +40,7 @@ struct WorkerSpawnArgs<F> {
     on_error: JobErrorStrategy,
     reporter: Arc<dyn ProgressReporter>,
     result_tx: mpsc::Sender<JobResult>,
+    pending_heap: Arc<Mutex<PendingHeap>>,
 }
 
 impl WorkerPool {
@@ -44,10 +52,12 @@ impl WorkerPool {
     /// 1. the receiver has been drained (producer dropped the `tx` end),
     /// 2. and every worker has finished its last in-flight job.
     ///
-    /// Workers claim work via [`crate::queue::JobQueue::claim`], which honors
-    /// the SQLite store's priority ordering (`ORDER BY priority ASC, created_at
-    /// ASC`). This is the same dispatch order used by `voom process` in batch
-    /// mode and by `--priority-by-date`.
+    /// Workers claim work from a run-scoped priority heap of ids enqueued by
+    /// this invocation, then call [`crate::queue::JobQueue::claim_by_id`] for
+    /// the specific row. The heap is ordered to match the SQLite store's
+    /// `ORDER BY priority ASC, created_at ASC`, so dispatch order matches the
+    /// batch path and `--priority-by-date`; the run-scoping prevents stale
+    /// Pending rows in the shared `jobs` table from leaking into the stream.
     ///
     /// Cancellation: the pool's internal token (passed via [`WorkerPool::new`])
     /// is the shared signal. When cancelled, the enqueuer stops draining the
@@ -90,6 +100,16 @@ impl WorkerPool {
         // rows that may already exist in a long-lived SQLite store.
         let enqueued_ids: Arc<Mutex<HashSet<Uuid>>> = Arc::new(Mutex::new(HashSet::new()));
 
+        // Run-scoped pending queue. The enqueuer pushes `(priority, seq, id)`
+        // for every successful enqueue; workers pop the best-priority entry
+        // and `claim_by_id` that specific row. Guarantees workers only see
+        // THIS pool's enqueued jobs (no spillover from stale Pending rows in
+        // the shared `jobs` table) AND preserves the SQLite store's
+        // `ORDER BY priority ASC, created_at ASC`. `seq` is a monotonic
+        // counter so equal-priority jobs come out in enqueue order.
+        let pending_heap: Arc<Mutex<PendingHeap>> = Arc::new(Mutex::new(BinaryHeap::new()));
+        let enqueue_seq = Arc::new(AtomicU64::new(0));
+
         let (result_tx, mut result_rx) = mpsc::channel::<JobResult>(effective_workers.max(1) * 4);
 
         // --- Enqueuer task --------------------------------------------------
@@ -97,6 +117,8 @@ impl WorkerPool {
             items,
             producer_done_flag.clone(),
             enqueued_ids.clone(),
+            pending_heap.clone(),
+            enqueue_seq.clone(),
             reporter.clone(),
             result_tx.clone(),
         );
@@ -111,6 +133,7 @@ impl WorkerPool {
                 on_error,
                 reporter: reporter.clone(),
                 result_tx: result_tx.clone(),
+                pending_heap: pending_heap.clone(),
             });
             worker_handles.push(handle);
         }
@@ -140,6 +163,9 @@ impl WorkerPool {
         // the SQLite store is long-lived and may legitimately hold Pending
         // rows from prior crashes or other code paths.
         if self.token.is_cancelled() {
+            // Drain the heap so no stale entries remain visible to any worker
+            // that might still be racing the cancellation signal.
+            pending_heap.lock().expect("pending_heap mutex").clear();
             let leftover = collect_unstarted_enqueued_ids(&self.queue, &enqueued_ids);
             cancel_unstarted_jobs(self.queue.clone(), leftover).await;
         }
@@ -155,12 +181,16 @@ impl WorkerPool {
     /// Spawn the single enqueuer task that drains `items` into the job queue
     /// and flips `producer_done_flag` on completion. Every successful enqueue
     /// id is recorded in `enqueued_ids` so cancellation cleanup can scope its
-    /// sweep to jobs produced by this run.
+    /// sweep to jobs produced by this run, and pushed onto `pending_heap` so
+    /// workers can pop the best-priority entry for `claim_by_id`.
+    #[allow(clippy::too_many_arguments)]
     fn spawn_enqueuer<P>(
         &self,
         mut items: mpsc::Receiver<WorkItem<P>>,
         producer_done_flag: Arc<AtomicBool>,
         enqueued_ids: Arc<Mutex<HashSet<Uuid>>>,
+        pending_heap: Arc<Mutex<PendingHeap>>,
+        enqueue_seq: Arc<AtomicU64>,
         reporter: Arc<dyn ProgressReporter>,
         result_tx: mpsc::Sender<JobResult>,
     ) -> JoinHandle<()>
@@ -182,6 +212,7 @@ impl WorkerPool {
                     break;
                 };
 
+                let priority = item.priority;
                 let json_payload = match item.payload.map(serde_json::to_value) {
                     Some(Ok(v)) => Some(v),
                     Some(Err(e)) => {
@@ -200,6 +231,11 @@ impl WorkerPool {
                 };
                 match queue.enqueue(item.job_type, item.priority, json_payload) {
                     Ok(id) => {
+                        let seq = enqueue_seq.fetch_add(1, Ordering::SeqCst);
+                        pending_heap
+                            .lock()
+                            .expect("pending_heap mutex poisoned")
+                            .push(Reverse((priority, seq, id)));
                         enqueued_ids
                             .lock()
                             .expect("enqueued_ids mutex poisoned")
@@ -239,6 +275,7 @@ impl WorkerPool {
             on_error,
             reporter,
             result_tx,
+            pending_heap,
         } = args;
         let queue = self.queue.clone();
         let token = self.token.clone();
@@ -266,23 +303,41 @@ impl WorkerPool {
                     return;
                 }
 
-                // Claim the next pending job via the queue, which honors the
-                // SQLite store's priority ordering. This is the same dispatch
-                // order used by the batch path and by `--priority-by-date`.
-                let claim_queue = queue.clone();
-                let wid = worker_id.clone();
-                let claim_result =
-                    tokio::task::spawn_blocking(move || claim_queue.claim(&wid)).await;
+                // Pop the best-priority entry that THIS pool enqueued. Using
+                // a run-scoped heap (instead of `queue.claim()`) ensures
+                // workers never observe stale Pending rows from prior runs
+                // or other code paths sharing the same SQLite store. The
+                // heap is ordered to match the store's priority + insert
+                // order, so dispatch order is unchanged.
+                let next_id_opt: Option<Uuid> = {
+                    let mut heap = pending_heap.lock().expect("pending_heap mutex");
+                    heap.pop().map(|Reverse((_, _, id))| id)
+                };
+
+                let claim_result = if let Some(id) = next_id_opt {
+                    let claim_queue = queue.clone();
+                    let wid = worker_id.clone();
+                    tokio::task::spawn_blocking(move || claim_queue.claim_by_id(&id, &wid)).await
+                } else {
+                    // Nothing in the heap right now. If the enqueuer has
+                    // finished and the heap is still empty, we're done.
+                    // Otherwise back off briefly and retry.
+                    if producer_done_flag.load(Ordering::SeqCst)
+                        && pending_heap.lock().expect("pending_heap mutex").is_empty()
+                    {
+                        return;
+                    }
+                    tokio::time::sleep(CLAIM_POLL_INTERVAL).await;
+                    continue;
+                };
 
                 let job = match claim_result {
                     Ok(Ok(Some(job))) => job,
                     Ok(Ok(None)) => {
-                        // No pending work right now. If the enqueuer is done,
-                        // we're finished; otherwise sleep briefly and retry.
-                        if producer_done_flag.load(Ordering::SeqCst) {
-                            return;
-                        }
-                        tokio::time::sleep(CLAIM_POLL_INTERVAL).await;
+                        // The job we popped was no longer claimable (e.g.
+                        // cancelled by another path). Loop to try the next
+                        // heap entry; if the heap drains and the producer is
+                        // done, the next iteration will exit cleanly.
                         continue;
                     }
                     Ok(Err(e)) => {
@@ -673,6 +728,73 @@ mod tests {
         let _ = handle.await.unwrap();
 
         assert_eq!(reporter.extended.load(Ordering::SeqCst), 6);
+    }
+
+    #[tokio::test]
+    async fn process_stream_ignores_unrelated_pending_jobs() {
+        let (pool, queue) = fresh_pool();
+        let (tx, rx) = mpsc::channel::<WorkItem<()>>(8);
+        let gate = Arc::new(Notify::new());
+
+        // Pre-seed an unrelated Pending job on the same queue (simulates a
+        // stale row from a prior run / other code path).
+        let alien_id = queue
+            .enqueue(
+                JobType::Process,
+                50,
+                Some(serde_json::json!({"alien": true})),
+            )
+            .expect("seed alien job");
+
+        // Now enqueue this run's jobs.
+        for _ in 0..3 {
+            tx.send(dummy_item()).await.unwrap();
+        }
+        drop(tx);
+
+        let invocations: Arc<Mutex<Vec<Uuid>>> = Arc::new(Mutex::new(Vec::new()));
+        let invocations_for_proc = invocations.clone();
+        let queue_for_assert = queue.clone();
+        let gate_for_task = gate.clone();
+        let handle = tokio::spawn(async move {
+            pool.process_stream(
+                rx,
+                gate_for_task,
+                move |job| {
+                    let invocations = invocations_for_proc.clone();
+                    async move {
+                        invocations.lock().expect("invocations mutex").push(job.id);
+                        Ok(None)
+                    }
+                },
+                JobErrorStrategy::Continue,
+                Arc::new(NoopReporter),
+            )
+            .await
+        });
+
+        // Wait for workers to register on gate.notified() before opening it
+        // (Notify::notify_waiters is edge-triggered).
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        gate.notify_waiters();
+        let results = handle.await.unwrap();
+
+        let seen = invocations.lock().expect("invocations mutex").clone();
+        assert_eq!(seen.len(), 3, "must NOT claim the alien pending job");
+        assert!(
+            !seen.contains(&alien_id),
+            "alien job leaked into the stream"
+        );
+        assert_eq!(results.iter().filter(|r| r.is_success()).count(), 3);
+
+        // Alien job remains Pending in the queue.
+        let mut filters = voom_domain::storage::JobFilters::default();
+        filters.status = Some(voom_domain::job::JobStatus::Pending);
+        let still_pending = queue_for_assert.list_jobs(&filters).unwrap();
+        assert!(
+            still_pending.iter().any(|j| j.id == alien_id),
+            "alien job should remain Pending after this run finishes"
+        );
     }
 
     /// Spec compliance: workers must dispatch jobs in SQLite priority order

--- a/plugins/job-manager/src/worker_stream.rs
+++ b/plugins/job-manager/src/worker_stream.rs
@@ -3,11 +3,38 @@
 //! claim/process them concurrently while an `execution_gate` is held open.
 
 use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 
 use tokio::sync::{Notify, mpsc};
+use tokio::task::JoinHandle;
+use uuid::Uuid;
 
 use crate::progress::ProgressReporter;
-use crate::worker::{JobErrorStrategy, JobResult, WorkItem, WorkerPool};
+use crate::worker::{
+    JobErrorStrategy, JobResult, WorkItem, WorkerContext, WorkerPool, cancel_unstarted_jobs,
+    run_one_job,
+};
+
+/// Polling interval workers use when the queue is momentarily empty but the
+/// enqueuer has not yet signalled it is done. Kept small to keep latency low;
+/// the loop only sleeps when there is genuinely no pending work.
+const CLAIM_POLL_INTERVAL: Duration = Duration::from_millis(5);
+
+/// Arguments shared across all workers in a single `process_stream` invocation.
+///
+/// Bundled into a struct to keep `spawn_worker`'s signature within the
+/// `clippy::too_many_arguments` budget.
+struct WorkerSpawnArgs<F> {
+    producer_done_flag: Arc<AtomicBool>,
+    pending: Arc<Mutex<Vec<Uuid>>>,
+    execution_gate: Arc<Notify>,
+    processor: Arc<F>,
+    on_error: JobErrorStrategy,
+    reporter: Arc<dyn ProgressReporter>,
+    result_tx: mpsc::Sender<JobResult>,
+}
 
 impl WorkerPool {
     /// Stream entries through the pool: consume items from `items`, enqueue
@@ -15,15 +42,22 @@ impl WorkerPool {
     /// loops in parallel. Workers wait on `execution_gate` before their first
     /// claim. The pool returns when:
     ///
-    /// 1. `producer_done` has been notified,
-    /// 2. the receiver has been drained,
-    /// 3. and every worker has finished its last in-flight job.
+    /// 1. the receiver has been drained (producer dropped the `tx` end),
+    /// 2. and every worker has finished its last in-flight job.
     ///
-    /// Cancellation: the pool's internal token (passed via `WorkerPool::new`)
+    /// Cancellation: the pool's internal token (passed via [`WorkerPool::new`])
     /// is the shared signal. When cancelled, the enqueuer stops draining the
     /// receiver, the remaining queued-but-unstarted jobs are cancelled via
-    /// the existing `cancel_unstarted_jobs` helper, and workers exit after
-    /// their current job.
+    /// [`cancel_unstarted_jobs`], and workers exit after their current job.
+    ///
+    /// The `producer_done` [`Notify`] parameter is accepted for API symmetry
+    /// with upstream callers that want to signal "no more items" explicitly,
+    /// but it is intentionally not consumed: dropping the `tx` end of `items`
+    /// is the canonical "producer done" signal and is sufficient on its own.
+    /// Internally we flip an `AtomicBool` when the receiver returns `None`,
+    /// avoiding the `Notify::notified()` consumption pitfall (notifications
+    /// don't latch — a poll loop on `notified()` would race itself).
+    #[tracing::instrument(skip(self, items, producer_done, execution_gate, processor, reporter))]
     pub async fn process_stream<P, F, Fut>(
         &self,
         items: mpsc::Receiver<WorkItem<P>>,
@@ -40,20 +74,576 @@ impl WorkerPool {
             + Send
             + 'static,
     {
-        // Replaced in the next task.
-        let _ = (
+        let _ = producer_done; // intentionally unused: see doc comment above.
+
+        let effective_workers = self.config.effective_workers();
+        let processor = Arc::new(processor);
+
+        tracing::info!(
+            workers = effective_workers,
+            "Starting streaming worker pool"
+        );
+
+        // Internal "producer done" flag. Flipped by the enqueuer when the
+        // receiver returns None (tx was dropped) or when cancellation fires.
+        // Using AtomicBool rather than Notify avoids the single-permit
+        // consumption pitfall of Notify::notified() in a polling loop.
+        let producer_done_flag = Arc::new(AtomicBool::new(false));
+
+        // Tracks job IDs that have been enqueued and not yet been claimed by
+        // a worker. Workers pop one before invoking `run_one_job`; on
+        // cancellation, leftover IDs are sent to `cancel_unstarted_jobs`.
+        let pending: Arc<Mutex<Vec<Uuid>>> = Arc::new(Mutex::new(Vec::new()));
+
+        let (result_tx, mut result_rx) = mpsc::channel::<JobResult>(effective_workers.max(1) * 4);
+
+        // --- Enqueuer task --------------------------------------------------
+        let enqueuer_handle = self.spawn_enqueuer(
             items,
-            producer_done,
+            producer_done_flag.clone(),
+            pending.clone(),
+            reporter.clone(),
+            result_tx.clone(),
+        );
+
+        // --- Worker tasks ---------------------------------------------------
+        let mut worker_handles: Vec<JoinHandle<()>> = Vec::with_capacity(effective_workers);
+        for _ in 0..effective_workers {
+            let handle = self.spawn_worker(WorkerSpawnArgs {
+                producer_done_flag: producer_done_flag.clone(),
+                pending: pending.clone(),
+                execution_gate: execution_gate.clone(),
+                processor: processor.clone(),
+                on_error,
+                reporter: reporter.clone(),
+                result_tx: result_tx.clone(),
+            });
+            worker_handles.push(handle);
+        }
+
+        // Drop the local sender so result_rx closes once all workers + the
+        // enqueuer have dropped their clones.
+        drop(result_tx);
+
+        // Wait for the enqueuer to exit before draining results: it owns the
+        // `pending` list and we want it fully populated before cancel cleanup.
+        if let Err(e) = enqueuer_handle.await {
+            tracing::error!(error = %e, "enqueuer task join error");
+        }
+
+        // Collect results as workers report them.
+        let mut results = Vec::new();
+        while let Some(result) = result_rx.recv().await {
+            results.push(result);
+        }
+
+        for handle in worker_handles {
+            if let Err(e) = handle.await {
+                tracing::error!(error = %e, "worker task join error");
+            }
+        }
+
+        // If we were cancelled, cancel anything still pending (i.e. enqueued
+        // but never claimed). On the happy path `pending` is empty here.
+        if self.token.is_cancelled() {
+            let leftover: Vec<Uuid> = {
+                let mut guard = pending.lock().expect("pending mutex poisoned");
+                std::mem::take(&mut *guard)
+            };
+            cancel_unstarted_jobs(self.queue.clone(), leftover).await;
+        }
+
+        reporter.on_batch_complete(
+            self.completed_count.load(Ordering::SeqCst),
+            self.failed_count.load(Ordering::SeqCst),
+        );
+
+        results
+    }
+
+    /// Spawn the single enqueuer task that drains `items` into the job queue,
+    /// tracks pending IDs, and flips `producer_done_flag` on completion.
+    fn spawn_enqueuer<P>(
+        &self,
+        mut items: mpsc::Receiver<WorkItem<P>>,
+        producer_done_flag: Arc<AtomicBool>,
+        pending: Arc<Mutex<Vec<Uuid>>>,
+        reporter: Arc<dyn ProgressReporter>,
+        result_tx: mpsc::Sender<JobResult>,
+    ) -> JoinHandle<()>
+    where
+        P: serde::Serialize + Send + 'static,
+    {
+        let queue = self.queue.clone();
+        let token = self.token.clone();
+        let failed = self.failed_count.clone();
+
+        tokio::spawn(async move {
+            loop {
+                let recv_result = tokio::select! {
+                    biased;
+                    () = token.cancelled() => break,
+                    item = items.recv() => item,
+                };
+                let Some(item) = recv_result else {
+                    break;
+                };
+
+                let json_payload = match item.payload.map(serde_json::to_value) {
+                    Some(Ok(v)) => Some(v),
+                    Some(Err(e)) => {
+                        let error = format!("payload serialization failed: {e}");
+                        tracing::error!(error = %error, "failed to serialize WorkItem payload");
+                        failed.fetch_add(1, Ordering::SeqCst);
+                        if let Err(send_err) = result_tx
+                            .send(JobResult::failure(Uuid::new_v4(), error))
+                            .await
+                        {
+                            tracing::warn!(error = %send_err, "failed to forward enqueuer failure");
+                        }
+                        continue;
+                    }
+                    None => None,
+                };
+                match queue.enqueue(item.job_type, item.priority, json_payload) {
+                    Ok(id) => {
+                        pending.lock().expect("pending mutex poisoned").push(id);
+                        reporter.on_jobs_extended(1);
+                    }
+                    Err(e) => {
+                        let error = format!("enqueue failed: {e}");
+                        tracing::error!(error = %error, "Failed to enqueue job");
+                        failed.fetch_add(1, Ordering::SeqCst);
+                        if let Err(send_err) = result_tx
+                            .send(JobResult::failure(Uuid::new_v4(), error))
+                            .await
+                        {
+                            tracing::warn!(error = %send_err, "failed to forward enqueuer failure");
+                        }
+                    }
+                }
+            }
+            producer_done_flag.store(true, Ordering::SeqCst);
+        })
+    }
+
+    /// Spawn one worker task that loops on `queue.claim`, runs each claimed
+    /// job, and exits cleanly when the enqueuer is done and no jobs remain.
+    fn spawn_worker<F, Fut>(&self, args: WorkerSpawnArgs<F>) -> JoinHandle<()>
+    where
+        F: Fn(voom_domain::job::Job) -> Fut + Send + Sync + 'static,
+        Fut: std::future::Future<Output = std::result::Result<Option<serde_json::Value>, String>>
+            + Send
+            + 'static,
+    {
+        let WorkerSpawnArgs {
+            producer_done_flag,
+            pending,
             execution_gate,
             processor,
             on_error,
             reporter,
+            result_tx,
+        } = args;
+        let queue = self.queue.clone();
+        let token = self.token.clone();
+        let completed = self.completed_count.clone();
+        let failed = self.failed_count.clone();
+        let already_claimed = self.already_claimed_count.clone();
+        let worker_id = format!(
+            "{}-{}",
+            self.config.worker_prefix,
+            uuid::Uuid::new_v4().as_simple()
         );
-        Vec::new()
+
+        tokio::spawn(async move {
+            // Wait on the execution gate (cancel-aware). The gate is fired
+            // via `Notify::notify_waiters()`, which wakes every current
+            // waiter — workers do not need to re-notify siblings.
+            tokio::select! {
+                biased;
+                () = token.cancelled() => return,
+                () = execution_gate.notified() => {}
+            }
+
+            loop {
+                if token.is_cancelled() {
+                    return;
+                }
+
+                // Pop the next job ID from the pending list. Workers consume
+                // IDs the enqueuer has produced; `run_one_job` then claims by
+                // ID and runs the processor.
+                let next_id = pending.lock().expect("pending mutex poisoned").pop();
+
+                let Some(job_id) = next_id else {
+                    // No pending work. If the enqueuer is done, we're
+                    // finished; otherwise sleep briefly and re-check.
+                    if producer_done_flag.load(Ordering::SeqCst) {
+                        return;
+                    }
+                    tokio::time::sleep(CLAIM_POLL_INTERVAL).await;
+                    continue;
+                };
+
+                let pre_failed = failed.load(Ordering::SeqCst);
+
+                let ctx = WorkerContext {
+                    queue: queue.clone(),
+                    token: token.clone(),
+                    completed: completed.clone(),
+                    failed: failed.clone(),
+                    already_claimed: already_claimed.clone(),
+                    processor: processor.clone(),
+                    reporter: reporter.clone(),
+                    result_tx: result_tx.clone(),
+                    worker_id: worker_id.clone(),
+                    on_error,
+                };
+                run_one_job(job_id, ctx).await;
+
+                // Fail-fast: if the on_error strategy is Fail and the failure
+                // counter just incremented, this worker exits. `run_one_job`
+                // itself cancels the token on failure under the Fail strategy,
+                // so sibling workers will observe the cancellation on their
+                // next loop iteration.
+                if matches!(on_error, JobErrorStrategy::Fail)
+                    && failed.load(Ordering::SeqCst) > pre_failed
+                {
+                    return;
+                }
+            }
+        })
     }
 }
 
 #[cfg(test)]
 mod tests {
-    // Tests follow in the next task.
+    use super::*;
+    use crate::progress::NoopReporter;
+    use crate::queue::JobQueue;
+    use crate::worker::{JobErrorStrategy, WorkerPool, WorkerPoolConfig};
+    use std::sync::atomic::AtomicU64;
+    use tokio_util::sync::CancellationToken;
+    use voom_domain::job::JobType;
+    use voom_domain::storage::JobStorage;
+    use voom_domain::test_support::InMemoryStore;
+
+    fn fresh_pool() -> (WorkerPool, Arc<JobQueue>) {
+        let store: Arc<dyn JobStorage> = Arc::new(InMemoryStore::new());
+        let queue = Arc::new(JobQueue::new(store));
+        let cfg = WorkerPoolConfig {
+            max_workers: 2,
+            worker_prefix: "test".into(),
+        };
+        let token = CancellationToken::new();
+        (WorkerPool::new(queue.clone(), cfg, token), queue)
+    }
+
+    fn dummy_item() -> WorkItem<()> {
+        WorkItem::new(JobType::Process, 100, None)
+    }
+
+    #[tokio::test]
+    async fn process_stream_basic() {
+        let (pool, _queue) = fresh_pool();
+        let (tx, rx) = mpsc::channel::<WorkItem<()>>(8);
+        let producer_done = Arc::new(Notify::new());
+        let gate = Arc::new(Notify::new());
+
+        for _ in 0..5 {
+            tx.send(dummy_item()).await.unwrap();
+        }
+        drop(tx);
+        producer_done.notify_waiters();
+
+        let counter = Arc::new(AtomicU64::new(0));
+        let counter_clone = counter.clone();
+        let gate_for_task = gate.clone();
+        let handle = tokio::spawn(async move {
+            pool.process_stream(
+                rx,
+                producer_done,
+                gate_for_task,
+                move |_job| {
+                    let c = counter_clone.clone();
+                    async move {
+                        c.fetch_add(1, Ordering::SeqCst);
+                        Ok(None)
+                    }
+                },
+                JobErrorStrategy::Continue,
+                Arc::new(NoopReporter),
+            )
+            .await
+        });
+
+        // Give workers time to register on gate.notified() before opening it.
+        // `Notify::notify_waiters` is edge-triggered; missed notifications are
+        // lost, so callers MUST notify after waiters are ready.
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        gate.notify_waiters();
+        let results = handle.await.unwrap();
+
+        assert_eq!(counter.load(Ordering::SeqCst), 5);
+        assert_eq!(results.iter().filter(|r| r.is_success()).count(), 5);
+    }
+
+    #[tokio::test]
+    async fn process_stream_respects_gate() {
+        let (pool, _queue) = fresh_pool();
+        let (tx, rx) = mpsc::channel::<WorkItem<()>>(8);
+        let producer_done = Arc::new(Notify::new());
+        let gate = Arc::new(Notify::new());
+
+        for _ in 0..3 {
+            tx.send(dummy_item()).await.unwrap();
+        }
+        drop(tx);
+        producer_done.notify_waiters();
+
+        let counter = Arc::new(AtomicU64::new(0));
+        let counter_clone = counter.clone();
+
+        let gate_for_task = gate.clone();
+        let handle = tokio::spawn(async move {
+            pool.process_stream(
+                rx,
+                producer_done,
+                gate_for_task,
+                move |_job| {
+                    let c = counter_clone.clone();
+                    async move {
+                        c.fetch_add(1, Ordering::SeqCst);
+                        Ok(None)
+                    }
+                },
+                JobErrorStrategy::Continue,
+                Arc::new(NoopReporter),
+            )
+            .await
+        });
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(counter.load(Ordering::SeqCst), 0);
+
+        gate.notify_waiters();
+        let results = handle.await.unwrap();
+        assert_eq!(counter.load(Ordering::SeqCst), 3);
+        assert_eq!(results.iter().filter(|r| r.is_success()).count(), 3);
+    }
+
+    #[tokio::test]
+    async fn process_stream_cancellation_before_gate() {
+        let store: Arc<dyn JobStorage> = Arc::new(InMemoryStore::new());
+        let queue = Arc::new(JobQueue::new(store));
+        let cfg = WorkerPoolConfig {
+            max_workers: 2,
+            worker_prefix: "test".into(),
+        };
+        let token = CancellationToken::new();
+        let pool = WorkerPool::new(queue.clone(), cfg, token.clone());
+
+        let (tx, rx) = mpsc::channel::<WorkItem<()>>(8);
+        let producer_done = Arc::new(Notify::new());
+        let gate = Arc::new(Notify::new());
+
+        for _ in 0..3 {
+            tx.send(dummy_item()).await.unwrap();
+        }
+        drop(tx);
+        producer_done.notify_waiters();
+
+        let counter = Arc::new(AtomicU64::new(0));
+        let counter_clone = counter.clone();
+        let gate_for_task = gate.clone();
+        let handle = tokio::spawn(async move {
+            pool.process_stream(
+                rx,
+                producer_done,
+                gate_for_task,
+                move |_job| {
+                    let c = counter_clone.clone();
+                    async move {
+                        c.fetch_add(1, Ordering::SeqCst);
+                        Ok(None)
+                    }
+                },
+                JobErrorStrategy::Continue,
+                Arc::new(NoopReporter),
+            )
+            .await
+        });
+
+        // Cancel before notifying the gate so no worker starts a claim.
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        token.cancel();
+        gate.notify_waiters();
+
+        let _ = handle.await.unwrap();
+        assert_eq!(counter.load(Ordering::SeqCst), 0);
+
+        let mut filters = voom_domain::storage::JobFilters::default();
+        filters.status = Some(voom_domain::job::JobStatus::Cancelled);
+        let cancelled = queue.list_jobs(&filters).unwrap();
+        assert_eq!(cancelled.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn process_stream_fail_fast() {
+        let (pool, _queue) = fresh_pool();
+        let (tx, rx) = mpsc::channel::<WorkItem<()>>(8);
+        let producer_done = Arc::new(Notify::new());
+        let gate = Arc::new(Notify::new());
+
+        for _ in 0..5 {
+            tx.send(dummy_item()).await.unwrap();
+        }
+        drop(tx);
+        producer_done.notify_waiters();
+
+        let invocations = Arc::new(AtomicU64::new(0));
+        let invocations_clone = invocations.clone();
+        let gate_for_task = gate.clone();
+        let handle = tokio::spawn(async move {
+            pool.process_stream(
+                rx,
+                producer_done,
+                gate_for_task,
+                move |_job| {
+                    let c = invocations_clone.clone();
+                    async move {
+                        let n = c.fetch_add(1, Ordering::SeqCst);
+                        if n == 1 {
+                            Err("boom".to_string())
+                        } else {
+                            Ok(None)
+                        }
+                    }
+                },
+                JobErrorStrategy::Fail,
+                Arc::new(NoopReporter),
+            )
+            .await
+        });
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        gate.notify_waiters();
+        let results = handle.await.unwrap();
+
+        assert!(results.iter().any(|r| !r.is_success()));
+        let successes = results.iter().filter(|r| r.is_success()).count();
+        assert!(
+            successes < 5,
+            "should not have run all five jobs to completion"
+        );
+    }
+
+    #[tokio::test]
+    async fn process_stream_continue_after_failures() {
+        let (pool, _queue) = fresh_pool();
+        let (tx, rx) = mpsc::channel::<WorkItem<()>>(8);
+        let producer_done = Arc::new(Notify::new());
+        let gate = Arc::new(Notify::new());
+
+        for _ in 0..4 {
+            tx.send(dummy_item()).await.unwrap();
+        }
+        drop(tx);
+        producer_done.notify_waiters();
+
+        let invocations = Arc::new(AtomicU64::new(0));
+        let invocations_clone = invocations.clone();
+        let gate_for_task = gate.clone();
+        let handle = tokio::spawn(async move {
+            pool.process_stream(
+                rx,
+                producer_done,
+                gate_for_task,
+                move |_job| {
+                    let c = invocations_clone.clone();
+                    async move {
+                        let n = c.fetch_add(1, Ordering::SeqCst);
+                        if n % 2 == 0 {
+                            Ok(None)
+                        } else {
+                            Err("oops".into())
+                        }
+                    }
+                },
+                JobErrorStrategy::Continue,
+                Arc::new(NoopReporter),
+            )
+            .await
+        });
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        gate.notify_waiters();
+        let results = handle.await.unwrap();
+
+        assert_eq!(invocations.load(Ordering::SeqCst), 4);
+        let failed = results.iter().filter(|r| !r.is_success()).count();
+        let ok = results.iter().filter(|r| r.is_success()).count();
+        assert_eq!(failed + ok, 4);
+        assert!(failed > 0 && ok > 0);
+    }
+
+    #[tokio::test]
+    async fn process_stream_enqueue_serialization_error() {
+        // Intentionally a no-op: there is no easy way to produce a payload
+        // type that fails to serialize except via a custom Serialize impl,
+        // and the same code path is already covered by the equivalent test
+        // in `worker.rs` (`payload_serialization_failure_returns_failed_result_and_continues`).
+    }
+
+    #[tokio::test]
+    async fn process_stream_extends_reporter_total() {
+        let (pool, _queue) = fresh_pool();
+        let (tx, rx) = mpsc::channel::<WorkItem<()>>(8);
+        let producer_done = Arc::new(Notify::new());
+        let gate = Arc::new(Notify::new());
+
+        struct CountReporter {
+            extended: AtomicU64,
+        }
+        impl ProgressReporter for CountReporter {
+            fn on_batch_start(&self, _total: usize) {}
+            fn on_job_start(&self, _job: &voom_domain::job::Job) {}
+            fn on_job_progress(&self, _id: Uuid, _p: f64, _m: Option<&str>) {}
+            fn on_job_complete(&self, _id: Uuid, _ok: bool, _err: Option<&str>) {}
+            fn on_batch_complete(&self, _c: u64, _f: u64) {}
+            fn on_jobs_extended(&self, additional: usize) {
+                self.extended.fetch_add(additional as u64, Ordering::SeqCst);
+            }
+        }
+        let reporter: Arc<CountReporter> = Arc::new(CountReporter {
+            extended: AtomicU64::new(0),
+        });
+
+        for _ in 0..6 {
+            tx.send(dummy_item()).await.unwrap();
+        }
+        drop(tx);
+        producer_done.notify_waiters();
+
+        let reporter_for_pool = reporter.clone();
+        let gate_for_task = gate.clone();
+        let handle = tokio::spawn(async move {
+            pool.process_stream(
+                rx,
+                producer_done,
+                gate_for_task,
+                move |_job| async { Ok(None) },
+                JobErrorStrategy::Continue,
+                reporter_for_pool,
+            )
+            .await
+        });
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        gate.notify_waiters();
+        let _ = handle.await.unwrap();
+
+        assert_eq!(reporter.extended.load(Ordering::SeqCst), 6);
+    }
 }

--- a/plugins/job-manager/src/worker_stream.rs
+++ b/plugins/job-manager/src/worker_stream.rs
@@ -2,8 +2,9 @@
 //! `mpsc::Receiver`, enqueue them into the SQLite-backed `JobQueue`, and
 //! claim/process them concurrently while an `execution_gate` is held open.
 
-use std::sync::Arc;
+use std::collections::HashSet;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use tokio::sync::{Notify, mpsc};
@@ -83,12 +84,19 @@ impl WorkerPool {
         // consumption pitfall of Notify::notified() in a polling loop.
         let producer_done_flag = Arc::new(AtomicBool::new(false));
 
+        // Track the ids we successfully enqueue in this run. On cancellation
+        // cleanup we intersect this set with the queue's current Pending list
+        // so we only cancel jobs this run produced — never unrelated Pending
+        // rows that may already exist in a long-lived SQLite store.
+        let enqueued_ids: Arc<Mutex<HashSet<Uuid>>> = Arc::new(Mutex::new(HashSet::new()));
+
         let (result_tx, mut result_rx) = mpsc::channel::<JobResult>(effective_workers.max(1) * 4);
 
         // --- Enqueuer task --------------------------------------------------
         let enqueuer_handle = self.spawn_enqueuer(
             items,
             producer_done_flag.clone(),
+            enqueued_ids.clone(),
             reporter.clone(),
             result_tx.clone(),
         );
@@ -128,12 +136,11 @@ impl WorkerPool {
         }
 
         // If we were cancelled, sweep any jobs that were enqueued but never
-        // claimed. We rely on the queue: anything still `Pending` by the time
-        // workers have joined was never claimed and should be cancelled. The
-        // streaming pool owns the queue for the duration of a run, so no
-        // unrelated `Pending` jobs are expected.
+        // claimed. We restrict cancellation to ids we enqueued in this run —
+        // the SQLite store is long-lived and may legitimately hold Pending
+        // rows from prior crashes or other code paths.
         if self.token.is_cancelled() {
-            let leftover = collect_pending_job_ids(&self.queue);
+            let leftover = collect_unstarted_enqueued_ids(&self.queue, &enqueued_ids);
             cancel_unstarted_jobs(self.queue.clone(), leftover).await;
         }
 
@@ -146,11 +153,14 @@ impl WorkerPool {
     }
 
     /// Spawn the single enqueuer task that drains `items` into the job queue
-    /// and flips `producer_done_flag` on completion.
+    /// and flips `producer_done_flag` on completion. Every successful enqueue
+    /// id is recorded in `enqueued_ids` so cancellation cleanup can scope its
+    /// sweep to jobs produced by this run.
     fn spawn_enqueuer<P>(
         &self,
         mut items: mpsc::Receiver<WorkItem<P>>,
         producer_done_flag: Arc<AtomicBool>,
+        enqueued_ids: Arc<Mutex<HashSet<Uuid>>>,
         reporter: Arc<dyn ProgressReporter>,
         result_tx: mpsc::Sender<JobResult>,
     ) -> JoinHandle<()>
@@ -189,7 +199,11 @@ impl WorkerPool {
                     None => None,
                 };
                 match queue.enqueue(item.job_type, item.priority, json_payload) {
-                    Ok(_id) => {
+                    Ok(id) => {
+                        enqueued_ids
+                            .lock()
+                            .expect("enqueued_ids mutex poisoned")
+                            .insert(id);
                         reporter.on_jobs_extended(1);
                     }
                     Err(e) => {
@@ -316,18 +330,35 @@ impl WorkerPool {
     }
 }
 
-/// Return the ids of all jobs still in `Pending` state. Used after streaming
-/// cancellation to cancel anything that was enqueued but never claimed.
-fn collect_pending_job_ids(queue: &Arc<crate::queue::JobQueue>) -> Vec<Uuid> {
+/// Return job ids we enqueued in this `process_stream` run that are still in
+/// `Pending` state. Used after streaming cancellation to cancel anything we
+/// enqueued but no worker ever claimed. Scoping the sweep to ids we produced
+/// avoids over-cancelling unrelated Pending rows that may exist in a
+/// long-lived SQLite store (e.g. left behind by a prior crash).
+fn collect_unstarted_enqueued_ids(
+    queue: &Arc<crate::queue::JobQueue>,
+    enqueued_ids: &Arc<Mutex<HashSet<Uuid>>>,
+) -> Vec<Uuid> {
     let mut filters = voom_domain::storage::JobFilters::default();
     filters.status = Some(voom_domain::job::JobStatus::Pending);
-    match queue.list_jobs(&filters) {
-        Ok(jobs) => jobs.into_iter().map(|j| j.id).collect(),
+    let pending = match queue.list_jobs(&filters) {
+        Ok(jobs) => jobs,
         Err(e) => {
             tracing::warn!(error = %e, "failed to enumerate pending jobs for cancellation");
-            Vec::new()
+            return Vec::new();
         }
-    }
+    };
+    let ours = enqueued_ids.lock().expect("enqueued_ids mutex poisoned");
+    pending
+        .into_iter()
+        .filter_map(|j| {
+            if ours.contains(&j.id) {
+                Some(j.id)
+            } else {
+                None
+            }
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -497,6 +528,9 @@ mod tests {
     #[tokio::test]
     async fn process_stream_fail_fast() {
         let (pool, _queue) = fresh_pool();
+        // Clone the cancellation token before moving the pool into the spawned
+        // task so we can assert post-run that fail-fast actually cancelled.
+        let pool_token = pool.token.clone();
         let (tx, rx) = mpsc::channel::<WorkItem<()>>(8);
         let gate = Arc::new(Notify::new());
 
@@ -534,10 +568,16 @@ mod tests {
         let results = handle.await.unwrap();
 
         assert!(results.iter().any(|r| !r.is_success()));
+        // Fail-fast must actually fire: the pool's cancellation token has to
+        // be set. Without this assertion, the test would still pass even if
+        // fail-fast didn't trigger.
+        assert!(pool_token.is_cancelled(), "fail-fast must cancel the pool");
+        // With max_workers = 2, at most two jobs should complete before the
+        // failing one trips cancellation. Allow a small race tolerance.
         let successes = results.iter().filter(|r| r.is_success()).count();
         assert!(
-            successes < 5,
-            "should not have run all five jobs to completion"
+            successes <= 2 + 1,
+            "fail-fast should have stopped after a couple of jobs, saw {successes}"
         );
     }
 

--- a/plugins/job-manager/src/worker_stream.rs
+++ b/plugins/job-manager/src/worker_stream.rs
@@ -142,14 +142,26 @@ impl WorkerPool {
         // enqueuer have dropped their clones.
         drop(result_tx);
 
+        // Spawn a collector that drains result_rx CONCURRENTLY with the
+        // enqueuer and workers. The enqueuer sends one `JobResult::failure`
+        // through `result_tx` for every enqueue/serialization failure. If we
+        // only drained AFTER `enqueuer_handle.await`, a burst of enqueue
+        // failures larger than the bounded channel capacity
+        // (`effective_workers * 4`) would block the enqueuer on
+        // `result_tx.send`, leave `producer_done_flag` unset, and deadlock
+        // the pool. The collector exits when every sender clone (held by the
+        // enqueuer + workers) has dropped, which only happens after those
+        // tasks finish.
+        let collector_handle: JoinHandle<Vec<JobResult>> = tokio::spawn(async move {
+            let mut results = Vec::new();
+            while let Some(result) = result_rx.recv().await {
+                results.push(result);
+            }
+            results
+        });
+
         if let Err(e) = enqueuer_handle.await {
             tracing::error!(error = %e, "enqueuer task join error");
-        }
-
-        // Collect results as workers report them.
-        let mut results = Vec::new();
-        while let Some(result) = result_rx.recv().await {
-            results.push(result);
         }
 
         for handle in worker_handles {
@@ -157,6 +169,13 @@ impl WorkerPool {
                 tracing::error!(error = %e, "worker task join error");
             }
         }
+
+        // All senders are dropped now (enqueuer + every worker have finished).
+        // The collector loop will observe `recv() -> None` and return.
+        let results = collector_handle.await.unwrap_or_else(|e| {
+            tracing::error!(error = %e, "result collector task join error");
+            Vec::new()
+        });
 
         // If we were cancelled, sweep any jobs that were enqueued but never
         // claimed. We restrict cancellation to ids we enqueued in this run —
@@ -863,5 +882,89 @@ mod tests {
             vec![10, 50, 100, 200],
             "workers must claim jobs in SQLite priority order"
         );
+    }
+
+    /// Regression test: `process_stream` must drain `result_rx` CONCURRENTLY
+    /// with the enqueuer task. The enqueuer sends one `JobResult::failure`
+    /// through the shared mpsc per enqueue/serialization error. If the
+    /// collector only runs AFTER `enqueuer_handle.await`, a burst of enqueue
+    /// failures larger than the channel capacity (`effective_workers * 4`)
+    /// will block the enqueuer on `result_tx.send`, never set
+    /// `producer_done_flag`, and deadlock `process_stream`.
+    #[tokio::test]
+    async fn process_stream_drains_results_concurrently_with_enqueuer() {
+        // One worker => channel capacity = 1 * 4 = 4. Sending 50 failures
+        // saturates the channel several times over, so the bug (if reintroduced)
+        // reliably manifests as a hang.
+        let store: Arc<dyn JobStorage> = Arc::new(InMemoryStore::new());
+        let queue = Arc::new(JobQueue::new(store));
+        let cfg = WorkerPoolConfig {
+            max_workers: 1,
+            worker_prefix: "test".into(),
+        };
+        let token = CancellationToken::new();
+        let pool = WorkerPool::new(queue.clone(), cfg, token);
+
+        let (tx, rx) = mpsc::channel::<WorkItem<FailingPayload>>(64);
+        let gate = Arc::new(Notify::new());
+
+        for _ in 0..50 {
+            tx.send(WorkItem::new(JobType::Process, 100, Some(FailingPayload)))
+                .await
+                .unwrap();
+        }
+        drop(tx);
+
+        // Open the gate AFTER `process_stream` starts so workers actually
+        // register on `gate.notified()` before being woken. Without this the
+        // workers would block on the gate forever, never drop their
+        // `result_tx` clones, and the collector would never observe channel
+        // closure even after the enqueuer finishes.
+        let gate_for_open = gate.clone();
+        let opener = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            gate_for_open.notify_waiters();
+        });
+
+        let outcome = tokio::time::timeout(
+            Duration::from_secs(10),
+            pool.process_stream(
+                rx,
+                gate,
+                |_job| async { Ok(None) },
+                JobErrorStrategy::Continue,
+                Arc::new(NoopReporter),
+            ),
+        )
+        .await;
+        let _ = opener.await;
+
+        let results = match outcome {
+            Ok(r) => r,
+            Err(_) => panic!("process_stream hung when enqueue failures filled result channel"),
+        };
+
+        assert_eq!(
+            results.len(),
+            50,
+            "every serialization failure must surface as a JobResult"
+        );
+        assert!(
+            results.iter().all(|r| !r.is_success()),
+            "all collected results should be failures"
+        );
+    }
+
+    /// Helper whose `Serialize` impl always errors. Used to force the enqueuer
+    /// onto its failure path (which sends a `JobResult::failure` through the
+    /// shared mpsc).
+    struct FailingPayload;
+    impl serde::Serialize for FailingPayload {
+        fn serialize<S: serde::Serializer>(
+            &self,
+            _serializer: S,
+        ) -> std::result::Result<S::Ok, S::Error> {
+            Err(serde::ser::Error::custom("intentional failure for test"))
+        }
     }
 }

--- a/plugins/job-manager/src/worker_stream.rs
+++ b/plugins/job-manager/src/worker_stream.rs
@@ -3,7 +3,6 @@
 //! claim/process them concurrently while an `execution_gate` is held open.
 
 use std::sync::Arc;
-use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
@@ -14,7 +13,7 @@ use uuid::Uuid;
 use crate::progress::ProgressReporter;
 use crate::worker::{
     JobErrorStrategy, JobResult, WorkItem, WorkerContext, WorkerPool, cancel_unstarted_jobs,
-    run_one_job,
+    run_claimed_job,
 };
 
 /// Polling interval workers use when the queue is momentarily empty but the
@@ -28,7 +27,6 @@ const CLAIM_POLL_INTERVAL: Duration = Duration::from_millis(5);
 /// `clippy::too_many_arguments` budget.
 struct WorkerSpawnArgs<F> {
     producer_done_flag: Arc<AtomicBool>,
-    pending: Arc<Mutex<Vec<Uuid>>>,
     execution_gate: Arc<Notify>,
     processor: Arc<F>,
     on_error: JobErrorStrategy,
@@ -45,23 +43,20 @@ impl WorkerPool {
     /// 1. the receiver has been drained (producer dropped the `tx` end),
     /// 2. and every worker has finished its last in-flight job.
     ///
+    /// Workers claim work via [`crate::queue::JobQueue::claim`], which honors
+    /// the SQLite store's priority ordering (`ORDER BY priority ASC, created_at
+    /// ASC`). This is the same dispatch order used by `voom process` in batch
+    /// mode and by `--priority-by-date`.
+    ///
     /// Cancellation: the pool's internal token (passed via [`WorkerPool::new`])
     /// is the shared signal. When cancelled, the enqueuer stops draining the
-    /// receiver, the remaining queued-but-unstarted jobs are cancelled via
-    /// [`cancel_unstarted_jobs`], and workers exit after their current job.
-    ///
-    /// The `producer_done` [`Notify`] parameter is accepted for API symmetry
-    /// with upstream callers that want to signal "no more items" explicitly,
-    /// but it is intentionally not consumed: dropping the `tx` end of `items`
-    /// is the canonical "producer done" signal and is sufficient on its own.
-    /// Internally we flip an `AtomicBool` when the receiver returns `None`,
-    /// avoiding the `Notify::notified()` consumption pitfall (notifications
-    /// don't latch — a poll loop on `notified()` would race itself).
-    #[tracing::instrument(skip(self, items, producer_done, execution_gate, processor, reporter))]
+    /// receiver, and workers exit after their current job. Any jobs that were
+    /// enqueued but never claimed (still in `Pending` state) are cancelled via
+    /// [`cancel_unstarted_jobs`].
+    #[tracing::instrument(skip(self, items, execution_gate, processor, reporter))]
     pub async fn process_stream<P, F, Fut>(
         &self,
         items: mpsc::Receiver<WorkItem<P>>,
-        producer_done: Arc<Notify>,
         execution_gate: Arc<Notify>,
         processor: F,
         on_error: JobErrorStrategy,
@@ -74,8 +69,6 @@ impl WorkerPool {
             + Send
             + 'static,
     {
-        let _ = producer_done; // intentionally unused: see doc comment above.
-
         let effective_workers = self.config.effective_workers();
         let processor = Arc::new(processor);
 
@@ -90,18 +83,12 @@ impl WorkerPool {
         // consumption pitfall of Notify::notified() in a polling loop.
         let producer_done_flag = Arc::new(AtomicBool::new(false));
 
-        // Tracks job IDs that have been enqueued and not yet been claimed by
-        // a worker. Workers pop one before invoking `run_one_job`; on
-        // cancellation, leftover IDs are sent to `cancel_unstarted_jobs`.
-        let pending: Arc<Mutex<Vec<Uuid>>> = Arc::new(Mutex::new(Vec::new()));
-
         let (result_tx, mut result_rx) = mpsc::channel::<JobResult>(effective_workers.max(1) * 4);
 
         // --- Enqueuer task --------------------------------------------------
         let enqueuer_handle = self.spawn_enqueuer(
             items,
             producer_done_flag.clone(),
-            pending.clone(),
             reporter.clone(),
             result_tx.clone(),
         );
@@ -111,7 +98,6 @@ impl WorkerPool {
         for _ in 0..effective_workers {
             let handle = self.spawn_worker(WorkerSpawnArgs {
                 producer_done_flag: producer_done_flag.clone(),
-                pending: pending.clone(),
                 execution_gate: execution_gate.clone(),
                 processor: processor.clone(),
                 on_error,
@@ -125,8 +111,6 @@ impl WorkerPool {
         // enqueuer have dropped their clones.
         drop(result_tx);
 
-        // Wait for the enqueuer to exit before draining results: it owns the
-        // `pending` list and we want it fully populated before cancel cleanup.
         if let Err(e) = enqueuer_handle.await {
             tracing::error!(error = %e, "enqueuer task join error");
         }
@@ -143,13 +127,13 @@ impl WorkerPool {
             }
         }
 
-        // If we were cancelled, cancel anything still pending (i.e. enqueued
-        // but never claimed). On the happy path `pending` is empty here.
+        // If we were cancelled, sweep any jobs that were enqueued but never
+        // claimed. We rely on the queue: anything still `Pending` by the time
+        // workers have joined was never claimed and should be cancelled. The
+        // streaming pool owns the queue for the duration of a run, so no
+        // unrelated `Pending` jobs are expected.
         if self.token.is_cancelled() {
-            let leftover: Vec<Uuid> = {
-                let mut guard = pending.lock().expect("pending mutex poisoned");
-                std::mem::take(&mut *guard)
-            };
+            let leftover = collect_pending_job_ids(&self.queue);
             cancel_unstarted_jobs(self.queue.clone(), leftover).await;
         }
 
@@ -161,13 +145,12 @@ impl WorkerPool {
         results
     }
 
-    /// Spawn the single enqueuer task that drains `items` into the job queue,
-    /// tracks pending IDs, and flips `producer_done_flag` on completion.
+    /// Spawn the single enqueuer task that drains `items` into the job queue
+    /// and flips `producer_done_flag` on completion.
     fn spawn_enqueuer<P>(
         &self,
         mut items: mpsc::Receiver<WorkItem<P>>,
         producer_done_flag: Arc<AtomicBool>,
-        pending: Arc<Mutex<Vec<Uuid>>>,
         reporter: Arc<dyn ProgressReporter>,
         result_tx: mpsc::Sender<JobResult>,
     ) -> JoinHandle<()>
@@ -206,8 +189,7 @@ impl WorkerPool {
                     None => None,
                 };
                 match queue.enqueue(item.job_type, item.priority, json_payload) {
-                    Ok(id) => {
-                        pending.lock().expect("pending mutex poisoned").push(id);
+                    Ok(_id) => {
                         reporter.on_jobs_extended(1);
                     }
                     Err(e) => {
@@ -228,7 +210,7 @@ impl WorkerPool {
     }
 
     /// Spawn one worker task that loops on `queue.claim`, runs each claimed
-    /// job, and exits cleanly when the enqueuer is done and no jobs remain.
+    /// job, and exits cleanly when the enqueuer is done and the queue drains.
     fn spawn_worker<F, Fut>(&self, args: WorkerSpawnArgs<F>) -> JoinHandle<()>
     where
         F: Fn(voom_domain::job::Job) -> Fut + Send + Sync + 'static,
@@ -238,7 +220,6 @@ impl WorkerPool {
     {
         let WorkerSpawnArgs {
             producer_done_flag,
-            pending,
             execution_gate,
             processor,
             on_error,
@@ -271,19 +252,37 @@ impl WorkerPool {
                     return;
                 }
 
-                // Pop the next job ID from the pending list. Workers consume
-                // IDs the enqueuer has produced; `run_one_job` then claims by
-                // ID and runs the processor.
-                let next_id = pending.lock().expect("pending mutex poisoned").pop();
+                // Claim the next pending job via the queue, which honors the
+                // SQLite store's priority ordering. This is the same dispatch
+                // order used by the batch path and by `--priority-by-date`.
+                let claim_queue = queue.clone();
+                let wid = worker_id.clone();
+                let claim_result =
+                    tokio::task::spawn_blocking(move || claim_queue.claim(&wid)).await;
 
-                let Some(job_id) = next_id else {
-                    // No pending work. If the enqueuer is done, we're
-                    // finished; otherwise sleep briefly and re-check.
-                    if producer_done_flag.load(Ordering::SeqCst) {
-                        return;
+                let job = match claim_result {
+                    Ok(Ok(Some(job))) => job,
+                    Ok(Ok(None)) => {
+                        // No pending work right now. If the enqueuer is done,
+                        // we're finished; otherwise sleep briefly and retry.
+                        if producer_done_flag.load(Ordering::SeqCst) {
+                            return;
+                        }
+                        tokio::time::sleep(CLAIM_POLL_INTERVAL).await;
+                        continue;
                     }
-                    tokio::time::sleep(CLAIM_POLL_INTERVAL).await;
-                    continue;
+                    Ok(Err(e)) => {
+                        tracing::error!(error = %e, "Failed to claim next job");
+                        // No job id to report against; keep looping. The token
+                        // will eventually be cancelled if storage is broken.
+                        tokio::time::sleep(CLAIM_POLL_INTERVAL).await;
+                        continue;
+                    }
+                    Err(e) => {
+                        tracing::error!(error = %e, "Task join error during claim");
+                        tokio::time::sleep(CLAIM_POLL_INTERVAL).await;
+                        continue;
+                    }
                 };
 
                 let pre_failed = failed.load(Ordering::SeqCst);
@@ -300,10 +299,10 @@ impl WorkerPool {
                     worker_id: worker_id.clone(),
                     on_error,
                 };
-                run_one_job(job_id, ctx).await;
+                run_claimed_job(job, ctx).await;
 
                 // Fail-fast: if the on_error strategy is Fail and the failure
-                // counter just incremented, this worker exits. `run_one_job`
+                // counter just incremented, this worker exits. `run_claimed_job`
                 // itself cancels the token on failure under the Fail strategy,
                 // so sibling workers will observe the cancellation on their
                 // next loop iteration.
@@ -317,12 +316,27 @@ impl WorkerPool {
     }
 }
 
+/// Return the ids of all jobs still in `Pending` state. Used after streaming
+/// cancellation to cancel anything that was enqueued but never claimed.
+fn collect_pending_job_ids(queue: &Arc<crate::queue::JobQueue>) -> Vec<Uuid> {
+    let mut filters = voom_domain::storage::JobFilters::default();
+    filters.status = Some(voom_domain::job::JobStatus::Pending);
+    match queue.list_jobs(&filters) {
+        Ok(jobs) => jobs.into_iter().map(|j| j.id).collect(),
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to enumerate pending jobs for cancellation");
+            Vec::new()
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::progress::NoopReporter;
     use crate::queue::JobQueue;
     use crate::worker::{JobErrorStrategy, WorkerPool, WorkerPoolConfig};
+    use std::sync::Mutex;
     use std::sync::atomic::AtomicU64;
     use tokio_util::sync::CancellationToken;
     use voom_domain::job::JobType;
@@ -348,14 +362,12 @@ mod tests {
     async fn process_stream_basic() {
         let (pool, _queue) = fresh_pool();
         let (tx, rx) = mpsc::channel::<WorkItem<()>>(8);
-        let producer_done = Arc::new(Notify::new());
         let gate = Arc::new(Notify::new());
 
         for _ in 0..5 {
             tx.send(dummy_item()).await.unwrap();
         }
         drop(tx);
-        producer_done.notify_waiters();
 
         let counter = Arc::new(AtomicU64::new(0));
         let counter_clone = counter.clone();
@@ -363,7 +375,6 @@ mod tests {
         let handle = tokio::spawn(async move {
             pool.process_stream(
                 rx,
-                producer_done,
                 gate_for_task,
                 move |_job| {
                     let c = counter_clone.clone();
@@ -393,14 +404,12 @@ mod tests {
     async fn process_stream_respects_gate() {
         let (pool, _queue) = fresh_pool();
         let (tx, rx) = mpsc::channel::<WorkItem<()>>(8);
-        let producer_done = Arc::new(Notify::new());
         let gate = Arc::new(Notify::new());
 
         for _ in 0..3 {
             tx.send(dummy_item()).await.unwrap();
         }
         drop(tx);
-        producer_done.notify_waiters();
 
         let counter = Arc::new(AtomicU64::new(0));
         let counter_clone = counter.clone();
@@ -409,7 +418,6 @@ mod tests {
         let handle = tokio::spawn(async move {
             pool.process_stream(
                 rx,
-                producer_done,
                 gate_for_task,
                 move |_job| {
                     let c = counter_clone.clone();
@@ -445,14 +453,12 @@ mod tests {
         let pool = WorkerPool::new(queue.clone(), cfg, token.clone());
 
         let (tx, rx) = mpsc::channel::<WorkItem<()>>(8);
-        let producer_done = Arc::new(Notify::new());
         let gate = Arc::new(Notify::new());
 
         for _ in 0..3 {
             tx.send(dummy_item()).await.unwrap();
         }
         drop(tx);
-        producer_done.notify_waiters();
 
         let counter = Arc::new(AtomicU64::new(0));
         let counter_clone = counter.clone();
@@ -460,7 +466,6 @@ mod tests {
         let handle = tokio::spawn(async move {
             pool.process_stream(
                 rx,
-                producer_done,
                 gate_for_task,
                 move |_job| {
                     let c = counter_clone.clone();
@@ -493,14 +498,12 @@ mod tests {
     async fn process_stream_fail_fast() {
         let (pool, _queue) = fresh_pool();
         let (tx, rx) = mpsc::channel::<WorkItem<()>>(8);
-        let producer_done = Arc::new(Notify::new());
         let gate = Arc::new(Notify::new());
 
         for _ in 0..5 {
             tx.send(dummy_item()).await.unwrap();
         }
         drop(tx);
-        producer_done.notify_waiters();
 
         let invocations = Arc::new(AtomicU64::new(0));
         let invocations_clone = invocations.clone();
@@ -508,7 +511,6 @@ mod tests {
         let handle = tokio::spawn(async move {
             pool.process_stream(
                 rx,
-                producer_done,
                 gate_for_task,
                 move |_job| {
                     let c = invocations_clone.clone();
@@ -543,14 +545,12 @@ mod tests {
     async fn process_stream_continue_after_failures() {
         let (pool, _queue) = fresh_pool();
         let (tx, rx) = mpsc::channel::<WorkItem<()>>(8);
-        let producer_done = Arc::new(Notify::new());
         let gate = Arc::new(Notify::new());
 
         for _ in 0..4 {
             tx.send(dummy_item()).await.unwrap();
         }
         drop(tx);
-        producer_done.notify_waiters();
 
         let invocations = Arc::new(AtomicU64::new(0));
         let invocations_clone = invocations.clone();
@@ -558,7 +558,6 @@ mod tests {
         let handle = tokio::spawn(async move {
             pool.process_stream(
                 rx,
-                producer_done,
                 gate_for_task,
                 move |_job| {
                     let c = invocations_clone.clone();
@@ -589,18 +588,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn process_stream_enqueue_serialization_error() {
-        // Intentionally a no-op: there is no easy way to produce a payload
-        // type that fails to serialize except via a custom Serialize impl,
-        // and the same code path is already covered by the equivalent test
-        // in `worker.rs` (`payload_serialization_failure_returns_failed_result_and_continues`).
-    }
-
-    #[tokio::test]
     async fn process_stream_extends_reporter_total() {
         let (pool, _queue) = fresh_pool();
         let (tx, rx) = mpsc::channel::<WorkItem<()>>(8);
-        let producer_done = Arc::new(Notify::new());
         let gate = Arc::new(Notify::new());
 
         struct CountReporter {
@@ -624,14 +614,12 @@ mod tests {
             tx.send(dummy_item()).await.unwrap();
         }
         drop(tx);
-        producer_done.notify_waiters();
 
         let reporter_for_pool = reporter.clone();
         let gate_for_task = gate.clone();
         let handle = tokio::spawn(async move {
             pool.process_stream(
                 rx,
-                producer_done,
                 gate_for_task,
                 move |_job| async { Ok(None) },
                 JobErrorStrategy::Continue,
@@ -645,5 +633,73 @@ mod tests {
         let _ = handle.await.unwrap();
 
         assert_eq!(reporter.extended.load(Ordering::SeqCst), 6);
+    }
+
+    /// Spec compliance: workers must dispatch jobs in SQLite priority order
+    /// (lowest priority number first, then created_at). Regression test for
+    /// the original `Vec::pop()` design which served jobs LIFO and bypassed
+    /// the queue's priority ordering used by `--priority-by-date`.
+    #[tokio::test]
+    async fn process_stream_honors_priority_ordering() {
+        let store: Arc<dyn JobStorage> = Arc::new(InMemoryStore::new());
+        let queue = Arc::new(JobQueue::new(store));
+        // Single worker so the dispatch order is deterministic.
+        let cfg = WorkerPoolConfig {
+            max_workers: 1,
+            worker_prefix: "prio".into(),
+        };
+        let token = CancellationToken::new();
+        let pool = WorkerPool::new(queue.clone(), cfg, token);
+
+        let (tx, rx) = mpsc::channel::<WorkItem<i32>>(8);
+        let gate = Arc::new(Notify::new());
+
+        // Enqueue in mixed priority order. Expected dispatch order: 10, 50, 100, 200.
+        for priority in [100, 50, 200, 10] {
+            tx.send(WorkItem::new(JobType::Process, priority, Some(priority)))
+                .await
+                .unwrap();
+        }
+        drop(tx);
+
+        let seen: Arc<Mutex<Vec<i32>>> = Arc::new(Mutex::new(Vec::new()));
+        let seen_clone = seen.clone();
+        let gate_for_task = gate.clone();
+
+        let handle = tokio::spawn(async move {
+            pool.process_stream(
+                rx,
+                gate_for_task,
+                move |job| {
+                    let seen = seen_clone.clone();
+                    async move {
+                        let payload = job.payload.as_ref().expect("priority payload missing");
+                        let priority =
+                            i32::try_from(payload.as_i64().expect("priority is integer"))
+                                .expect("priority fits in i32");
+                        seen.lock().expect("seen mutex").push(priority);
+                        Ok(None)
+                    }
+                },
+                JobErrorStrategy::Continue,
+                Arc::new(NoopReporter),
+            )
+            .await
+        });
+
+        // Give the enqueuer a moment to insert all four jobs before opening
+        // the gate. If we open the gate first, a worker could claim job 1
+        // (priority 100) before jobs 2-4 are enqueued.
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        gate.notify_waiters();
+        let results = handle.await.unwrap();
+
+        assert_eq!(results.iter().filter(|r| r.is_success()).count(), 4);
+        let order = seen.lock().expect("seen mutex").clone();
+        assert_eq!(
+            order,
+            vec![10, 50, 100, 200],
+            "workers must claim jobs in SQLite priority order"
+        );
     }
 }

--- a/plugins/job-manager/src/worker_stream.rs
+++ b/plugins/job-manager/src/worker_stream.rs
@@ -1,0 +1,59 @@
+//! Streaming entry point for `WorkerPool`: consume `WorkItem`s from an
+//! `mpsc::Receiver`, enqueue them into the SQLite-backed `JobQueue`, and
+//! claim/process them concurrently while an `execution_gate` is held open.
+
+use std::sync::Arc;
+
+use tokio::sync::{Notify, mpsc};
+
+use crate::progress::ProgressReporter;
+use crate::worker::{JobErrorStrategy, JobResult, WorkItem, WorkerPool};
+
+impl WorkerPool {
+    /// Stream entries through the pool: consume items from `items`, enqueue
+    /// each one into the job queue, and run up to `effective_workers` claim
+    /// loops in parallel. Workers wait on `execution_gate` before their first
+    /// claim. The pool returns when:
+    ///
+    /// 1. `producer_done` has been notified,
+    /// 2. the receiver has been drained,
+    /// 3. and every worker has finished its last in-flight job.
+    ///
+    /// Cancellation: the pool's internal token (passed via `WorkerPool::new`)
+    /// is the shared signal. When cancelled, the enqueuer stops draining the
+    /// receiver, the remaining queued-but-unstarted jobs are cancelled via
+    /// the existing `cancel_unstarted_jobs` helper, and workers exit after
+    /// their current job.
+    pub async fn process_stream<P, F, Fut>(
+        &self,
+        items: mpsc::Receiver<WorkItem<P>>,
+        producer_done: Arc<Notify>,
+        execution_gate: Arc<Notify>,
+        processor: F,
+        on_error: JobErrorStrategy,
+        reporter: Arc<dyn ProgressReporter>,
+    ) -> Vec<JobResult>
+    where
+        P: serde::Serialize + Send + 'static,
+        F: Fn(voom_domain::job::Job) -> Fut + Send + Sync + 'static,
+        Fut: std::future::Future<Output = std::result::Result<Option<serde_json::Value>, String>>
+            + Send
+            + 'static,
+    {
+        // Replaced in the next task.
+        let _ = (
+            items,
+            producer_done,
+            execution_gate,
+            processor,
+            on_error,
+            reporter,
+        );
+        Vec::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // Tests follow in the next task.
+}

--- a/plugins/sqlite-store/src/schema.rs
+++ b/plugins/sqlite-store/src/schema.rs
@@ -1019,10 +1019,15 @@ fn migrate_from_path_column(
 
 /// Configure `SQLite` connection for optimal performance.
 pub fn configure_connection(conn: &Connection) -> rusqlite::Result<()> {
+    // busy_timeout = 15000ms gives slow ffprobe-followed-by-write transactions
+    // enough headroom under heavy parallel load (e.g. corrupt-corpus tests with
+    // many probe workers + a streaming ingest task + the periodic heartbeat).
+    // 5s was too tight; 15s comfortably covers worst-case writer queueing
+    // without masking real deadlocks.
     conn.execute_batch(
         "PRAGMA journal_mode = WAL;
          PRAGMA foreign_keys = ON;
-         PRAGMA busy_timeout = 5000;
+         PRAGMA busy_timeout = 15000;
          PRAGMA synchronous = NORMAL;
          PRAGMA cache_size = -8000;",
     )

--- a/plugins/sqlite-store/src/store/file_storage.rs
+++ b/plugins/sqlite-store/src/store/file_storage.rs
@@ -47,8 +47,12 @@ impl FileStorage for SqliteStore {
 
         let effective_id = existing_id.clone().unwrap_or_else(|| file.id.to_string());
 
+        // BEGIN IMMEDIATE so the writer lock is acquired up front, before any
+        // other writer can slip in between BEGIN and the first write. Without
+        // this, deferred transactions can fail with SQLITE_BUSY mid-transaction
+        // under heavy parallel load (multiple probe workers + ingest + heartbeat).
         let tx = conn
-            .transaction()
+            .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
             .map_err(storage_err("failed to begin transaction"))?;
 
         // Delete old tracks before upserting
@@ -390,7 +394,7 @@ impl FileStorage for SqliteStore {
         let id_str = transition.file_id.to_string();
         let mut conn = self.conn()?;
         let tx = conn
-            .transaction()
+            .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
             .map_err(storage_err("failed to begin post-execution transaction"))?;
 
         if let Some(new_path) = new_path {
@@ -515,7 +519,7 @@ impl FileStorage for SqliteStore {
         let id = voom_domain::transition::ScanSessionId::new();
 
         let tx = conn
-            .transaction()
+            .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
             .map_err(storage_err("failed to begin scan_session transaction"))?;
 
         // Inspect existing in_progress sessions. Auto-cancel only those whose
@@ -600,11 +604,16 @@ impl FileStorage for SqliteStore {
         let filename = filename_string(&file.path);
 
         let tx = conn
-            .transaction()
+            .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
             .map_err(storage_err("failed to begin ingest transaction"))?;
 
         validate_session_in_progress_in_tx(&tx, &session_str)?;
-        bump_session_heartbeat_in_tx(&tx, &session_str, &now)?;
+        // Heartbeat is bumped out-of-band by the periodic heartbeat task spawned
+        // inside `with_scan_session` (see scan/pipeline.rs:716). Keeping an
+        // additional UPDATE inside every ingest transaction multiplied SQLite
+        // write contention under heavy load (many probe writers + many ingest
+        // transactions + the periodic heartbeat) and tripped `busy_timeout` on
+        // corpus tests that include slow-to-probe corrupt files.
 
         let ctx = IngestCtx {
             now: &now,
@@ -690,7 +699,7 @@ impl FileStorage for SqliteStore {
         let session_str = session.to_string();
 
         let tx = conn
-            .transaction()
+            .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
             .map_err(storage_err("failed to begin finish_scan_session tx"))?;
 
         let row: Option<(String, String, String)> = tx
@@ -824,21 +833,6 @@ fn validate_session_in_progress_in_tx(
             message: format!("unknown scan session {session_str}"),
         }),
     }
-}
-
-/// Bump the `last_heartbeat_at` of the given scan session inside the caller's
-/// transaction.
-fn bump_session_heartbeat_in_tx(
-    tx: &rusqlite::Transaction<'_>,
-    session_str: &str,
-    now: &str,
-) -> Result<()> {
-    tx.execute(
-        "UPDATE scan_sessions SET last_heartbeat_at = ?1 WHERE id = ?2",
-        params![now, session_str],
-    )
-    .map_err(storage_err("failed to bump scan session heartbeat"))?;
-    Ok(())
 }
 
 /// Existing-file lookup result: `(id, expected_hash, size, last_seen_session_id)`.
@@ -3500,7 +3494,13 @@ mod tests {
     }
 
     #[test]
-    fn ingest_bumps_heartbeat() {
+    fn ingest_does_not_bump_heartbeat_inline() {
+        // Contract: `ingest_discovered_file` does NOT keep the session
+        // heartbeat fresh on its own. Callers (the streaming CLI pipeline,
+        // see `scan/pipeline.rs::spawn_heartbeat_task`) are responsible for
+        // calling `heartbeat_scan_session` periodically. This separation
+        // avoids an extra write inside every per-file ingest transaction,
+        // which was a hot path for SQLite writer contention under load.
         use std::path::PathBuf;
         use voom_domain::transition::DiscoveredFile;
 
@@ -3522,7 +3522,7 @@ mod tests {
         let df = DiscoveredFile::new(PathBuf::from("/m/a.mkv"), 100, "h-a".to_string());
         store.ingest_discovered_file(session, &df).unwrap();
 
-        let after: String = store
+        let after_ingest: String = store
             .conn()
             .unwrap()
             .query_row(
@@ -3532,9 +3532,26 @@ mod tests {
             )
             .unwrap();
 
+        assert_eq!(
+            after_ingest, before,
+            "ingest must NOT bump heartbeat inline; before={before} after={after_ingest}"
+        );
+
+        // A subsequent explicit heartbeat call DOES advance it — that's the
+        // mechanism the streaming pipeline uses.
+        store.heartbeat_scan_session(session).unwrap();
+        let after_explicit: String = store
+            .conn()
+            .unwrap()
+            .query_row(
+                "SELECT last_heartbeat_at FROM scan_sessions WHERE id = ?1",
+                params![session.to_string()],
+                |r| r.get(0),
+            )
+            .unwrap();
         assert!(
-            after > before,
-            "heartbeat must advance after ingest; before={before} after={after}"
+            after_explicit > before,
+            "heartbeat_scan_session must advance the heartbeat; before={before} after={after_explicit}"
         );
     }
 


### PR DESCRIPTION
## Summary

Closes #360. Converts `voom process` from batch discovery + batch processing to a streaming pipeline so per-file policy work begins enqueueing while filesystem discovery is still walking. Mutating plan execution remains gated behind discovery completion (the conservative default the issue called for); dry-run / plan-only / estimate paths proceed immediately.

Spec: `docs/superpowers/specs/2026-05-12-issue-360-process-streaming-phase-3-design.md`
Plan: `docs/superpowers/plans/2026-05-12-issue-360-process-streaming-phase-3.md`

### What's new

- **`WorkerPool::process_stream`** (`plugins/job-manager/src/worker_stream.rs`) — new entry point alongside `process_batch`. Single enqueuer task drains an `mpsc::Receiver<WorkItem<P>>` into the SQLite-backed `JobQueue`; up to `max_workers` claim tasks loop on `queue.claim()` once the `execution_gate` (`tokio::sync::Notify`) fires. Workers honor SQLite priority ordering, so `--priority-by-date` still works.
- **Three-stage async pipeline** (`crates/voom-cli/src/commands/process/pipeline_streaming.rs`) — discovery (`DiscoveryPlugin::scan_streaming` via `spawn_blocking`) → ingest (bad-file filter + dedup + `FileDiscovered` event dispatch + `WorkItem` build) → execution. `mpsc` channels with backpressure; child `CancellationToken` for cross-stage error propagation; reporter receives `seed_events` + `on_batch_start` once the file set is known.
- **`process::run` swap-over** — `discover_files`, `filter_bad_files`, `build_work_items` deleted (~240 lines removed). Behavior is preserved: every CLI flag, summary line, and exit code matches the pre-change implementation.
- **`ProgressReporter`** gains `on_jobs_extended(n)` and `seed_events(&[..])` default no-ops; `BatchProgress` overrides them so its determinate bar grows during streaming and its ETA state seeds from the now-known event list once discovery completes.

### Cancellation, fail-fast, and panic handling

- Cancellation drops pending-but-unstarted jobs (precisely tracked by id; queue scans intersected with the pool's own set so we never cancel jobs belonging to other code paths).
- `JobErrorStrategy::Fail` cancels the pool on the first failure; verified by an explicit `pool.is_cancelled()` assertion in the test.
- The pool future is wrapped in `tokio::spawn` so a panic in any stage doesn't detach the other two; `pipeline_cancel` fires on first error and stages drain in source order.

### SQLite-store contention fix (also fixes a pre-existing flake on main)

The streaming pipeline added enough writer-lock pressure to expose a pre-existing flake in scan streaming phase 2: under heavy parallel load (`--test-threads=4` + a corpus with slow-to-probe corrupt files), the scan pipeline could hit "database is locked" mid-transaction. Root cause: scan-session write transactions used `BEGIN DEFERRED`, which acquires the writer lock lazily — another writer could slip in between BEGIN and the first write, returning SQLITE_BUSY without retry.

Fix:
- Convert every write-heavy transaction in `file_storage.rs` to `BEGIN IMMEDIATE` (matches the existing pattern in `job_storage.rs`).
- Drop the redundant inline heartbeat bump from `ingest_discovered_file` (the periodic heartbeat task spawned by `with_scan_session` already keeps the session fresh).
- Bump `busy_timeout` from 5s to 15s as headroom for genuinely slow transactions.

Reproduced on bare main (1/2 stress runs fail). Resolved on this branch (5/5 stress runs pass).

### Stats

- 11 functional commits + 1 sqlite-store fix commit
- 1500+ lines added net (most of it in two new modules + tests; ~244 lines removed from `process/mod.rs`)
- 13 new tests (6 worker_stream unit + 5 pipeline integration + 2 progress reporter)

## Test plan

- [x] `cargo test --workspace` — all 25 test suites green
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test -p voom-cli --features functional -- --test-threads=4` — green 5 consecutive runs (flake resolved)
- [x] All existing process integration tests stay green (`process_batch` is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)