### PR TITLE
Add structured CLI JSON outputs for e2e consumers

### DIFF
--- a/crates/voom-cli/build.rs
+++ b/crates/voom-cli/build.rs
@@ -8,6 +8,18 @@ fn main() {
     let package_version = std::env::var("CARGO_PKG_VERSION").expect("CARGO_PKG_VERSION is set");
     let product_version = product_version(&package_version);
     println!("cargo:rustc-env=VOOM_PRODUCT_VERSION={product_version}");
+    println!(
+        "cargo:rustc-env=VOOM_GIT_SHA={}",
+        git_short_sha().unwrap_or_else(|| "unknown".to_string())
+    );
+    println!(
+        "cargo:rustc-env=VOOM_GIT_DIRTY={}",
+        if git_dirty() { "true" } else { "false" }
+    );
+    println!(
+        "cargo:rustc-env=VOOM_BUILD_TARGET={}",
+        std::env::var("TARGET").unwrap_or_else(|_| "unknown".to_string())
+    );
 }
 
 fn emit_git_rerun_instructions() {
@@ -56,6 +68,13 @@ fn git_head_is_release_tag(expected_tag: &str) -> bool {
 
 fn git_short_sha() -> Option<String> {
     git_output(&["rev-parse", "--short=12", "HEAD"])
+}
+
+fn git_dirty() -> bool {
+    Command::new("git")
+        .args(["diff", "--quiet", "--ignore-submodules", "HEAD"])
+        .status()
+        .is_ok_and(|status| !status.success())
 }
 
 fn git_output(args: &[&str]) -> Option<String> {

--- a/crates/voom-cli/src/cli.rs
+++ b/crates/voom-cli/src/cli.rs
@@ -66,6 +66,9 @@ pub enum Commands {
     /// View event log
     Events(EventsArgs),
 
+    /// Show VOOM build and version metadata
+    Version(VersionArgs),
+
     /// Environment diagnostics and history
     #[command(subcommand)]
     Env(EnvCommands),
@@ -250,6 +253,10 @@ pub struct ProcessArgs {
     /// model and recommended use cases.
     #[arg(long)]
     pub execute_during_discovery: bool,
+
+    /// Output format for execution summaries
+    #[arg(short, long, default_value = "table")]
+    pub format: OutputFormat,
 }
 
 #[derive(clap::Args)]
@@ -281,6 +288,15 @@ pub struct EstimateArgs {
     /// Maximum generated corpus fixtures to benchmark during calibration
     #[arg(long, default_value_t = 3)]
     pub max_fixtures: usize,
+}
+
+// === Version ===
+
+#[derive(clap::Args)]
+pub struct VersionArgs {
+    /// Output format
+    #[arg(short, long, default_value = "table")]
+    pub format: OutputFormat,
 }
 
 fn parse_size_bytes(value: &str) -> std::result::Result<u64, String> {
@@ -2324,6 +2340,15 @@ mod tests {
     }
 
     #[test]
+    fn test_version_json_format() {
+        let cli = parse(&["voom", "version", "--format", "json"]);
+        match cli.command {
+            Commands::Version(args) => assert!(matches!(args.format, OutputFormat::Json)),
+            _ => panic!("expected Version command"),
+        }
+    }
+
+    #[test]
     fn test_invalid_on_error_rejected() {
         assert!(
             try_parse(&[
@@ -2623,6 +2648,17 @@ mod tests {
             Commands::Process(args) => {
                 assert_eq!(args.paths, vec![PathBuf::from("/media")]);
             }
+            _ => panic!("expected Process"),
+        }
+    }
+
+    #[test]
+    fn test_process_json_format() {
+        let cli = parse(&[
+            "voom", "process", "/media", "--policy", "p.voom", "--format", "json",
+        ]);
+        match cli.command {
+            Commands::Process(args) => assert!(matches!(args.format, OutputFormat::Json)),
             _ => panic!("expected Process"),
         }
     }

--- a/crates/voom-cli/src/commands/estimate.rs
+++ b/crates/voom-cli/src/commands/estimate.rs
@@ -40,6 +40,7 @@ impl EstimateArgs {
             confirm_savings: None,
             priority_by_date: false,
             execute_during_discovery: false,
+            format: crate::cli::OutputFormat::Table,
         }
     }
 }

--- a/crates/voom-cli/src/commands/mod.rs
+++ b/crates/voom-cli/src/commands/mod.rs
@@ -21,3 +21,4 @@ pub mod scan;
 pub mod serve;
 pub mod tools;
 pub mod verify;
+pub mod version;

--- a/crates/voom-cli/src/commands/process/mod.rs
+++ b/crates/voom-cli/src/commands/process/mod.rs
@@ -10,6 +10,7 @@ mod transitions;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
+use std::time::Instant;
 
 use anyhow::{Context, Result};
 use console::style;
@@ -20,7 +21,7 @@ use tokio_util::sync::CancellationToken;
 use pipeline::process_single_file;
 
 use crate::app;
-use crate::cli::{ErrorHandling, ProcessArgs};
+use crate::cli::{ErrorHandling, OutputFormat, ProcessArgs};
 use crate::config;
 use crate::paths::resolve_paths;
 use crate::policy_map::PolicyResolver;
@@ -74,6 +75,7 @@ pub async fn run(args: ProcessArgs, quiet: bool, token: CancellationToken) -> Re
     let estimate_mode = args.estimate || args.estimate_only;
     let plan_only = args.plan_only;
     let dry_run = args.dry_run || plan_only || estimate_mode;
+    let started = Instant::now();
 
     let config = config::load_config()?;
     let app::BootstrapResult {
@@ -464,11 +466,13 @@ pub async fn run(args: ProcessArgs, quiet: bool, token: CancellationToken) -> Re
             store: store.as_ref(),
             plan_only,
             estimate_mode,
+            format: args.format,
             quiet,
             cancelled: token.is_cancelled(),
             pool: pool.as_ref(),
             file_count,
             effective_workers,
+            elapsed_ms: u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
             dry_run,
             paths: &paths,
             all_phase_names: &all_phase_names,
@@ -512,11 +516,13 @@ struct RunResultsContext<'a> {
     store: &'a dyn voom_domain::storage::StorageTrait,
     plan_only: bool,
     estimate_mode: bool,
+    format: OutputFormat,
     quiet: bool,
     cancelled: bool,
     pool: &'a WorkerPool,
     file_count: usize,
     effective_workers: usize,
+    elapsed_ms: u64,
     dry_run: bool,
     paths: &'a [std::path::PathBuf],
     all_phase_names: &'a [String],
@@ -551,6 +557,10 @@ fn print_run_results(ctx: &RunResultsContext<'_>) -> Result<()> {
 
     let modified = ctx.counters.modified_count.load(AtomicOrdering::Relaxed);
     let backup_total = ctx.counters.backup_bytes.load(AtomicOrdering::Relaxed);
+    if matches!(ctx.format, OutputFormat::Json) {
+        crate::output::print_json(&process_run_summary_json(ctx, modified, backup_total))?;
+        return Ok(());
+    }
     if !ctx.quiet {
         if ctx.cancelled {
             print_interrupted_summary(ctx.pool, ctx.file_count, modified);
@@ -585,6 +595,55 @@ fn print_run_results(ctx: &RunResultsContext<'_>) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn process_run_summary_json(
+    ctx: &RunResultsContext<'_>,
+    modified: u64,
+    backup_bytes: u64,
+) -> serde_json::Value {
+    let phase_stats = ctx.counters.phase_stats.lock();
+    let phase_stats_json: BTreeMap<String, serde_json::Value> = phase_stats
+        .iter()
+        .map(|(phase, stats)| {
+            (
+                phase.clone(),
+                serde_json::json!({
+                    "completed": stats.completed,
+                    "skipped": stats.skipped,
+                    "failed": stats.failed,
+                    "skip_reasons": stats.skip_reasons,
+                }),
+            )
+        })
+        .collect();
+    let failed_plans: u64 = phase_stats.values().map(|stats| stats.failed).sum();
+    let completed = ctx.pool.completed_count();
+    let failed_files = ctx.pool.failed_count();
+    let skipped = (ctx.file_count as u64)
+        .saturating_sub(completed)
+        .saturating_sub(failed_files);
+
+    serde_json::json!({
+        "command": "process",
+        "status": if ctx.cancelled { "cancelled" } else { "ok" },
+        "session_id": ctx.counters.session_id,
+        "cancelled": ctx.cancelled,
+        "dry_run": ctx.dry_run,
+        "paths": ctx.paths.iter().map(|p| p.display().to_string()).collect::<Vec<_>>(),
+        "workers": ctx.effective_workers,
+        "elapsed_ms": ctx.elapsed_ms,
+        "counts": {
+            "files": ctx.file_count,
+            "processed": completed,
+            "modified": modified,
+            "skipped": skipped,
+            "failed_files": failed_files,
+            "failed_plans": failed_plans,
+            "backup_bytes": backup_bytes,
+        },
+        "phase_stats": phase_stats_json,
+    })
 }
 
 fn print_estimate(estimate: &voom_domain::EstimateRun) {
@@ -1037,6 +1096,68 @@ mod tests {
         );
         assert_eq!(hw_resource_for_backend("none"), None);
         assert_eq!(hw_resource_for_backend("unknown"), None);
+    }
+
+    #[test]
+    fn process_run_summary_json_includes_counts_and_phase_stats() {
+        let counters = RunCounters::new();
+        record_phase_stat(
+            &counters.phase_stats,
+            "transcode-video",
+            PhaseOutcomeKind::Completed,
+        );
+        record_phase_stat(
+            &counters.phase_stats,
+            "transcode-video",
+            PhaseOutcomeKind::Skipped("already-compatible".to_string()),
+        );
+        record_phase_stat(
+            &counters.phase_stats,
+            "transcode-video",
+            PhaseOutcomeKind::Failed,
+        );
+
+        let job_store: Arc<dyn voom_domain::storage::JobStorage> =
+            Arc::new(voom_domain::test_support::InMemoryStore::new());
+        let queue = Arc::new(voom_job_manager::queue::JobQueue::new(job_store));
+        let mut config = WorkerPoolConfig::default();
+        config.max_workers = 4;
+        let pool = WorkerPool::new(queue, config, CancellationToken::new());
+        let store = voom_domain::test_support::InMemoryStore::new();
+        let paths = vec![PathBuf::from("/media")];
+        let phases = vec!["transcode-video".to_string()];
+        let ctx = RunResultsContext {
+            counters: &counters,
+            store: &store,
+            plan_only: false,
+            estimate_mode: false,
+            format: OutputFormat::Json,
+            quiet: true,
+            cancelled: false,
+            pool: &pool,
+            file_count: 3,
+            effective_workers: 4,
+            elapsed_ms: 42,
+            dry_run: false,
+            paths: &paths,
+            all_phase_names: &phases,
+        };
+
+        let json = process_run_summary_json(&ctx, 2, 1024);
+
+        assert_eq!(json["command"], "process");
+        assert_eq!(json["elapsed_ms"], 42);
+        assert_eq!(json["counts"]["files"], 3);
+        assert_eq!(json["counts"]["modified"], 2);
+        assert_eq!(json["counts"]["failed_plans"], 1);
+        assert_eq!(json["counts"]["backup_bytes"], 1024);
+        assert_eq!(json["phase_stats"]["transcode-video"]["completed"], 1);
+        assert_eq!(json["phase_stats"]["transcode-video"]["skipped"], 1);
+        assert_eq!(json["phase_stats"]["transcode-video"]["failed"], 1);
+        assert_eq!(
+            json["phase_stats"]["transcode-video"]["skip_reasons"]["already-compatible"],
+            1
+        );
     }
 
     /// A test plugin that counts received plan lifecycle events.

--- a/crates/voom-cli/src/commands/process/pipeline.rs
+++ b/crates/voom-cli/src/commands/process/pipeline.rs
@@ -171,7 +171,7 @@ fn process_single_file_dry_run(
         let plans_json: Vec<serde_json::Value> = result
             .plans
             .iter()
-            .filter(|p| !p.is_empty() && !p.is_skipped())
+            .filter(|p| include_in_plan_only_output(p))
             .filter_map(|p| {
                 serde_json::to_value(p)
                     .inspect_err(|e| {
@@ -217,6 +217,10 @@ fn process_single_file_dry_run(
         "needs_execution": needs_exec,
         "plans": plan_summaries,
     })))
+}
+
+fn include_in_plan_only_output(plan: &voom_domain::plan::Plan) -> bool {
+    !plan.is_empty() || plan.is_skipped()
 }
 
 /// Real execution: evaluate → execute → re-introspect per phase.
@@ -925,6 +929,39 @@ mod tests {
             }
             Ok(None)
         }
+    }
+
+    #[test]
+    fn plan_only_output_filter_includes_skipped_plans_for_audit_diff() {
+        let skipped = voom_domain::plan::Plan::new(
+            voom_domain::media::MediaFile::new(std::path::PathBuf::from("/media/a.mkv")),
+            "test-policy",
+            "transcode-video",
+        )
+        .with_skip_reason("already-compatible");
+
+        let executable = voom_domain::plan::Plan::new(
+            voom_domain::media::MediaFile::new(std::path::PathBuf::from("/media/b.mkv")),
+            "test-policy",
+            "transcode-video",
+        )
+        .with_action(voom_domain::plan::PlannedAction::file_op(
+            voom_domain::plan::OperationType::ConvertContainer,
+            voom_domain::plan::ActionParams::Container {
+                container: voom_domain::media::Container::Mkv,
+            },
+            "convert container",
+        ));
+
+        let empty = voom_domain::plan::Plan::new(
+            voom_domain::media::MediaFile::new(std::path::PathBuf::from("/media/c.mkv")),
+            "test-policy",
+            "metadata",
+        );
+
+        assert!(super::include_in_plan_only_output(&skipped));
+        assert!(super::include_in_plan_only_output(&executable));
+        assert!(!super::include_in_plan_only_output(&empty));
     }
 
     struct FailingExecutor;

--- a/crates/voom-cli/src/commands/process/pipeline_streaming.rs
+++ b/crates/voom-cli/src/commands/process/pipeline_streaming.rs
@@ -699,6 +699,7 @@ mod tests {
             confirm_savings: None,
             priority_by_date: false,
             execute_during_discovery: false,
+            format: crate::cli::OutputFormat::Table,
         }
     }
 

--- a/crates/voom-cli/src/commands/scan/mod.rs
+++ b/crates/voom-cli/src/commands/scan/mod.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -95,10 +96,12 @@ pub async fn run(args: ScanArgs, quiet: bool, token: CancellationToken) -> Resul
                 }
             }
             if matches!(args.format, Some(crate::cli::OutputFormat::Json)) {
-                #[allow(clippy::print_stdout)]
-                {
-                    println!("[]");
-                }
+                output::print_json(&scan_json_summary(
+                    &outcome,
+                    &paths,
+                    start.elapsed(),
+                    token.is_cancelled(),
+                ))?;
             }
             return Ok(());
         }
@@ -144,7 +147,7 @@ pub async fn run(args: ScanArgs, quiet: bool, token: CancellationToken) -> Resul
 
         if token.is_cancelled() {
             if let Some(format) = args.format {
-                output::format_scan_results(&outcome.formatted, format);
+                format_scan_output(&outcome, &paths, start.elapsed(), true, format)?;
             }
             return Ok(());
         }
@@ -184,7 +187,7 @@ pub async fn run(args: ScanArgs, quiet: bool, token: CancellationToken) -> Resul
         )));
 
         if let Some(format) = args.format {
-            output::format_scan_results(&outcome.formatted, format);
+            format_scan_output(&outcome, &paths, start.elapsed(), false, format)?;
         }
 
         Ok(())
@@ -194,6 +197,54 @@ pub async fn run(args: ScanArgs, quiet: bool, token: CancellationToken) -> Resul
     crate::retention::maybe_run_after_cli(store, &config.retention, Some(kernel));
 
     primary_result
+}
+
+fn format_scan_output(
+    outcome: &pipeline::PipelineOutcome,
+    paths: &[PathBuf],
+    elapsed: Duration,
+    cancelled: bool,
+    format: crate::cli::OutputFormat,
+) -> Result<()> {
+    if matches!(format, crate::cli::OutputFormat::Json) {
+        output::print_json(&scan_json_summary(outcome, paths, elapsed, cancelled))?;
+    } else {
+        output::format_scan_results(&outcome.formatted, format);
+    }
+    Ok(())
+}
+
+fn scan_json_summary(
+    outcome: &pipeline::PipelineOutcome,
+    paths: &[PathBuf],
+    elapsed: Duration,
+    cancelled: bool,
+) -> serde_json::Value {
+    serde_json::json!({
+        "command": "scan",
+        "status": if cancelled { "cancelled" } else { "ok" },
+        "cancelled": cancelled,
+        "paths": paths.iter().map(|p| p.display().to_string()).collect::<Vec<_>>(),
+        "elapsed_ms": u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX),
+        "counts": {
+            "files_discovered": outcome.files_discovered,
+            "files_introspected": outcome.files_introspected,
+            "discovery_errors": outcome.discovery_errors,
+            "probe_errors": outcome.probe_errors,
+            "errors": outcome.errors(),
+            "orphans": outcome.orphans,
+            "missing": outcome.missing,
+            "moved": outcome.moved,
+            "external_changes": outcome.external_changes,
+        },
+        "files": outcome.formatted.iter().map(|(path, size, hash)| {
+            serde_json::json!({
+                "path": path.display().to_string(),
+                "size": size,
+                "hash": hash,
+            })
+        }).collect::<Vec<_>>(),
+    })
 }
 
 /// Print the discovery/hashing summary line.
