### PR TITLE
feat: per-plugin runtime stats (Deliverable 1 of #92)

### DIFF
--- a/crates/voom-cli/src/app.rs
+++ b/crates/voom-cli/src/app.rs
@@ -130,6 +130,9 @@ pub fn bootstrap_kernel_with_store(config: &AppConfig) -> Result<BootstrapResult
             // sqlite-store disabled: open a standalone pool so callers always
             // get a usable handle.  No plugin is registered, so events will
             // not be persisted, but read-only CLI commands still work.
+            tracing::warn!(
+                "sqlite-store disabled — plugin invocation stats will not be recorded (issue #92)"
+            );
             open_store_in(data_dir).context("Failed to open storage")?
         } else {
             let mut plugin = voom_sqlite_store::SqliteStorePlugin::new();
@@ -137,13 +140,25 @@ pub fn bootstrap_kernel_with_store(config: &AppConfig) -> Result<BootstrapResult
                 voom_kernel::PluginContext::new(plugin_json("sqlite-store"), data_dir.clone());
             let init_events = plugin.init(&ctx).context("Failed to initialize storage")?;
 
-            // Capture the store handle before moving the plugin into an Arc.
-            // `plugin.store()` is always Some after a successful init().
-            let handle = plugin
+            // Capture the concrete `Arc<SqliteStore>` BEFORE casting to the
+            // trait-object handle returned to callers. The stats sink needs the
+            // concrete type because `insert_plugin_stats_batch` is a SqliteStore
+            // inherent method, and we don't want to widen the public StorageTrait
+            // surface for one consumer.
+            let concrete_store: Arc<voom_sqlite_store::store::SqliteStore> = plugin
                 .store()
-                .map(|s| Arc::clone(s) as Arc<dyn voom_domain::storage::StorageTrait>)
+                .cloned()
                 .expect("store is Some after successful init");
 
+            // Install the stats sink BEFORE registering the plugin on the bus so
+            // the storage plugin's own init events (dispatched below) are captured.
+            // Until this call, the bus uses NoopStatsSink.
+            let stats_sink: Arc<dyn voom_kernel::stats_sink::StatsSink> = Arc::new(
+                voom_sqlite_store::SqliteStatsSink::new(concrete_store.clone()),
+            );
+            kernel.set_stats_sink(stats_sink);
+
+            let handle = concrete_store.clone() as Arc<dyn voom_domain::storage::StorageTrait>;
             let plugin_arc: Arc<dyn voom_kernel::Plugin> = Arc::new(plugin);
             kernel.register_plugin(plugin_arc, PRIORITY_STORAGE)?;
 

--- a/crates/voom-cli/src/cli.rs
+++ b/crates/voom-cli/src/cli.rs
@@ -428,6 +428,21 @@ pub enum PluginCommands {
         /// Path to .wasm file
         path: PathBuf,
     },
+    /// Show per-plugin invocation rollup (p50/p95/p99, outcome counts).
+    Stats {
+        /// Filter to a single plugin by name.
+        #[arg(long)]
+        plugin: Option<String>,
+        /// Look back this far (e.g. "24h", "7d", "30m").
+        #[arg(long)]
+        since: Option<String>,
+        /// Show only the top N slowest plugins (by p95).
+        #[arg(long)]
+        top: Option<usize>,
+        /// Output format
+        #[arg(short, long, default_value = "table")]
+        format: OutputFormat,
+    },
 }
 
 // === Jobs ===

--- a/crates/voom-cli/src/commands/mod.rs
+++ b/crates/voom-cli/src/commands/mod.rs
@@ -13,6 +13,7 @@ pub mod inspect;
 pub mod jobs;
 pub mod plans;
 pub mod plugin;
+pub mod plugin_stats;
 pub mod policy;
 pub mod process;
 pub mod report;

--- a/crates/voom-cli/src/commands/plugin.rs
+++ b/crates/voom-cli/src/commands/plugin.rs
@@ -13,6 +13,12 @@ pub fn run(cmd: PluginCommands) -> Result<()> {
         PluginCommands::Enable { name } => enable(&name),
         PluginCommands::Disable { name } => disable(&name),
         PluginCommands::Install { path } => install(&path),
+        PluginCommands::Stats {
+            plugin,
+            since,
+            top,
+            format,
+        } => crate::commands::plugin_stats::run(plugin, since, top, format),
     }
 }
 

--- a/crates/voom-cli/src/commands/plugin_stats.rs
+++ b/crates/voom-cli/src/commands/plugin_stats.rs
@@ -17,13 +17,17 @@ pub fn run(
 ) -> Result<()> {
     let since_dt = since.as_deref().map(parse_since).transpose()?;
     let cfg = config::load_config()?;
-    let result = app::bootstrap_kernel_with_store(&cfg)?;
+    // Read-only path: open the SQLite pool directly. Do NOT construct a
+    // kernel or install a stats sink — that would write to event_log and
+    // plugin_stats just by running this command. See Codex adversarial
+    // review (May 2026).
+    let store = app::open_store(&cfg)?;
     let filter = PluginStatsFilter {
         plugin,
         since: since_dt,
         top,
     };
-    let rollups = result.store.rollup_plugin_stats(&filter)?;
+    let rollups = store.rollup_plugin_stats(&filter)?;
     render(&rollups, format)
 }
 

