### PR TITLE
docs(architecture): publisher-coverage decision for plugin_stats (#378)

### DIFF
--- a/.plans/issue-378-plan.md
+++ b/.plans/issue-378-plan.md
@@ -1,0 +1,114 @@
+# Plan: Instrument pure-publisher plugins in plugin_stats (#378)
+
+## Problem
+
+The dispatcher only times plugins that **subscribe** to events. Pure
+publishers (Discovery, Phase Orchestrator, Policy Evaluator) emit events
+but never enter the dispatcher path, so they have zero rows in
+`plugin_stats`. Documented as a gap in `docs/cli-reference.md` and
+`docs/architecture.md`.
+
+## Approach selection
+
+The issue lists three options:
+
+1. **Publish-side timing** — instrument the publisher's call to
+   `kernel.dispatch(event)`. Doesn't reflect plugin work; just measures
+   dispatch latency.
+2. **Plugin self-reporting via a `PluginStats::record(key, value)` host
+   API** — requires plugin code changes; the right design but bigger
+   scope than #378.
+3. **Documented gap** — accept the limit; rely on Prometheus / OTel
+   (Deliverables 2 and 3) for end-to-end visibility.
+
+Option 1 measures the wrong thing (dispatch latency is a property of
+the bus, not the publisher). Option 2 is the correct long-term design
+but requires kernel API surface, WASM host-function additions, and
+plugin migrations — out of scope for a single follow-up issue.
+
+**Recommendation: Option 3** — document the gap explicitly as a design
+decision, with a forward pointer to Prometheus/OTel for full coverage.
+File a separate issue if/when someone needs Option 2's API.
+
+## Changes
+
+### `docs/architecture.md`
+
+Expand the existing "Bus dispatcher instrumentation" subsection with:
+
+```markdown
+### Coverage: subscribers only
+
+The dispatcher instruments only plugins that subscribe to events
+through the bus. Pure publishers — Discovery, Phase Orchestrator,
+Policy Evaluator — emit events but never have their work timed at the
+dispatcher boundary.
+
+This is intentional for Deliverable 1:
+
+- The dispatcher's natural instrumentation point is the
+  `handler.on_event(...)` invocation. Publishers do not pass through
+  it.
+- A publish-side timer (timing `bus.publish(event)`) would measure the
+  cost of dispatching to other plugins, not the publisher's own work.
+- A plugin-self-reporting host API (e.g. `PluginStats::record(key,
+  value)`) is the right long-term primitive but requires kernel + WASM
+  surface that is out of scope for #92.
+
+For end-to-end visibility across publishers and subscribers, use
+Deliverables 2 and 3 (Prometheus `/metrics`, OpenTelemetry).
+```
+
+### `docs/cli-reference.md`
+
+The existing caveat under `voom plugin stats` says rows exist only for
+subscribers. Strengthen it to reference the architecture-doc design
+rationale:
+
+```markdown
+> **Coverage:** `plugin_stats` rows are recorded only for plugins that
+> subscribe to events (Bus instrumentation point). Pure publishers
+> (`discovery`, `phase-orchestrator`, `policy-evaluator`) do not appear
+> in the table. See [Bus dispatcher instrumentation — Coverage:
+> subscribers only][arch] for design rationale and the path to full
+> coverage via Prometheus/OTel (Deliverables 2 and 3).
+>
+> [arch]: ../architecture.md#coverage-subscribers-only
+```
+
+### Follow-up issue (file at PR-merge time)
+
+File `Add PluginStats::record host API for self-reporting publishers`
+referencing #378's analysis, scoped to:
+
+- Extend `voom-kernel::PluginContext` with a `stats: Arc<dyn StatsSink>`
+  handle.
+- Add a `record(plugin_id, event_type, duration, outcome)` host function.
+- Migrate Discovery / Phase Orchestrator / Policy Evaluator to call it.
+- WASM `host.wit` addition for WASM plugins.
+
+This is real work; punt it as its own issue rather than smuggling it
+into #378.
+
+## Acceptance
+
+- [ ] Architecture-doc subsection added.
+- [ ] CLI-reference caveat strengthened with link to architecture doc.
+- [ ] Follow-up issue filed for Option 2.
+- [ ] No code changes (this is the documented-gap path).
+
+## Validation commands
+
+```bash
+# Docs lint, if a markdown linter is configured (none currently).
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+```
+
+(No code changes means tests should pass trivially.)
+
+## Out of scope
+
+- Implementing Option 1 or Option 2.
+- Any code changes to plugins or the kernel.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -214,9 +214,28 @@ Records carry `plugin_id`, `event_type`, `started_at`, `duration_ms`, and an
 written in background batches and dropped if the bounded channel overflows —
 the bus must not block.
 
-**Coverage:** the dispatcher only times handlers invoked through
-`Plugin::on_event`. Pure publishers (plugins that emit events but don't
-subscribe to any) are not represented in `plugin_stats`.
+#### Coverage: subscribers only
+
+The dispatcher instruments only plugins that subscribe to events through
+the bus. Pure publishers — `discovery` (walks filesystem and emits
+`FileDiscovered`), `phase-orchestrator` (CLI-called, emits phase events),
+and `policy-evaluator` (CLI-called, emits `Plan` events) — emit events
+but never have their work timed at the dispatcher boundary.
+
+This is intentional for Deliverable 1 (#92):
+
+- The dispatcher's natural instrumentation point is the
+  `handler.on_event(...)` invocation. Publishers do not pass through it.
+- A publish-side timer (timing `bus.publish(event)`) would measure the
+  cost of dispatching to *other* plugins, not the publisher's own work.
+- A plugin self-reporting host API (e.g.
+  `PluginStats::record(key, value)`) is the right long-term primitive
+  but requires kernel + WASM surface that is out of scope for #92.
+
+For end-to-end visibility across publishers and subscribers, use the
+Deliverable-2 (Prometheus `/metrics`) and Deliverable-3 (OpenTelemetry)
+exporters that #92 builds toward. Issue #378 records this decision and
+the deferred work; a future host-API issue can revisit the trade-offs.
 
 ### Retention invariants
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -216,26 +216,34 @@ the bus must not block.
 
 #### Coverage: subscribers only
 
-The dispatcher instruments only plugins that subscribe to events through
-the bus. Pure publishers — `discovery` (walks filesystem and emits
-`FileDiscovered`), `phase-orchestrator` (CLI-called, emits phase events),
-and `policy-evaluator` (CLI-called, emits `Plan` events) — emit events
-but never have their work timed at the dispatcher boundary.
+The dispatcher instruments only plugins that subscribe to events
+through the bus — its instrumentation point is the
+`Plugin::on_event(...)` invocation. Two distinct kinds of code emit
+events but never enter that path, and their absence from
+`plugin_stats` is for two different reasons:
 
-This is intentional for Deliverable 1 (#92):
+- **Kernel-registered no-subscriber plugins.** `discovery` is a
+  registered plugin whose `handles()` returns `false` for every event,
+  so the dispatcher never calls `on_event` on it. It emits
+  `FileDiscovered` events via `kernel.dispatch(...)` from within its
+  own scan loop. This is the textbook "publisher-only plugin" case:
+  the work *is* a plugin invocation, just not one the dispatcher
+  observes.
+- **Library-only callees.** `phase-orchestrator` and `policy-evaluator`
+  are not registered with the kernel at all (see
+  [Two-Tier Plugin Model](#two-tier-plugin-model)). The CLI calls them
+  directly; the corresponding `PlanCreated` / `PlanExecuting` /
+  `PlanCompleted` events are dispatched by the CLI's `PlanDispatcher`,
+  not by the libraries themselves. There is no plugin invocation to
+  attribute time to.
 
-- The dispatcher's natural instrumentation point is the
-  `handler.on_event(...)` invocation. Publishers do not pass through it.
-- A publish-side timer (timing `bus.publish(event)`) would measure the
-  cost of dispatching to *other* plugins, not the publisher's own work.
-- A plugin self-reporting host API (e.g.
-  `PluginStats::record(key, value)`) is the right long-term primitive
-  but requires kernel + WASM surface that is out of scope for #92.
-
-For end-to-end visibility across publishers and subscribers, use the
-Deliverable-2 (Prometheus `/metrics`) and Deliverable-3 (OpenTelemetry)
-exporters that #92 builds toward. Issue #378 records this decision and
-the deferred work; a future host-API issue can revisit the trade-offs.
+For end-to-end visibility across both kinds of gap, use the
+Deliverable-2 (Prometheus `/metrics`) and Deliverable-3
+(OpenTelemetry) exporters that #92 builds toward. Issue #378 records
+the decision to leave Deliverable 1 scoped to dispatcher-observed
+subscribers; a future host-API issue can revisit a plugin
+self-reporting primitive if `discovery`-class coverage gaps become a
+measured operational pain point.
 
 ### Retention invariants
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -354,11 +354,18 @@ Stats are persisted to the `plugin_stats` SQLite table with retention managed
 by the same `[retention.plugin_stats]` config section as other tables (PR #170).
 Defaults: keep for 30 days, keep last 100,000 rows.
 
-**Note (coverage):** Only plugins that *subscribe* to events appear in the
-rollup. Pure publishers — `discovery`, `phase-orchestrator`, and
-`policy-evaluator` — emit events but never receive them through
-`Plugin::on_event`, so the dispatcher does not time their work. This is
-an intentional design boundary for Deliverable 1 of #92; see
+**Note (coverage):** Only plugins that *subscribe* to events appear in
+the rollup. Two kinds of code are missing for distinct reasons:
+
+- `discovery` is a kernel-registered plugin that publishes
+  `FileDiscovered` but does not subscribe to anything, so the
+  dispatcher never observes it.
+- `phase-orchestrator` and `policy-evaluator` are not plugins at all —
+  they are library-only crates the CLI calls directly. The
+  corresponding `Plan*` events come from the CLI's `PlanDispatcher`,
+  not from those crates.
+
+This is an intentional design boundary for Deliverable 1 of #92; see
 [Bus dispatcher instrumentation — Coverage: subscribers only][arch] in
 the architecture docs for the rationale and the path to full coverage
 via Prometheus / OpenTelemetry (Deliverables 2 and 3). Tracked as

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -354,10 +354,17 @@ Stats are persisted to the `plugin_stats` SQLite table with retention managed
 by the same `[retention.plugin_stats]` config section as other tables (PR #170).
 Defaults: keep for 30 days, keep last 100,000 rows.
 
-**Note:** Only plugins that *subscribe* to events appear in the rollup. Pure
-publishers (e.g., the `discovery` plugin, which walks the filesystem and emits
-`FileDiscovered` events but doesn't consume any events) are not timed by the
-dispatcher and therefore have no rows.
+**Note (coverage):** Only plugins that *subscribe* to events appear in the
+rollup. Pure publishers — `discovery`, `phase-orchestrator`, and
+`policy-evaluator` — emit events but never receive them through
+`Plugin::on_event`, so the dispatcher does not time their work. This is
+an intentional design boundary for Deliverable 1 of #92; see
+[Bus dispatcher instrumentation — Coverage: subscribers only][arch] in
+the architecture docs for the rationale and the path to full coverage
+via Prometheus / OpenTelemetry (Deliverables 2 and 3). Tracked as
+follow-up #378.
+
+[arch]: ../docs/architecture.md#coverage-subscribers-only
 
 ---
 


### PR DESCRIPTION
## Summary

Resolves #378 via the **documented-gap** path (Option 3 from the plan).

The issue presented three options:

1. Publish-side timing (measures dispatch latency, not publisher work).
2. Plugin self-reporting host API (right long-term design, big scope).
3. Documented gap (rely on Prometheus/OTel for end-to-end coverage).

Option 1 measures the wrong thing. Option 2 is the correct future
design but requires kernel + WASM API surface that is out of scope for
this issue. Option 3 is what this PR ships.

## Changes

- `docs/architecture.md`: new \"Coverage: subscribers only\" subsection
  under \"Bus dispatcher instrumentation\" explaining the design.
- `docs/cli-reference.md`: existing caveat strengthened with a link to
  the architecture-doc rationale and the names of the three known pure
  publishers.

No code changes; CI is doc-only.

## Test plan

- [ ] CI workspace build/tests (no-op for doc-only PR but standard).