@@ -494,7 +545,10 @@ fn print_verify_summary(records: &[VerificationRecord]) {
 #[cfg(test)]
 mod streaming_tests {
     use super::pipeline::{self, PipelineOutcome};
+    use super::scan_json_summary;
+    use std::path::PathBuf;
     use std::sync::Arc;
+    use std::time::Duration;
     use tempfile::TempDir;
     use tokio_util::sync::CancellationToken;
     use voom_domain::media::{Container, MediaFile, Track, TrackType};
@@ -562,6 +616,45 @@ mod streaming_tests {
         for n in names {
             std::fs::write(root.join(n), b"fake-media-data").unwrap();
         }
+    }
+
+    #[test]
+    fn scan_json_summary_includes_counts_and_files() {
+        let outcome = PipelineOutcome {
+            files_discovered: 1,
+            files_introspected: 1,
+            discovery_errors: 0,
+            probe_errors: 0,
+            moved: 2,
+            external_changes: 3,
+            missing: 4,
+            orphans: 5,
+            formatted: vec![(
+                PathBuf::from("/media/a.mkv"),
+                123,
+                Some("abcdef".to_string()),
+            )],
+        };
+
+        let json = scan_json_summary(
+            &outcome,
+            &[PathBuf::from("/media")],
+            Duration::from_millis(42),
+            false,
+        );
+
+        assert_eq!(json["command"], "scan");
+        assert_eq!(json["status"], "ok");
+        assert_eq!(json["elapsed_ms"], 42);
+        assert_eq!(json["counts"]["files_discovered"], 1);
+        assert_eq!(json["counts"]["files_introspected"], 1);
+        assert_eq!(json["counts"]["moved"], 2);
+        assert_eq!(json["counts"]["external_changes"], 3);
+        assert_eq!(json["counts"]["missing"], 4);
+        assert_eq!(json["counts"]["orphans"], 5);
+        assert_eq!(json["files"][0]["path"], "/media/a.mkv");
+        assert_eq!(json["files"][0]["size"], 123);
+        assert_eq!(json["files"][0]["hash"], "abcdef");
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/voom-cli/src/commands/serve.rs
+++ b/crates/voom-cli/src/commands/serve.rs
@@ -69,6 +69,7 @@ fn process_args_from_launch_request(request: ProcessRunLaunchRequest) -> Process
         confirm_savings: None,
         priority_by_date: false,
         execute_during_discovery: false,
+        format: crate::cli::OutputFormat::Table,
     }
 }
 

--- a/crates/voom-cli/src/commands/version.rs
+++ b/crates/voom-cli/src/commands/version.rs
@@ -1,0 +1,44 @@
+use anyhow::Result;
+use serde::Serialize;
+
+use crate::cli::OutputFormat;
+use crate::output;
+
+#[derive(Serialize)]
+struct VersionMetadata {
+    command: &'static str,
+    product_version: &'static str,
+    package_version: &'static str,
+    git_sha: &'static str,
+    git_dirty: bool,
+    build_profile: &'static str,
+    target: &'static str,
+}
+
+pub fn run(format: OutputFormat) -> Result<()> {
+    let metadata = VersionMetadata {
+        command: "version",
+        product_version: env!("VOOM_PRODUCT_VERSION"),
+        package_version: env!("CARGO_PKG_VERSION"),
+        git_sha: env!("VOOM_GIT_SHA"),
+        git_dirty: env!("VOOM_GIT_DIRTY") == "true",
+        build_profile: build_profile(),
+        target: env!("VOOM_BUILD_TARGET"),
+    };
+
+    match format {
+        OutputFormat::Json => output::print_json(&metadata),
+        OutputFormat::Table | OutputFormat::Plain | OutputFormat::Csv => {
+            println!("voom {}", metadata.product_version);
+            Ok(())
+        }
+    }
+}
+
+fn build_profile() -> &'static str {
+    if cfg!(debug_assertions) {
+        "debug"
+    } else {
+        "release"
+    }
+}

