### PR TITLE
chore(domain): mark plugin_stats types #[non_exhaustive] (#380)

### DIFF
--- a/.plans/issue-380-plan.md
+++ b/.plans/issue-380-plan.md
@@ -1,0 +1,114 @@
+# Plan: Mark voom-domain stats types as #[non_exhaustive] (#380)
+
+## Problem
+
+Four new public types in `crates/voom-domain/src/plugin_stats.rs` were
+added without `#[non_exhaustive]`:
+
+- `PluginInvocationOutcome` (enum, four variants)
+- `PluginStatRecord` (struct, five fields)
+- `PluginStatsRollup` (struct, ten fields)
+- `PluginStatsFilter` (struct, three fields)
+
+As soon as anything outside `voom-domain` starts constructing these by
+name (CLI today, WASM plugin bindings tomorrow), adding a field becomes
+a breaking change.
+
+## Approach
+
+Add `#[non_exhaustive]` to all four types. Provide named constructors so
+external (and internal) callers can keep building values cleanly.
+
+`#[non_exhaustive]` on enums also blocks exhaustive `match` from outside
+the crate. The two known exhaustive matches today are in:
+
+- `crates/voom-kernel/src/bus.rs` — uses `outcome_to_sql` analog
+  inline; classifier returns `Ok`/`Skipped`/`Err{category}`/`Panic`.
+- `plugins/sqlite-store/src/store/plugin_stats_storage.rs` — outcome
+  encode/decode.
+
+Both will need a catch-all `_ =>` arm. (The kernel's `error_category`
+already has one for `VoomError`.) Acceptable: an unknown outcome maps
+to a safe default ("unknown" string for SQL, log+skip for kernel).
+
+## Changes
+
+### `crates/voom-domain/src/plugin_stats.rs`
+
+1. Add `#[non_exhaustive]` to all four types.
+2. Add `PluginStatRecord::new(...)` and (optional) `PluginStatsRollup::new()`
+   constructors so internal call sites that currently build by struct
+   literal can switch (or be left alone since this crate has full
+   field-access).
+3. Add `PluginStatsFilter::new()` (already `#[derive(Default)]` — keep).
+
+### `crates/voom-kernel/src/bus.rs`
+
+Already has catch-all arms (`_ => "unknown"`); verify no exhaustive
+match on `PluginInvocationOutcome` from outside the crate is broken.
+Internal matches inside the kernel still see all variants because the
+kernel depends on voom-domain and patterns are not affected by
+`non_exhaustive` from outside the defining crate. Wait — kernel is NOT
+the defining crate, so kernel's matches ARE affected. Confirm the
+existing `match` statements compile; add `_ =>` if necessary.
+
+### `plugins/sqlite-store/src/store/plugin_stats_storage.rs`
+
+Same as kernel: it's a separate crate consuming `voom-domain` types.
+Existing matches on `PluginInvocationOutcome` need catch-all arms.
+`outcome_to_sql` already has one (`_ => "unknown"` per the issue).
+
+### `plugins/sqlite-store/src/stats_sink.rs`
+
+The test helper `rec()` builds a `PluginStatRecord` by struct literal.
+External crate construction of a `#[non_exhaustive]` struct is forbidden
+when there are private fields, but with all-public fields the only
+restriction is that struct-literal syntax requires `..Default::default()`
+or a named constructor. We add `PluginStatRecord::new(...)` and switch
+the test helper to use it.
+
+Similarly for `voom-cli/src/commands/plugin_stats.rs` (constructs
+`PluginStatsFilter` by struct literal):
+
+```rust
+let filter = PluginStatsFilter {
+    plugin: args.plugin,
+    since,
+    top: args.top,
+};
+```
+
+→ replace with `PluginStatsFilter::new(args.plugin, since, args.top)`
+or, more idiomatically, `PluginStatsFilter { plugin: …, since: …,
+top: …, ..PluginStatsFilter::default() }`.
+
+Same pattern in `voom-cli/tests/plugin_stats_e2e.rs`.
+
+## Caveat / risk
+
+The Rust rule: `#[non_exhaustive]` on a struct with public fields means
+external callers cannot use struct-literal construction (`Type { … }`)
+without functional-update syntax `..Default::default()`. Internal
+(in-crate) callers are unaffected. The fix is mechanical: add `new`
+constructors and update external callers.
+
+## Test plan
+
+- `cargo test --workspace` — verifies all match arms still compile.
+- `cargo test -p voom-cli` — covers the CLI's filter construction.
+- `cargo test -p voom-sqlite-store stats_sink::` — covers the test helper.
+
+## Validation commands
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+cargo test -p voom-cli --features functional -- --test-threads=4
+```
+
+## Out of scope
+
+- Adding `#[non_exhaustive]` to other public domain types not flagged
+  in #380.
+- Changing the serde representation of any type.

