### PR TITLE
test(sqlite-store): deterministic stats_sink overflow assertion (#384)

### DIFF
--- a/.plans/issue-384-plan.md
+++ b/.plans/issue-384-plan.md
@@ -1,0 +1,133 @@
+# Plan: Deterministic stats_sink overflow test (#384)
+
+## Problem
+
+`overflow_increments_dropped_counter_when_channel_full` in
+`plugins/sqlite-store/src/stats_sink.rs` uses a `capacity=0` rendezvous
+channel plus a real writer thread, and relies on scheduling to observe at
+least one `try_send` failure. It already flaked once (tightened to
+`>= 150/200`, then weakened to `> 0`). Codex stop-time review flagged
+that even the weakened form is scheduling-dependent — there is no
+mathematical guarantee.
+
+## Approach
+
+Add a test seam constructor that does **not** spawn the writer thread.
+The test holds the receiver alive in scope but never calls `recv`. With a
+small capacity (e.g. 4), the channel fills after 4 sends, and every
+subsequent `try_send` deterministically returns `Err(Full)` because no
+consumer is draining. The test asserts the exact drop count.
+
+## Changes
+
+### `plugins/sqlite-store/src/stats_sink.rs`
+
+1. Add a test-only constructor (cfg(test)):
+
+   ```rust
+   #[cfg(test)]
+   impl SqliteStatsSink {
+       /// Test-only: build a sink with a held receiver and NO writer
+       /// thread. Caller is responsible for keeping the returned
+       /// `Receiver` alive so the channel doesn't `Disconnected`.
+       /// `dropped_count` increments deterministically once the channel
+       /// fills.
+       pub(crate) fn with_held_receiver_for_tests(
+           capacity: usize,
+       ) -> (Self, std::sync::mpsc::Receiver<PluginStatRecord>) {
+           let (tx, rx) = sync_channel::<PluginStatRecord>(capacity);
+           let dropped = Arc::new(AtomicU64::new(0));
+           let failed_flushes = Arc::new(AtomicU64::new(0));
+           let evicted = Arc::new(AtomicU64::new(0));
+           let sink = Self {
+               tx: Some(tx),
+               dropped,
+               failed_flushes,
+               evicted,
+               writer: None, // no writer thread
+           };
+           (sink, rx)
+       }
+   }
+   ```
+
+   Note: the existing `Drop` impl is `if let Some(h) = self.writer.take()`
+   — already gracefully handles `writer: None`, so no Drop change needed.
+
+2. Rewrite the flaky test:
+
+   ```rust
+   #[test]
+   fn overflow_increments_dropped_counter_when_channel_full() {
+       const CAP: usize = 4;
+       const EXTRA: u64 = 10;
+       let (sink, _rx) = SqliteStatsSink::with_held_receiver_for_tests(CAP);
+       // Fill the channel exactly to capacity.
+       for i in 0..CAP as u64 {
+           sink.record(rec(i));
+       }
+       assert_eq!(
+           sink.dropped_count(),
+           0,
+           "no drops expected while the channel still has slots"
+       );
+       // Every subsequent send must fail: no consumer is draining and
+       // capacity is full.
+       for i in 0..EXTRA {
+           sink.record(rec(CAP as u64 + i));
+       }
+       assert_eq!(
+           sink.dropped_count(),
+           EXTRA,
+           "expected exactly EXTRA drops with no consumer draining"
+       );
+       // `_rx` kept alive deliberately: dropping it would change the
+       // failure from `Full` (counted as a drop) to `Disconnected` (also
+       // counted as a drop, but no longer a true overflow test).
+       drop(_rx);
+   }
+   ```
+
+3. Keep `channel_overflow_does_not_panic` as the no-assertion stress
+   test for the production constructor (already does no claim about the
+   counter).
+
+4. Remove `with_capacity_for_tests` once nothing else uses it. (Currently
+   only the now-replaced test calls it. Verify with `rg`.)
+
+## Edge cases
+
+- `writer: None` in Drop. The existing `Drop` impl already handles None
+  via `if let Some(h) = self.writer.take()`. Confirmed by reading source.
+- Test runs independently of scheduler speed. Channel capacity is fixed;
+  sends are synchronous; receiver is never touched. No flake surface.
+- Ordering: the `tx.try_send` returns `Err(Full)` (not `Disconnected`)
+  while `_rx` is alive. After `drop(_rx)` at the end, no further sends
+  happen. The bookkeeping path `is_err() → fetch_add` is identical for
+  both error variants.
+
+## Test plan
+
+- Run the new test 50× to confirm determinism:
+  `for i in {1..50}; do cargo test -p voom-sqlite-store
+   overflow_increments_dropped_counter_when_channel_full -- --exact ||
+   exit 1; done`
+- Run the existing test file fully:
+  `cargo test -p voom-sqlite-store stats_sink::`.
+- Run the full workspace:
+  `cargo test --workspace`.
+
+## Validation commands
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+```
+
+## Out of scope
+
+- Refactoring `SqliteStatsSink`'s production constructor.
+- Changing the `dropped_count` semantics or the drop-on-Disconnected
+  policy.
+- Adding `with_held_receiver_for_tests` to non-test code paths.

--- a/plugins/sqlite-store/src/stats_sink.rs
+++ b/plugins/sqlite-store/src/stats_sink.rs
@@ -115,30 +115,35 @@ impl SqliteStatsSink {
         self.evicted.clone()
     }
 
-    /// Test-only constructor allowing a custom channel capacity to
-    /// deterministically exercise the overflow path. `capacity=0` produces a
-    /// rendezvous channel where every `try_send` fails unless the writer is
-    /// actively in `recv`.
-    pub(crate) fn with_capacity_for_tests(store: Arc<SqliteStore>, capacity: usize) -> Self {
+    /// Test-only constructor that builds a sink with a bounded channel of
+    /// the given capacity and returns the receiver to the caller — **no
+    /// writer thread is spawned**. The caller is responsible for keeping
+    /// the returned `Receiver` alive (so the channel stays in the `Full`
+    /// state rather than transitioning to `Disconnected`). With no
+    /// consumer draining, sends past `capacity` deterministically return
+    /// `Err(SendError::Full)` and `dropped_count` increments by exactly
+    /// one per excess send.
+    ///
+    /// This is the seam used by
+    /// `overflow_increments_dropped_counter_when_channel_full` so that
+    /// the assertion does not depend on thread scheduling — it removes
+    /// the writer entirely. The production `Drop` impl already handles
+    /// `writer: None` (it conditionally joins).
+    pub(crate) fn with_held_receiver_for_tests(
+        capacity: usize,
+    ) -> (Self, Receiver<PluginStatRecord>) {
         let (tx, rx) = sync_channel::<PluginStatRecord>(capacity);
         let dropped = Arc::new(AtomicU64::new(0));
         let failed_flushes = Arc::new(AtomicU64::new(0));
         let evicted = Arc::new(AtomicU64::new(0));
-        let writer = std::thread::Builder::new()
-            .name("voom-stats-writer-test".into())
-            .spawn({
-                let failed_flushes = failed_flushes.clone();
-                let evicted = evicted.clone();
-                move || writer_loop(rx, store, failed_flushes, evicted)
-            })
-            .expect("spawn voom-stats-writer-test thread");
-        Self {
+        let sink = Self {
             tx: Some(tx),
             dropped,
             failed_flushes,
             evicted,
-            writer: Some(writer),
-        }
+            writer: None,
+        };
+        (sink, rx)
     }
 }
 
@@ -382,24 +387,54 @@ mod tests {
 
     #[test]
     fn overflow_increments_dropped_counter_when_channel_full() {
-        // capacity=0 makes the channel "rendezvous": try_send succeeds only
-        // when a receiver is actively in recv. The writer thread oscillates
-        // between recv_timeout and a tiny in-body slice (push + cap_buffer),
-        // so a flood of try_sends will see the channel full whenever the
-        // writer is mid-body. We only assert the *contract* — that overflow
-        // bumps the counter — not a specific ratio, because the exact number
-        // of drops is purely scheduler-dependent (and prior tighter bounds
-        // flaked on faster CI runners).
-        let store = Arc::new(SqliteStore::in_memory().unwrap());
-        let sink = SqliteStatsSink::with_capacity_for_tests(store, 0);
-        for i in 0..10_000u64 {
+        // Deterministic overflow test: build a sink with a small bounded
+        // channel and NO writer thread. Hold the receiver alive so the
+        // channel reports `Full` (not `Disconnected`) past capacity. Every
+        // send past `CAP` MUST return `Err(SendError::Full)` because there
+        // is no consumer draining and the channel is fixed-size.
+        //
+        // Both `Full` and `Disconnected` are handled identically by the
+        // `record` path (`tx.try_send(...).is_err()` → `fetch_add(1)`), so
+        // exercising the `Full` branch covers the same bookkeeping the
+        // production overflow path takes.
+        //
+        // No `std::thread::sleep`, no thresholds, no scheduling. Adversarial
+        // review trail: see #384 for the prior flaky implementation.
+        const CAP: usize = 4;
+        const EXTRA: u64 = 10;
+
+        let (sink, _rx) = SqliteStatsSink::with_held_receiver_for_tests(CAP);
+
+        // Fill the channel exactly to capacity. With no consumer draining
+        // every one of these MUST succeed because each occupies a buffer
+        // slot.
+        for i in 0..CAP as u64 {
             sink.record(rec(i));
         }
-        assert!(
-            sink.dropped_count() > 0,
-            "expected at least one drop with rendezvous channel and 10k tight sends, got {}",
+        assert_eq!(
+            sink.dropped_count(),
+            0,
+            "no drops expected while the channel still has free slots"
+        );
+
+        // Every further send must be dropped: the channel is full, the
+        // receiver is alive but never consuming, so try_send returns
+        // `Err(Full)` deterministically.
+        for i in 0..EXTRA {
+            sink.record(rec(CAP as u64 + i));
+        }
+        assert_eq!(
+            sink.dropped_count(),
+            EXTRA,
+            "expected exactly {EXTRA} drops with channel at capacity and no consumer; got {}",
             sink.dropped_count()
         );
+
+        // `_rx` was held alive for the entirety of the test on purpose:
+        // dropping it earlier would transition the channel to
+        // `Disconnected`, which is still counted as a drop but is no
+        // longer a true overflow test.
+        drop(_rx);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #384. Replaces the scheduling-dependent
`overflow_increments_dropped_counter_when_channel_full` test in
`plugins/sqlite-store/src/stats_sink.rs` with one that does not depend
on thread timing.

## Approach

New test-only constructor `with_held_receiver_for_tests(capacity)` that
builds the sink without spawning a writer thread and returns the
receiver to the caller. The test holds the receiver alive but never
consumes; a small-capacity channel fills exactly to `CAP` and every
send past it deterministically returns `Err(SendError::Full)`.

Old `with_capacity_for_tests` (capacity=0 rendezvous channel + writer
thread) is removed — no remaining callers.

## Verification

Plan adversarial review — approved (no findings).

Test passes locally with `cargo test -p voom-sqlite-store stats_sink::`
including the new exact-count assertion `dropped_count() == EXTRA`.

## Test plan

- [x] `cargo build -p voom-sqlite-store --tests`
- [x] `cargo test -p voom-sqlite-store stats_sink` — 8 passed
- [ ] CI workspace tests