--- a/crates/voom-cli/src/main.rs
+++ b/crates/voom-cli/src/main.rs
@@ -60,6 +60,7 @@ async fn main() -> Result<()> {
         Commands::Files(sub) => commands::files::run(sub, global_yes),
         Commands::Plans(sub) => commands::plans::run(sub),
         Commands::Events(args) => commands::events::run(args, token).await,
+        Commands::Version(args) => commands::version::run(args.format),
         Commands::Env(sub) => commands::env::run(sub),
         Commands::Health(sub) => {
             commands::env::warn_health_deprecated();
@@ -116,8 +117,10 @@ fn command_output_format(command: &Commands) -> Option<OutputFormat> {
     match command {
         Commands::Scan(args) => args.format,
         Commands::Inspect(args) => Some(args.format),
+        Commands::Process(args) => Some(args.format),
         Commands::Report(args) => Some(args.format),
         Commands::Events(args) => Some(args.format),
+        Commands::Version(args) => Some(args.format),
         Commands::History(args) => Some(args.format),
         Commands::Plans(cli::PlansCommands::Show { format, .. }) => Some(*format),
         Commands::Policy(PolicyCommands::List { format }) => Some(*format),

--- a/crates/voom-cli/tests/cli_tests.rs
+++ b/crates/voom-cli/tests/cli_tests.rs
@@ -162,6 +162,19 @@ fn test_version() {
 }
 
 #[test]
+fn test_version_json() {
+    let json = assert_stdout_is_json(&["version", "--format", "json"]);
+
+    assert_eq!(json["command"], "version");
+    assert_eq!(json["package_version"], env!("CARGO_PKG_VERSION"));
+    assert!(
+        json["product_version"]
+            .as_str()
+            .is_some_and(|s| !s.is_empty())
+    );
+}
+
+#[test]
 fn test_no_args_shows_help() {
     voom()
         .assert()
@@ -313,7 +326,9 @@ fn test_existing_json_outputs_are_parseable() {
         "json",
         "--no-hash",
     ]);
-    assert_eq!(empty_scan, Value::Array(vec![]));
+    assert_eq!(empty_scan["command"], "scan");
+    assert_eq!(empty_scan["counts"]["files_discovered"], 0);
+    assert_eq!(empty_scan["files"], Value::Array(vec![]));
 
     let tools = assert_stdout_is_json(&["tools", "list", "--format", "json"]);
     assert!(tools.is_array());

--- a/docs/cli-agent-friendliness-audit.md
+++ b/docs/cli-agent-friendliness-audit.md
@@ -17,9 +17,10 @@ agent-friendly output work. It should be updated as phases land.
 
 | Command | Mutates state | Format flag | JSON support | Empty JSON shape | Prompts | Progress/status notes |
 |---|---:|---:|---:|---|---:|---|
-| `scan` | yes | partial | yes | `[]` | no | progress/status should be quiet for machine formats |
+| `version` | no | yes | yes | version metadata object | no | query command |
+| `scan` | yes | partial | yes | scan summary object with empty `files` | no | progress/status should be quiet for machine formats |
 | `inspect` | no | yes | yes | n/a | no | may introspect missing DB entries |
-| `process` | yes | no | `--plan-only` only | `[]` for no plans | optional approval | long-running progress/status |
+| `process` | yes | yes | yes | process summary object; `--plan-only` still emits plan array | optional approval | long-running progress/status |
 | `estimate` | yes, calibration data | no | no | n/a | no | summary is human-only |
 | `policy list` | no | yes | yes | `[]` | no | query command |
 | `policy validate` | no | yes | yes | validation object | no | query command |
@@ -77,7 +78,24 @@ agent-friendly output work. It should be updated as phases land.
 
 The initial contract tests cover:
 
-- Existing JSON stdout parses for `scan --format json`, `tools list --format
-  json`, and `env check --format json`.
+- Existing JSON stdout parses for `version --format json`, `scan --format
+  json`, `process --format json`, `tools list --format json`, and `env check
+  --format json`.
 - JSON stdout excludes representative human status text.
 - Human scan status is emitted on stderr for table/human output.
+
+## E2E JSON Consumers
+
+The `scripts/e2e-policy-audit` harness now captures JSON artifacts from
+agent-facing commands and uses them in summary checks:
+
+- `env/version.json` from `voom version --format json`.
+- `reports/env-check.json` from `voom env check --format json`.
+- `reports/policy-validate.json` from `voom policy validate --format json`.
+- `reports/scan.json` from `voom scan --format json`.
+- `reports/process.json` from `voom process --format json`.
+- `reports/jobs.json` from `voom jobs list --format json`.
+- `reports/report.json` from `voom report --all --format json`.
+
+`jobs.json` is the preferred source for detecting non-terminal jobs in the
+generated run summary; the human `jobs.txt` artifact remains a fallback.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -25,6 +25,31 @@ progress, warnings, status notes, and deprecation notices are written to stderr.
 
 ## Commands
 
+### `voom version`
+
+Print version and build metadata.
+
+```
+voom version [OPTIONS]
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `-f`, `--format <FORMAT>` | `table` | Output format: `table`, `json`, `plain`, or `csv` |
+
+Human formats print `voom <version>`. JSON output is intended for automation
+and includes stable top-level fields: `command`, `product_version`,
+`package_version`, `git_sha`, `git_dirty`, `build_profile`, and `target`.
+
+**Examples:**
+
+```bash
+voom version
+voom version --format json
+```
+
+---
+
 ### `voom scan`
 
 Discover and introspect media files in one or more directories.
@@ -38,12 +63,21 @@ voom scan <PATH>... [OPTIONS]
 | `<PATH>...` | *required* | Directories to scan for media files (one or more) |
 | `-r`, `--recursive` | `true` | Recurse into subdirectories |
 | `-w`, `--workers <N>` | `0` (auto) | Number of parallel workers for hashing |
+| `--probe-workers <N>` | `0` (auto) | Number of parallel workers for ffprobe introspection |
 | `--no-hash` | `false` | Skip content hashing (faster scans) |
+| `--verify` | `false` | Run a quick verification pass after introspection |
 | `-f`, `--format <FORMAT>` | *none* | Output format (omit for summary only) |
 
 Before scanning, stale database entries for files that no longer exist under the scanned directory are automatically pruned (along with their associated plans and processing stats).
 
 The scanner walks the directory tree (using rayon for parallelism), identifies media files by extension, computes xxHash64 content hashes (unless `--no-hash`), and runs ffprobe for metadata extraction. Results are stored in the SQLite database. Files that fail introspection are recorded as "bad files" for tracking and can be reviewed with `voom db list-bad`.
+
+`--format json` emits a scan summary object with `command`, `status`,
+`cancelled`, `paths`, `elapsed_ms`, `counts`, and `files`. The `counts` object
+includes discovered/introspected file counts plus discovery, probe, missing,
+orphan, moved, and external-change counts. `files` contains scanned file
+entries with `path`, `size`, and `hash`; an empty scan returns the same envelope
+with `files: []`.
 
 **Examples:**
 
@@ -51,6 +85,7 @@ The scanner walks the directory tree (using rayon for parallelism), identifies m
 voom scan /media/movies -r
 voom scan /media/tv --workers 8 --no-hash
 voom scan /media/movies /media/tv --format table
+voom scan /media/movies --format json
 ```
 
 ---
@@ -108,6 +143,7 @@ voom process <PATH>... [--policy <FILE> | --policy-map <TOML>] [OPTIONS]
 | `--confirm-savings <SIZE>` | *optional* | Execute only files whose estimated savings meet the per-file threshold |
 | `--priority-by-date` | `false` | Assign job priority based on file modification date |
 | `--execute-during-discovery` | `false` | Unlock each root for execution as soon as its walk finishes (see below) |
+| `-f`, `--format <FORMAT>` | `table` | Output format for execution summaries: `table`, `json`, `plain`, or `csv` |
 
 Before processing, stale database entries for files that no longer exist under the target directory are automatically pruned (along with their associated plans and processing stats). Files that previously failed introspection (tracked as "bad files") are automatically skipped unless `--force-rescan` is set.
 
@@ -119,6 +155,17 @@ If an executable plan fails, the file job is marked failed and the final
 summary error count is non-zero. With `--on-error continue`, the command still
 finishes the batch; inspect `voom jobs list --status failed` and
 `voom report errors --session <session>` for details.
+
+`--format json` emits a process execution summary object after execution. It
+includes `command`, `status`, `session_id`, `cancelled`, `dry_run`, `paths`,
+`workers`, `elapsed_ms`, `counts`, and `phase_stats`. The `counts` object
+includes file, processed, modified, skipped, failed-file, failed-plan, and
+backup-byte totals. `phase_stats` is keyed by phase name and reports completed,
+skipped, failed, and skip-reason counts.
+
+`--plan-only` keeps its existing behavior: it implies `--dry-run` and writes the
+raw plan array as JSON to stdout instead of the execution summary. Estimate mode
+continues to print the estimate report.
 
 #### `--execute-during-discovery` (advanced, opt-in)
 
@@ -170,6 +217,9 @@ voom process /media --policy-map policies.toml
 
 # Output plans as JSON without executing
 voom process /media/movies --policy normalize.voom --plan-only
+
+# Output an execution summary as JSON
+voom process /media/movies --policy normalize.voom --dry-run --format json
 
 # Estimate cost without executing
 voom process /media/movies --policy normalize.voom --estimate

--- a/scripts/e2e-policy-audit/README.md
+++ b/scripts/e2e-policy-audit/README.md
@@ -41,6 +41,16 @@ small library containing representative problem files:
 
 Then rerun the harness against `/tmp/voom-repro-library` with the same policy.
 
+To rerun only files that had failed plans:
+
+```bash
+~/voom-e2e-runs/<run>/repro/replay.sh
+BUILD=target/release/voom POLICY=/path/to/policy.voom ~/voom-e2e-runs/<run>/repro/replay.sh
+```
+
+`replay.sh` defaults to `command -v voom` and the policy snapshot copied into
+`env/policy.voom`.
+
 ## Pre-conditions
 
 - `~/.config/voom/voom.db` must NOT exist.
@@ -77,10 +87,14 @@ Then rerun the harness against `/tmp/voom-repro-library` with the same policy.
 │   ├── env-check.json            structured environment check result
 │   ├── events.json               raw `voom events -f json` capture
 │   └── events-deduped.json       raw events with repeated plugin errors compacted
-├── repro/                        problem-file lists + copy-repro-set.sh
+├── repro/                        problem-file lists + replay/copy scripts
+│   ├── replay.sh                 rerun failed-plan files against BUILD/POLICY
+│   └── copy-repro-set.sh         copy representative problem files to a small library
 ├── web-smoke/                    statuses + body samples + content assertions
 ├── diffs/
 │   ├── plugin-error-summary.md   repeated plugin.error signatures by plugin
+│   ├── plan-preview-vs-executed.tsv/.md  planned vs executed phase/action/skip diff
+│   ├── deprecations.md           `warning:` lines from logs/*.log
 │   ├── failure-timeline.md       failed plans bucketed by hour and cause
 │   ├── runtime-timeline.md       summarized runtime host state changes
 │   ├── env-check-timeline.md     summarized env check state changes
@@ -114,6 +128,9 @@ For large runs, start with the aggregate views:
   spread across the run.
 - `diffs/failure-clusters.md` groups failed plans by phase, error signature,
   exit code, source container, and source video codec.
+- `diffs/plan-preview-vs-executed.md` highlights drift between `--plan-only`
+  preview plans and the plans persisted after execution.
+- `diffs/deprecations.md` lists `warning:` lines emitted by CLI invocations.
 - `diffs/plugin-error-summary.md` compresses repeated plugin error payloads and
   points to per-plugin logs under `logs/plugin-errors/`.
 - `diffs/db-vs-ffprobe-post-summary.md` groups post-run introspection
@@ -123,6 +140,17 @@ For large runs, start with the aggregate views:
   independently of VOOM's DB view.
 - `repro/minimal-covering-set.tsv` picks a capped set of representative files
   per failure/diff signature for faster follow-up runs.
+
+## Pre-Release Audit Gates
+
+Pre-release audit runs should have:
+
+- zero rows in `diffs/plan-preview-vs-executed.tsv`, unless each divergence is
+  intentionally explained in release notes;
+- zero warnings in `diffs/deprecations.md`.
+
+Set `VOOM_E2E_FAIL_ON_DEPRECATIONS=1` to make warning lines a hard summary
+failure instead of a soft warning.
 
 ## Canonical metadata comparison
 

--- a/scripts/e2e-policy-audit/README.md
+++ b/scripts/e2e-policy-audit/README.md
@@ -59,6 +59,7 @@ Then rerun the harness against `/tmp/voom-repro-library` with the same policy.
 │   └── voom-db-tables/           raw SQLite export (per-table TSV) post-scan / post-process
 ├── runtime/                      5-minute host state samples during voom process
 ├── env/                          tool versions, GPU state, policy copy, redacted config
+│   ├── version.json              structured VOOM build/version metadata
 │   ├── journal.log               host journal captured after voom process
 │   ├── dmesg.log                 kernel ring buffer captured after voom process
 │   ├── dnf-history.txt           recent package manager history
@@ -68,6 +69,12 @@ Then rerun the harness against `/tmp/voom-repro-library` with the same policy.
 │   └── env-check/                hourly voom env check snapshots during process
 ├── db-export/                    raw SQLite tables (post-process; consumed by build-summary)
 ├── reports/                      voom report --all, files, plans, jobs, events
+│   ├── scan.json                 structured `voom scan --format json` summary
+│   ├── process.json              structured `voom process --format json` summary
+│   ├── jobs.json                 structured `voom jobs list --format json` output
+│   ├── report.json               structured `voom report --all --format json` output
+│   ├── policy-validate.json      structured policy validation result
+│   ├── env-check.json            structured environment check result
 │   ├── events.json               raw `voom events -f json` capture
 │   └── events-deduped.json       raw events with repeated plugin errors compacted
 ├── repro/                        problem-file lists + copy-repro-set.sh

--- a/scripts/e2e-policy-audit/lib/build-replay-script.py
+++ b/scripts/e2e-policy-audit/lib/build-replay-script.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Generate repro/replay.sh for failed e2e plan files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+SCRIPT = """#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+run_dir="$(cd "${script_dir}/.." && pwd)"
+
+BUILD="${BUILD:-$(command -v voom)}"
+POLICY="${POLICY:-${run_dir}/env/policy.voom}"
+paths_file="${script_dir}/failed-plan-files.tsv"
+
+if [[ -z "${BUILD}" || ! -x "${BUILD}" ]]; then
+  echo "voom binary not found; set BUILD=/path/to/voom" >&2
+  exit 1
+fi
+
+if [[ ! -r "${paths_file}" ]]; then
+  echo "failed plan list not found: ${paths_file}" >&2
+  exit 1
+fi
+
+mapfile -t paths < <(awk -F '\\t' 'NR > 1 && $1 != "" {print $1}' "${paths_file}")
+if ((${#paths[@]} == 0)); then
+  echo "No failed plan files to replay."
+  exit 0
+fi
+
+exec "${BUILD}" process -y --on-error continue --policy "${POLICY}" "${paths[@]}"
+"""
+
+
+def validate_json_if_present(path: Path) -> None:
+    if path.exists():
+        with path.open() as f:
+            json.load(f)
+
+
+def build(run_dir: Path) -> None:
+    validate_json_if_present(run_dir / "manifest.json")
+    validate_json_if_present(run_dir / "reports" / "process.json")
+
+    repro_dir = run_dir / "repro"
+    repro_dir.mkdir(parents=True, exist_ok=True)
+    script = repro_dir / "replay.sh"
+    script.write_text(SCRIPT)
+    script.chmod(0o755)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("run_dir")
+    args = parser.parse_args()
+    build(Path(args.run_dir))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/e2e-policy-audit/lib/build-summary.sh
+++ b/scripts/e2e-policy-audit/lib/build-summary.sh
@@ -146,8 +146,24 @@ if ((total_failed_plans > 0)); then
   fi
 fi
 
-"${script_dir}/build-repro-set.py" "${run}" ||
-  note_warn "failed to build repro file set"
+plan_diff_tsv="${run}/diffs/plan-preview-vs-executed.tsv"
+if [[ -f "${plan_diff_tsv}" ]]; then
+  plan_diff_count=$(awk 'NR > 1 {count++} END {print count + 0}' "${plan_diff_tsv}")
+  ((plan_diff_count > 0)) && note_warn "${plan_diff_count} plan preview/executed divergence(s)"
+fi
+
+deprecations_md="${run}/diffs/deprecations.md"
+if [[ -f "${deprecations_md}" ]]; then
+  deprecation_count=$(awk '/^Warnings:/ {print $2}' "${deprecations_md}")
+  [[ -z "${deprecation_count}" ]] && deprecation_count=0
+  if ((deprecation_count > 0)); then
+    if [[ "${VOOM_E2E_FAIL_ON_DEPRECATIONS:-0}" == "1" ]]; then
+      note_fail "${deprecation_count} deprecation warning(s)"
+    else
+      note_warn "${deprecation_count} deprecation warning(s)"
+    fi
+  fi
+fi
 
 # Render
 {
@@ -213,6 +229,20 @@ fi
     echo "(not generated)"
   fi
   echo
+  echo "### Plan preview vs executed"
+  if [[ -s "${run}/diffs/plan-preview-vs-executed.md" ]]; then
+    sed -n '1,24p' "${run}/diffs/plan-preview-vs-executed.md"
+  else
+    echo "(not generated)"
+  fi
+  echo
+  echo "### Deprecation warnings"
+  if [[ -s "${run}/diffs/deprecations.md" ]]; then
+    sed -n '1,24p' "${run}/diffs/deprecations.md"
+  else
+    echo "(not generated)"
+  fi
+  echo
   echo "### Failed plans (first 20)"
   echo '```'
   if [[ -f "${failed_plans}" ]] && [[ $(awk 'END {print NR}' "${failed_plans}") -gt 1 ]]; then
@@ -270,6 +300,10 @@ fi
   link_artifact_if_exists "diffs/env-check-timeline.md"
   link_artifact_if_exists "diffs/failure-timeline.md"
   link_artifact_if_exists "diffs/plugin-error-summary.md"
+  link_artifact_if_exists "diffs/plan-preview-vs-executed.md"
+  link_artifact_if_exists "diffs/plan-preview-vs-executed.tsv"
+  link_artifact_if_exists "diffs/deprecations.md"
+  link_artifact_if_exists "repro/replay.sh"
   link_artifact_if_exists "reports/events-deduped.json"
   link_artifact_if_exists "reports/process.json"
   link_artifact_if_exists "reports/scan.json"

--- a/scripts/e2e-policy-audit/lib/build-summary.sh
+++ b/scripts/e2e-policy-audit/lib/build-summary.sh
@@ -91,8 +91,14 @@ if [[ -f "${statuses}" ]]; then
 fi
 
 # Job stragglers
+jobs_json="${run}/reports/jobs.json"
 jobs_report="${run}/reports/jobs.txt"
-if [[ -f "${jobs_report}" ]]; then
+if [[ -f "${jobs_json}" ]]; then
+  if jq -e '.jobs[]? | select(.status == "running" or .status == "pending")' \
+    "${jobs_json}" >/dev/null; then
+    note_fail "jobs report contains non-terminal states (running/pending)"
+  fi
+elif [[ -f "${jobs_report}" ]]; then
   if grep -Eqi '\b(running|pending)\b' "${jobs_report}"; then
     note_fail "jobs report contains non-terminal states (running/pending)"
   fi
@@ -128,7 +134,12 @@ if ((total_failed_plans > 0)); then
   if [[ -f "${process_rc_file}" ]] && [[ "$(cat "${process_rc_file}")" == "0" ]]; then
     note_warn "process exited 0 despite ${total_failed_plans} failed plan(s)"
   fi
-  if [[ -f "${jobs_report}" ]] &&
+  if [[ -f "${jobs_json}" ]] &&
+    jq -e '([.jobs[]? | select(.status == "completed")] | length) > 0
+           and ([.jobs[]? | select(.status == "failed")] | length) == 0' \
+      "${jobs_json}" >/dev/null; then
+    note_warn "jobs report has completed jobs but no failed jobs despite ${total_failed_plans} failed plan(s)"
+  elif [[ -f "${jobs_report}" ]] &&
     grep -qE 'completed:[[:space:]]+[1-9][0-9]*' "${jobs_report}" &&
     ! grep -qE 'failed:[[:space:]]+[1-9][0-9]*' "${jobs_report}"; then
     note_warn "jobs report has completed jobs but no failed jobs despite ${total_failed_plans} failed plan(s)"
@@ -260,6 +271,13 @@ fi
   link_artifact_if_exists "diffs/failure-timeline.md"
   link_artifact_if_exists "diffs/plugin-error-summary.md"
   link_artifact_if_exists "reports/events-deduped.json"
+  link_artifact_if_exists "reports/process.json"
+  link_artifact_if_exists "reports/scan.json"
+  link_artifact_if_exists "reports/jobs.json"
+  link_artifact_if_exists "reports/report.json"
+  link_artifact_if_exists "reports/policy-validate.json"
+  link_artifact_if_exists "reports/env-check.json"
+  link_artifact_if_exists "env/version.json"
   link_artifact_if_exists "logs/plugin-errors/"
   link_artifact_if_exists "runtime/"
   link_artifact_if_exists "env/journal.log"

--- a/scripts/e2e-policy-audit/lib/deprecations.py
+++ b/scripts/e2e-policy-audit/lib/deprecations.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Collect CLI warning lines from e2e logs."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def collect(logs_dir: Path) -> list[tuple[str, int, str]]:
+    rows: list[tuple[str, int, str]] = []
+    for log in sorted(logs_dir.glob("*.log")):
+        with log.open(errors="replace") as f:
+            for number, line in enumerate(f, start=1):
+                text = line.rstrip("\n")
+                if text.startswith("warning:"):
+                    rows.append((log.name, number, text))
+    return rows
+
+
+def write_md(path: Path, rows: list[tuple[str, int, str]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as f:
+        f.write("# Deprecation Warnings\n\n")
+        f.write(f"Warnings: {len(rows)}\n\n")
+        if not rows:
+            f.write("(none)\n")
+            return
+        f.write("| Log | Line | Warning |\n")
+        f.write("|---|---:|---|\n")
+        for log_name, line_number, warning in rows:
+            escaped = warning.replace("|", "\\|")
+            f.write(f"| {log_name} | {line_number} | {escaped} |\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("logs_dir")
+    parser.add_argument("out_md")
+    args = parser.parse_args()
+    write_md(Path(args.out_md), collect(Path(args.logs_dir)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/e2e-policy-audit/lib/plan-preview-vs-executed.py
+++ b/scripts/e2e-policy-audit/lib/plan-preview-vs-executed.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Compare plan-only preview JSON with executed plans.tsv."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_json(path: Path) -> list[dict[str, Any]]:
+    text = path.read_text().strip()
+    if not text:
+        return []
+    data = json.loads(text)
+    if not isinstance(data, list):
+        raise SystemExit(f"{path}: expected a JSON array")
+    return data
+
+
+def file_paths(files_tsv: Path) -> dict[str, str]:
+    with files_tsv.open(newline="") as f:
+        reader = csv.DictReader(f, delimiter="\t")
+        return {
+            row["id"]: row["path"]
+            for row in reader
+            if row.get("id") and row.get("path")
+        }
+
+
+def stable_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def normalize_action(action: dict[str, Any]) -> str:
+    fields = {key: value for key, value in action.items() if value is not None}
+    parts: list[str] = []
+    for key in sorted(fields):
+        value = fields[key]
+        if isinstance(value, (dict, list)):
+            parts.append(f"{key}={stable_json(value)}")
+        else:
+            parts.append(f"{key}={value}")
+    return ";".join(parts)
+
+
+def action_signature(actions: Any) -> str:
+    if isinstance(actions, str):
+        actions = json.loads(actions or "[]")
+    if not actions:
+        return ""
+    return " | ".join(normalize_action(action) for action in actions)
+
+
+def preview_rows(preview_json: Path) -> dict[tuple[str, str], dict[str, str]]:
+    rows: dict[tuple[str, str], dict[str, str]] = {}
+    for item in load_json(preview_json):
+        path = str((item.get("file") or {}).get("path") or item.get("path") or "")
+        phase = str(item.get("phase_name") or item.get("phase") or "")
+        if not path or not phase:
+            continue
+        rows[(path, phase)] = {
+            "status": "skipped" if item.get("skip_reason") else "planned",
+            "actions": action_signature(item.get("actions") or []),
+            "skip_reason": str(item.get("skip_reason") or ""),
+        }
+    return rows
+
+
+def executed_rows(plans_tsv: Path, files_tsv: Path) -> dict[tuple[str, str], dict[str, str]]:
+    paths = file_paths(files_tsv)
+    rows: dict[tuple[str, str], dict[str, str]] = {}
+    with plans_tsv.open(newline="") as f:
+        reader = csv.DictReader(f, delimiter="\t")
+        for row in reader:
+            path = paths.get(row.get("file_id", ""), "")
+            phase = row.get("phase_name", "")
+            if not path or not phase:
+                continue
+            rows[(path, phase)] = {
+                "status": row.get("status", ""),
+                "actions": action_signature(row.get("actions", "[]")),
+                "skip_reason": row.get("skip_reason", ""),
+            }
+    return rows
+
+
+def diff_rows(
+    preview: dict[tuple[str, str], dict[str, str]],
+    executed: dict[tuple[str, str], dict[str, str]],
+) -> list[dict[str, str]]:
+    out: list[dict[str, str]] = []
+    for key in sorted(set(preview) | set(executed)):
+        p = preview.get(key)
+        e = executed.get(key)
+        path, phase = key
+        if p is None:
+            out.append(
+                {
+                    "path": path,
+                    "phase": phase,
+                    "diff_class": "executed-only",
+                    "preview": "",
+                    "executed": e["status"],
+                }
+            )
+            continue
+        if e is None:
+            out.append(
+                {
+                    "path": path,
+                    "phase": phase,
+                    "diff_class": "preview-only",
+                    "preview": p["status"],
+                    "executed": "",
+                }
+            )
+            continue
+        if p["skip_reason"] != e["skip_reason"]:
+            out.append(
+                {
+                    "path": path,
+                    "phase": phase,
+                    "diff_class": "skip-reason",
+                    "preview": p["skip_reason"],
+                    "executed": e["skip_reason"],
+                }
+            )
+        if p["actions"] != e["actions"]:
+            out.append(
+                {
+                    "path": path,
+                    "phase": phase,
+                    "diff_class": "action-params",
+                    "preview": p["actions"],
+                    "executed": e["actions"],
+                }
+            )
+    return out
+
+
+def write_tsv(path: Path, rows: list[dict[str, str]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fields = ["path", "phase", "diff_class", "preview", "executed"]
+    with path.open("w") as f:
+        f.write("\t".join(fields) + "\n")
+        for row in rows:
+            f.write("\t".join(row[field].replace("\t", " ") for field in fields) + "\n")
+
+
+def md_escape(value: str) -> str:
+    return value.replace("|", "\\|")
+
+
+def write_md(path: Path, rows: list[dict[str, str]]) -> None:
+    with path.open("w") as f:
+        f.write("# Plan Preview vs Executed\n\n")
+        f.write(f"Divergences: {len(rows)}\n\n")
+        if not rows:
+            f.write("(none)\n")
+            return
+        f.write("| Path | Phase | Diff | Preview | Executed |\n")
+        f.write("|---|---|---|---|---|\n")
+        for row in rows[:100]:
+            f.write(
+                f"| `{md_escape(row['path'])}` | {md_escape(row['phase'])} | "
+                f"{md_escape(row['diff_class'])} | {md_escape(row['preview'])} | "
+                f"{md_escape(row['executed'])} |\n"
+            )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("preview_json")
+    parser.add_argument("plans_tsv")
+    parser.add_argument("files_tsv")
+    parser.add_argument("out_tsv")
+    parser.add_argument("out_md")
+    args = parser.parse_args()
+    rows = diff_rows(
+        preview_rows(Path(args.preview_json)),
+        executed_rows(Path(args.plans_tsv), Path(args.files_tsv)),
+    )
+    write_tsv(Path(args.out_tsv), rows)
+    write_md(Path(args.out_md), rows)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/e2e-policy-audit/run.sh
+++ b/scripts/e2e-policy-audit/run.sh
@@ -101,6 +101,16 @@ log_run() {
     return 0
 }
 
+json_run() {
+    local name="$1"
+    local out="$2"
+    shift 2
+    local rc=0
+    "$@" >"${out}" 2>"${run_dir}/logs/${name}.log" || rc=$?
+    echo "${rc}" >"${run_dir}/logs/${name}.log.rc"
+    return 0
+}
+
 runtime_sampler_pid=""
 env_check_sampler_pid=""
 runtime_sampler_uses_group=0
@@ -215,7 +225,7 @@ run_process_command() {
         active_process_uses_group=1
     else
         active_process_uses_group=0
-    fi >"${run_dir}/logs/process.log" 2>&1
+    fi >"${run_dir}/reports/process.json" 2>"${run_dir}/logs/process.log"
     active_process_pid=$!
 
     trap 'stop_process_samplers' EXIT
@@ -248,9 +258,11 @@ fi
     exit 1
 }
 
+json_run version-json "${run_dir}/env/version.json" "${voom_bin}" version --format json
 log_run version "${voom_bin}" --version
-log_run env-check "${voom_bin}" env check
-log_run policy-validate "${voom_bin}" policy validate "${policy}"
+json_run env-check "${run_dir}/reports/env-check.json" "${voom_bin}" env check --format json
+json_run policy-validate "${run_dir}/reports/policy-validate.json" \
+    "${voom_bin}" policy validate "${policy}" --format json
 
 # ---- Pre snapshot + probe ----
 echo "==> Pre-snapshot"
@@ -269,7 +281,7 @@ fi
 # ---- Discover + introspect ----
 echo "==> voom scan"
 t=$(stage_start)
-log_run scan "${voom_bin}" scan -r -y "${library}"
+json_run scan "${run_dir}/reports/scan.json" "${voom_bin}" scan -r -y "${library}" --format json
 stage_end scan "$t"
 
 log_run files-list "${voom_bin}" files list -f csv
@@ -291,12 +303,13 @@ run_start=$(date -Iseconds)
 echo "==> voom process (long run starts at ${run_start})"
 t=$(stage_start)
 start_process_samplers
-run_process_command "${voom_bin}" process -y --on-error continue --policy "${policy}" "${library}"
+run_process_command "${voom_bin}" process -y --on-error continue --policy "${policy}" --format json "${library}"
 stop_process_samplers
 trap - EXIT INT TERM
 stage_end process "$t"
 "${lib_dir}/capture-host-journal.sh" "${run_dir}" "${run_start}" ||
     echo "host journal capture failed (continuing)" >&2
+json_run jobs-list-json "${run_dir}/reports/jobs.json" "${voom_bin}" jobs list --format json
 log_run jobs-list "${voom_bin}" jobs list
 cp "${run_dir}/logs/jobs-list.log" "${run_dir}/reports/jobs.txt"
 
@@ -336,6 +349,7 @@ cp "${run_dir}/logs/events.log" "${run_dir}/reports/events.json"
     "${run_dir}/logs/plugin-errors" \
     "${run_dir}/diffs/plugin-error-summary.md" ||
     echo "plugin error dedupe failed (continuing)" >&2
+json_run report-json "${run_dir}/reports/report.json" "${voom_bin}" report --all --format json
 log_run report "${voom_bin}" report --all
 cp "${run_dir}/logs/report.log" "${run_dir}/reports/report.txt"
 

--- a/scripts/e2e-policy-audit/run.sh
+++ b/scripts/e2e-policy-audit/run.sh
@@ -151,7 +151,6 @@ signal_process() {
 stop_process_tree() {
     local pid="$1" uses_group="$2"
     local initial_signal="${3:-TERM}"
-    local i
 
     if [[ -z "${pid}" ]]; then
         return 0
@@ -167,7 +166,7 @@ stop_process_tree() {
     done
 
     signal_process "${pid}" "${uses_group}" KILL
-    for i in {1..5}; do
+    for _ in {1..5}; do
         if ! process_is_live "${pid}" "${uses_group}"; then
             break
         fi
@@ -427,6 +426,25 @@ if [[ -f "${run_dir}/db-export/plans.tsv" ]]; then
         "${run_dir}/diffs/failure-timeline.md" ||
         echo "failure timeline generation failed (continuing)" >&2
 fi
+"${lib_dir}/build-repro-set.py" "${run_dir}" ||
+    echo "failed to build repro file set (continuing)" >&2
+"${lib_dir}/build-replay-script.py" "${run_dir}" ||
+    echo "failed to build replay script (continuing)" >&2
+if [[ -r "${run_dir}/reports/plans.json" &&
+    -r "${run_dir}/db-export/plans.tsv" &&
+    -r "${run_dir}/db-export/files.tsv" ]]; then
+    "${lib_dir}/plan-preview-vs-executed.py" \
+        "${run_dir}/reports/plans.json" \
+        "${run_dir}/db-export/plans.tsv" \
+        "${run_dir}/db-export/files.tsv" \
+        "${run_dir}/diffs/plan-preview-vs-executed.tsv" \
+        "${run_dir}/diffs/plan-preview-vs-executed.md" ||
+        echo "plan preview/executed diff failed (continuing)" >&2
+fi
+"${lib_dir}/deprecations.py" \
+    "${run_dir}/logs" \
+    "${run_dir}/diffs/deprecations.md" ||
+    echo "deprecation scan failed (continuing)" >&2
 stage_end diff "$t"
 
 # Mark completion timestamp

--- a/scripts/e2e-policy-audit/tests/expected/deprecations/deprecations.md
+++ b/scripts/e2e-policy-audit/tests/expected/deprecations/deprecations.md
@@ -1,0 +1,7 @@
+# Deprecation Warnings
+
+Warnings: 1
+
+| Log | Line | Warning |
+|---|---:|---|
+| doctor.log | 1 | warning: `voom doctor` is deprecated; use `voom env check` instead |

--- a/scripts/e2e-policy-audit/tests/expected/plan-preview-vs-executed/plan-preview-vs-executed.md
+++ b/scripts/e2e-policy-audit/tests/expected/plan-preview-vs-executed/plan-preview-vs-executed.md
@@ -1,0 +1,8 @@
+# Plan Preview vs Executed
+
+Divergences: 2
+
+| Path | Phase | Diff | Preview | Executed |
+|---|---|---|---|---|
+| `/lib/a.mkv` | transcode-video | action-params | operation=transcode;parameters={"codec":"hevc","crf":23,"hw":"nvenc","hw_fallback":true,"preset":"slow"} | operation=transcode;parameters={"codec":"hevc","crf":24,"hw":"nvenc","hw_fallback":true,"preset":"slow"} |
+| `/lib/c.mkv` | metadata | action-params | operation=set_language;parameters={"language":"eng"};track_index=1 | operation=set_language;parameters={"language":"jpn"};track_index=1 |

--- a/scripts/e2e-policy-audit/tests/expected/plan-preview-vs-executed/plan-preview-vs-executed.tsv
+++ b/scripts/e2e-policy-audit/tests/expected/plan-preview-vs-executed/plan-preview-vs-executed.tsv
@@ -1,0 +1,3 @@
+path	phase	diff_class	preview	executed
+/lib/a.mkv	transcode-video	action-params	operation=transcode;parameters={"codec":"hevc","crf":23,"hw":"nvenc","hw_fallback":true,"preset":"slow"}	operation=transcode;parameters={"codec":"hevc","crf":24,"hw":"nvenc","hw_fallback":true,"preset":"slow"}
+/lib/c.mkv	metadata	action-params	operation=set_language;parameters={"language":"eng"};track_index=1	operation=set_language;parameters={"language":"jpn"};track_index=1

--- a/scripts/e2e-policy-audit/tests/expected/replay/replay.sh
+++ b/scripts/e2e-policy-audit/tests/expected/replay/replay.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+run_dir="$(cd "${script_dir}/.." && pwd)"
+
+BUILD="${BUILD:-$(command -v voom)}"
+POLICY="${POLICY:-${run_dir}/env/policy.voom}"
+paths_file="${script_dir}/failed-plan-files.tsv"
+
+if [[ -z "${BUILD}" || ! -x "${BUILD}" ]]; then
+  echo "voom binary not found; set BUILD=/path/to/voom" >&2
+  exit 1
+fi
+
+if [[ ! -r "${paths_file}" ]]; then
+  echo "failed plan list not found: ${paths_file}" >&2
+  exit 1
+fi
+
+mapfile -t paths < <(awk -F '\t' 'NR > 1 && $1 != "" {print $1}' "${paths_file}")
+if ((${#paths[@]} == 0)); then
+  echo "No failed plan files to replay."
+  exit 0
+fi
+
+exec "${BUILD}" process -y --on-error continue --policy "${POLICY}" "${paths[@]}"

--- a/scripts/e2e-policy-audit/tests/expected/summary-failed-phase/summary.md
+++ b/scripts/e2e-policy-audit/tests/expected/summary-failed-phase/summary.md
@@ -38,6 +38,12 @@ transcode-video	unknown				1			plan-4	encoder failed
 ### Plugin error summary
 (not generated)
 
+### Plan preview vs executed
+(not generated)
+
+### Deprecation warnings
+(not generated)
+
 ### Failed plans (first 20)
 ```
 plan_id	file_id	phase	result

--- a/scripts/e2e-policy-audit/tests/test.sh
+++ b/scripts/e2e-policy-audit/tests/test.sh
@@ -177,6 +177,166 @@ EOF
 
 run_summary_jobs_json_straggler_test
 
+run_summary_deprecation_gate_test() {
+  local actual
+  local summary
+
+  actual=$(mktemp -d)
+  trap 'rm -R "${actual}"' EXIT
+
+  mkdir -p "${actual}/logs" "${actual}/reports" "${actual}/db-export" "${actual}/diffs"
+
+  for log_name in env-check policy-validate scan; do
+    printf '0\n' >"${actual}/logs/${log_name}.log.rc"
+  done
+
+  cat >"${actual}/diffs/files-summary.md" <<'EOF'
+# Snapshot Diff Summary
+
+Disappeared paths: 0
+Missing backup post-run: 0
+EOF
+  cat >"${actual}/diffs/deprecations.md" <<'EOF'
+# Deprecation Warnings
+
+Warnings: 1
+
+| Log | Line | Warning |
+|---|---:|---|
+| doctor.log | 1 | warning: deprecated |
+EOF
+
+  VOOM_E2E_FAIL_ON_DEPRECATIONS=1 "lib/build-summary.sh" "${actual}" 0 0
+
+  summary="${actual}/summary.md"
+  if ! grep -Fq "FAIL: 1 deprecation warning(s)" "${summary}"; then
+    echo "FAIL: deprecation hard gate did not fail summary" >&2
+    fail=1
+  fi
+
+  rm -R "${actual}"
+  trap - EXIT
+}
+
+run_summary_deprecation_gate_test
+
+run_replay_script_test() {
+  local actual
+  actual=$(mktemp -d)
+  trap 'rm -R "${actual}"' EXIT
+  mkdir -p "${actual}/repro" "${actual}/env" "${actual}/reports"
+
+  cat >"${actual}/manifest.json" <<'EOF'
+{"library":"/lib","policy":"/policies/source.voom"}
+EOF
+  cat >"${actual}/env/policy.voom" <<'EOF'
+policy test {}
+EOF
+  cat >"${actual}/reports/process.json" <<'EOF'
+{"command":"process","status":"ok","session_id":"session-1","paths":["/lib"],"counts":{"failed_plans":1}}
+EOF
+  cat >"${actual}/repro/failed-plan-files.tsv" <<'EOF'
+path	phase	signature	exit_code	container	video_codec	resolution	plan_id	file_id
+/lib/show/S01E01.mkv	transcode-video	cuda-context-oom	187	mkv	h264	1920x1080	plan-1	file-1
+EOF
+
+  "lib/build-replay-script.py" "${actual}"
+  assert_match "${actual}/repro/replay.sh" "tests/expected/replay/replay.sh"
+
+  rm -R "${actual}"
+  trap - EXIT
+}
+
+run_replay_script_test
+
+run_plan_preview_vs_executed_test() {
+  local actual
+  actual=$(mktemp -d)
+  trap 'rm -R "${actual}"' EXIT
+  mkdir -p "${actual}/reports" "${actual}/db-export" "${actual}/diffs"
+
+  cat >"${actual}/reports/plans.json" <<'EOF'
+[
+  {
+    "file": {"path": "/lib/a.mkv"},
+    "phase_name": "transcode-video",
+    "actions": [
+      {"operation": "transcode", "parameters": {"codec": "hevc", "crf": 23, "preset": "slow", "hw": "nvenc", "hw_fallback": true}}
+    ],
+    "skip_reason": null
+  },
+  {
+    "file": {"path": "/lib/b.mkv"},
+    "phase_name": "transcode-video",
+    "actions": [],
+    "skip_reason": "already-compatible"
+  },
+  {
+    "file": {"path": "/lib/c.mkv"},
+    "phase_name": "metadata",
+    "actions": [
+      {"operation": "set_language", "track_index": 1, "parameters": {"language": "eng"}}
+    ],
+    "skip_reason": null
+  }
+]
+EOF
+  cat >"${actual}/db-export/files.tsv" <<'EOF'
+id	path
+file-a	/lib/a.mkv
+file-b	/lib/b.mkv
+file-c	/lib/c.mkv
+EOF
+  cat >"${actual}/db-export/plans.tsv" <<'EOF'
+id	file_id	policy_name	phase_name	status	actions	warnings	skip_reason	policy_hash	evaluated_at	created_at	session_id	executed_at	result
+plan-a	file-a	p	transcode-video	completed	[{"operation":"transcode","parameters":{"codec":"hevc","crf":24,"preset":"slow","hw":"nvenc","hw_fallback":true}}]	[]		hash	t	t	s	t	{"ok":true}
+plan-b	file-b	p	transcode-video	skipped	[]	[]	already-compatible	hash	t	t	s	t	{}
+plan-c	file-c	p	metadata	completed	[{"operation":"set_language","track_index":1,"parameters":{"language":"jpn"}}]	[]		hash	t	t	s	t	{"ok":true}
+EOF
+
+  "lib/plan-preview-vs-executed.py" \
+    "${actual}/reports/plans.json" \
+    "${actual}/db-export/plans.tsv" \
+    "${actual}/db-export/files.tsv" \
+    "${actual}/diffs/plan-preview-vs-executed.tsv" \
+    "${actual}/diffs/plan-preview-vs-executed.md"
+
+  assert_match \
+    "${actual}/diffs/plan-preview-vs-executed.tsv" \
+    "tests/expected/plan-preview-vs-executed/plan-preview-vs-executed.tsv"
+  assert_match \
+    "${actual}/diffs/plan-preview-vs-executed.md" \
+    "tests/expected/plan-preview-vs-executed/plan-preview-vs-executed.md"
+
+  rm -R "${actual}"
+  trap - EXIT
+}
+
+run_plan_preview_vs_executed_test
+
+run_deprecations_test() {
+  local actual
+  actual=$(mktemp -d)
+  trap 'rm -R "${actual}"' EXIT
+  mkdir -p "${actual}/logs" "${actual}/diffs"
+
+  cat >"${actual}/logs/doctor.log" <<'EOF'
+warning: `voom doctor` is deprecated; use `voom env check` instead
+ok
+EOF
+  cat >"${actual}/logs/process.log" <<'EOF'
+processing
+EOF
+
+  "lib/deprecations.py" "${actual}/logs" "${actual}/diffs/deprecations.md"
+  assert_match "${actual}/diffs/deprecations.md" "tests/expected/deprecations/deprecations.md"
+
+  rm -R "${actual}"
+  trap - EXIT
+}
+
+run_deprecations_test
+
 run_summary_web_smoke_fail_then_sse_warn_test() {
   local actual
   local summary

--- a/scripts/e2e-policy-audit/tests/test.sh
+++ b/scripts/e2e-policy-audit/tests/test.sh
@@ -127,6 +127,56 @@ EOF
 
 run_summary_doctor_log_rc_compat_test
 
+run_summary_jobs_json_straggler_test() {
+  local actual
+  local summary
+
+  actual=$(mktemp -d)
+  trap 'rm -R "${actual}"' EXIT
+
+  mkdir -p \
+    "${actual}/logs" \
+    "${actual}/reports" \
+    "${actual}/db-export" \
+    "${actual}/diffs"
+
+  for log_name in env-check policy-validate scan; do
+    printf '0\n' >"${actual}/logs/${log_name}.log.rc"
+  done
+
+  cat >"${actual}/diffs/files-summary.md" <<'EOF'
+# Snapshot Diff Summary
+
+Disappeared paths: 0
+Missing backup post-run: 0
+EOF
+
+  cat >"${actual}/reports/jobs.json" <<'EOF'
+{
+  "jobs": [
+    {"id": "job-1", "status": "completed"},
+    {"id": "job-2", "status": "pending"}
+  ],
+  "counts": [],
+  "limit": 50,
+  "offset": 0
+}
+EOF
+
+  "lib/build-summary.sh" "${actual}" 0 0
+
+  summary="${actual}/summary.md"
+  if ! grep -Fq "FAIL: jobs report contains non-terminal states (running/pending)" "${summary}"; then
+    echo "FAIL: jobs.json non-terminal state did not fail summary" >&2
+    fail=1
+  fi
+
+  rm -R "${actual}"
+  trap - EXIT
+}
+
+run_summary_jobs_json_straggler_test
+
 run_summary_web_smoke_fail_then_sse_warn_test() {
   local actual
   local summary


### PR DESCRIPTION
## Summary
- add `voom version --format json` with product, package, git, build profile, and target metadata
- add structured JSON envelopes for `voom scan --format json` and `voom process --format json` execution summaries
- update the e2e policy audit harness to capture and consume CLI JSON artifacts
- add issue #401 actionable e2e artifacts: replay script, preview-vs-executed plan diff, and deprecation report/gate
- document the new CLI JSON surfaces and e2e audit artifacts

## Verification
- `cargo test -p voom-cli`
- `cargo test -p voom-cli commands::process`
- `scripts/e2e-policy-audit/tests/test.sh`
- `shellcheck scripts/e2e-policy-audit/run.sh scripts/e2e-policy-audit/lib/build-summary.sh`
- `git diff --check`
- pre-commit: `cargo fmt`, `cargo clippy`

Closes #401
Closes #412
Closes #413
Closes #414
Closes #415