--- a/crates/voom-cli/src/commands/plugin_stats.rs
+++ b/crates/voom-cli/src/commands/plugin_stats.rs
@@ -22,11 +22,7 @@ pub fn run(
     // plugin_stats just by running this command. See Codex adversarial
     // review (May 2026).
     let store = app::open_store(&cfg)?;
-    let filter = PluginStatsFilter {
-        plugin,
-        since: since_dt,
-        top,
-    };
+    let filter = PluginStatsFilter::new(plugin, since_dt, top);
     let rollups = store.rollup_plugin_stats(&filter)?;
     render(&rollups, format)
 }

--- a/crates/voom-cli/tests/plugin_stats_e2e.rs
+++ b/crates/voom-cli/tests/plugin_stats_e2e.rs
@@ -76,11 +76,7 @@ async fn scan_populates_plugin_stats_table() {
     tokio::time::sleep(Duration::from_millis(2000)).await;
 
     let store = open_store(&env);
-    let filter = PluginStatsFilter {
-        plugin: None,
-        since: None,
-        top: None,
-    };
+    let filter = PluginStatsFilter::new(None, None, None);
     let rollups = store
         .rollup_plugin_stats(&filter)
         .expect("rollup_plugin_stats should succeed");

--- a/crates/voom-domain/src/plugin_stats.rs
+++ b/crates/voom-domain/src/plugin_stats.rs
@@ -4,6 +4,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+#[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum PluginInvocationOutcome {
@@ -36,6 +37,7 @@ impl PluginInvocationOutcome {
 /// One record is produced per (plugin, event) handler call and later persisted
 /// to the `plugin_stats` SQLite table. This is the raw unit that rollups
 /// aggregate over.
+#[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PluginStatRecord {
     pub plugin_id: String,
@@ -45,12 +47,34 @@ pub struct PluginStatRecord {
     pub outcome: PluginInvocationOutcome,
 }
 
+impl PluginStatRecord {
+    /// Construct a `PluginStatRecord`. Use this from outside the crate to
+    /// avoid struct-literal construction, which `#[non_exhaustive]` blocks.
+    #[must_use]
+    pub fn new(
+        plugin_id: impl Into<String>,
+        event_type: impl Into<String>,
+        started_at: DateTime<Utc>,
+        duration_ms: u64,
+        outcome: PluginInvocationOutcome,
+    ) -> Self {
+        Self {
+            plugin_id: plugin_id.into(),
+            event_type: event_type.into(),
+            started_at,
+            duration_ms,
+            outcome,
+        }
+    }
+}
+
 /// Aggregated per-plugin summary computed from a collection of
 /// [`PluginStatRecord`]s.
 ///
 /// Produced by both the in-memory rollup (recent window) and the SQLite-backed
 /// historical rollup. Latency percentiles use nearest-rank over the matching
 /// records' `duration_ms` values.
+#[non_exhaustive]
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PluginStatsRollup {
     pub plugin_id: String,
@@ -69,11 +93,25 @@ pub struct PluginStatsRollup {
 ///
 /// Passed to the in-memory and SQLite rollup APIs. Intentionally omits Serde
 /// derives because it's an in-process query parameter, not a wire type.
+#[non_exhaustive]
 #[derive(Debug, Clone, Default)]
 pub struct PluginStatsFilter {
     pub plugin: Option<String>,
     pub since: Option<DateTime<Utc>>,
     pub top: Option<usize>,
+}
+
+impl PluginStatsFilter {
+    /// Construct a `PluginStatsFilter`. Use this from outside the crate to
+    /// avoid struct-literal construction, which `#[non_exhaustive]` blocks.
+    #[must_use]
+    pub fn new(plugin: Option<String>, since: Option<DateTime<Utc>>, top: Option<usize>) -> Self {
+        Self {
+            plugin,
+            since,
+            top,
+        }
+    }
 }
 
 /// Nearest-rank percentile (1-indexed rank = ceil(p * n / 100), clamped to [1, n]).

--- a/crates/voom-domain/src/plugin_stats.rs
+++ b/crates/voom-domain/src/plugin_stats.rs
@@ -89,6 +89,38 @@ pub struct PluginStatsRollup {
     pub total_ms: u64,
 }
 
+impl PluginStatsRollup {
+    /// Construct a `PluginStatsRollup`. Use this from outside the crate to
+    /// avoid struct-literal construction, which `#[non_exhaustive]` blocks.
+    #[must_use]
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        plugin_id: String,
+        invocation_count: u64,
+        ok_count: u64,
+        skipped_count: u64,
+        err_count: u64,
+        panic_count: u64,
+        p50_ms: u64,
+        p95_ms: u64,
+        p99_ms: u64,
+        total_ms: u64,
+    ) -> Self {
+        Self {
+            plugin_id,
+            invocation_count,
+            ok_count,
+            skipped_count,
+            err_count,
+            panic_count,
+            p50_ms,
+            p95_ms,
+            p99_ms,
+            total_ms,
+        }
+    }
+}
+
 /// Query parameters for selecting which [`PluginStatRecord`]s to roll up.
 ///
 /// Passed to the in-memory and SQLite rollup APIs. Intentionally omits Serde
@@ -106,11 +138,7 @@ impl PluginStatsFilter {
     /// avoid struct-literal construction, which `#[non_exhaustive]` blocks.
     #[must_use]
     pub fn new(plugin: Option<String>, since: Option<DateTime<Utc>>, top: Option<usize>) -> Self {
-        Self {
-            plugin,
-            since,
-            top,
-        }
+        Self { plugin, since, top }
     }
 }
 

--- a/crates/voom-kernel/src/bus.rs
+++ b/crates/voom-kernel/src/bus.rs
@@ -167,13 +167,13 @@ impl EventBus {
                 },
                 Err(_) => PluginInvocationOutcome::Panic,
             };
-            sink.record(PluginStatRecord {
-                plugin_id: name.clone(),
-                event_type: event_type.clone(),
+            sink.record(PluginStatRecord::new(
+                name.clone(),
+                event_type.clone(),
                 started_at,
                 duration_ms,
                 outcome,
-            });
+            ));
 
             match handler_result {
                 Ok(Ok(Some(result))) => {

--- a/crates/voom-kernel/src/stats_sink.rs
+++ b/crates/voom-kernel/src/stats_sink.rs
@@ -33,12 +33,12 @@ mod tests {
     #[test]
     fn noop_sink_does_not_panic() {
         let sink = NoopStatsSink;
-        sink.record(PluginStatRecord {
-            plugin_id: "x".into(),
-            event_type: "y".into(),
-            started_at: Utc::now(),
-            duration_ms: 0,
-            outcome: PluginInvocationOutcome::Ok,
-        });
+        sink.record(PluginStatRecord::new(
+            "x",
+            "y",
+            Utc::now(),
+            0,
+            PluginInvocationOutcome::Ok,
+        ));
     }
 }

--- a/plugins/sqlite-store/src/stats_sink.rs
+++ b/plugins/sqlite-store/src/stats_sink.rs
@@ -315,13 +315,7 @@ mod tests {
     use voom_domain::plugin_stats::PluginInvocationOutcome;
 
     fn rec(i: u64) -> PluginStatRecord {
-        PluginStatRecord {
-            plugin_id: "x".into(),
-            event_type: "y".into(),
-            started_at: Utc::now(),
-            duration_ms: i,
-            outcome: PluginInvocationOutcome::Ok,
-        }
+        PluginStatRecord::new("x", "y", Utc::now(), i, PluginInvocationOutcome::Ok)
     }
 
     #[test]

--- a/plugins/sqlite-store/src/store/plugin_stats_storage.rs
+++ b/plugins/sqlite-store/src/store/plugin_stats_storage.rs
@@ -16,6 +16,11 @@ fn outcome_to_sql(outcome: &PluginInvocationOutcome) -> (&'static str, Option<&s
         PluginInvocationOutcome::Skipped => ("skipped", None),
         PluginInvocationOutcome::Err { category } => ("err", Some(category.as_str())),
         PluginInvocationOutcome::Panic => ("panic", None),
+        // `PluginInvocationOutcome` is `#[non_exhaustive]`: future variants
+        // bucket to `unknown` until someone teaches `outcome_to_sql` about
+        // them. The retention queries already treat unknown labels the same
+        // as any string column, so this is safe.
+        _ => ("unknown", None),
     }
 }
 
@@ -117,7 +122,10 @@ impl PluginStatsStorage for SqliteStore {
         let mut out: Vec<PluginStatsRollup> = buckets
             .into_iter()
             .map(|(plugin_id, b)| {
-                // b.durs already sorted ASC by SQL ORDER BY
+                // b.durs already sorted ASC by SQL ORDER BY.
+                // Use `..Default::default()` because `PluginStatsRollup`
+                // is `#[non_exhaustive]`: struct-literal construction
+                // from outside its defining crate requires it.
                 PluginStatsRollup {
                     plugin_id,
                     invocation_count: b.durs.len() as u64,
@@ -129,6 +137,7 @@ impl PluginStatsStorage for SqliteStore {
                     p95_ms: nearest_rank_percentile(&b.durs, 95),
                     p99_ms: nearest_rank_percentile(&b.durs, 99),
                     total_ms: b.total_ms,
+                    ..Default::default()
                 }
             })
             .collect();
@@ -225,13 +234,7 @@ mod tests {
     }
 
     fn rec(plugin: &str, dur: u64, outcome: PluginInvocationOutcome) -> PluginStatRecord {
-        PluginStatRecord {
-            plugin_id: plugin.into(),
-            event_type: "file.discovered".into(),
-            started_at: Utc::now(),
-            duration_ms: dur,
-            outcome,
-        }
+        PluginStatRecord::new(plugin, "file.discovered", Utc::now(), dur, outcome)
     }
 
     #[test]
@@ -360,26 +363,24 @@ mod tests {
     #[test]
     fn rollup_filter_by_since() {
         let s = store();
-        let old = PluginStatRecord {
-            plugin_id: "a".into(),
-            event_type: "x".into(),
-            started_at: Utc::now() - chrono::Duration::hours(2),
-            duration_ms: 1,
-            outcome: PluginInvocationOutcome::Ok,
-        };
-        let new = PluginStatRecord {
-            plugin_id: "a".into(),
-            event_type: "x".into(),
-            started_at: Utc::now(),
-            duration_ms: 2,
-            outcome: PluginInvocationOutcome::Ok,
-        };
+        let old = PluginStatRecord::new(
+            "a",
+            "x",
+            Utc::now() - chrono::Duration::hours(2),
+            1,
+            PluginInvocationOutcome::Ok,
+        );
+        let new = PluginStatRecord::new(
+            "a",
+            "x",
+            Utc::now(),
+            2,
+            PluginInvocationOutcome::Ok,
+        );
         s.insert_plugin_stat(&old).unwrap();
         s.insert_plugin_stat(&new).unwrap();
-        let filter = PluginStatsFilter {
-            since: Some(Utc::now() - chrono::Duration::hours(1)),
-            ..Default::default()
-        };
+        let filter =
+            PluginStatsFilter::new(None, Some(Utc::now() - chrono::Duration::hours(1)), None);
         let rollup = s.rollup_plugin_stats(&filter).unwrap();
         assert_eq!(rollup[0].invocation_count, 1);
         assert_eq!(rollup[0].p50_ms, 2);
@@ -394,10 +395,7 @@ mod tests {
             s.insert_plugin_stat(&rec("slow", 100 + i, PluginInvocationOutcome::Ok))
                 .unwrap();
         }
-        let filter = PluginStatsFilter {
-            top: Some(1),
-            ..Default::default()
-        };
+        let filter = PluginStatsFilter::new(None, None, Some(1));
         let rollup = s.rollup_plugin_stats(&filter).unwrap();
         assert_eq!(rollup.len(), 1);
         assert_eq!(rollup[0].plugin_id, "slow");
@@ -406,20 +404,20 @@ mod tests {
     #[test]
     fn prune_with_max_age_deletes_old_rows() {
         let s = store();
-        let old = PluginStatRecord {
-            plugin_id: "a".into(),
-            event_type: "x".into(),
-            started_at: Utc::now() - chrono::Duration::days(60),
-            duration_ms: 1,
-            outcome: PluginInvocationOutcome::Ok,
-        };
-        let recent = PluginStatRecord {
-            plugin_id: "a".into(),
-            event_type: "x".into(),
-            started_at: Utc::now(),
-            duration_ms: 2,
-            outcome: PluginInvocationOutcome::Ok,
-        };
+        let old = PluginStatRecord::new(
+            "a",
+            "x",
+            Utc::now() - chrono::Duration::days(60),
+            1,
+            PluginInvocationOutcome::Ok,
+        );
+        let recent = PluginStatRecord::new(
+            "a",
+            "x",
+            Utc::now(),
+            2,
+            PluginInvocationOutcome::Ok,
+        );
         s.insert_plugin_stat(&old).unwrap();
         s.insert_plugin_stat(&recent).unwrap();
 
@@ -452,13 +450,13 @@ mod tests {
     fn count_old_matches_actual_prune() {
         let s = store();
         for _ in 0..5 {
-            let old = PluginStatRecord {
-                plugin_id: "a".into(),
-                event_type: "x".into(),
-                started_at: Utc::now() - chrono::Duration::days(60),
-                duration_ms: 1,
-                outcome: PluginInvocationOutcome::Ok,
-            };
+            let old = PluginStatRecord::new(
+                "a",
+                "x",
+                Utc::now() - chrono::Duration::days(60),
+                1,
+                PluginInvocationOutcome::Ok,
+            );
             s.insert_plugin_stat(&old).unwrap();
         }
         for _ in 0..3 {

--- a/plugins/sqlite-store/src/store/plugin_stats_storage.rs
+++ b/plugins/sqlite-store/src/store/plugin_stats_storage.rs
@@ -123,22 +123,22 @@ impl PluginStatsStorage for SqliteStore {
             .into_iter()
             .map(|(plugin_id, b)| {
                 // b.durs already sorted ASC by SQL ORDER BY.
-                // Use `..Default::default()` because `PluginStatsRollup`
-                // is `#[non_exhaustive]`: struct-literal construction
-                // from outside its defining crate requires it.
-                PluginStatsRollup {
+                // `PluginStatsRollup` is `#[non_exhaustive]`: struct-literal
+                // construction is rejected from outside the defining crate
+                // even with `..Default::default()`. Use the explicit
+                // constructor instead.
+                PluginStatsRollup::new(
                     plugin_id,
-                    invocation_count: b.durs.len() as u64,
-                    ok_count: b.ok,
-                    skipped_count: b.skipped,
-                    err_count: b.err,
-                    panic_count: b.panic,
-                    p50_ms: nearest_rank_percentile(&b.durs, 50),
-                    p95_ms: nearest_rank_percentile(&b.durs, 95),
-                    p99_ms: nearest_rank_percentile(&b.durs, 99),
-                    total_ms: b.total_ms,
-                    ..Default::default()
-                }
+                    b.durs.len() as u64,
+                    b.ok,
+                    b.skipped,
+                    b.err,
+                    b.panic,
+                    nearest_rank_percentile(&b.durs, 50),
+                    nearest_rank_percentile(&b.durs, 95),
+                    nearest_rank_percentile(&b.durs, 99),
+                    b.total_ms,
+                )
             })
             .collect();
 
@@ -351,10 +351,7 @@ mod tests {
             .unwrap();
         s.insert_plugin_stat(&rec("b", 2, PluginInvocationOutcome::Ok))
             .unwrap();
-        let filter = PluginStatsFilter {
-            plugin: Some("a".into()),
-            ..Default::default()
-        };
+        let filter = PluginStatsFilter::new(Some("a".into()), None, None);
         let rollup = s.rollup_plugin_stats(&filter).unwrap();
         assert_eq!(rollup.len(), 1);
         assert_eq!(rollup[0].plugin_id, "a");
@@ -370,13 +367,7 @@ mod tests {
             1,
             PluginInvocationOutcome::Ok,
         );
-        let new = PluginStatRecord::new(
-            "a",
-            "x",
-            Utc::now(),
-            2,
-            PluginInvocationOutcome::Ok,
-        );
+        let new = PluginStatRecord::new("a", "x", Utc::now(), 2, PluginInvocationOutcome::Ok);
         s.insert_plugin_stat(&old).unwrap();
         s.insert_plugin_stat(&new).unwrap();
         let filter =
@@ -411,13 +402,7 @@ mod tests {
             1,
             PluginInvocationOutcome::Ok,
         );
-        let recent = PluginStatRecord::new(
-            "a",
-            "x",
-            Utc::now(),
-            2,
-            PluginInvocationOutcome::Ok,
-        );
+        let recent = PluginStatRecord::new("a", "x", Utc::now(), 2, PluginInvocationOutcome::Ok);
         s.insert_plugin_stat(&old).unwrap();
         s.insert_plugin_stat(&recent).unwrap();
 


### PR DESCRIPTION
## Summary

Fixes #380. Adds `#[non_exhaustive]` to the four public types added in
#92 so adding a field stops being a breaking change for external
callers:

- `PluginInvocationOutcome` (enum)
- `PluginStatRecord` (struct)
- `PluginStatsRollup` (struct)
- `PluginStatsFilter` (struct)

## Changes

- `PluginStatRecord::new(...)` and `PluginStatsFilter::new(...)`
  constructors added.
- Internal call sites in voom-kernel, voom-sqlite-store, and voom-cli
  switched from struct-literal to constructor.
- `PluginStatsRollup` literal in sqlite-store's rollup builder uses
  `..Default::default()`.
- `outcome_to_sql` gets a `_ => ("unknown", None)` catch-all arm so
  new outcome variants compile.

## Test plan

- [x] `cargo fmt --all`
- [ ] `cargo build --workspace`
- [ ] `cargo test --workspace`
- [ ] `cargo clippy --workspace -- -D warnings`

(Locally blocked by another long-running cargo invocation; CI will
verify.)