### PR TITLE
fix(estimate): use open_store, not bootstrap_kernel_with_store (#382)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
       - run: cargo run -q -- policy test docs/examples/tests
       - run: cargo test -p voom-cli --features functional -- --test-threads=4 test_init test_doctor test_policy test_config test_status test_jobs test_plugin test_verify
       - run: cargo test -p voom-cli --features functional -- --test-threads=4 test_process crash_recovery normal_backup_not_treated_as_orphan
+      - run: cargo test -p voom-cli --features functional --test plugin_stats_e2e -- --test-threads=1
 
   test-wasm:
     name: Test (WASM feature)

--- a/.plans/issue-382-plan.md
+++ b/.plans/issue-382-plan.md
@@ -1,0 +1,72 @@
+# Plan: voom estimate should use open_store, not bootstrap_kernel (#382)
+
+## Problem
+
+`crates/voom-cli/src/commands/estimate.rs:50` calls
+`bootstrap_kernel_with_store` and uses only `result.store`, ignoring
+`result.kernel` and `result.collector`. Same anti-pattern that was fixed
+for `voom plugin stats` in commit `de69c75`. Side effects:
+
+- Full plugin initialization (bus-tracer, health-checker, tool-detector,
+  sqlite-store) runs for a read-only-ish operation.
+- Bus-tracer writes `event_log` rows for every init event.
+- Plugin-stats sink (#383) records timing rows for those init dispatches.
+
+## Verification that `estimate calibrate` only needs the store
+
+`calibrate()` body (estimate.rs:48-64):
+
+- Loads config.
+- Inserts cost-model samples via `store.insert_cost_model_sample(...)`.
+- Prints a count.
+
+No kernel dispatch, no event bus use, no capability collector. The fix
+is mechanical.
+
+## Changes
+
+### `crates/voom-cli/src/commands/estimate.rs`
+
+```rust
+async fn calibrate(args: &EstimateArgs) -> Result<()> {
+    let config = crate::config::load_config()?;
+    let store = crate::app::open_store(&config)?;            // ← was bootstrap_kernel_with_store
+    let completed_at = chrono::Utc::now();
+    // ... unchanged ...
+}
+```
+
+### `crates/voom-cli/tests/plugin_stats_e2e.rs`
+
+Add a regression test mirroring
+`plugin_stats_query_does_not_mutate_database`: assert that running
+`voom estimate calibrate` does NOT add rows to `plugin_stats` or
+`event_log`.
+
+## Edge cases / risks
+
+- `estimate.rs` has a separate non-calibrate path that goes through
+  `into_process_args` + `commands::process::run`. That path is
+  unchanged (it needs the kernel).
+- No public-API changes; pure internal substitution.
+
+## Test plan
+
+```bash
+cargo test -p voom-cli --features functional estimate_calibrate -- --test-threads=1
+cargo test -p voom-cli --features functional plugin_stats_query_does_not_mutate
+```
+
+## Validation commands
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+```
+
+## Out of scope
+
+- Refactoring the rest of the estimate command.
+- Adding stricter linting against `BootstrapResult { store, .. }`
+  destructuring patterns (suggestion for a separate hygiene PR).

--- a/crates/voom-cli/src/commands/estimate.rs
+++ b/crates/voom-cli/src/commands/estimate.rs
@@ -4,7 +4,6 @@ use std::time::{Duration, Instant};
 use anyhow::{Context, Result, bail};
 use tokio_util::sync::CancellationToken;
 
-use crate::app;
 use crate::cli::{ErrorHandling, EstimateArgs, ProcessArgs};
 
 pub async fn run(args: EstimateArgs, quiet: bool, token: CancellationToken) -> Result<()> {
@@ -46,8 +45,14 @@ impl EstimateArgs {
 }
 
 async fn calibrate(args: &EstimateArgs) -> Result<()> {
+    // Same anti-pattern fix as `voom plugin stats` (commit de69c75):
+    // `calibrate` only inserts cost-model samples; it does not dispatch
+    // events. Using `bootstrap_kernel_with_store` here would register
+    // plugins and fire init events through the bus, contaminating
+    // `plugin_stats` and `event_log` with bookkeeping from this
+    // read-mostly path.
     let config = crate::config::load_config()?;
-    let app::BootstrapResult { store, .. } = crate::app::bootstrap_kernel_with_store(&config)?;
+    let store = crate::app::open_store(&config)?;
     let completed_at = chrono::Utc::now();
     let samples = if let Some(corpus) = &args.benchmark_corpus {
         let result = benchmark_calibration_samples(corpus, args.max_fixtures)?;

--- a/crates/voom-cli/tests/plugin_stats_e2e.rs
+++ b/crates/voom-cli/tests/plugin_stats_e2e.rs
@@ -214,3 +214,96 @@ async fn plugin_stats_query_does_not_mutate_database() {
          {after_event_log}"
     );
 }
+
+// ─── Test 4 (issue #382) ─────────────────────────────────────────────────────
+
+/// `voom estimate calibrate` must NOT add rows to `plugin_stats` or
+/// `event_log`. It only writes `cost_model_samples`; using
+/// `bootstrap_kernel_with_store` for this would register every plugin
+/// and dispatch their init events through the bus, polluting the
+/// bookkeeping tables — the same anti-pattern that was fixed for
+/// `voom plugin stats` in de69c75.
+#[tokio::test]
+async fn estimate_calibrate_does_not_mutate_database() {
+    use clap::Parser;
+
+    let _lock = TEST_LOCK.lock().await;
+    let env = TestEnv::new().await;
+    // Seed the DB by running a scan first, so plugin_stats and
+    // event_log are non-empty before we measure deltas.
+    env.write_media("a.mkv", 1);
+    run_scan(&env).await;
+    tokio::time::sleep(Duration::from_millis(2000)).await;
+
+    let db_path = env.db_path();
+    let baseline_plugin_stats: i64 = {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.query_row("SELECT COUNT(*) FROM plugin_stats", [], |r| r.get(0))
+            .unwrap()
+    };
+    let baseline_event_log: i64 = {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.query_row("SELECT COUNT(*) FROM event_log", [], |r| r.get(0))
+            .unwrap()
+    };
+    let baseline_cost_model_samples: i64 = {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.query_row("SELECT COUNT(*) FROM cost_model_samples", [], |r| r.get(0))
+            .unwrap()
+    };
+    assert!(
+        baseline_plugin_stats > 0,
+        "scan must produce stats first; got {baseline_plugin_stats}"
+    );
+
+    // Run `voom estimate calibrate` end-to-end in-process.
+    let config_home = env.config_home().to_str().expect("utf-8 config_home");
+    let _guard = EnvOverride::set("XDG_CONFIG_HOME", config_home);
+    let argv = ["voom", "estimate", "calibrate"];
+    let cli = voom_cli::cli::Cli::try_parse_from(argv)
+        .unwrap_or_else(|e| panic!("CLI parse failed: {e}"));
+    let estimate_args = match cli.command {
+        voom_cli::cli::Commands::Estimate(a) => a,
+        _ => panic!("expected Estimate subcommand"),
+    };
+    let token = tokio_util::sync::CancellationToken::new();
+    voom_cli::commands::estimate::run(estimate_args, true, token)
+        .await
+        .expect("voom estimate calibrate must succeed");
+    drop(_guard);
+
+    // Settle any (theoretically nonexistent) pending writer work.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let after_plugin_stats: i64 = {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.query_row("SELECT COUNT(*) FROM plugin_stats", [], |r| r.get(0))
+            .unwrap()
+    };
+    let after_event_log: i64 = {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.query_row("SELECT COUNT(*) FROM event_log", [], |r| r.get(0))
+            .unwrap()
+    };
+    let after_cost_model_samples: i64 = {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.query_row("SELECT COUNT(*) FROM cost_model_samples", [], |r| r.get(0))
+            .unwrap()
+    };
+
+    assert_eq!(
+        after_plugin_stats, baseline_plugin_stats,
+        "estimate calibrate must not add plugin_stats rows: was {baseline_plugin_stats}, \
+         now {after_plugin_stats}"
+    );
+    assert_eq!(
+        after_event_log, baseline_event_log,
+        "estimate calibrate must not add event_log rows: was {baseline_event_log}, now \
+         {after_event_log}"
+    );
+    assert!(
+        after_cost_model_samples > baseline_cost_model_samples,
+        "estimate calibrate MUST add cost_model_samples rows: was \
+         {baseline_cost_model_samples}, now {after_cost_model_samples}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #382. `voom estimate calibrate` was calling
`bootstrap_kernel_with_store` and only using the `store`. Same anti-
pattern that was fixed for `voom plugin stats` in commit `de69c75`.

## Changes

- `crates/voom-cli/src/commands/estimate.rs::calibrate` switched to
  `crate::app::open_store(&config)`.
- `crates/voom-cli/tests/plugin_stats_e2e.rs` — new regression test
  `estimate_calibrate_does_not_mutate_database` asserts the command
  does not add rows to `plugin_stats` or `event_log` (and DOES add
  rows to `cost_model_samples`).

## Test plan

- [ ] `cargo build --workspace`
- [ ] `cargo test -p voom-cli --features functional estimate_calibrate_does_not_mutate_database`
- [ ] CI workspace tests