--- a/crates/voom-cli/src/commands/plugin_stats.rs
+++ b/crates/voom-cli/src/commands/plugin_stats.rs
@@ -29,10 +29,15 @@ pub fn run(
 
 fn parse_since(s: &str) -> Result<DateTime<Utc>> {
     // Accept "24h", "7d", "30m" — number + unit (s/m/h/d).
-    let (num_str, unit) = s.split_at(s.len().saturating_sub(1));
+    // Split on a char boundary so multi-byte trailing chars don't panic.
+    let split = s.char_indices().next_back().map(|(i, _)| i).unwrap_or(0);
+    let (num_str, unit) = s.split_at(split);
     let n: i64 = num_str
         .parse()
         .map_err(|_| anyhow!("invalid --since value: {s}"))?;
+    if n <= 0 {
+        return Err(anyhow!("--since must be a positive duration, got: {s}"));
+    }
     let d = match unit {
         "s" => Duration::seconds(n),
         "m" => Duration::minutes(n),
@@ -44,11 +49,20 @@ fn parse_since(s: &str) -> Result<DateTime<Utc>> {
 }
 
 fn render(rollups: &[PluginStatsRollup], format: OutputFormat) -> Result<()> {
-    if matches!(format, OutputFormat::Json) {
-        let json = serde_json::to_string_pretty(rollups)?;
-        println!("{json}");
-        return Ok(());
+    match format {
+        OutputFormat::Json => {
+            let json = serde_json::to_string_pretty(rollups)?;
+            println!("{json}");
+            Ok(())
+        }
+        OutputFormat::Table => render_table(rollups),
+        OutputFormat::Plain | OutputFormat::Csv => Err(anyhow!(
+            "--format {format:?} is not supported for `voom plugin stats`; use table or json"
+        )),
     }
+}
+
+fn render_table(rollups: &[PluginStatsRollup]) -> Result<()> {
     if rollups.is_empty() {
         println!("No plugin invocations recorded.");
         return Ok(());
@@ -100,5 +114,23 @@ mod tests {
     #[test]
     fn parse_since_rejects_non_numeric() {
         assert!(parse_since("abh").is_err());
+    }
+
+    #[test]
+    fn parse_since_rejects_negative() {
+        assert!(parse_since("-1h").is_err());
+    }
+
+    #[test]
+    fn parse_since_rejects_zero() {
+        assert!(parse_since("0h").is_err());
+    }
+
+    #[test]
+    fn parse_since_multibyte_does_not_panic() {
+        // Returns Err because "⏱" is not a valid unit; the important property
+        // is that we do not panic on the byte split.
+        let r = parse_since("24⏱");
+        assert!(r.is_err());
     }
 }

--- a/crates/voom-cli/src/commands/plugin_stats.rs
+++ b/crates/voom-cli/src/commands/plugin_stats.rs
@@ -1,0 +1,104 @@
+//! `voom plugin stats` — render a per-plugin invocation rollup with
+//! p50/p95/p99 latencies and outcome counts.
+
+use anyhow::{Result, anyhow};
+use chrono::{DateTime, Duration, Utc};
+use voom_domain::plugin_stats::{PluginStatsFilter, PluginStatsRollup};
+
+use crate::app;
+use crate::cli::OutputFormat;
+use crate::config;
+
+pub fn run(
+    plugin: Option<String>,
+    since: Option<String>,
+    top: Option<usize>,
+    format: OutputFormat,
+) -> Result<()> {
+    let since_dt = since.as_deref().map(parse_since).transpose()?;
+    let cfg = config::load_config()?;
+    let result = app::bootstrap_kernel_with_store(&cfg)?;
+    let filter = PluginStatsFilter {
+        plugin,
+        since: since_dt,
+        top,
+    };
+    let rollups = result.store.rollup_plugin_stats(&filter)?;
+    render(&rollups, format)
+}
+
+fn parse_since(s: &str) -> Result<DateTime<Utc>> {
+    // Accept "24h", "7d", "30m" — number + unit (s/m/h/d).
+    let (num_str, unit) = s.split_at(s.len().saturating_sub(1));
+    let n: i64 = num_str
+        .parse()
+        .map_err(|_| anyhow!("invalid --since value: {s}"))?;
+    let d = match unit {
+        "s" => Duration::seconds(n),
+        "m" => Duration::minutes(n),
+        "h" => Duration::hours(n),
+        "d" => Duration::days(n),
+        _ => return Err(anyhow!("invalid --since unit '{unit}'; expected s|m|h|d")),
+    };
+    Ok(Utc::now() - d)
+}
+
+fn render(rollups: &[PluginStatsRollup], format: OutputFormat) -> Result<()> {
+    if matches!(format, OutputFormat::Json) {
+        let json = serde_json::to_string_pretty(rollups)?;
+        println!("{json}");
+        return Ok(());
+    }
+    if rollups.is_empty() {
+        println!("No plugin invocations recorded.");
+        return Ok(());
+    }
+    println!(
+        "{:<28} {:>8} {:>6} {:>8} {:>6} {:>6} {:>8} {:>8} {:>8}",
+        "plugin", "calls", "ok", "skipped", "err", "panic", "p50ms", "p95ms", "p99ms"
+    );
+    for r in rollups {
+        println!(
+            "{:<28} {:>8} {:>6} {:>8} {:>6} {:>6} {:>8} {:>8} {:>8}",
+            r.plugin_id,
+            r.invocation_count,
+            r.ok_count,
+            r.skipped_count,
+            r.err_count,
+            r.panic_count,
+            r.p50_ms,
+            r.p95_ms,
+            r.p99_ms
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_since_hours() {
+        let dt = parse_since("24h").unwrap();
+        let diff = Utc::now() - dt;
+        assert!(diff.num_hours() >= 23 && diff.num_hours() <= 25);
+    }
+
+    #[test]
+    fn parse_since_days() {
+        let dt = parse_since("7d").unwrap();
+        let diff = Utc::now() - dt;
+        assert!(diff.num_days() >= 6 && diff.num_days() <= 8);
+    }
+
+    #[test]
+    fn parse_since_rejects_bad_unit() {
+        assert!(parse_since("24x").is_err());
+    }
+
+    #[test]
+    fn parse_since_rejects_non_numeric() {
+        assert!(parse_since("abh").is_err());
+    }
+}

--- a/crates/voom-cli/src/commands/serve.rs
+++ b/crates/voom-cli/src/commands/serve.rs
@@ -273,21 +273,17 @@ mod tests {
         use std::sync::Arc;
         use voom_domain::test_support::InMemoryStore;
 
+        let zero = crate::config::TableRetention {
+            keep_for_days: Some(0),
+            keep_last: Some(0),
+        };
         let cfg = crate::config::RetentionConfig {
             schedule_interval_minutes: 60,
             run_after_cli: true,
-            jobs: crate::config::TableRetention {
-                keep_for_days: Some(0),
-                keep_last: Some(0),
-            },
-            event_log: crate::config::TableRetention {
-                keep_for_days: Some(0),
-                keep_last: Some(0),
-            },
-            file_transitions: crate::config::TableRetention {
-                keep_for_days: Some(0),
-                keep_last: Some(0),
-            },
+            jobs: zero.clone(),
+            event_log: zero.clone(),
+            file_transitions: zero.clone(),
+            plugin_stats: zero,
         };
 
         let store: Arc<dyn voom_domain::storage::StorageTrait> = Arc::new(InMemoryStore::new());

--- a/crates/voom-cli/src/config.rs
+++ b/crates/voom-cli/src/config.rs
@@ -397,9 +397,10 @@ mode = "always_recover"
 [pruning]
 retention_days = 30
 
-# Database retention. Bounds the size of jobs, event_log, and file_transitions
-# to keep the database from growing forever. Set keep_for_days = 0 and keep_last = 0
-# for any table to disable retention for that table.
+# Database retention. Bounds the size of jobs, event_log, file_transitions,
+# and plugin_stats to keep the database from growing forever. Set
+# keep_for_days = 0 and keep_last = 0 for any table to disable retention for
+# that table.
 #
 # Invariant: event_log must outlive jobs by ~10x on both axes. Each job row
 # produces ~7 event_log rows (file.discovered, file.introspected, three
@@ -426,6 +427,10 @@ keep_last = 500000
 [retention.file_transitions]
 keep_for_days = 90
 keep_last = 500000
+
+[retention.plugin_stats]
+keep_for_days = 30
+keep_last = 100000
 "#
     )
 }
@@ -659,6 +664,7 @@ mod tests {
         assert!(contents.contains("[retention.jobs]"));
         assert!(contents.contains("[retention.event_log]"));
         assert!(contents.contains("[retention.file_transitions]"));
+        assert!(contents.contains("[retention.plugin_stats]"));
     }
 
     // ── load_config with temp files ──────────────────────────

--- a/crates/voom-cli/src/config.rs
+++ b/crates/voom-cli/src/config.rs
@@ -77,6 +77,12 @@ impl TableRetention {
             keep_last: Some(500_000),
         }
     }
+    fn for_plugin_stats() -> Self {
+        Self {
+            keep_for_days: Some(30),
+            keep_last: Some(100_000),
+        }
+    }
 }
 
 /// Top-level retention configuration.
@@ -92,6 +98,8 @@ pub struct RetentionConfig {
     pub event_log: TableRetention,
     #[serde(default = "TableRetention::for_file_transitions")]
     pub file_transitions: TableRetention,
+    #[serde(default = "TableRetention::for_plugin_stats")]
+    pub plugin_stats: TableRetention,
 }
 
 impl Default for RetentionConfig {
@@ -102,6 +110,7 @@ impl Default for RetentionConfig {
             jobs: TableRetention::for_jobs(),
             event_log: TableRetention::for_event_log(),
             file_transitions: TableRetention::for_file_transitions(),
+            plugin_stats: TableRetention::for_plugin_stats(),
         }
     }
 }

--- a/crates/voom-cli/src/retention.rs
+++ b/crates/voom-cli/src/retention.rs
@@ -276,4 +276,28 @@ mod tests {
         let runner = RetentionRunner::new(store, config, None);
         assert!(runner.is_fully_disabled());
     }
+
+    #[test]
+    fn is_fully_disabled_false_when_only_plugin_stats_is_enabled() {
+        let zero = TableRetention {
+            keep_for_days: Some(0),
+            keep_last: Some(0),
+        };
+        let config = RetentionConfig {
+            jobs: zero.clone(),
+            event_log: zero.clone(),
+            file_transitions: zero.clone(),
+            plugin_stats: TableRetention {
+                keep_for_days: Some(30),
+                keep_last: Some(100_000),
+            },
+            ..RetentionConfig::default()
+        };
+        let store: Arc<dyn voom_domain::storage::StorageTrait> = Arc::new(InMemoryStore::new());
+        let runner = RetentionRunner::new(store, config, None);
+        assert!(
+            !runner.is_fully_disabled(),
+            "plugin_stats alone enabled must make is_fully_disabled return false"
+        );
+    }
 }

--- a/crates/voom-cli/src/retention.rs
+++ b/crates/voom-cli/src/retention.rs
@@ -55,9 +55,10 @@ impl RetentionRunner {
         table_retention_to_policy(&self.config.jobs).is_disabled()
             && table_retention_to_policy(&self.config.event_log).is_disabled()
             && table_retention_to_policy(&self.config.file_transitions).is_disabled()
+            && table_retention_to_policy(&self.config.plugin_stats).is_disabled()
     }
 
-    /// Run all three table prunes, log results, and emit `RetentionCompletedEvent`.
+    /// Run all four table prunes, log results, and emit `RetentionCompletedEvent`.
     pub fn run_once(&self, trigger: RetentionTrigger) -> RetentionSummary {
         let start = Instant::now();
         let per_table: Vec<(String, anyhow::Result<PruneReport>)> = vec![
@@ -67,6 +68,7 @@ impl RetentionRunner {
                 "file_transitions".to_string(),
                 self.prune_file_transitions(),
             ),
+            ("plugin_stats".to_string(), self.prune_plugin_stats()),
         ];
 
         let duration = start.elapsed();
@@ -120,6 +122,7 @@ impl RetentionRunner {
                 "file_transitions".to_string(),
                 self.count_file_transitions(),
             ),
+            ("plugin_stats".to_string(), self.count_plugin_stats()),
         ];
         RetentionSummary {
             per_table,
@@ -155,6 +158,16 @@ impl RetentionRunner {
     fn count_file_transitions(&self) -> anyhow::Result<PruneReport> {
         let policy = table_retention_to_policy(&self.config.file_transitions);
         Ok(self.store.count_old_file_transitions(policy)?)
+    }
+
+    fn prune_plugin_stats(&self) -> anyhow::Result<PruneReport> {
+        let policy = table_retention_to_policy(&self.config.plugin_stats);
+        Ok(self.store.prune_old_plugin_stats(policy)?)
+    }
+
+    fn count_plugin_stats(&self) -> anyhow::Result<PruneReport> {
+        let policy = table_retention_to_policy(&self.config.plugin_stats);
+        Ok(self.store.count_old_plugin_stats(policy)?)
     }
 }
 
@@ -207,7 +220,7 @@ mod tests {
         let store: Arc<dyn voom_domain::storage::StorageTrait> = Arc::new(InMemoryStore::new());
         let runner = RetentionRunner::new(store, RetentionConfig::default(), None);
         let summary = runner.run_once(RetentionTrigger::OnDemand);
-        assert_eq!(summary.per_table.len(), 3);
+        assert_eq!(summary.per_table.len(), 4);
         assert!(summary.per_table.iter().all(|(_, r)| r.is_ok()));
     }
 
@@ -220,7 +233,8 @@ mod tests {
         let config = RetentionConfig {
             jobs: zero.clone(),
             event_log: zero.clone(),
-            file_transitions: zero,
+            file_transitions: zero.clone(),
+            plugin_stats: zero,
             ..RetentionConfig::default()
         };
         let store: Arc<dyn voom_domain::storage::StorageTrait> = Arc::new(InMemoryStore::new());
@@ -233,5 +247,33 @@ mod tests {
         let store: Arc<dyn voom_domain::storage::StorageTrait> = Arc::new(InMemoryStore::new());
         let runner = RetentionRunner::new(store, RetentionConfig::default(), None);
         assert!(!runner.is_fully_disabled());
+    }
+
+    #[test]
+    fn run_once_returns_four_table_results() {
+        let store: Arc<dyn voom_domain::storage::StorageTrait> = Arc::new(InMemoryStore::new());
+        let runner = RetentionRunner::new(store, RetentionConfig::default(), None);
+        let summary = runner.run_once(RetentionTrigger::OnDemand);
+        assert_eq!(summary.per_table.len(), 4);
+        let names: Vec<&str> = summary.per_table.iter().map(|(n, _)| n.as_str()).collect();
+        assert!(names.contains(&"plugin_stats"));
+    }
+
+    #[test]
+    fn is_fully_disabled_includes_plugin_stats() {
+        let zero = TableRetention {
+            keep_for_days: Some(0),
+            keep_last: Some(0),
+        };
+        let config = RetentionConfig {
+            jobs: zero.clone(),
+            event_log: zero.clone(),
+            file_transitions: zero.clone(),
+            plugin_stats: zero,
+            ..RetentionConfig::default()
+        };
+        let store: Arc<dyn voom_domain::storage::StorageTrait> = Arc::new(InMemoryStore::new());
+        let runner = RetentionRunner::new(store, config, None);
+        assert!(runner.is_fully_disabled());
     }
 }

--- a/crates/voom-cli/tests/common/mod.rs
+++ b/crates/voom-cli/tests/common/mod.rs
@@ -237,6 +237,19 @@ impl TestEnv {
         &self.primary_root
     }
 
+    /// Return the path to the SQLite database (`<data_dir>/voom.db`).
+    pub fn db_path(&self) -> PathBuf {
+        self.data_dir.join("voom.db")
+    }
+
+    /// Return the config home directory (`<tmp>/config`).
+    ///
+    /// Set `XDG_CONFIG_HOME` to this path to isolate a scan run that calls
+    /// `config::load_config` directly (e.g. `commands::scan::run`).
+    pub fn config_home(&self) -> &Path {
+        &self.config_home
+    }
+
     /// Write a synthetic media file at `<root>/<name>` with `size` bytes.
     ///
     /// Content is a repeating byte pattern derived from the file name so

--- a/crates/voom-cli/tests/common/mod.rs
+++ b/crates/voom-cli/tests/common/mod.rs
@@ -513,13 +513,13 @@ fn path_from_payload(payload: Option<&serde_json::Value>) -> PathBuf {
 /// test must run with `--test-threads=1` or be wrapped in a per-test mutex.
 /// The acceptance tests call `run_process` sequentially within a single async
 /// test body, which is safe.
-struct EnvOverride {
+pub struct EnvOverride {
     key: &'static str,
     prior: Option<std::ffi::OsString>,
 }
 
 impl EnvOverride {
-    fn set(key: &'static str, value: &str) -> Self {
+    pub fn set(key: &'static str, value: &str) -> Self {
         let prior = std::env::var_os(key);
         // SAFETY: single-threaded test context; see struct-level note.
         #[allow(unused_unsafe)]

--- a/crates/voom-cli/tests/plugin_stats_e2e.rs
+++ b/crates/voom-cli/tests/plugin_stats_e2e.rs
@@ -17,7 +17,7 @@ use voom_domain::plugin_stats::PluginStatsFilter;
 use voom_domain::storage::PluginStatsStorage;
 use voom_sqlite_store::store::SqliteStore;
 
-use common::TestEnv;
+use common::{EnvOverride, TestEnv};
 
 // All tests in this file manipulate `XDG_CONFIG_HOME` via std::env::set_var.
 // That is not safe to do concurrently. Serialize with this mutex.
@@ -26,18 +26,12 @@ static TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 /// Run a `voom scan` in-process for the given `TestEnv`, with `XDG_CONFIG_HOME`
 /// pointed at the env's isolated config dir.
 ///
-/// Returns once the scan completes. The caller is responsible for waiting an
-/// additional moment for the stats-sink writer thread to flush.
+/// The `XDG_CONFIG_HOME` override is held via a RAII guard so that even if any
+/// `.expect()` / `panic!()` below trips, the env var is restored before the
+/// next test runs.
 async fn run_scan(env: &TestEnv) {
-    // Point config loading at our isolated tempdir so `bootstrap_kernel_with_store`
-    // uses the test env's data_dir rather than the user's real config.
     let config_home = env.config_home().to_str().expect("utf-8 config_home");
-    let prior = std::env::var_os("XDG_CONFIG_HOME");
-    // SAFETY: tests are serialized by TEST_LOCK; see struct-level note in common/mod.rs.
-    #[allow(unused_unsafe)]
-    unsafe {
-        std::env::set_var("XDG_CONFIG_HOME", config_home);
-    }
+    let _guard = EnvOverride::set("XDG_CONFIG_HOME", config_home);
 
     let root_str = env.root().to_str().expect("utf-8 root");
     let argv = ["voom", "scan", "--no-hash", root_str];
@@ -49,18 +43,9 @@ async fn run_scan(env: &TestEnv) {
     };
 
     let token = CancellationToken::new();
-    let result = voom_cli::commands::scan::run(scan_args, true, token).await;
-
-    // Restore the prior env var before asserting so cleanup happens even on panic.
-    #[allow(unused_unsafe)]
-    unsafe {
-        match &prior {
-            Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
-            None => std::env::remove_var("XDG_CONFIG_HOME"),
-        }
-    }
-
-    result.unwrap_or_else(|e| panic!("voom scan failed: {e}"));
+    voom_cli::commands::scan::run(scan_args, true, token)
+        .await
+        .unwrap_or_else(|e| panic!("voom scan failed: {e}"));
 }
 
 /// Open a read-only handle to the env's SQLite DB for post-run queries.
@@ -73,7 +58,8 @@ fn open_store(env: &TestEnv) -> std::sync::Arc<SqliteStore> {
 
 // ─── Test 1 ──────────────────────────────────────────────────────────────────
 
-/// A `voom scan` must record at least one row in `plugin_stats`.
+/// A `voom scan` must record at least one row in `plugin_stats`, and at least
+/// one of those rows must come from the `discovery` plugin.
 #[tokio::test]
 async fn scan_populates_plugin_stats_table() {
     let _lock = TEST_LOCK.lock().await;
@@ -103,18 +89,41 @@ async fn scan_populates_plugin_stats_table() {
         !rollups.is_empty(),
         "plugin_stats rollup should have at least one row after a scan; got zero"
     );
+
+    // Direct SQL assertion that a specific named plugin appears in the table.
+    // The dispatcher records the *subscriber's* plugin_id, not the publisher's
+    // (see `Bus::publish_recursive` in voom-kernel/src/bus.rs). Discovery is a
+    // pure publisher (`handles()` returns false for every event — see
+    // `DiscoveryPlugin::test_handles_no_events`), so it never appears in
+    // `plugin_stats`. We assert on `sqlite-store` instead, which subscribes to
+    // every event for persistence and is therefore the canonical reliable
+    // subscriber on any scan run.
+    let db_path = env.db_path();
+    let conn = rusqlite::Connection::open(&db_path)
+        .unwrap_or_else(|e| panic!("open {}: {e}", db_path.display()));
+    let store_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM plugin_stats WHERE plugin_id = 'sqlite-store'",
+            [],
+            |r| r.get(0),
+        )
+        .expect("count sqlite-store rows");
+    assert!(
+        store_count > 0,
+        "expected at least one sqlite-store row in plugin_stats"
+    );
 }
 
 // ─── Test 2 ──────────────────────────────────────────────────────────────────
 
-/// After a `voom scan`, the `rollup_plugin_stats` query must return a non-empty
-/// slice — the same data that `voom plugin stats` renders.
+/// After a `voom scan`, calling the `voom plugin stats --format json` CLI
+/// handler in-process must run to completion without error.
 ///
-/// This mirrors the behaviour the CLI exercises: it calls
-/// `bootstrap_kernel_with_store` → `rollup_plugin_stats`. We test the same
-/// path without spawning an external binary.
+/// We don't capture stdout — the rendered contents are exercised by Test 1's
+/// direct DB assertion. What this test contributes is end-to-end coverage of
+/// the handler's `args → filter → rollup → JSON serialization → stdout` path.
 #[tokio::test]
-async fn plugin_stats_rollup_non_empty_after_scan() {
+async fn plugin_stats_handler_runs_after_scan() {
     let _lock = TEST_LOCK.lock().await;
     let env = TestEnv::new().await;
     env.write_media("a.mkv", 1);
@@ -123,33 +132,20 @@ async fn plugin_stats_rollup_non_empty_after_scan() {
 
     tokio::time::sleep(Duration::from_millis(2000)).await;
 
-    let store = open_store(&env);
-    let filter = PluginStatsFilter {
-        plugin: None,
-        since: None,
-        top: None,
-    };
-    let rollups = store
-        .rollup_plugin_stats(&filter)
-        .expect("rollup_plugin_stats should succeed");
+    // The handler reloads config via `config::load_config()`, so we need
+    // `XDG_CONFIG_HOME` still pointed at the test env's config dir while it runs.
+    let config_home = env.config_home().to_str().expect("utf-8 config_home");
+    let _guard = EnvOverride::set("XDG_CONFIG_HOME", config_home);
 
-    assert!(
-        !rollups.is_empty(),
-        "expected at least one rollup row; the stats sink pipeline may not be wired correctly"
+    let result = voom_cli::commands::plugin_stats::run(
+        None,                              // plugin filter
+        None,                              // since
+        None,                              // top
+        voom_cli::cli::OutputFormat::Json, // format
     );
-
-    // Verify the rollup shape: every row must have a non-empty plugin_id and a
-    // non-negative invocation count.
-    for r in &rollups {
-        assert!(
-            !r.plugin_id.is_empty(),
-            "plugin_id must be non-empty; got {:?}",
-            r
-        );
-        assert!(
-            r.invocation_count > 0,
-            "invocation_count must be > 0; got {:?}",
-            r
-        );
-    }
+    assert!(
+        result.is_ok(),
+        "voom plugin stats --format json must succeed end-to-end, got: {:?}",
+        result.err()
+    );
 }

--- a/crates/voom-cli/tests/plugin_stats_e2e.rs
+++ b/crates/voom-cli/tests/plugin_stats_e2e.rs
@@ -149,3 +149,68 @@ async fn plugin_stats_handler_runs_after_scan() {
         result.err()
     );
 }
+
+// ─── Test 3 ──────────────────────────────────────────────────────────────────
+
+/// After a scan populates `plugin_stats` and `event_log`, invoking
+/// `plugin_stats::run` must NOT add new rows to either table. The command is
+/// read-only; bootstrapping a full kernel just to render a rollup is the bug
+/// this test guards against (Codex adversarial review, May 2026).
+#[tokio::test]
+async fn plugin_stats_query_does_not_mutate_database() {
+    let _lock = TEST_LOCK.lock().await;
+    let env = TestEnv::new().await;
+    env.write_media("a.mkv", 1);
+
+    run_scan(&env).await;
+
+    // Allow the writer thread to flush.
+    tokio::time::sleep(Duration::from_millis(2000)).await;
+
+    let db_path = env.db_path();
+    let baseline_plugin_stats: i64 = {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.query_row("SELECT COUNT(*) FROM plugin_stats", [], |r| r.get(0))
+            .unwrap()
+    };
+    let baseline_event_log: i64 = {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.query_row("SELECT COUNT(*) FROM event_log", [], |r| r.get(0))
+            .unwrap()
+    };
+    assert!(baseline_plugin_stats > 0, "scan must produce stats first");
+
+    // Run the stats query the same way the CLI handler does.
+    let config_home = env.config_home().to_str().expect("utf-8 config_home");
+    let _guard = EnvOverride::set("XDG_CONFIG_HOME", config_home);
+
+    voom_cli::commands::plugin_stats::run(None, None, None, voom_cli::cli::OutputFormat::Json)
+        .expect("plugin stats query must succeed");
+
+    drop(_guard);
+
+    // Allow any pending writer-thread work (there should be none) to settle.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let after_plugin_stats: i64 = {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.query_row("SELECT COUNT(*) FROM plugin_stats", [], |r| r.get(0))
+            .unwrap()
+    };
+    let after_event_log: i64 = {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.query_row("SELECT COUNT(*) FROM event_log", [], |r| r.get(0))
+            .unwrap()
+    };
+
+    assert_eq!(
+        after_plugin_stats, baseline_plugin_stats,
+        "plugin_stats query must not add plugin_stats rows: was {baseline_plugin_stats}, now \
+         {after_plugin_stats}"
+    );
+    assert_eq!(
+        after_event_log, baseline_event_log,
+        "plugin_stats query must not add event_log rows: was {baseline_event_log}, now \
+         {after_event_log}"
+    );
+}

--- a/crates/voom-cli/tests/plugin_stats_e2e.rs
+++ b/crates/voom-cli/tests/plugin_stats_e2e.rs
@@ -1,0 +1,155 @@
+//! End-to-end test: run a `voom scan` in-process against a tiny fixture and
+//! verify the `plugin_stats` table is populated (issue #92).
+//!
+//! These tests exercise the full pipeline:
+//!   bus dispatcher → StatsSink → SqliteStatsSink writer thread → SQLite
+//!   → rollup_plugin_stats → voom plugin stats
+
+#![cfg(feature = "functional")]
+
+mod common;
+
+use std::time::Duration;
+
+use clap::Parser;
+use tokio_util::sync::CancellationToken;
+use voom_domain::plugin_stats::PluginStatsFilter;
+use voom_domain::storage::PluginStatsStorage;
+use voom_sqlite_store::store::SqliteStore;
+
+use common::TestEnv;
+
+// All tests in this file manipulate `XDG_CONFIG_HOME` via std::env::set_var.
+// That is not safe to do concurrently. Serialize with this mutex.
+static TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// Run a `voom scan` in-process for the given `TestEnv`, with `XDG_CONFIG_HOME`
+/// pointed at the env's isolated config dir.
+///
+/// Returns once the scan completes. The caller is responsible for waiting an
+/// additional moment for the stats-sink writer thread to flush.
+async fn run_scan(env: &TestEnv) {
+    // Point config loading at our isolated tempdir so `bootstrap_kernel_with_store`
+    // uses the test env's data_dir rather than the user's real config.
+    let config_home = env.config_home().to_str().expect("utf-8 config_home");
+    let prior = std::env::var_os("XDG_CONFIG_HOME");
+    // SAFETY: tests are serialized by TEST_LOCK; see struct-level note in common/mod.rs.
+    #[allow(unused_unsafe)]
+    unsafe {
+        std::env::set_var("XDG_CONFIG_HOME", config_home);
+    }
+
+    let root_str = env.root().to_str().expect("utf-8 root");
+    let argv = ["voom", "scan", "--no-hash", root_str];
+    let cli = voom_cli::cli::Cli::try_parse_from(argv)
+        .unwrap_or_else(|e| panic!("CLI parse failed: {e}"));
+    let scan_args = match cli.command {
+        voom_cli::cli::Commands::Scan(a) => a,
+        _ => panic!("expected Scan subcommand"),
+    };
+
+    let token = CancellationToken::new();
+    let result = voom_cli::commands::scan::run(scan_args, true, token).await;
+
+    // Restore the prior env var before asserting so cleanup happens even on panic.
+    #[allow(unused_unsafe)]
+    unsafe {
+        match &prior {
+            Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+            None => std::env::remove_var("XDG_CONFIG_HOME"),
+        }
+    }
+
+    result.unwrap_or_else(|e| panic!("voom scan failed: {e}"));
+}
+
+/// Open a read-only handle to the env's SQLite DB for post-run queries.
+fn open_store(env: &TestEnv) -> std::sync::Arc<SqliteStore> {
+    let db_path = env.db_path();
+    let store = SqliteStore::open(&db_path)
+        .unwrap_or_else(|e| panic!("failed to open store at {}: {e}", db_path.display()));
+    std::sync::Arc::new(store)
+}
+
+// ─── Test 1 ──────────────────────────────────────────────────────────────────
+
+/// A `voom scan` must record at least one row in `plugin_stats`.
+#[tokio::test]
+async fn scan_populates_plugin_stats_table() {
+    let _lock = TEST_LOCK.lock().await;
+    let env = TestEnv::new().await;
+
+    // A non-empty file is sufficient to trigger the discovery plugin's emit path.
+    // Introspection may fail (it's not a real MKV), but that failure is itself
+    // an invocation record and counts toward the row total.
+    env.write_media("a.mkv", 32);
+
+    run_scan(&env).await;
+
+    // Allow the writer thread up to 2 s to flush batched rows.
+    tokio::time::sleep(Duration::from_millis(2000)).await;
+
+    let store = open_store(&env);
+    let filter = PluginStatsFilter {
+        plugin: None,
+        since: None,
+        top: None,
+    };
+    let rollups = store
+        .rollup_plugin_stats(&filter)
+        .expect("rollup_plugin_stats should succeed");
+
+    assert!(
+        !rollups.is_empty(),
+        "plugin_stats rollup should have at least one row after a scan; got zero"
+    );
+}
+
+// ─── Test 2 ──────────────────────────────────────────────────────────────────
+
+/// After a `voom scan`, the `rollup_plugin_stats` query must return a non-empty
+/// slice — the same data that `voom plugin stats` renders.
+///
+/// This mirrors the behaviour the CLI exercises: it calls
+/// `bootstrap_kernel_with_store` → `rollup_plugin_stats`. We test the same
+/// path without spawning an external binary.
+#[tokio::test]
+async fn plugin_stats_rollup_non_empty_after_scan() {
+    let _lock = TEST_LOCK.lock().await;
+    let env = TestEnv::new().await;
+    env.write_media("a.mkv", 1);
+
+    run_scan(&env).await;
+
+    tokio::time::sleep(Duration::from_millis(2000)).await;
+
+    let store = open_store(&env);
+    let filter = PluginStatsFilter {
+        plugin: None,
+        since: None,
+        top: None,
+    };
+    let rollups = store
+        .rollup_plugin_stats(&filter)
+        .expect("rollup_plugin_stats should succeed");
+
+    assert!(
+        !rollups.is_empty(),
+        "expected at least one rollup row; the stats sink pipeline may not be wired correctly"
+    );
+
+    // Verify the rollup shape: every row must have a non-empty plugin_id and a
+    // non-negative invocation count.
+    for r in &rollups {
+        assert!(
+            !r.plugin_id.is_empty(),
+            "plugin_id must be non-empty; got {:?}",
+            r
+        );
+        assert!(
+            r.invocation_count > 0,
+            "invocation_count must be > 0; got {:?}",
+            r
+        );
+    }
+}

--- a/crates/voom-domain/src/lib.rs
+++ b/crates/voom-domain/src/lib.rs
@@ -10,6 +10,7 @@ pub mod host_types;
 pub mod job;
 pub mod media;
 pub mod plan;
+pub mod plugin_stats;
 pub mod safeguard;
 pub mod scan_session_mutations;
 pub mod snapshot;

--- a/crates/voom-domain/src/plugin_stats.rs
+++ b/crates/voom-domain/src/plugin_stats.rs
@@ -31,6 +31,11 @@ impl PluginInvocationOutcome {
     }
 }
 
+/// A single plugin invocation as captured by the event bus dispatcher.
+///
+/// One record is produced per (plugin, event) handler call and later persisted
+/// to the `plugin_stats` SQLite table. This is the raw unit that rollups
+/// aggregate over.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PluginStatRecord {
     pub plugin_id: String,
@@ -40,6 +45,12 @@ pub struct PluginStatRecord {
     pub outcome: PluginInvocationOutcome,
 }
 
+/// Aggregated per-plugin summary computed from a collection of
+/// [`PluginStatRecord`]s.
+///
+/// Produced by both the in-memory rollup (recent window) and the SQLite-backed
+/// historical rollup. Latency percentiles use nearest-rank over the matching
+/// records' `duration_ms` values.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PluginStatsRollup {
     pub plugin_id: String,
@@ -54,6 +65,10 @@ pub struct PluginStatsRollup {
     pub total_ms: u64,
 }
 
+/// Query parameters for selecting which [`PluginStatRecord`]s to roll up.
+///
+/// Passed to the in-memory and SQLite rollup APIs. Intentionally omits Serde
+/// derives because it's an in-process query parameter, not a wire type.
 #[derive(Debug, Clone, Default)]
 pub struct PluginStatsFilter {
     pub plugin: Option<String>,
@@ -69,13 +84,16 @@ pub struct PluginStatsFilter {
 /// - `nearest_rank_percentile(&v, 99)` → `99`
 ///
 /// Returns `0` when the slice is empty. Inputs MUST be sorted ascending.
+/// Boundary behavior: `p = 0` returns the minimum element (via the `.max(1)`
+/// rank clamp); `p > 100` returns the maximum element (via the `.min(n)` clamp).
 #[must_use]
 pub fn nearest_rank_percentile(sorted: &[u64], p: u64) -> u64 {
     let n = sorted.len();
     if n == 0 {
         return 0;
     }
-    let rank = ((p * n as u64).div_ceil(100)).max(1) as usize;
+    let rank_u128 = ((p as u128) * (n as u128)).div_ceil(100).max(1);
+    let rank = usize::try_from(rank_u128).unwrap_or(usize::MAX);
     let idx = rank.min(n) - 1;
     sorted[idx]
 }
@@ -131,5 +149,21 @@ mod tests {
         let s = serde_json::to_string(&r).unwrap();
         let back: PluginStatRecord = serde_json::from_str(&s).unwrap();
         assert_eq!(r, back);
+    }
+
+    #[test]
+    fn outcome_err_roundtrip() {
+        let outcome = PluginInvocationOutcome::Err {
+            category: "storage".into(),
+        };
+        let s = serde_json::to_string(&outcome).unwrap();
+        assert_eq!(s, r#"{"err":{"category":"storage"}}"#);
+        let back: PluginInvocationOutcome = serde_json::from_str(&s).unwrap();
+        assert_eq!(outcome, back);
+    }
+
+    #[test]
+    fn nearest_rank_handles_p_over_100() {
+        assert_eq!(nearest_rank_percentile(&[1, 2, 3, 4, 5], 200), 5);
     }
 }

--- a/crates/voom-domain/src/plugin_stats.rs
+++ b/crates/voom-domain/src/plugin_stats.rs
@@ -1,0 +1,135 @@
+//! Per-plugin invocation statistics: the unit captured by the event bus
+//! dispatcher and persisted to the `plugin_stats` SQLite table.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PluginInvocationOutcome {
+    /// Plugin handled the event and produced an `EventResult`.
+    Ok,
+    /// Plugin handled the event but produced no result (returned `Ok(None)`).
+    /// Mapped from the bus dispatcher's "event acknowledged (no result)" path.
+    Skipped,
+    /// Plugin returned `Err`. `category` is the low-cardinality variant name
+    /// of `VoomError` (e.g. `"storage"`, `"plugin"`).
+    Err { category: String },
+    /// Plugin panicked. Caught by `catch_unwind` in the dispatcher.
+    Panic,
+}
+
+impl PluginInvocationOutcome {
+    #[must_use]
+    pub fn as_label(&self) -> &'static str {
+        match self {
+            Self::Ok => "ok",
+            Self::Skipped => "skipped",
+            Self::Err { .. } => "err",
+            Self::Panic => "panic",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PluginStatRecord {
+    pub plugin_id: String,
+    pub event_type: String,
+    pub started_at: DateTime<Utc>,
+    pub duration_ms: u64,
+    pub outcome: PluginInvocationOutcome,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PluginStatsRollup {
+    pub plugin_id: String,
+    pub invocation_count: u64,
+    pub ok_count: u64,
+    pub skipped_count: u64,
+    pub err_count: u64,
+    pub panic_count: u64,
+    pub p50_ms: u64,
+    pub p95_ms: u64,
+    pub p99_ms: u64,
+    pub total_ms: u64,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct PluginStatsFilter {
+    pub plugin: Option<String>,
+    pub since: Option<DateTime<Utc>>,
+    pub top: Option<usize>,
+}
+
+/// Nearest-rank percentile (1-indexed rank = ceil(p * n / 100), clamped to [1, n]).
+///
+/// For `sorted = 1..=100`:
+/// - `nearest_rank_percentile(&v, 50)` → `50` (rank 50)
+/// - `nearest_rank_percentile(&v, 95)` → `95`
+/// - `nearest_rank_percentile(&v, 99)` → `99`
+///
+/// Returns `0` when the slice is empty. Inputs MUST be sorted ascending.
+#[must_use]
+pub fn nearest_rank_percentile(sorted: &[u64], p: u64) -> u64 {
+    let n = sorted.len();
+    if n == 0 {
+        return 0;
+    }
+    let rank = ((p * n as u64).div_ceil(100)).max(1) as usize;
+    let idx = rank.min(n) - 1;
+    sorted[idx]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nearest_rank_matches_ceil_definition() {
+        let v: Vec<u64> = (1..=100).collect();
+        assert_eq!(nearest_rank_percentile(&v, 50), 50);
+        assert_eq!(nearest_rank_percentile(&v, 95), 95);
+        assert_eq!(nearest_rank_percentile(&v, 99), 99);
+        assert_eq!(nearest_rank_percentile(&v, 100), 100);
+        assert_eq!(nearest_rank_percentile(&v, 1), 1);
+    }
+
+    #[test]
+    fn nearest_rank_empty_returns_zero() {
+        assert_eq!(nearest_rank_percentile(&[], 50), 0);
+    }
+
+    #[test]
+    fn nearest_rank_single_element() {
+        assert_eq!(nearest_rank_percentile(&[42], 50), 42);
+        assert_eq!(nearest_rank_percentile(&[42], 99), 42);
+    }
+
+    #[test]
+    fn outcome_labels_match() {
+        assert_eq!(PluginInvocationOutcome::Ok.as_label(), "ok");
+        assert_eq!(PluginInvocationOutcome::Skipped.as_label(), "skipped");
+        assert_eq!(
+            PluginInvocationOutcome::Err {
+                category: "io".into()
+            }
+            .as_label(),
+            "err"
+        );
+        assert_eq!(PluginInvocationOutcome::Panic.as_label(), "panic");
+    }
+
+    #[test]
+    fn record_roundtrips_via_serde() {
+        let r = PluginStatRecord {
+            plugin_id: "discovery".into(),
+            event_type: "file.discovered".into(),
+            started_at: Utc::now(),
+            duration_ms: 12,
+            outcome: PluginInvocationOutcome::Ok,
+        };
+        let s = serde_json::to_string(&r).unwrap();
+        let back: PluginStatRecord = serde_json::from_str(&s).unwrap();
+        assert_eq!(r, back);
+    }
+}

--- a/crates/voom-domain/src/storage.rs
+++ b/crates/voom-domain/src/storage.rs
@@ -751,6 +751,39 @@ pub trait EstimateStorage: Send + Sync {
     ) -> Result<Vec<CostModelSample>>;
 }
 
+/// Per-plugin invocation statistics (issue #92).
+///
+/// # Errors
+/// Methods return `VoomError::Storage` on database failures.
+pub trait PluginStatsStorage: Send + Sync {
+    /// Insert a single invocation record. Called from the event bus
+    /// dispatcher (indirectly via `StatsSink`). Must be tolerant of
+    /// high write rates.
+    fn insert_plugin_stat(&self, record: &crate::plugin_stats::PluginStatRecord) -> Result<()>;
+
+    /// Insert a batch of invocation records in a single transaction.
+    /// Used by `SqliteStatsSink` for amortized write cost.
+    fn insert_plugin_stats_batch(
+        &self,
+        records: &[crate::plugin_stats::PluginStatRecord],
+    ) -> Result<()>;
+
+    /// Aggregate counts and percentile latencies per plugin, optionally
+    /// filtered by `plugin`, `since`, and limited to the `top` slowest
+    /// (by p95).
+    fn rollup_plugin_stats(
+        &self,
+        filter: &crate::plugin_stats::PluginStatsFilter,
+    ) -> Result<Vec<crate::plugin_stats::PluginStatsRollup>>;
+
+    /// Delete invocation rows per retention `policy`.
+    fn prune_old_plugin_stats(&self, policy: RetentionPolicy) -> Result<PruneReport>;
+
+    /// Count rows that would be deleted by `prune_old_plugin_stats`,
+    /// without modifying the database.
+    fn count_old_plugin_stats(&self, policy: RetentionPolicy) -> Result<PruneReport>;
+}
+
 /// Storage trait for recording and querying VOOM-originated filesystem mutations.
 ///
 /// Called by executor plugins (`ffmpeg-executor`, `mkvtoolnix-executor`) to mark
@@ -805,6 +838,7 @@ pub trait StorageTrait:
     + TranscodeOutcomeStorage
     + EstimateStorage
     + ScanSessionMutationStorage
+    + PluginStatsStorage
 {
 }
 
@@ -825,6 +859,7 @@ impl<T> StorageTrait for T where
         + TranscodeOutcomeStorage
         + EstimateStorage
         + ScanSessionMutationStorage
+        + PluginStatsStorage
 {
 }
 
@@ -943,6 +978,12 @@ impl PlanSummary {
             result: None,
         }
     }
+}
+
+#[cfg(test)]
+mod plugin_stats_storage_compile_check {
+    use super::*;
+    fn _assert_object_safe(_x: &dyn PluginStatsStorage) {}
 }
 
 #[cfg(test)]

--- a/crates/voom-domain/src/test_support.rs
+++ b/crates/voom-domain/src/test_support.rs
@@ -28,8 +28,8 @@ use crate::storage::{
     BadFileFilters, BadFileStorage, CostModelSampleFilters, EstimateStorage, FileFilters,
     FileStorage, FileTransitionStorage, HealthCheckFilters, HealthCheckRecord, HealthCheckStorage,
     JobFilters, JobStorage, MaintenanceStorage, PageStats, PendingOperation, PendingOpsStorage,
-    PlanStorage, PlanSummary, PluginDataStorage, ScanSessionMutationStorage, SnapshotStorage,
-    TranscodeOutcomeFilters, TranscodeOutcomeStorage,
+    PlanStorage, PlanSummary, PluginDataStorage, PluginStatsStorage, PruneReport, RetentionPolicy,
+    ScanSessionMutationStorage, SnapshotStorage, TranscodeOutcomeFilters, TranscodeOutcomeStorage,
 };
 use crate::transcode::TranscodeOutcome;
 use crate::transition::{
@@ -149,6 +149,7 @@ pub struct InMemoryStore {
     mutations: Mutex<
         HashMap<(crate::transition::ScanSessionId, std::path::PathBuf), VoomOriginatedMutation>,
     >,
+    plugin_stats: Mutex<Vec<crate::plugin_stats::PluginStatRecord>>,
 }
 
 impl InMemoryStore {
@@ -170,6 +171,7 @@ impl InMemoryStore {
             new_in_session: Default::default(),
             file_session_affinity: Default::default(),
             mutations: Default::default(),
+            plugin_stats: Mutex::new(Vec::new()),
         }
     }
 
@@ -1966,6 +1968,134 @@ mod transcode_outcome_storage_tests {
             .expect("some outcome");
 
         assert_eq!(latest.id, Uuid::from_u128(2));
+    }
+}
+
+impl PluginStatsStorage for InMemoryStore {
+    fn insert_plugin_stat(&self, record: &crate::plugin_stats::PluginStatRecord) -> Result<()> {
+        self.plugin_stats.lock().push(record.clone());
+        Ok(())
+    }
+
+    fn insert_plugin_stats_batch(
+        &self,
+        records: &[crate::plugin_stats::PluginStatRecord],
+    ) -> Result<()> {
+        let mut guard = self.plugin_stats.lock();
+        guard.extend_from_slice(records);
+        Ok(())
+    }
+
+    fn rollup_plugin_stats(
+        &self,
+        filter: &crate::plugin_stats::PluginStatsFilter,
+    ) -> Result<Vec<crate::plugin_stats::PluginStatsRollup>> {
+        let guard = self.plugin_stats.lock();
+        let mut by_plugin: std::collections::BTreeMap<
+            String,
+            Vec<&crate::plugin_stats::PluginStatRecord>,
+        > = std::collections::BTreeMap::new();
+        for r in guard.iter() {
+            if let Some(p) = &filter.plugin {
+                if &r.plugin_id != p {
+                    continue;
+                }
+            }
+            if let Some(since) = filter.since {
+                if r.started_at < since {
+                    continue;
+                }
+            }
+            by_plugin.entry(r.plugin_id.clone()).or_default().push(r);
+        }
+        let mut out = Vec::new();
+        for (plugin_id, mut rows) in by_plugin {
+            rows.sort_by_key(|r| r.duration_ms);
+            let mut rollup = crate::plugin_stats::PluginStatsRollup {
+                plugin_id,
+                invocation_count: rows.len() as u64,
+                ..Default::default()
+            };
+            for r in &rows {
+                match &r.outcome {
+                    crate::plugin_stats::PluginInvocationOutcome::Ok => rollup.ok_count += 1,
+                    crate::plugin_stats::PluginInvocationOutcome::Skipped => {
+                        rollup.skipped_count += 1;
+                    }
+                    crate::plugin_stats::PluginInvocationOutcome::Err { .. } => {
+                        rollup.err_count += 1;
+                    }
+                    crate::plugin_stats::PluginInvocationOutcome::Panic => {
+                        rollup.panic_count += 1;
+                    }
+                }
+                rollup.total_ms = rollup.total_ms.saturating_add(r.duration_ms);
+            }
+            if !rows.is_empty() {
+                let durs: Vec<u64> = rows.iter().map(|r| r.duration_ms).collect();
+                // `durs` is sorted ASC because `rows` was sorted by duration_ms above.
+                rollup.p50_ms = crate::plugin_stats::nearest_rank_percentile(&durs, 50);
+                rollup.p95_ms = crate::plugin_stats::nearest_rank_percentile(&durs, 95);
+                rollup.p99_ms = crate::plugin_stats::nearest_rank_percentile(&durs, 99);
+            }
+            out.push(rollup);
+        }
+        out.sort_by(|a, b| b.p95_ms.cmp(&a.p95_ms));
+        if let Some(top) = filter.top {
+            out.truncate(top);
+        }
+        Ok(out)
+    }
+
+    fn prune_old_plugin_stats(&self, policy: RetentionPolicy) -> Result<PruneReport> {
+        if policy.is_disabled() {
+            let kept = self.plugin_stats.lock().len() as u64;
+            return Ok(PruneReport { deleted: 0, kept });
+        }
+        let cutoff = policy.max_age.map(|d| chrono::Utc::now() - d);
+        let keep_last = policy.keep_last.map(|n| n as usize);
+        let mut guard = self.plugin_stats.lock();
+        guard.sort_by_key(|r| std::cmp::Reverse(r.started_at));
+        let before = guard.len();
+        let mut kept_rows = Vec::new();
+        for (idx, row) in guard.drain(..).enumerate() {
+            let too_old = cutoff.is_some_and(|c| row.started_at < c);
+            let over_cap = keep_last.is_some_and(|k| idx >= k);
+            if !(too_old || over_cap) {
+                kept_rows.push(row);
+            }
+        }
+        *guard = kept_rows;
+        let after = guard.len();
+        Ok(PruneReport {
+            deleted: (before - after) as u64,
+            kept: after as u64,
+        })
+    }
+
+    fn count_old_plugin_stats(&self, policy: RetentionPolicy) -> Result<PruneReport> {
+        if policy.is_disabled() {
+            let kept = self.plugin_stats.lock().len() as u64;
+            return Ok(PruneReport { deleted: 0, kept });
+        }
+        let guard = self.plugin_stats.lock();
+        let cutoff = policy.max_age.map(|d| chrono::Utc::now() - d);
+        let keep_last = policy.keep_last.map(|n| n as usize);
+        let mut sorted: Vec<_> = guard.iter().collect();
+        sorted.sort_by_key(|r| std::cmp::Reverse(r.started_at));
+        let mut deleted = 0u64;
+        for (idx, row) in sorted.iter().enumerate() {
+            let too_old = cutoff.is_some_and(|c| row.started_at < c);
+            let over_cap = keep_last.is_some_and(|k| idx >= k);
+            if too_old || over_cap {
+                deleted += 1;
+            }
+        }
+        let total = guard.len() as u64;
+        Ok(PruneReport {
+            deleted,
+            kept: total.saturating_sub(deleted),
+        })
     }
 }
 

--- a/crates/voom-kernel/Cargo.toml
+++ b/crates/voom-kernel/Cargo.toml
@@ -14,6 +14,7 @@ description = "Core kernel for VOOM — event bus, plugin registry, and capabili
 [dependencies]
 voom-domain = { workspace = true }
 voom-wit = { workspace = true }
+chrono = { workspace = true }
 tracing = { workspace = true }
 parking_lot = { workspace = true }
 serde = { workspace = true }

--- a/crates/voom-kernel/Cargo.toml
+++ b/crates/voom-kernel/Cargo.toml
@@ -40,5 +40,4 @@ tokio = { workspace = true, features = ["test-util"] }
 tracing-subscriber = { workspace = true }
 tracing-test = { workspace = true }
 tempfile = { workspace = true }
-chrono = { workspace = true }
 voom-domain = { workspace = true, features = ["testing"] }

--- a/crates/voom-kernel/src/bus.rs
+++ b/crates/voom-kernel/src/bus.rs
@@ -1,10 +1,13 @@
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::Arc;
+use std::time::Instant;
 
 use parking_lot::RwLock;
 use voom_domain::events::{Event, EventResult, PluginErrorEvent};
+use voom_domain::plugin_stats::{PluginInvocationOutcome, PluginStatRecord};
 
 use crate::Plugin;
+use crate::stats_sink::{NoopStatsSink, StatsSink};
 
 /// Maximum recursion depth for event cascading to prevent infinite loops.
 const MAX_CASCADE_DEPTH: u8 = 8;
@@ -13,6 +16,35 @@ struct Subscriber {
     plugin_name: String,
     priority: i32,
     handler: Arc<dyn Plugin>,
+}
+
+/// Map a `VoomError` to a fixed low-cardinality label for stats recording.
+///
+/// Every match arm returns a `'static` string literal; the `.to_string()` call
+/// converts it to the `String` expected by `PluginInvocationOutcome::Err`.
+/// The catch-all `_ => "unknown"` handles future `#[non_exhaustive]` variants
+/// without breaking existing metrics pipelines.
+fn error_category(err: &voom_domain::errors::VoomError) -> String {
+    use voom_domain::errors::{StorageErrorKind, VoomError};
+    match err {
+        VoomError::Plugin { .. } => "plugin",
+        VoomError::Wasm(_) => "wasm",
+        VoomError::Storage { kind, .. } => match kind {
+            StorageErrorKind::ConstraintViolation => "storage.constraint",
+            StorageErrorKind::NotFound => "storage.not_found",
+            StorageErrorKind::Other => "storage.other",
+            _ => "storage.other",
+        },
+        VoomError::ToolNotFound { .. } => "tool_not_found",
+        VoomError::ToolExecution { .. } => "tool_execution",
+        VoomError::Validation(_) => "validation",
+        VoomError::Io(_) => "io",
+        VoomError::Other(_) => "other",
+        // `VoomError` is `#[non_exhaustive]`. Any new variant gets a stable
+        // bucket until someone adds a dedicated label here.
+        _ => "unknown",
+    }
+    .to_string()
 }
 
 /// Create an error `EventResult` for a plugin failure (error or panic).
@@ -38,14 +70,29 @@ fn make_error_result(plugin_name: String, event_type: &str, error: String) -> Ev
 /// a fixed depth limit to prevent infinite loops.
 pub struct EventBus {
     subscribers: RwLock<Vec<Subscriber>>,
+    stats_sink: RwLock<Arc<dyn StatsSink>>,
 }
 
 impl EventBus {
     #[must_use]
     pub fn new() -> Self {
+        Self::with_stats_sink(Arc::new(NoopStatsSink))
+    }
+
+    #[must_use]
+    pub fn with_stats_sink(sink: Arc<dyn StatsSink>) -> Self {
         Self {
             subscribers: RwLock::new(Vec::new()),
+            stats_sink: RwLock::new(sink),
         }
+    }
+
+    /// Replace the active stats sink. Intended for one-shot wiring at
+    /// bootstrap once the SQLite handle is available; callers may also
+    /// install a Noop sink to disable recording at runtime. Cheap to call
+    /// (one write lock acquisition); not a hot path.
+    pub fn set_stats_sink(&self, sink: Arc<dyn StatsSink>) {
+        *self.stats_sink.write() = sink;
     }
 
     /// Register a plugin at the given priority (lower = earlier dispatch).
@@ -102,9 +149,31 @@ impl EventBus {
                 .collect()
         };
 
+        // Snapshot the sink once per dispatch. Read-only access from this point on.
+        let sink: Arc<dyn StatsSink> = self.stats_sink.read().clone();
+
         let mut results = Vec::new();
         for (name, handler) in handlers {
+            let started_at = chrono::Utc::now();
+            let timer = Instant::now();
             let handler_result = catch_unwind(AssertUnwindSafe(|| handler.on_event(&event)));
+            let duration_ms = u64::try_from(timer.elapsed().as_millis()).unwrap_or(u64::MAX);
+
+            let outcome = match &handler_result {
+                Ok(Ok(Some(_))) => PluginInvocationOutcome::Ok,
+                Ok(Ok(None)) => PluginInvocationOutcome::Skipped,
+                Ok(Err(e)) => PluginInvocationOutcome::Err {
+                    category: error_category(e),
+                },
+                Err(_) => PluginInvocationOutcome::Panic,
+            };
+            sink.record(PluginStatRecord {
+                plugin_id: name.clone(),
+                event_type: event_type.clone(),
+                started_at,
+                duration_ms,
+                outcome,
+            });
 
             match handler_result {
                 Ok(Ok(Some(result))) => {
@@ -684,6 +753,220 @@ mod tests {
         assert_eq!(results[0].plugin_name, "first");
         assert_eq!(results[1].plugin_name, "second");
         assert_eq!(results[2].plugin_name, "third");
+    }
+
+    // --- StatsSink instrumentation tests ---
+
+    use crate::stats_sink::StatsSink;
+    use std::sync::Mutex;
+    use voom_domain::plugin_stats::{PluginInvocationOutcome, PluginStatRecord};
+
+    #[derive(Default)]
+    struct RecordingSink {
+        records: Mutex<Vec<PluginStatRecord>>,
+    }
+
+    impl StatsSink for RecordingSink {
+        fn record(&self, record: PluginStatRecord) {
+            self.records.lock().unwrap().push(record);
+        }
+    }
+
+    #[test]
+    fn dispatcher_records_ok_outcome() {
+        let sink = Arc::new(RecordingSink::default());
+        let bus = EventBus::with_stats_sink(sink.clone());
+        bus.subscribe_plugin(
+            Arc::new(TestPlugin::new("ok-plugin", &[Event::FILE_DISCOVERED])),
+            0,
+        );
+
+        let event = Event::FileDiscovered(FileDiscoveredEvent::new(
+            "/test.mkv".into(),
+            1024,
+            Some("abc".into()),
+        ));
+        bus.publish(event);
+
+        let recs = sink.records.lock().unwrap();
+        assert_eq!(recs.len(), 1);
+        assert_eq!(recs[0].plugin_id, "ok-plugin");
+        assert_eq!(recs[0].event_type, "file.discovered");
+        assert!(matches!(recs[0].outcome, PluginInvocationOutcome::Ok));
+    }
+
+    #[test]
+    fn dispatcher_records_skipped_outcome_when_plugin_returns_none() {
+        let sink = Arc::new(RecordingSink::default());
+        let bus = EventBus::with_stats_sink(sink.clone());
+
+        struct Decliner;
+        impl Plugin for Decliner {
+            fn name(&self) -> &str {
+                "decliner"
+            }
+            fn version(&self) -> &str {
+                "0.1.0"
+            }
+            fn capabilities(&self) -> &[Capability] {
+                &[]
+            }
+            fn handles(&self, event_type: &str) -> bool {
+                event_type == Event::FILE_DISCOVERED
+            }
+            fn on_event(&self, _event: &Event) -> voom_domain::errors::Result<Option<EventResult>> {
+                Ok(None)
+            }
+        }
+
+        bus.subscribe_plugin(Arc::new(Decliner), 0);
+        bus.publish(Event::FileDiscovered(FileDiscoveredEvent::new(
+            "/test.mkv".into(),
+            1024,
+            Some("abc".into()),
+        )));
+
+        let recs = sink.records.lock().unwrap();
+        assert_eq!(recs.len(), 1);
+        assert!(matches!(recs[0].outcome, PluginInvocationOutcome::Skipped));
+    }
+
+    #[test]
+    fn dispatcher_records_err_outcome_with_category() {
+        let sink = Arc::new(RecordingSink::default());
+        let bus = EventBus::with_stats_sink(sink.clone());
+        bus.subscribe_plugin(
+            Arc::new(ErrorPlugin {
+                name: "bad".into(),
+                handled_types: vec![Event::FILE_DISCOVERED.into()],
+            }),
+            0,
+        );
+
+        bus.publish(Event::FileDiscovered(FileDiscoveredEvent::new(
+            "/test.mkv".into(),
+            1024,
+            Some("abc".into()),
+        )));
+
+        let recs = sink.records.lock().unwrap();
+        assert_eq!(recs.len(), 1);
+        assert!(matches!(
+            &recs[0].outcome,
+            PluginInvocationOutcome::Err { category } if !category.is_empty()
+        ));
+    }
+
+    #[test]
+    fn dispatcher_records_panic_outcome() {
+        let sink = Arc::new(RecordingSink::default());
+        let bus = EventBus::with_stats_sink(sink.clone());
+        bus.subscribe_plugin(
+            Arc::new(PanickingPlugin::new("panicker", &[Event::FILE_DISCOVERED])),
+            0,
+        );
+
+        bus.publish(Event::FileDiscovered(FileDiscoveredEvent::new(
+            "/test.mkv".into(),
+            1024,
+            Some("abc".into()),
+        )));
+
+        let recs = sink.records.lock().unwrap();
+        assert_eq!(recs.len(), 1);
+        assert!(matches!(recs[0].outcome, PluginInvocationOutcome::Panic));
+    }
+
+    #[test]
+    fn dispatcher_records_each_handler_separately() {
+        let sink = Arc::new(RecordingSink::default());
+        let bus = EventBus::with_stats_sink(sink.clone());
+        bus.subscribe_plugin(Arc::new(TestPlugin::new("a", &[Event::FILE_DISCOVERED])), 0);
+        bus.subscribe_plugin(
+            Arc::new(TestPlugin::new("b", &[Event::FILE_DISCOVERED])),
+            10,
+        );
+
+        bus.publish(Event::FileDiscovered(FileDiscoveredEvent::new(
+            "/test.mkv".into(),
+            1024,
+            Some("abc".into()),
+        )));
+
+        let recs = sink.records.lock().unwrap();
+        assert_eq!(recs.len(), 2);
+        assert_eq!(recs[0].plugin_id, "a");
+        assert_eq!(recs[1].plugin_id, "b");
+    }
+
+    // --- error_category unit tests ---
+
+    #[test]
+    fn error_category_returns_fixed_labels_for_each_variant() {
+        use std::io;
+        use voom_domain::errors::{StorageErrorKind, VoomError};
+
+        assert_eq!(
+            super::error_category(&VoomError::Plugin {
+                plugin: "x".into(),
+                message: "/secret/path leaked".into(),
+            }),
+            "plugin"
+        );
+        assert_eq!(
+            super::error_category(&VoomError::Wasm("/secret/path leaked".into())),
+            "wasm"
+        );
+        assert_eq!(
+            super::error_category(&VoomError::Storage {
+                kind: StorageErrorKind::ConstraintViolation,
+                message: "unique violation on /home/user/file.mkv".into(),
+            }),
+            "storage.constraint"
+        );
+        assert_eq!(
+            super::error_category(&VoomError::Storage {
+                kind: StorageErrorKind::NotFound,
+                message: "x".into(),
+            }),
+            "storage.not_found"
+        );
+        assert_eq!(
+            super::error_category(&VoomError::Storage {
+                kind: StorageErrorKind::Other,
+                message: "x".into(),
+            }),
+            "storage.other"
+        );
+        assert_eq!(
+            super::error_category(&VoomError::ToolNotFound {
+                tool: "ffprobe".into()
+            }),
+            "tool_not_found"
+        );
+        assert_eq!(
+            super::error_category(&VoomError::ToolExecution {
+                tool: "ffmpeg".into(),
+                message: "exit 1".into(),
+            }),
+            "tool_execution"
+        );
+        assert_eq!(
+            super::error_category(&VoomError::Validation("user typed bad input".into())),
+            "validation"
+        );
+        let io_err: VoomError = io::Error::new(io::ErrorKind::NotFound, "gone").into();
+        assert_eq!(super::error_category(&io_err), "io");
+    }
+
+    #[test]
+    fn error_category_label_does_not_contain_message_text() {
+        use voom_domain::errors::VoomError;
+        let secret = "/home/alice/private/diary.txt";
+        let err = VoomError::Validation(secret.into());
+        let cat = super::error_category(&err);
+        assert!(!cat.contains("alice"), "category leaks user input: {cat}");
+        assert!(!cat.contains("diary"), "category leaks filename: {cat}");
     }
 
     #[test]

--- a/crates/voom-kernel/src/lib.rs
+++ b/crates/voom-kernel/src/lib.rs
@@ -7,6 +7,7 @@ pub mod host;
 pub mod loader;
 pub mod manifest;
 pub mod registry;
+pub mod stats_sink;
 
 use std::any::{Any, TypeId};
 use std::collections::HashMap;

--- a/crates/voom-kernel/src/lib.rs
+++ b/crates/voom-kernel/src/lib.rs
@@ -317,6 +317,13 @@ impl Kernel {
         Ok(())
     }
 
+    /// Install a `StatsSink` that the event bus will forward every plugin
+    /// invocation record to. Idempotent; calling repeatedly replaces the
+    /// previous sink. Intended for one-shot wiring at bootstrap.
+    pub fn set_stats_sink(&self, sink: Arc<dyn stats_sink::StatsSink>) {
+        self.bus.set_stats_sink(sink);
+    }
+
     /// Dispatch an event through the bus to all matching subscribers.
     pub fn dispatch(&self, event: Event) -> Vec<EventResult> {
         let event_type = event.event_type().to_string();
@@ -695,5 +702,84 @@ mod tests {
         );
         assert_eq!(kernel.registry.len(), 1);
         assert_eq!(kernel.subscriber_count(), 1);
+    }
+}
+
+#[cfg(test)]
+mod stats_sink_wiring_tests {
+    use super::*;
+    use crate::stats_sink::StatsSink;
+    use std::sync::Mutex;
+    use voom_domain::plugin_stats::PluginStatRecord;
+
+    #[derive(Default)]
+    struct CountingSink(Mutex<u64>);
+
+    impl StatsSink for CountingSink {
+        fn record(&self, _r: PluginStatRecord) {
+            *self.0.lock().unwrap() += 1;
+        }
+    }
+
+    struct MinimalPlugin {
+        name: String,
+    }
+
+    impl Plugin for MinimalPlugin {
+        fn name(&self) -> &str {
+            &self.name
+        }
+        fn version(&self) -> &str {
+            "0.1.0"
+        }
+        fn capabilities(&self) -> &[voom_domain::capabilities::Capability] {
+            &[]
+        }
+        fn handles(&self, event_type: &str) -> bool {
+            event_type == voom_domain::events::Event::TOOL_DETECTED
+        }
+        fn on_event(
+            &self,
+            _event: &voom_domain::events::Event,
+        ) -> voom_domain::errors::Result<Option<voom_domain::events::EventResult>> {
+            Ok(Some(voom_domain::events::EventResult::new(
+                self.name.clone(),
+            )))
+        }
+    }
+
+    #[test]
+    fn set_stats_sink_swaps_the_active_sink() {
+        let mut kernel = Kernel::new();
+        let sink = Arc::new(CountingSink::default());
+
+        // Register a plugin that handles TOOL_DETECTED before installing the sink.
+        kernel
+            .register_plugin(
+                Arc::new(MinimalPlugin {
+                    name: "test-plugin".into(),
+                }),
+                10,
+            )
+            .unwrap();
+
+        // Install the new sink.
+        kernel.set_stats_sink(sink.clone());
+
+        // Dispatch one event the plugin handles.
+        let event =
+            voom_domain::events::Event::ToolDetected(voom_domain::events::ToolDetectedEvent::new(
+                "test-tool",
+                "1.0.0",
+                "/usr/bin/test-tool".into(),
+            ));
+        kernel.dispatch(event);
+
+        // The new sink must have seen exactly one record.
+        assert_eq!(
+            *sink.0.lock().unwrap(),
+            1,
+            "CountingSink should record exactly one invocation"
+        );
     }
 }

--- a/crates/voom-kernel/src/stats_sink.rs
+++ b/crates/voom-kernel/src/stats_sink.rs
@@ -1,0 +1,44 @@
+//! Stats sink for plugin invocation records.
+//!
+//! The event bus dispatcher wraps each plugin handler invocation in a timer
+//! and forwards a [`PluginStatRecord`] to the configured sink. The default
+//! sink is [`NoopStatsSink`], which discards all records — used in tests and
+//! when stats collection is disabled.
+//!
+//! Production sinks (e.g. `SqliteStatsSink` in `plugins/sqlite-store`) must
+//! be non-blocking: `record` is called inside the bus dispatch loop, which
+//! holds the subscriber lock. A bounded channel + writer thread is the
+//! expected pattern.
+
+use voom_domain::plugin_stats::PluginStatRecord;
+
+pub trait StatsSink: Send + Sync {
+    fn record(&self, record: PluginStatRecord);
+}
+
+/// Sink that discards all records. Used when stats collection is disabled.
+#[derive(Default)]
+pub struct NoopStatsSink;
+
+impl StatsSink for NoopStatsSink {
+    fn record(&self, _record: PluginStatRecord) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use voom_domain::plugin_stats::PluginInvocationOutcome;
+
+    #[test]
+    fn noop_sink_does_not_panic() {
+        let sink = NoopStatsSink;
+        sink.record(PluginStatRecord {
+            plugin_id: "x".into(),
+            event_type: "y".into(),
+            started_at: Utc::now(),
+            duration_ms: 0,
+            outcome: PluginInvocationOutcome::Ok,
+        });
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -204,6 +204,20 @@ The event bus is the sole communication mechanism between plugins. It uses synch
 
 Events are published to all subscribed plugins, ordered by priority (lower = runs first). Each subscriber can optionally return an `EventResult` that may influence downstream processing.
 
+### Bus dispatcher instrumentation
+
+Every plugin invocation is timed by the dispatcher and forwarded to a
+`StatsSink` (issue #92). The default sink (`NoopStatsSink`) discards records;
+the CLI wires `SqliteStatsSink` to persist to the `plugin_stats` table.
+Records carry `plugin_id`, `event_type`, `started_at`, `duration_ms`, and an
+`outcome` of `ok` / `skipped` / `err{category}` / `panic`. Records are
+written in background batches and dropped if the bounded channel overflows —
+the bus must not block.
+
+**Coverage:** the dispatcher only times handlers invoked through
+`Plugin::on_event`. Pure publishers (plugins that emit events but don't
+subscribe to any) are not represented in `plugin_stats`.
+
 ### Retention invariants
 
 `event_log` records every event dispatched on the bus, including

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -327,6 +327,38 @@ voom plugin install <PATH>
 
 Copies the WASM binary to `~/.config/voom/plugins/wasm/` and registers it.
 
+#### `voom plugin stats`
+
+Show a per-plugin invocation rollup capturing automatic timing and outcome
+metrics. Stats are recorded by the event bus dispatcher with no plugin code
+changes required (issue #92).
+
+| Flag         | Default | Description                                         |
+|--------------|---------|-----------------------------------------------------|
+| `--plugin`   | —       | Filter to a single plugin by name.                  |
+| `--since`    | —       | Look back this far. Format: `<N>{s,m,h,d}`.         |
+| `--top`      | —       | Show only the top N slowest plugins (ranked by p95).|
+| `--format`   | `table` | `table` or `json`.                                  |
+
+Example:
+
+```
+voom plugin stats --since 24h --top 10
+plugin                          calls     ok  skipped    err  panic    p50ms    p95ms    p99ms
+ffmpeg-executor                    18     17        0      1      0    32100    98722    99812
+ffprobe-introspector              412    410        0      2      0       42      180      290
+mkvtoolnix-executor                 5      5        0      0      0      850     2100     2400
+```
+
+Stats are persisted to the `plugin_stats` SQLite table with retention managed
+by the same `[retention.plugin_stats]` config section as other tables (PR #170).
+Defaults: keep for 30 days, keep last 100,000 rows.
+
+**Note:** Only plugins that *subscribe* to events appear in the rollup. Pure
+publishers (e.g., the `discovery` plugin, which walks the filesystem and emits
+`FileDiscovered` events but doesn't consume any events) are not timed by the
+dispatcher and therefore have no rows.
+
 ---
 
 ### `voom jobs`

--- a/plugins/sqlite-store/src/lib.rs
+++ b/plugins/sqlite-store/src/lib.rs
@@ -1,7 +1,10 @@
 //! `SQLite` storage plugin: persistent storage for files, tracks, jobs, plans, and plugin data.
 
 pub mod schema;
+pub mod stats_sink;
 pub mod store;
+
+pub use stats_sink::SqliteStatsSink;
 
 use std::sync::Arc;
 

--- a/plugins/sqlite-store/src/schema.rs
+++ b/plugins/sqlite-store/src/schema.rs
@@ -321,6 +321,21 @@ CREATE TABLE IF NOT EXISTS scan_session_mutations (
 
 CREATE INDEX IF NOT EXISTS idx_scan_session_mutations_session
     ON scan_session_mutations(session_id);
+
+CREATE TABLE IF NOT EXISTS plugin_stats (
+    rowid INTEGER PRIMARY KEY AUTOINCREMENT,
+    plugin_id TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    started_at TEXT NOT NULL,
+    duration_ms INTEGER NOT NULL,
+    outcome TEXT NOT NULL,
+    error_category TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_plugin_stats_started
+    ON plugin_stats(started_at);
+CREATE INDEX IF NOT EXISTS idx_plugin_stats_plugin_started
+    ON plugin_stats(plugin_id, started_at);
 ";
 
 /// Initialize the database schema.
@@ -1621,5 +1636,39 @@ mod tests {
             )
             .unwrap();
         assert_eq!(heartbeat, "1970-01-01T00:00:00Z");
+    }
+
+    #[test]
+    fn plugin_stats_table_and_indexes_exist() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        create_schema(&conn).unwrap();
+        let table: String = conn
+            .query_row(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='plugin_stats'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("plugin_stats table must exist");
+        assert_eq!(table, "plugin_stats");
+
+        let idx_started: String = conn
+            .query_row(
+                "SELECT name FROM sqlite_master WHERE type='index' \
+                 AND name='idx_plugin_stats_started'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("idx_plugin_stats_started must exist");
+        assert_eq!(idx_started, "idx_plugin_stats_started");
+
+        let idx_plugin: String = conn
+            .query_row(
+                "SELECT name FROM sqlite_master WHERE type='index' \
+                 AND name='idx_plugin_stats_plugin_started'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("idx_plugin_stats_plugin_started must exist");
+        assert_eq!(idx_plugin, "idx_plugin_stats_plugin_started");
     }
 }

--- a/plugins/sqlite-store/src/stats_sink.rs
+++ b/plugins/sqlite-store/src/stats_sink.rs
@@ -1,0 +1,390 @@
+//! SQLite-backed StatsSink: non-blocking buffer + background writer thread.
+//!
+//! The bus dispatcher calls [`SqliteStatsSink::record`] from inside the
+//! synchronous dispatch loop, which holds a `parking_lot::RwLock` read
+//! lock on the subscriber list. The sink MUST NOT block. We use a bounded
+//! `std::sync::mpsc::sync_channel` and `try_send`; on overflow, the record
+//! is dropped (logged once at warn level).
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::mpsc::{Receiver, SyncSender, sync_channel};
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+use voom_domain::plugin_stats::PluginStatRecord;
+use voom_domain::storage::PluginStatsStorage;
+use voom_kernel::stats_sink::StatsSink;
+
+use crate::store::SqliteStore;
+
+const DEFAULT_CHANNEL_CAPACITY: usize = 4096;
+const DEFAULT_BATCH_SIZE: usize = 256;
+const DEFAULT_FLUSH_INTERVAL: Duration = Duration::from_millis(500);
+/// Maximum consecutive failed flushes before the buffer is dropped as a last
+/// resort to prevent unbounded memory growth. 30 attempts at 500ms ≈ 15s of
+/// transient lock contention, which is well beyond normal SQLite back-off.
+const MAX_CONSECUTIVE_FLUSH_FAILURES: u32 = 30;
+/// Hard ceiling on the in-memory retry buffer. If the writer thread cannot
+/// drain (e.g. DB completely unavailable), the oldest records are evicted
+/// instead of growing the buffer without bound.
+const MAX_BUFFER_RECORDS: usize = 64 * 1024;
+
+pub struct SqliteStatsSink {
+    tx: SyncSender<PluginStatRecord>,
+    dropped: Arc<AtomicU64>,
+    failed_flushes: Arc<AtomicU64>,
+    evicted: Arc<AtomicU64>,
+    shutdown: Arc<AtomicBool>,
+    writer: Option<JoinHandle<()>>,
+}
+
+impl SqliteStatsSink {
+    /// Spawn a writer thread bound to `store`. The thread batches records
+    /// up to `DEFAULT_BATCH_SIZE` or `DEFAULT_FLUSH_INTERVAL`, whichever
+    /// comes first, and inserts via [`PluginStatsStorage::insert_plugin_stats_batch`].
+    /// On insert failure the batch is RETAINED in the writer's buffer and
+    /// retried on the next flush tick; records are only evicted when the
+    /// buffer exceeds [`MAX_BUFFER_RECORDS`] or after
+    /// [`MAX_CONSECUTIVE_FLUSH_FAILURES`] consecutive failures.
+    #[must_use]
+    pub fn new(store: Arc<SqliteStore>) -> Self {
+        let (tx, rx) = sync_channel::<PluginStatRecord>(DEFAULT_CHANNEL_CAPACITY);
+        let dropped = Arc::new(AtomicU64::new(0));
+        let failed_flushes = Arc::new(AtomicU64::new(0));
+        let evicted = Arc::new(AtomicU64::new(0));
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let writer = std::thread::Builder::new()
+            .name("voom-stats-writer".into())
+            .spawn({
+                let shutdown = shutdown.clone();
+                let failed_flushes = failed_flushes.clone();
+                let evicted = evicted.clone();
+                move || writer_loop(rx, store, shutdown, failed_flushes, evicted)
+            })
+            .expect("spawn voom-stats-writer thread");
+        Self {
+            tx,
+            dropped,
+            failed_flushes,
+            evicted,
+            shutdown,
+            writer: Some(writer),
+        }
+    }
+
+    /// Records the dispatcher had to drop because the bounded channel was
+    /// full or the writer thread had exited.
+    #[must_use]
+    pub fn dropped_count(&self) -> u64 {
+        self.dropped.load(Ordering::Relaxed)
+    }
+
+    /// Number of times `insert_plugin_stats_batch` returned an error.
+    /// The batch is retained for the next attempt; this counter goes up by
+    /// one per failed attempt, not per record.
+    #[must_use]
+    pub fn failed_flush_count(&self) -> u64 {
+        self.failed_flushes.load(Ordering::Relaxed)
+    }
+
+    /// Records evicted from the in-memory retry buffer to keep memory bounded
+    /// (oldest-first, after `MAX_BUFFER_RECORDS` or
+    /// `MAX_CONSECUTIVE_FLUSH_FAILURES`). Non-zero values mean the SQLite
+    /// store has been unavailable long enough to lose data — alert worthy.
+    #[must_use]
+    pub fn evicted_count(&self) -> u64 {
+        self.evicted.load(Ordering::Relaxed)
+    }
+}
+
+impl StatsSink for SqliteStatsSink {
+    fn record(&self, record: PluginStatRecord) {
+        if self.tx.try_send(record).is_err() {
+            let prev = self.dropped.fetch_add(1, Ordering::Relaxed);
+            if prev == 0 {
+                tracing::warn!(
+                    "voom-stats-writer channel full or closed; dropping records (first occurrence)"
+                );
+            }
+        }
+    }
+}
+
+impl Drop for SqliteStatsSink {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::Relaxed);
+        // Closing the sender side breaks the recv loop.
+        // Move tx out by replacing with a dummy is not possible here; relying
+        // on the original tx being the last clone, this sink owns it. When
+        // SqliteStatsSink is dropped, tx is dropped, channel closes, writer exits.
+        if let Some(h) = self.writer.take() {
+            let _ = h.join();
+        }
+    }
+}
+
+fn writer_loop(
+    rx: Receiver<PluginStatRecord>,
+    store: Arc<SqliteStore>,
+    shutdown: Arc<AtomicBool>,
+    failed_flushes: Arc<AtomicU64>,
+    evicted: Arc<AtomicU64>,
+) {
+    let mut buf: Vec<PluginStatRecord> = Vec::with_capacity(DEFAULT_BATCH_SIZE);
+    let mut last_flush = Instant::now();
+    let mut consecutive_failures: u32 = 0;
+    loop {
+        match rx.recv_timeout(DEFAULT_FLUSH_INTERVAL) {
+            Ok(record) => {
+                buf.push(record);
+                cap_buffer(&mut buf, &evicted);
+                if buf.len() >= DEFAULT_BATCH_SIZE || last_flush.elapsed() >= DEFAULT_FLUSH_INTERVAL
+                {
+                    flush(
+                        &store,
+                        &mut buf,
+                        &failed_flushes,
+                        &evicted,
+                        &mut consecutive_failures,
+                    );
+                    last_flush = Instant::now();
+                }
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                if !buf.is_empty() {
+                    flush(
+                        &store,
+                        &mut buf,
+                        &failed_flushes,
+                        &evicted,
+                        &mut consecutive_failures,
+                    );
+                    last_flush = Instant::now();
+                }
+                if shutdown.load(Ordering::Relaxed) {
+                    break;
+                }
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                if !buf.is_empty() {
+                    flush(
+                        &store,
+                        &mut buf,
+                        &failed_flushes,
+                        &evicted,
+                        &mut consecutive_failures,
+                    );
+                }
+                break;
+            }
+        }
+    }
+}
+
+/// Drop oldest records when the retry buffer grows past `MAX_BUFFER_RECORDS`.
+/// Accounted in `evicted` so callers can alert on data loss.
+fn cap_buffer(buf: &mut Vec<PluginStatRecord>, evicted: &AtomicU64) {
+    if buf.len() <= MAX_BUFFER_RECORDS {
+        return;
+    }
+    let overflow = buf.len() - MAX_BUFFER_RECORDS;
+    buf.drain(..overflow);
+    evicted.fetch_add(overflow as u64, Ordering::Relaxed);
+    tracing::warn!(
+        overflow = overflow,
+        cap = MAX_BUFFER_RECORDS,
+        "plugin_stats retry buffer at capacity; oldest records evicted"
+    );
+}
+
+/// Attempt to insert the buffered batch. On success the buffer is cleared
+/// and the consecutive-failure counter is reset. On error the buffer is
+/// RETAINED for the next tick. After `MAX_CONSECUTIVE_FLUSH_FAILURES`
+/// consecutive failures the buffer is cleared as a last-resort safety vent
+/// and the eviction counter records the loss.
+fn flush(
+    store: &SqliteStore,
+    buf: &mut Vec<PluginStatRecord>,
+    failed_flushes: &AtomicU64,
+    evicted: &AtomicU64,
+    consecutive_failures: &mut u32,
+) {
+    if buf.is_empty() {
+        return;
+    }
+    match store.insert_plugin_stats_batch(buf) {
+        Ok(()) => {
+            buf.clear();
+            *consecutive_failures = 0;
+        }
+        Err(e) => {
+            failed_flushes.fetch_add(1, Ordering::Relaxed);
+            *consecutive_failures = consecutive_failures.saturating_add(1);
+            tracing::warn!(
+                error = %e,
+                attempt = *consecutive_failures,
+                retained = buf.len(),
+                "failed to flush plugin_stats batch; retaining for retry"
+            );
+            if *consecutive_failures >= MAX_CONSECUTIVE_FLUSH_FAILURES {
+                evicted.fetch_add(buf.len() as u64, Ordering::Relaxed);
+                tracing::error!(
+                    attempts = *consecutive_failures,
+                    dropped = buf.len(),
+                    "plugin_stats writer giving up after consecutive failures; dropping buffer"
+                );
+                buf.clear();
+                *consecutive_failures = 0;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use voom_domain::plugin_stats::PluginInvocationOutcome;
+
+    fn rec(i: u64) -> PluginStatRecord {
+        PluginStatRecord {
+            plugin_id: "x".into(),
+            event_type: "y".into(),
+            started_at: Utc::now(),
+            duration_ms: i,
+            outcome: PluginInvocationOutcome::Ok,
+        }
+    }
+
+    #[test]
+    fn records_flush_to_store_within_one_second() {
+        let store = Arc::new(SqliteStore::in_memory().unwrap());
+        let sink = SqliteStatsSink::new(store.clone());
+        for i in 0..50 {
+            sink.record(rec(i));
+        }
+        std::thread::sleep(Duration::from_millis(800));
+        let conn = store.conn().unwrap();
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM plugin_stats", [], |r| r.get(0))
+            .unwrap();
+        assert!(count >= 50, "expected at least 50 rows, got {count}");
+    }
+
+    #[test]
+    fn drop_flushes_remaining_records() {
+        let store = Arc::new(SqliteStore::in_memory().unwrap());
+        {
+            let sink = SqliteStatsSink::new(store.clone());
+            for i in 0..10 {
+                sink.record(rec(i));
+            }
+            // drop sink → writer thread joins after final flush
+        }
+        let conn = store.conn().unwrap();
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM plugin_stats", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 10);
+    }
+
+    #[test]
+    fn channel_overflow_increments_dropped_counter() {
+        // Build a sink whose writer thread can't keep up: use a custom
+        // sink with capacity=1 by wrapping `new` internals.
+        // For simplicity, just spam records and assume some get dropped
+        // because the channel cap is 4096. To force overflow, send 100k.
+        let store = Arc::new(SqliteStore::in_memory().unwrap());
+        let sink = SqliteStatsSink::new(store);
+        for i in 0..50_000u64 {
+            sink.record(rec(i));
+        }
+        std::thread::sleep(Duration::from_millis(200));
+        // We expect the writer to catch up eventually; the assertion here
+        // is just that calling record many times never panics.
+        let _ = sink.dropped_count();
+    }
+
+    #[test]
+    fn flush_failure_retains_buffer_and_recovers() {
+        // Drive the writer's flush() directly so we can simulate a store
+        // that fails the first attempt, then succeeds. Bypasses the channel.
+        use std::sync::Arc;
+
+        let store = Arc::new(SqliteStore::in_memory().unwrap());
+        // Drop the underlying table to force the next insert to fail, then
+        // recreate it before the second attempt. This exercises the retain-
+        // on-error path without requiring a mock storage implementation.
+        {
+            let conn = store.conn().unwrap();
+            conn.execute("DROP TABLE plugin_stats", []).unwrap();
+        }
+
+        let failed_flushes = Arc::new(AtomicU64::new(0));
+        let evicted = Arc::new(AtomicU64::new(0));
+        let mut buf = vec![rec(1), rec(2), rec(3)];
+        let mut consecutive = 0u32;
+
+        super::flush(
+            &store,
+            &mut buf,
+            &failed_flushes,
+            &evicted,
+            &mut consecutive,
+        );
+        assert_eq!(failed_flushes.load(Ordering::Relaxed), 1);
+        assert_eq!(buf.len(), 3, "buffer must be retained after failure");
+        assert_eq!(evicted.load(Ordering::Relaxed), 0);
+        assert_eq!(consecutive, 1);
+
+        // Now recreate the table and re-run flush; the same records should land.
+        {
+            let conn = store.conn().unwrap();
+            crate::schema::create_schema(&conn).unwrap();
+        }
+        super::flush(
+            &store,
+            &mut buf,
+            &failed_flushes,
+            &evicted,
+            &mut consecutive,
+        );
+        assert_eq!(buf.len(), 0, "buffer must be cleared after success");
+        assert_eq!(consecutive, 0);
+
+        let conn = store.conn().unwrap();
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM plugin_stats", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 3);
+    }
+
+    #[test]
+    fn flush_gives_up_after_consecutive_failures_and_evicts() {
+        // Persistently failing store: drop the table and never recreate.
+        let store = Arc::new(SqliteStore::in_memory().unwrap());
+        {
+            let conn = store.conn().unwrap();
+            conn.execute("DROP TABLE plugin_stats", []).unwrap();
+        }
+
+        let failed_flushes = Arc::new(AtomicU64::new(0));
+        let evicted = Arc::new(AtomicU64::new(0));
+        let mut buf = vec![rec(1), rec(2)];
+        let mut consecutive = 0u32;
+
+        for _ in 0..super::MAX_CONSECUTIVE_FLUSH_FAILURES {
+            super::flush(
+                &store,
+                &mut buf,
+                &failed_flushes,
+                &evicted,
+                &mut consecutive,
+            );
+        }
+        assert_eq!(buf.len(), 0, "buffer must be evicted after cap reached");
+        assert_eq!(evicted.load(Ordering::Relaxed), 2);
+        assert_eq!(consecutive, 0, "counter resets after eviction");
+    }
+}

--- a/plugins/sqlite-store/src/stats_sink.rs
+++ b/plugins/sqlite-store/src/stats_sink.rs
@@ -382,21 +382,22 @@ mod tests {
 
     #[test]
     fn overflow_increments_dropped_counter_when_channel_full() {
-        // capacity=0 makes the channel "rendezvous": try_send succeeds only when
-        // a receiver is actively recv'ing. The writer thread is parked in
-        // recv_timeout for up to 500ms between iterations, so the overwhelming
-        // majority of these try_send calls will see a full channel and drop.
+        // capacity=0 makes the channel "rendezvous": try_send succeeds only
+        // when a receiver is actively in recv. The writer thread oscillates
+        // between recv_timeout and a tiny in-body slice (push + cap_buffer),
+        // so a flood of try_sends will see the channel full whenever the
+        // writer is mid-body. We only assert the *contract* — that overflow
+        // bumps the counter — not a specific ratio, because the exact number
+        // of drops is purely scheduler-dependent (and prior tighter bounds
+        // flaked on faster CI runners).
         let store = Arc::new(SqliteStore::in_memory().unwrap());
         let sink = SqliteStatsSink::with_capacity_for_tests(store, 0);
-        for i in 0..200u64 {
+        for i in 0..10_000u64 {
             sink.record(rec(i));
         }
-        // Allow scheduler slack: with capacity=0 and a single writer parked in
-        // recv_timeout, ≥150 of 200 try_sends must fail. Concrete number tuned
-        // to be robust against scheduler noise without becoming vacuous.
         assert!(
-            sink.dropped_count() >= 150,
-            "expected at least 150 drops with rendezvous channel, got {}",
+            sink.dropped_count() > 0,
+            "expected at least one drop with rendezvous channel and 10k tight sends, got {}",
             sink.dropped_count()
         );
     }

--- a/plugins/sqlite-store/src/stats_sink.rs
+++ b/plugins/sqlite-store/src/stats_sink.rs
@@ -12,7 +12,7 @@
 //! logged at error level — never silently lost.
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc::{Receiver, SyncSender, sync_channel};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
@@ -47,7 +47,6 @@ pub struct SqliteStatsSink {
     dropped: Arc<AtomicU64>,
     failed_flushes: Arc<AtomicU64>,
     evicted: Arc<AtomicU64>,
-    shutdown: Arc<AtomicBool>,
     writer: Option<JoinHandle<()>>,
 }
 
@@ -65,14 +64,12 @@ impl SqliteStatsSink {
         let dropped = Arc::new(AtomicU64::new(0));
         let failed_flushes = Arc::new(AtomicU64::new(0));
         let evicted = Arc::new(AtomicU64::new(0));
-        let shutdown = Arc::new(AtomicBool::new(false));
         let writer = std::thread::Builder::new()
             .name("voom-stats-writer".into())
             .spawn({
-                let shutdown = shutdown.clone();
                 let failed_flushes = failed_flushes.clone();
                 let evicted = evicted.clone();
-                move || writer_loop(rx, store, shutdown, failed_flushes, evicted)
+                move || writer_loop(rx, store, failed_flushes, evicted)
             })
             .expect("spawn voom-stats-writer thread");
         Self {
@@ -80,7 +77,6 @@ impl SqliteStatsSink {
             dropped,
             failed_flushes,
             evicted,
-            shutdown,
             writer: Some(writer),
         }
     }
@@ -128,14 +124,12 @@ impl SqliteStatsSink {
         let dropped = Arc::new(AtomicU64::new(0));
         let failed_flushes = Arc::new(AtomicU64::new(0));
         let evicted = Arc::new(AtomicU64::new(0));
-        let shutdown = Arc::new(AtomicBool::new(false));
         let writer = std::thread::Builder::new()
             .name("voom-stats-writer-test".into())
             .spawn({
-                let shutdown = shutdown.clone();
                 let failed_flushes = failed_flushes.clone();
                 let evicted = evicted.clone();
-                move || writer_loop(rx, store, shutdown, failed_flushes, evicted)
+                move || writer_loop(rx, store, failed_flushes, evicted)
             })
             .expect("spawn voom-stats-writer-test thread");
         Self {
@@ -143,7 +137,6 @@ impl SqliteStatsSink {
             dropped,
             failed_flushes,
             evicted,
-            shutdown,
             writer: Some(writer),
         }
     }
@@ -168,13 +161,9 @@ impl Drop for SqliteStatsSink {
     fn drop(&mut self) {
         // Drop the sender FIRST so the writer's recv_timeout returns
         // Err(Disconnected) on the next tick — the Disconnected arm
-        // is the single path that performs the bounded-retry drain.
-        // Setting `shutdown` before tx is dropped would race the Timeout
-        // arm and let it break out without draining the surviving buf.
+        // is the single path that performs the bounded-retry drain
+        // and exits the loop.
         drop(self.tx.take());
-        // Safety net for late observers; functionally redundant once tx
-        // is dropped because the next recv returns Disconnected.
-        self.shutdown.store(true, Ordering::Relaxed);
         if let Some(h) = self.writer.take() {
             let _ = h.join();
         }
@@ -184,12 +173,6 @@ impl Drop for SqliteStatsSink {
 fn writer_loop(
     rx: Receiver<PluginStatRecord>,
     store: Arc<SqliteStore>,
-    // The `shutdown` flag is set by `SqliteStatsSink::drop` as a safety net,
-    // but the writer no longer observes it: the channel-disconnect signal
-    // from dropping `tx` is the single shutdown path through the
-    // bounded-retry drain. Kept on the struct/signature to avoid a deeper
-    // refactor; prefixed `_` to silence unused-variable lints.
-    _shutdown: Arc<AtomicBool>,
     failed_flushes: Arc<AtomicU64>,
     evicted: Arc<AtomicU64>,
 ) {

--- a/plugins/sqlite-store/src/stats_sink.rs
+++ b/plugins/sqlite-store/src/stats_sink.rs
@@ -98,6 +98,38 @@ impl SqliteStatsSink {
     }
 }
 
+#[cfg(test)]
+impl SqliteStatsSink {
+    /// Test-only constructor allowing a custom channel capacity to
+    /// deterministically exercise the overflow path. `capacity=0` produces a
+    /// rendezvous channel where every `try_send` fails unless the writer is
+    /// actively in `recv`.
+    pub(crate) fn with_capacity_for_tests(store: Arc<SqliteStore>, capacity: usize) -> Self {
+        let (tx, rx) = sync_channel::<PluginStatRecord>(capacity);
+        let dropped = Arc::new(AtomicU64::new(0));
+        let failed_flushes = Arc::new(AtomicU64::new(0));
+        let evicted = Arc::new(AtomicU64::new(0));
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let writer = std::thread::Builder::new()
+            .name("voom-stats-writer-test".into())
+            .spawn({
+                let shutdown = shutdown.clone();
+                let failed_flushes = failed_flushes.clone();
+                let evicted = evicted.clone();
+                move || writer_loop(rx, store, shutdown, failed_flushes, evicted)
+            })
+            .expect("spawn voom-stats-writer-test thread");
+        Self {
+            tx: Some(tx),
+            dropped,
+            failed_flushes,
+            evicted,
+            shutdown,
+            writer: Some(writer),
+        }
+    }
+}
+
 impl StatsSink for SqliteStatsSink {
     fn record(&self, record: PluginStatRecord) {
         if let Some(tx) = &self.tx {
@@ -311,22 +343,40 @@ mod tests {
     }
 
     #[test]
-    fn channel_overflow_increments_dropped_counter() {
-        // Build a sink whose writer thread can't keep up: use a custom
-        // sink with capacity=1 by wrapping `new` internals.
-        // For simplicity, just spam records and assume some get dropped
-        // because the channel cap is 4096. To force overflow, send 100k.
+    fn channel_overflow_does_not_panic() {
+        // Smoke test: spamming record() at saturating speed must never panic,
+        // even when the bounded channel overflows. We cannot deterministically
+        // assert `dropped_count > 0` here because the writer-thread drain rate
+        // varies with hardware. See `overflow_increments_dropped_counter_when_channel_full`
+        // for deterministic overflow coverage.
         let store = Arc::new(SqliteStore::in_memory().unwrap());
         let sink = SqliteStatsSink::new(store);
         for i in 0..50_000u64 {
             sink.record(rec(i));
         }
         std::thread::sleep(Duration::from_millis(200));
-        // With channel capacity 4096 and 50k records sent in a tight loop,
-        // drops are inevitable — the writer thread cannot drain fast enough.
+        // No assertion beyond no-panic: dropped_count() is informational only.
+        let _ = sink.dropped_count();
+    }
+
+    #[test]
+    fn overflow_increments_dropped_counter_when_channel_full() {
+        // capacity=0 makes the channel "rendezvous": try_send succeeds only when
+        // a receiver is actively recv'ing. The writer thread is parked in
+        // recv_timeout for up to 500ms between iterations, so the overwhelming
+        // majority of these try_send calls will see a full channel and drop.
+        let store = Arc::new(SqliteStore::in_memory().unwrap());
+        let sink = SqliteStatsSink::with_capacity_for_tests(store, 0);
+        for i in 0..200u64 {
+            sink.record(rec(i));
+        }
+        // Allow scheduler slack: with capacity=0 and a single writer parked in
+        // recv_timeout, ≥150 of 200 try_sends must fail. Concrete number tuned
+        // to be robust against scheduler noise without becoming vacuous.
         assert!(
-            sink.dropped_count() > 0,
-            "expected some records to be dropped due to channel overflow"
+            sink.dropped_count() >= 150,
+            "expected at least 150 drops with rendezvous channel, got {}",
+            sink.dropped_count()
         );
     }
 

--- a/plugins/sqlite-store/src/stats_sink.rs
+++ b/plugins/sqlite-store/src/stats_sink.rs
@@ -166,17 +166,15 @@ impl StatsSink for SqliteStatsSink {
 
 impl Drop for SqliteStatsSink {
     fn drop(&mut self) {
-        // Setting shutdown is no longer strictly necessary — the writer's
-        // Disconnected arm runs the final flush and exits — but leave it as
-        // a safety net in case the writer is in the middle of a long flush
-        // when we drop tx.
-        self.shutdown.store(true, Ordering::Relaxed);
         // Drop the sender FIRST so the writer's recv_timeout returns
-        // Err(Disconnected) on the next tick; the Disconnected arm drains
-        // the channel and runs the guaranteed final flush before exiting.
-        // Struct fields are dropped AFTER Drop::drop returns, so we must
-        // explicitly take() and drop tx here, before joining the writer.
+        // Err(Disconnected) on the next tick — the Disconnected arm
+        // is the single path that performs the bounded-retry drain.
+        // Setting `shutdown` before tx is dropped would race the Timeout
+        // arm and let it break out without draining the surviving buf.
         drop(self.tx.take());
+        // Safety net for late observers; functionally redundant once tx
+        // is dropped because the next recv returns Disconnected.
+        self.shutdown.store(true, Ordering::Relaxed);
         if let Some(h) = self.writer.take() {
             let _ = h.join();
         }
@@ -186,7 +184,12 @@ impl Drop for SqliteStatsSink {
 fn writer_loop(
     rx: Receiver<PluginStatRecord>,
     store: Arc<SqliteStore>,
-    shutdown: Arc<AtomicBool>,
+    // The `shutdown` flag is set by `SqliteStatsSink::drop` as a safety net,
+    // but the writer no longer observes it: the channel-disconnect signal
+    // from dropping `tx` is the single shutdown path through the
+    // bounded-retry drain. Kept on the struct/signature to avoid a deeper
+    // refactor; prefixed `_` to silence unused-variable lints.
+    _shutdown: Arc<AtomicBool>,
     failed_flushes: Arc<AtomicU64>,
     evicted: Arc<AtomicU64>,
 ) {
@@ -221,9 +224,8 @@ fn writer_loop(
                     );
                     last_flush = Instant::now();
                 }
-                if shutdown.load(Ordering::Relaxed) {
-                    break;
-                }
+                // No `shutdown` check here — the Disconnected arm is the single
+                // shutdown path. See SqliteStatsSink::drop ordering comment.
             }
             Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
                 // Drain any remaining records from the closed channel so they are
@@ -505,6 +507,41 @@ mod tests {
         assert!(
             lost >= 10,
             "expected >= 10 evicted records after persistent flush failure on shutdown, got {lost}"
+        );
+    }
+
+    #[test]
+    fn shutdown_during_timeout_arm_still_drains_via_disconnected() {
+        // Regression test for the Timeout-arm bypass: even if the Drop impl
+        // races the writer through its periodic-flush tick at shutdown, the
+        // surviving buf must be drained or evicted — never silently lost.
+        // (Codex stop-time review follow-up, May 2026.)
+        use std::sync::Arc;
+        use std::sync::atomic::AtomicU64;
+
+        let store = Arc::new(SqliteStore::in_memory().unwrap());
+        {
+            let conn = store.conn().unwrap();
+            conn.execute("DROP TABLE plugin_stats", []).unwrap();
+        }
+
+        let sink = SqliteStatsSink::new(store.clone());
+        let evicted_handle: Arc<AtomicU64> = sink.evicted_handle_for_tests();
+
+        // Send enough records that the writer is busy when we drop.
+        for i in 0..50 {
+            sink.record(rec(i));
+        }
+        // Sleep PAST the flush interval so the writer is most likely sitting
+        // in recv_timeout / processing a Timeout tick when Drop fires.
+        std::thread::sleep(Duration::from_millis(700));
+
+        drop(sink);
+
+        let lost = evicted_handle.load(Ordering::Relaxed);
+        assert!(
+            lost >= 50,
+            "shutdown must drain or evict every record even when it races the Timeout arm; got {lost}"
         );
     }
 

--- a/plugins/sqlite-store/src/stats_sink.rs
+++ b/plugins/sqlite-store/src/stats_sink.rs
@@ -31,7 +31,7 @@ const MAX_CONSECUTIVE_FLUSH_FAILURES: u32 = 30;
 const MAX_BUFFER_RECORDS: usize = 64 * 1024;
 
 pub struct SqliteStatsSink {
-    tx: SyncSender<PluginStatRecord>,
+    tx: Option<SyncSender<PluginStatRecord>>,
     dropped: Arc<AtomicU64>,
     failed_flushes: Arc<AtomicU64>,
     evicted: Arc<AtomicU64>,
@@ -64,7 +64,7 @@ impl SqliteStatsSink {
             })
             .expect("spawn voom-stats-writer thread");
         Self {
-            tx,
+            tx: Some(tx),
             dropped,
             failed_flushes,
             evicted,
@@ -100,12 +100,14 @@ impl SqliteStatsSink {
 
 impl StatsSink for SqliteStatsSink {
     fn record(&self, record: PluginStatRecord) {
-        if self.tx.try_send(record).is_err() {
-            let prev = self.dropped.fetch_add(1, Ordering::Relaxed);
-            if prev == 0 {
-                tracing::warn!(
-                    "voom-stats-writer channel full or closed; dropping records (first occurrence)"
-                );
+        if let Some(tx) = &self.tx {
+            if tx.try_send(record).is_err() {
+                let prev = self.dropped.fetch_add(1, Ordering::Relaxed);
+                if prev == 0 {
+                    tracing::warn!(
+                        "voom-stats-writer channel full or closed; dropping records (first occurrence)"
+                    );
+                }
             }
         }
     }
@@ -113,11 +115,17 @@ impl StatsSink for SqliteStatsSink {
 
 impl Drop for SqliteStatsSink {
     fn drop(&mut self) {
+        // Setting shutdown is no longer strictly necessary — the writer's
+        // Disconnected arm runs the final flush and exits — but leave it as
+        // a safety net in case the writer is in the middle of a long flush
+        // when we drop tx.
         self.shutdown.store(true, Ordering::Relaxed);
-        // Closing the sender side breaks the recv loop.
-        // Move tx out by replacing with a dummy is not possible here; relying
-        // on the original tx being the last clone, this sink owns it. When
-        // SqliteStatsSink is dropped, tx is dropped, channel closes, writer exits.
+        // Drop the sender FIRST so the writer's recv_timeout returns
+        // Err(Disconnected) on the next tick; the Disconnected arm drains
+        // the channel and runs the guaranteed final flush before exiting.
+        // Struct fields are dropped AFTER Drop::drop returns, so we must
+        // explicitly take() and drop tx here, before joining the writer.
+        drop(self.tx.take());
         if let Some(h) = self.writer.take() {
             let _ = h.join();
         }
@@ -167,6 +175,12 @@ fn writer_loop(
                 }
             }
             Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                // Drain any remaining records from the closed channel so
+                // they are included in the final guaranteed flush.
+                while let Ok(record) = rx.try_recv() {
+                    buf.push(record);
+                    cap_buffer(&mut buf, &evicted);
+                }
                 if !buf.is_empty() {
                     flush(
                         &store,
@@ -231,7 +245,7 @@ fn flush(
                 evicted.fetch_add(buf.len() as u64, Ordering::Relaxed);
                 tracing::error!(
                     attempts = *consecutive_failures,
-                    dropped = buf.len(),
+                    evicted = buf.len(),
                     "plugin_stats writer giving up after consecutive failures; dropping buffer"
                 );
                 buf.clear();
@@ -260,16 +274,23 @@ mod tests {
     #[test]
     fn records_flush_to_store_within_one_second() {
         let store = Arc::new(SqliteStore::in_memory().unwrap());
-        let sink = SqliteStatsSink::new(store.clone());
-        for i in 0..50 {
-            sink.record(rec(i));
+        {
+            let sink = SqliteStatsSink::new(store.clone());
+            for i in 0..50 {
+                sink.record(rec(i));
+            }
+            // Wait for at least one periodic flush to fire.
+            std::thread::sleep(Duration::from_millis(800));
+            let conn = store.conn().unwrap();
+            let count: i64 = conn
+                .query_row("SELECT COUNT(*) FROM plugin_stats", [], |r| r.get(0))
+                .unwrap();
+            assert!(
+                count >= 50,
+                "expected at least 50 rows after periodic flush, got {count}"
+            );
+            // sink dropped here — additional cleanup not relied on
         }
-        std::thread::sleep(Duration::from_millis(800));
-        let conn = store.conn().unwrap();
-        let count: i64 = conn
-            .query_row("SELECT COUNT(*) FROM plugin_stats", [], |r| r.get(0))
-            .unwrap();
-        assert!(count >= 50, "expected at least 50 rows, got {count}");
     }
 
     #[test]
@@ -301,9 +322,12 @@ mod tests {
             sink.record(rec(i));
         }
         std::thread::sleep(Duration::from_millis(200));
-        // We expect the writer to catch up eventually; the assertion here
-        // is just that calling record many times never panics.
-        let _ = sink.dropped_count();
+        // With channel capacity 4096 and 50k records sent in a tight loop,
+        // drops are inevitable — the writer thread cannot drain fast enough.
+        assert!(
+            sink.dropped_count() > 0,
+            "expected some records to be dropped due to channel overflow"
+        );
     }
 
     #[test]

--- a/plugins/sqlite-store/src/stats_sink.rs
+++ b/plugins/sqlite-store/src/stats_sink.rs
@@ -5,6 +5,11 @@
 //! lock on the subscriber list. The sink MUST NOT block. We use a bounded
 //! `std::sync::mpsc::sync_channel` and `try_send`; on overflow, the record
 //! is dropped (logged once at warn level).
+//!
+//! On shutdown, the writer drains the channel and retries the final flush
+//! for up to [`SHUTDOWN_FLUSH_DEADLINE`]. Records that survive past the
+//! deadline are accounted for in [`SqliteStatsSink::evicted_count`] and
+//! logged at error level — never silently lost.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -29,6 +34,13 @@ const MAX_CONSECUTIVE_FLUSH_FAILURES: u32 = 30;
 /// drain (e.g. DB completely unavailable), the oldest records are evicted
 /// instead of growing the buffer without bound.
 const MAX_BUFFER_RECORDS: usize = 64 * 1024;
+/// Maximum time the writer will spend retrying the final flush at
+/// shutdown. Tuned to ride out typical SQLite WAL lock contention while
+/// keeping process shutdown bounded. Records that survive past the
+/// deadline are evicted and the eviction is logged.
+const SHUTDOWN_FLUSH_DEADLINE: Duration = Duration::from_secs(5);
+/// Sleep between retry attempts during the shutdown drain.
+const SHUTDOWN_RETRY_INTERVAL: Duration = Duration::from_millis(200);
 
 pub struct SqliteStatsSink {
     tx: Option<SyncSender<PluginStatRecord>>,
@@ -100,6 +112,13 @@ impl SqliteStatsSink {
 
 #[cfg(test)]
 impl SqliteStatsSink {
+    /// Test-only accessor that clones the evicted-counter Arc. Used by
+    /// shutdown tests that need to observe the counter AFTER the sink is
+    /// dropped (which moves the field).
+    pub(crate) fn evicted_handle_for_tests(&self) -> Arc<AtomicU64> {
+        self.evicted.clone()
+    }
+
     /// Test-only constructor allowing a custom channel capacity to
     /// deterministically exercise the overflow path. `capacity=0` produces a
     /// rendezvous channel where every `try_send` fails unless the writer is
@@ -207,20 +226,37 @@ fn writer_loop(
                 }
             }
             Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-                // Drain any remaining records from the closed channel so
-                // they are included in the final guaranteed flush.
+                // Drain any remaining records from the closed channel so they are
+                // included in the final flush attempts.
                 while let Ok(record) = rx.try_recv() {
                     buf.push(record);
                     cap_buffer(&mut buf, &evicted);
                 }
                 if !buf.is_empty() {
-                    flush(
-                        &store,
-                        &mut buf,
-                        &failed_flushes,
-                        &evicted,
-                        &mut consecutive_failures,
-                    );
+                    let deadline = Instant::now() + SHUTDOWN_FLUSH_DEADLINE;
+                    while !buf.is_empty() && Instant::now() < deadline {
+                        flush(
+                            &store,
+                            &mut buf,
+                            &failed_flushes,
+                            &evicted,
+                            &mut consecutive_failures,
+                        );
+                        if !buf.is_empty() {
+                            std::thread::sleep(SHUTDOWN_RETRY_INTERVAL);
+                        }
+                    }
+                    if !buf.is_empty() {
+                        evicted.fetch_add(buf.len() as u64, Ordering::Relaxed);
+                        tracing::error!(
+                            dropped = buf.len(),
+                            deadline_ms = u64::try_from(SHUTDOWN_FLUSH_DEADLINE.as_millis())
+                                .unwrap_or(u64::MAX),
+                            "plugin_stats writer abandoning records at shutdown after retry deadline; \
+                             store unavailable"
+                        );
+                        buf.clear();
+                    }
                 }
                 break;
             }
@@ -432,6 +468,44 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM plugin_stats", [], |r| r.get(0))
             .unwrap();
         assert_eq!(count, 3);
+    }
+
+    #[test]
+    fn shutdown_evicts_records_when_final_flush_fails() {
+        // The Disconnected arm must not silently drop the buffer on shutdown.
+        // If the final flush cannot succeed within the shutdown deadline, the
+        // surviving buffer must be accounted for in `evicted` and surfaced via
+        // tracing — never lost without trace. (Codex adversarial review, May 2026)
+        use std::sync::Arc;
+        use std::sync::atomic::AtomicU64;
+
+        let store = Arc::new(SqliteStore::in_memory().unwrap());
+        // Persistently fail every insert by dropping the table.
+        {
+            let conn = store.conn().unwrap();
+            conn.execute("DROP TABLE plugin_stats", []).unwrap();
+        }
+
+        // The sink owns evicted: Arc<AtomicU64>. We need to observe it AFTER
+        // the sink is dropped, so capture a clone of the Arc via a test-only
+        // accessor before drop.
+        let sink = SqliteStatsSink::new(store.clone());
+        let evicted_handle: Arc<AtomicU64> = sink.evicted_handle_for_tests();
+
+        for i in 0..10 {
+            sink.record(rec(i));
+        }
+        // Allow the writer thread to receive and try (and fail) at least one
+        // flush before shutdown.
+        std::thread::sleep(Duration::from_millis(600));
+
+        drop(sink);
+
+        let lost = evicted_handle.load(Ordering::Relaxed);
+        assert!(
+            lost >= 10,
+            "expected >= 10 evicted records after persistent flush failure on shutdown, got {lost}"
+        );
     }
 
     #[test]

--- a/plugins/sqlite-store/src/store/mod.rs
+++ b/plugins/sqlite-store/src/store/mod.rs
@@ -10,6 +10,7 @@ mod maintenance_storage;
 mod pending_ops_storage;
 mod plan_storage;
 mod plugin_data_storage;
+mod plugin_stats_storage;
 mod row_mappers;
 pub(crate) mod scan_session_mutations_storage;
 mod snapshot_storage;

--- a/plugins/sqlite-store/src/store/plugin_stats_storage.rs
+++ b/plugins/sqlite-store/src/store/plugin_stats_storage.rs
@@ -64,9 +64,80 @@ impl PluginStatsStorage for SqliteStore {
         Ok(())
     }
 
-    fn rollup_plugin_stats(&self, _filter: &PluginStatsFilter) -> Result<Vec<PluginStatsRollup>> {
-        // Implemented in Task 5.
-        Ok(Vec::new())
+    fn rollup_plugin_stats(&self, filter: &PluginStatsFilter) -> Result<Vec<PluginStatsRollup>> {
+        let conn = self.conn()?;
+        let since = filter.since.as_ref().map(iso);
+        // Pull rows that match the filter; we compute percentiles in Rust.
+        let sql = "SELECT plugin_id, duration_ms, outcome
+                   FROM plugin_stats
+                   WHERE (?1 IS NULL OR plugin_id = ?1)
+                     AND (?2 IS NULL OR started_at >= ?2)
+                   ORDER BY plugin_id ASC, duration_ms ASC";
+
+        let mut stmt = conn
+            .prepare(sql)
+            .map_err(storage_err("failed to prepare rollup query"))?;
+        let mut rows = stmt
+            .query(params![filter.plugin, since])
+            .map_err(storage_err("failed to run rollup query"))?;
+
+        #[derive(Default)]
+        struct Bucket {
+            durs: Vec<u64>,
+            ok: u64,
+            skipped: u64,
+            err: u64,
+            panic: u64,
+            total_ms: u64,
+        }
+        use std::collections::BTreeMap;
+        let mut buckets: BTreeMap<String, Bucket> = BTreeMap::new();
+        while let Some(row) = rows
+            .next()
+            .map_err(storage_err("failed to read rollup row"))?
+        {
+            let plugin: String = row.get(0).map_err(storage_err("plugin_id col"))?;
+            let dur: i64 = row.get(1).map_err(storage_err("duration_ms col"))?;
+            let outcome: String = row.get(2).map_err(storage_err("outcome col"))?;
+            let dur_u = u64::try_from(dur).unwrap_or(0);
+            let entry = buckets.entry(plugin).or_default();
+            entry.durs.push(dur_u);
+            entry.total_ms = entry.total_ms.saturating_add(dur_u);
+            match outcome.as_str() {
+                "ok" => entry.ok += 1,
+                "skipped" => entry.skipped += 1,
+                "err" => entry.err += 1,
+                "panic" => entry.panic += 1,
+                _ => {}
+            }
+        }
+
+        use voom_domain::plugin_stats::nearest_rank_percentile;
+
+        let mut out: Vec<PluginStatsRollup> = buckets
+            .into_iter()
+            .map(|(plugin_id, b)| {
+                // b.durs already sorted ASC by SQL ORDER BY
+                PluginStatsRollup {
+                    plugin_id,
+                    invocation_count: b.durs.len() as u64,
+                    ok_count: b.ok,
+                    skipped_count: b.skipped,
+                    err_count: b.err,
+                    panic_count: b.panic,
+                    p50_ms: nearest_rank_percentile(&b.durs, 50),
+                    p95_ms: nearest_rank_percentile(&b.durs, 95),
+                    p99_ms: nearest_rank_percentile(&b.durs, 99),
+                    total_ms: b.total_ms,
+                }
+            })
+            .collect();
+
+        out.sort_by(|a, b| b.p95_ms.cmp(&a.p95_ms));
+        if let Some(top) = filter.top {
+            out.truncate(top);
+        }
+        Ok(out)
     }
 
     fn prune_old_plugin_stats(&self, _policy: RetentionPolicy) -> Result<PruneReport> {
@@ -153,5 +224,118 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM plugin_stats", [], |r| r.get(0))
             .unwrap();
         assert_eq!(count, 100);
+    }
+
+    #[test]
+    fn rollup_groups_by_plugin_and_computes_percentiles() {
+        let s = store();
+        // 100 rows for "discovery" with durations 1..=100
+        let batch: Vec<_> = (1..=100u64)
+            .map(|d| rec("discovery", d, PluginInvocationOutcome::Ok))
+            .collect();
+        s.insert_plugin_stats_batch(&batch).unwrap();
+        // 10 rows for "ffprobe-introspector" with mixed outcomes
+        let mut batch2 = Vec::new();
+        for _i in 0..8 {
+            batch2.push(rec("ffprobe-introspector", 10, PluginInvocationOutcome::Ok));
+        }
+        batch2.push(rec(
+            "ffprobe-introspector",
+            20,
+            PluginInvocationOutcome::Err {
+                category: "io".into(),
+            },
+        ));
+        batch2.push(rec(
+            "ffprobe-introspector",
+            30,
+            PluginInvocationOutcome::Panic,
+        ));
+        s.insert_plugin_stats_batch(&batch2).unwrap();
+
+        let mut rollup = s
+            .rollup_plugin_stats(&PluginStatsFilter::default())
+            .unwrap();
+        rollup.sort_by(|a, b| a.plugin_id.cmp(&b.plugin_id));
+        assert_eq!(rollup.len(), 2);
+
+        let disc = rollup.iter().find(|r| r.plugin_id == "discovery").unwrap();
+        assert_eq!(disc.invocation_count, 100);
+        assert_eq!(disc.ok_count, 100);
+        // Nearest-rank percentile on durations 1..=100
+        assert_eq!(disc.p50_ms, 50);
+        assert_eq!(disc.p95_ms, 95);
+        assert_eq!(disc.p99_ms, 99);
+
+        let ffp = rollup
+            .iter()
+            .find(|r| r.plugin_id == "ffprobe-introspector")
+            .unwrap();
+        assert_eq!(ffp.invocation_count, 10);
+        assert_eq!(ffp.ok_count, 8);
+        assert_eq!(ffp.err_count, 1);
+        assert_eq!(ffp.panic_count, 1);
+    }
+
+    #[test]
+    fn rollup_filter_by_plugin() {
+        let s = store();
+        s.insert_plugin_stat(&rec("a", 1, PluginInvocationOutcome::Ok))
+            .unwrap();
+        s.insert_plugin_stat(&rec("b", 2, PluginInvocationOutcome::Ok))
+            .unwrap();
+        let filter = PluginStatsFilter {
+            plugin: Some("a".into()),
+            ..Default::default()
+        };
+        let rollup = s.rollup_plugin_stats(&filter).unwrap();
+        assert_eq!(rollup.len(), 1);
+        assert_eq!(rollup[0].plugin_id, "a");
+    }
+
+    #[test]
+    fn rollup_filter_by_since() {
+        let s = store();
+        let old = PluginStatRecord {
+            plugin_id: "a".into(),
+            event_type: "x".into(),
+            started_at: Utc::now() - chrono::Duration::hours(2),
+            duration_ms: 1,
+            outcome: PluginInvocationOutcome::Ok,
+        };
+        let new = PluginStatRecord {
+            plugin_id: "a".into(),
+            event_type: "x".into(),
+            started_at: Utc::now(),
+            duration_ms: 2,
+            outcome: PluginInvocationOutcome::Ok,
+        };
+        s.insert_plugin_stat(&old).unwrap();
+        s.insert_plugin_stat(&new).unwrap();
+        let filter = PluginStatsFilter {
+            since: Some(Utc::now() - chrono::Duration::hours(1)),
+            ..Default::default()
+        };
+        let rollup = s.rollup_plugin_stats(&filter).unwrap();
+        assert_eq!(rollup[0].invocation_count, 1);
+        assert_eq!(rollup[0].p50_ms, 2);
+    }
+
+    #[test]
+    fn rollup_top_n_sorts_by_p95_descending() {
+        let s = store();
+        for i in 0..20 {
+            s.insert_plugin_stat(&rec("fast", 1, PluginInvocationOutcome::Ok))
+                .unwrap();
+            s.insert_plugin_stat(&rec("slow", 100 + i, PluginInvocationOutcome::Ok))
+                .unwrap();
+        }
+        let filter = PluginStatsFilter {
+            top: Some(1),
+            ..Default::default()
+        };
+        let rollup = s.rollup_plugin_stats(&filter).unwrap();
+        assert_eq!(rollup.len(), 1);
+        assert_eq!(rollup[0].plugin_id, "slow");
     }
 }

--- a/plugins/sqlite-store/src/store/plugin_stats_storage.rs
+++ b/plugins/sqlite-store/src/store/plugin_stats_storage.rs
@@ -1,0 +1,157 @@
+//! SQLite-backed `PluginStatsStorage` implementation (issue #92).
+
+use rusqlite::params;
+
+use voom_domain::errors::Result;
+use voom_domain::plugin_stats::{
+    PluginInvocationOutcome, PluginStatRecord, PluginStatsFilter, PluginStatsRollup,
+};
+use voom_domain::storage::{PluginStatsStorage, PruneReport, RetentionPolicy};
+
+use super::{SqliteStore, storage_err};
+
+fn outcome_to_sql(outcome: &PluginInvocationOutcome) -> (&'static str, Option<&str>) {
+    match outcome {
+        PluginInvocationOutcome::Ok => ("ok", None),
+        PluginInvocationOutcome::Skipped => ("skipped", None),
+        PluginInvocationOutcome::Err { category } => ("err", Some(category.as_str())),
+        PluginInvocationOutcome::Panic => ("panic", None),
+    }
+}
+
+fn iso(ts: &chrono::DateTime<chrono::Utc>) -> String {
+    voom_domain::utils::format::format_iso(ts)
+}
+
+fn insert_one(conn: &rusqlite::Connection, record: &PluginStatRecord) -> Result<()> {
+    let (label, category) = outcome_to_sql(&record.outcome);
+    conn.execute(
+        "INSERT INTO plugin_stats
+            (plugin_id, event_type, started_at, duration_ms, outcome, error_category)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        params![
+            record.plugin_id,
+            record.event_type,
+            iso(&record.started_at),
+            i64::try_from(record.duration_ms).unwrap_or(i64::MAX),
+            label,
+            category,
+        ],
+    )
+    .map_err(storage_err("failed to insert plugin_stats row"))?;
+    Ok(())
+}
+
+impl PluginStatsStorage for SqliteStore {
+    fn insert_plugin_stat(&self, record: &PluginStatRecord) -> Result<()> {
+        let conn = self.conn()?;
+        insert_one(&conn, record)
+    }
+
+    fn insert_plugin_stats_batch(&self, records: &[PluginStatRecord]) -> Result<()> {
+        if records.is_empty() {
+            return Ok(());
+        }
+        let mut conn = self.conn()?;
+        let tx = conn
+            .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+            .map_err(storage_err("failed to begin plugin_stats tx"))?;
+        for r in records {
+            insert_one(&tx, r)?;
+        }
+        tx.commit()
+            .map_err(storage_err("failed to commit plugin_stats tx"))?;
+        Ok(())
+    }
+
+    fn rollup_plugin_stats(&self, _filter: &PluginStatsFilter) -> Result<Vec<PluginStatsRollup>> {
+        // Implemented in Task 5.
+        Ok(Vec::new())
+    }
+
+    fn prune_old_plugin_stats(&self, _policy: RetentionPolicy) -> Result<PruneReport> {
+        // Implemented in Task 6.
+        Ok(PruneReport::default())
+    }
+
+    fn count_old_plugin_stats(&self, _policy: RetentionPolicy) -> Result<PruneReport> {
+        // Implemented in Task 6.
+        Ok(PruneReport::default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    fn store() -> SqliteStore {
+        SqliteStore::in_memory().expect("store")
+    }
+
+    fn rec(plugin: &str, dur: u64, outcome: PluginInvocationOutcome) -> PluginStatRecord {
+        PluginStatRecord {
+            plugin_id: plugin.into(),
+            event_type: "file.discovered".into(),
+            started_at: Utc::now(),
+            duration_ms: dur,
+            outcome,
+        }
+    }
+
+    #[test]
+    fn insert_one_round_trips() {
+        let s = store();
+        let r = rec("discovery", 12, PluginInvocationOutcome::Ok);
+        s.insert_plugin_stat(&r).unwrap();
+        let conn = s.conn().unwrap();
+        let (plugin, dur, label, cat): (String, i64, String, Option<String>) = conn
+            .query_row(
+                "SELECT plugin_id, duration_ms, outcome, error_category FROM plugin_stats",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(plugin, "discovery");
+        assert_eq!(dur, 12);
+        assert_eq!(label, "ok");
+        assert!(cat.is_none());
+    }
+
+    #[test]
+    fn err_outcome_persists_category() {
+        let s = store();
+        let r = rec(
+            "ffmpeg-executor",
+            500,
+            PluginInvocationOutcome::Err {
+                category: "spawn".into(),
+            },
+        );
+        s.insert_plugin_stat(&r).unwrap();
+        let conn = s.conn().unwrap();
+        let (label, cat): (String, Option<String>) = conn
+            .query_row(
+                "SELECT outcome, error_category FROM plugin_stats",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(label, "err");
+        assert_eq!(cat, Some("spawn".into()));
+    }
+
+    #[test]
+    fn batch_insert_uses_single_tx() {
+        let s = store();
+        let records: Vec<_> = (0..100)
+            .map(|i| rec("discovery", i, PluginInvocationOutcome::Ok))
+            .collect();
+        s.insert_plugin_stats_batch(&records).unwrap();
+        let conn = s.conn().unwrap();
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM plugin_stats", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 100);
+    }
+}

--- a/plugins/sqlite-store/src/store/plugin_stats_storage.rs
+++ b/plugins/sqlite-store/src/store/plugin_stats_storage.rs
@@ -140,14 +140,78 @@ impl PluginStatsStorage for SqliteStore {
         Ok(out)
     }
 
-    fn prune_old_plugin_stats(&self, _policy: RetentionPolicy) -> Result<PruneReport> {
-        // Implemented in Task 6.
-        Ok(PruneReport::default())
+    fn prune_old_plugin_stats(&self, policy: RetentionPolicy) -> Result<PruneReport> {
+        if policy.is_disabled() {
+            let conn = self.conn()?;
+            let kept: u64 = conn
+                .query_row("SELECT COUNT(*) FROM plugin_stats", [], |row| row.get(0))
+                .map_err(storage_err("failed to count plugin_stats"))?;
+            return Ok(PruneReport { deleted: 0, kept });
+        }
+
+        let conn = self.conn()?;
+        let cutoff = policy.cutoff_str();
+        let keep_last = policy.keep_last_i64();
+
+        let deleted = conn
+            .execute(
+                "WITH ranked AS (
+                    SELECT rowid,
+                           ROW_NUMBER() OVER (ORDER BY started_at DESC, rowid DESC) AS rn,
+                           started_at
+                    FROM plugin_stats
+                )
+                DELETE FROM plugin_stats
+                WHERE rowid IN (
+                    SELECT rowid FROM ranked
+                    WHERE (?1 IS NOT NULL AND started_at < ?1)
+                       OR (?2 IS NOT NULL AND rn > ?2)
+                )",
+                params![cutoff, keep_last],
+            )
+            .map_err(storage_err("failed to prune plugin_stats"))? as u64;
+
+        let kept: u64 = conn
+            .query_row("SELECT COUNT(*) FROM plugin_stats", [], |row| row.get(0))
+            .map_err(storage_err("failed to count remaining plugin_stats"))?;
+        Ok(PruneReport { deleted, kept })
     }
 
-    fn count_old_plugin_stats(&self, _policy: RetentionPolicy) -> Result<PruneReport> {
-        // Implemented in Task 6.
-        Ok(PruneReport::default())
+    fn count_old_plugin_stats(&self, policy: RetentionPolicy) -> Result<PruneReport> {
+        if policy.is_disabled() {
+            let conn = self.conn()?;
+            let kept: u64 = conn
+                .query_row("SELECT COUNT(*) FROM plugin_stats", [], |row| row.get(0))
+                .map_err(storage_err("failed to count plugin_stats"))?;
+            return Ok(PruneReport { deleted: 0, kept });
+        }
+
+        let conn = self.conn()?;
+        let cutoff = policy.cutoff_str();
+        let keep_last = policy.keep_last_i64();
+
+        let deleted: u64 = conn
+            .query_row(
+                "WITH ranked AS (
+                    SELECT rowid,
+                           ROW_NUMBER() OVER (ORDER BY started_at DESC, rowid DESC) AS rn,
+                           started_at
+                    FROM plugin_stats
+                )
+                SELECT COUNT(*) FROM ranked
+                WHERE (?1 IS NOT NULL AND started_at < ?1)
+                   OR (?2 IS NOT NULL AND rn > ?2)",
+                params![cutoff, keep_last],
+                |row| row.get(0),
+            )
+            .map_err(storage_err("failed to count old plugin_stats"))?;
+        let total: u64 = conn
+            .query_row("SELECT COUNT(*) FROM plugin_stats", [], |row| row.get(0))
+            .map_err(storage_err("failed to count plugin_stats"))?;
+        Ok(PruneReport {
+            deleted,
+            kept: total.saturating_sub(deleted),
+        })
     }
 }
 
@@ -337,5 +401,90 @@ mod tests {
         let rollup = s.rollup_plugin_stats(&filter).unwrap();
         assert_eq!(rollup.len(), 1);
         assert_eq!(rollup[0].plugin_id, "slow");
+    }
+
+    #[test]
+    fn prune_with_max_age_deletes_old_rows() {
+        let s = store();
+        let old = PluginStatRecord {
+            plugin_id: "a".into(),
+            event_type: "x".into(),
+            started_at: Utc::now() - chrono::Duration::days(60),
+            duration_ms: 1,
+            outcome: PluginInvocationOutcome::Ok,
+        };
+        let recent = PluginStatRecord {
+            plugin_id: "a".into(),
+            event_type: "x".into(),
+            started_at: Utc::now(),
+            duration_ms: 2,
+            outcome: PluginInvocationOutcome::Ok,
+        };
+        s.insert_plugin_stat(&old).unwrap();
+        s.insert_plugin_stat(&recent).unwrap();
+
+        let policy = RetentionPolicy {
+            max_age: Some(chrono::Duration::days(30)),
+            keep_last: None,
+        };
+        let report = s.prune_old_plugin_stats(policy).unwrap();
+        assert_eq!(report.deleted, 1);
+        assert_eq!(report.kept, 1);
+    }
+
+    #[test]
+    fn prune_with_keep_last_deletes_excess_rows() {
+        let s = store();
+        for i in 0..10 {
+            s.insert_plugin_stat(&rec("a", i, PluginInvocationOutcome::Ok))
+                .unwrap();
+        }
+        let policy = RetentionPolicy {
+            max_age: None,
+            keep_last: Some(3),
+        };
+        let report = s.prune_old_plugin_stats(policy).unwrap();
+        assert_eq!(report.deleted, 7);
+        assert_eq!(report.kept, 3);
+    }
+
+    #[test]
+    fn count_old_matches_actual_prune() {
+        let s = store();
+        for _ in 0..5 {
+            let old = PluginStatRecord {
+                plugin_id: "a".into(),
+                event_type: "x".into(),
+                started_at: Utc::now() - chrono::Duration::days(60),
+                duration_ms: 1,
+                outcome: PluginInvocationOutcome::Ok,
+            };
+            s.insert_plugin_stat(&old).unwrap();
+        }
+        for _ in 0..3 {
+            s.insert_plugin_stat(&rec("a", 1, PluginInvocationOutcome::Ok))
+                .unwrap();
+        }
+        let policy = RetentionPolicy {
+            max_age: Some(chrono::Duration::days(30)),
+            keep_last: None,
+        };
+        let count = s.count_old_plugin_stats(policy).unwrap();
+        assert_eq!(count.deleted, 5);
+        assert_eq!(count.kept, 3);
+        let prune = s.prune_old_plugin_stats(policy).unwrap();
+        assert_eq!(prune.deleted, count.deleted);
+        assert_eq!(prune.kept, count.kept);
+    }
+
+    #[test]
+    fn disabled_policy_is_noop() {
+        let s = store();
+        s.insert_plugin_stat(&rec("a", 1, PluginInvocationOutcome::Ok))
+            .unwrap();
+        let policy = RetentionPolicy::default();
+        let report = s.prune_old_plugin_stats(policy).unwrap();
+        assert_eq!(report.deleted, 0);
+        assert_eq!(report.kept, 1);
     }
 }


### PR DESCRIPTION
## Summary

Implements Deliverable 1 of issue #92: every plugin invocation through the event bus is automatically timed and persisted to a new `plugin_stats` SQLite table. A new `voom plugin stats` subcommand exposes per-plugin rollups with p50/p95/p99 latencies and outcome counts. Stats are pruned by the existing retention machinery from PR #170.

No plugin code changes required — the bus dispatcher does all the work.

Deliverables 2 (Prometheus `/metrics`), 3 (OpenTelemetry), and the Web UI Stats page are out of scope for this PR.

## Changes

**voom-domain** (`crates/voom-domain`)
- New `plugin_stats` module: `PluginStatRecord`, `PluginStatsRollup`, `PluginStatsFilter`, `PluginInvocationOutcome` (Ok / Skipped / Err{category} / Panic), and a shared `nearest_rank_percentile` helper.
- New `PluginStatsStorage` trait added to `StorageTrait` supertrait list.

**voom-kernel** (`crates/voom-kernel`)
- New `StatsSink` trait + `NoopStatsSink`.
- `EventBus` stores the sink in `RwLock<Arc<dyn StatsSink>>` with `with_stats_sink` / `set_stats_sink` constructors.
- Bus dispatcher times every `handler.on_event` invocation, classifies the outcome (catching panics), and forwards a `PluginStatRecord` to the sink with no locks held across the handler call.
- `error_category` helper does an explicit match over every `VoomError` variant — no Debug-string parsing, no message text leaks into category labels.

**voom-sqlite-store** (`plugins/sqlite-store`)
- New `plugin_stats` table + indexes on `(started_at)` and `(plugin_id, started_at)`.
- `PluginStatsStorage` impl: insert, batch insert (single transaction), rollup with in-process percentile computation, prune/count using the same CTE pattern as `event_log`.
- `SqliteStatsSink`: bounded `sync_channel` (4096) + background writer thread that batches up to 256 records or flushes every 500ms. Non-blocking `try_send` on the hot path. Failed flushes retain the buffer for retry. Three accountability counters: `dropped`, `failed_flushes`, `evicted`.
- Bounded shutdown drain: on channel close the writer retries the final flush for up to 5 seconds (200 ms backoff). Records that survive past the deadline are accounted for in `evicted_count` and logged at error level — never silently lost.

**voom-cli** (`crates/voom-cli`)
- `app::bootstrap_kernel_with_store` captures the concrete `Arc<SqliteStore>` from `plugin.store()` and installs `SqliteStatsSink` between `plugin.init` and `kernel.register_plugin` so the storage plugin's own init events get recorded. Disabled-`sqlite-store` branch warn-logs and leaves the bus on `NoopStatsSink`.
- New `[retention.plugin_stats]` config section with defaults (30 days / 100,000 rows). `RetentionRunner` extended; `voom db prune --dry-run` and the periodic retention task now cover the new table.
- New `voom plugin stats` subcommand: `--plugin`, `--since <N>{s,m,h,d}`, `--top N`, `--format {table,json}`. The stats command uses `app::open_store` directly — it does **not** construct a kernel or install a sink, so reading stats does not contaminate the data it queries.

**Docs**
- `docs/cli-reference.md`: new `voom plugin stats` section with flag table, example output, retention defaults, and a coverage caveat for pure publishers.
- `docs/architecture.md`: new "Bus dispatcher instrumentation" subsection documenting the sink contract and the same coverage caveat.

## Testing

**Unit tests (added)**
- `voom-domain`: stats type round-trips, percentile algorithm (`p50`/`p95`/`p99` over `1..=100`, empty slice, single element, p>100).
- `voom-kernel`: dispatcher records ok / skipped / err / panic outcomes, records each handler separately, `error_category` returns fixed labels and does not leak message text, `Kernel::set_stats_sink` swaps the active sink.
- `voom-sqlite-store`: schema migration creates the table + indexes; insert + batch insert + outcome encoding; rollup with filters and top-N sorted by p95; prune/count with OR semantics and `is_disabled` no-op; SqliteStatsSink flush-failure retention, deterministic channel overflow (capacity=0), shutdown drain via Disconnected, shutdown drain when racing the Timeout arm.
- `voom-cli`: `parse_since` accepts s/m/h/d, rejects negative/zero/bad-unit/multibyte, retention `plugin_stats` participates in `is_fully_disabled`.

**Functional tests** (`crates/voom-cli/tests/plugin_stats_e2e.rs`, gated by `--features functional`)
- `scan_populates_plugin_stats_table` — `voom scan` end-to-end produces non-empty rollups including `sqlite-store` rows.
- `plugin_stats_handler_runs_after_scan` — `voom_cli::commands::plugin_stats::run` succeeds in-process with `--format json`.
- `plugin_stats_query_does_not_mutate_database` — running the stats query does not change `plugin_stats` or `event_log` row counts. Regression test for the read-only path.

**Manual verification**
```
cargo fmt --all -- --check                                            # clean
cargo clippy --workspace --all-targets -- -D warnings                 # clean
cargo test --workspace                                                # clean
cargo test -p voom-cli --features functional -- --test-threads=4      # clean
```

## Notes

**Coverage caveat:** the dispatcher only times plugins that *subscribe* to events. Pure publishers — Discovery (walks filesystem, emits `FileDiscovered` only), Phase Orchestrator, Policy Evaluator — never enter the dispatcher path and therefore have no rows in `plugin_stats`. Documented in both architecture and CLI reference docs.

**Performance:** Per-handler instrumentation adds one read-lock acquisition + `Arc::clone` per dispatch and a `PluginStatRecord` allocation + virtual sink call per handler. With `NoopStatsSink` (default) the record path is a no-op. A criterion benchmark to gate against the issue's stated `<5%` regression target was deliberately deferred — see follow-up #379.

**Follow-up issues filed:**
- #378 — Instrument pure-publisher plugins in plugin_stats.
- #379 — Add criterion benchmark for `EventBus::publish` stats overhead.
- #380 — Mark voom-domain stats types as `#[non_exhaustive]` before API stabilizes.
- #381 — Refactor StorageTrait: 16 supertraits is approaching unwieldy.
- #382 — `voom estimate` uses `bootstrap_kernel_with_store` but only needs the store (same anti-pattern this PR fixed for `voom plugin stats`).

**Codex adversarial review** caught two real bugs after the initial implementation passed all 14 plan tasks:
1. Stats command was not read-only (calling `bootstrap_kernel_with_store` registered plugins and dispatched init events). Fixed in `de69c75` — `voom plugin stats` now uses `app::open_store` directly.
2. `SqliteStatsSink`'s `Disconnected` arm did a single-shot final flush — records were silently lost if the final flush failed. Fixed in `10fee3d` / `277d3b1` / `28bc8e2` — bounded retry with deadline, single shutdown path via `Disconnected`, no dead state remaining.

Closes part of #92. Follow-up issues (above) track the deferred items.
