### PR TITLE
Plugin contract rev 6 (#378) — Phase 3: discovery migration

### DIFF
--- a/crates/voom-cli/src/app.rs
+++ b/crates/voom-cli/src/app.rs
@@ -218,7 +218,7 @@ pub fn bootstrap_kernel_with_store(config: &AppConfig) -> Result<BootstrapResult
     // Discovery
     register_if_enabled!(
         "discovery",
-        voom_discovery::DiscoveryPlugin::new(),
+        voom_discovery::DiscoveryPlugin::for_bootstrap(),
         PRIORITY_DISCOVERY,
         "discovery"
     );

--- a/crates/voom-cli/src/app.rs
+++ b/crates/voom-cli/src/app.rs
@@ -80,6 +80,11 @@ pub fn bootstrap_kernel(config: &AppConfig) -> Result<Kernel> {
 // and the collected data through many extra parameters.
 #[allow(clippy::too_many_lines)]
 pub fn bootstrap_kernel_with_store(config: &AppConfig) -> Result<BootstrapResult> {
+    // Validate config before any plugin registration so the user sees a
+    // clear "required plugin disabled" error instead of an opaque "no
+    // handler for capability" failure deep inside dispatch.
+    config.validate()?;
+
     let mut kernel = Kernel::new();
     let data_dir = &config.data_dir;
 
@@ -504,6 +509,33 @@ mod tests {
         assert!(
             !registered.iter().any(|n| n == "capability-collector"),
             "capability-collector should not be registered when disabled (registered: {registered:?})"
+        );
+    }
+
+    #[test]
+    fn bootstrap_fails_when_discovery_is_disabled() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = AppConfig {
+            data_dir: dir.path().to_path_buf(),
+            plugins: crate::config::PluginsConfig {
+                disabled_plugins: vec!["discovery".into()],
+                ..crate::config::PluginsConfig::default()
+            },
+            ..AppConfig::default()
+        };
+
+        let err = match bootstrap_kernel_with_store(&config) {
+            Ok(_) => panic!("bootstrap must fail when discovery is disabled"),
+            Err(e) => e,
+        };
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("discovery"),
+            "error must name discovery; got: {msg}"
+        );
+        assert!(
+            msg.contains("disabled_plugins") || msg.contains("required"),
+            "error must explain the cause; got: {msg}"
         );
     }
 }

--- a/crates/voom-cli/src/commands/discovery_dispatch.rs
+++ b/crates/voom-cli/src/commands/discovery_dispatch.rs
@@ -26,10 +26,6 @@ use voom_domain::call::CallResponse;
 ///   doesn't match the request. The caller fails closed.
 /// - `Err(e)`: wraps with `"filesystem scan failed for {path}"` context and
 ///   returns `Err`.
-// Tasks 5 and 6 (PR #420 follow-up) wire this helper into scan/pipeline.rs
-// and process/pipeline_streaming.rs respectively; until then it is exercised
-// only by the unit tests in this module.
-#[allow(dead_code)]
 pub(crate) fn handle_dispatch_result(
     result: std::result::Result<CallResponse, voom_domain::errors::VoomError>,
     path: &Path,

--- a/crates/voom-cli/src/commands/discovery_dispatch.rs
+++ b/crates/voom-cli/src/commands/discovery_dispatch.rs
@@ -1,0 +1,127 @@
+//! Helper for the CLI's two discovery-stage dispatchers (scan/pipeline.rs
+//! and process/pipeline_streaming.rs). Validates the `CallResponse` variant
+//! returned by `Kernel::dispatch_to_capability`, folds any `summary.errors`
+//! the plugin reported into the shared discovery-error counter, and turns a
+//! wrong response variant into a hard error.
+//!
+//! Native discovery currently always returns `errors: vec![]` because all
+//! errors flow through the in-process `options.on_error` callback. But the
+//! `Call::ScanLibrary` contract allows non-native (e.g. WASM) discovery
+//! plugins that report errors only via `summary.errors` — those would
+//! otherwise be silently discarded by the CLI.
+
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use anyhow::{Context, Result, anyhow};
+use voom_domain::call::CallResponse;
+
+/// Handle the result of `kernel.dispatch_to_capability(query, Call::ScanLibrary { ... })`
+/// for one root.
+///
+/// - `Ok(CallResponse::ScanLibrary(summary))`: increments `discovery_errors`
+///   by `summary.errors.len()` and returns `Ok(())`.
+/// - `Ok(other_variant)`: returns `Err` — the kernel returned a response that
+///   doesn't match the request. The caller fails closed.
+/// - `Err(e)`: wraps with `"filesystem scan failed for {path}"` context and
+///   returns `Err`.
+// Tasks 5 and 6 (PR #420 follow-up) wire this helper into scan/pipeline.rs
+// and process/pipeline_streaming.rs respectively; until then it is exercised
+// only by the unit tests in this module.
+#[allow(dead_code)]
+pub(crate) fn handle_dispatch_result(
+    result: std::result::Result<CallResponse, voom_domain::errors::VoomError>,
+    path: &Path,
+    discovery_errors: &Arc<AtomicU64>,
+) -> Result<()> {
+    match result {
+        Ok(CallResponse::ScanLibrary(summary)) => {
+            let added = u64::try_from(summary.errors.len()).unwrap_or(u64::MAX);
+            if added > 0 {
+                discovery_errors.fetch_add(added, Ordering::Relaxed);
+                tracing::warn!(
+                    root = %path.display(),
+                    error_count = added,
+                    "discovery dispatch reported {added} errors via ScanSummary"
+                );
+            }
+            Ok(())
+        }
+        Ok(other) => Err(anyhow!(
+            "discovery dispatch returned wrong CallResponse variant for {}: {other:?}",
+            path.display()
+        )),
+        Err(e) => Err(anyhow::Error::new(e))
+            .with_context(|| format!("filesystem scan failed for {}", path.display())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicU64;
+    use voom_domain::call::{CallResponse, DiscoveryError, ScanSummary};
+
+    #[test]
+    fn handle_ok_with_empty_errors_does_not_increment_counter() {
+        let counter = Arc::new(AtomicU64::new(0));
+        let response = Ok(CallResponse::ScanLibrary(ScanSummary::new(7, vec![], 1)));
+        let res = handle_dispatch_result(response, &PathBuf::from("/some/root"), &counter);
+        assert!(res.is_ok());
+        assert_eq!(counter.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn handle_ok_with_summary_errors_folds_into_counter() {
+        let counter = Arc::new(AtomicU64::new(0));
+        let errs = vec![
+            DiscoveryError::new("a".into(), "boom".into()),
+            DiscoveryError::new("b".into(), "kaboom".into()),
+            DiscoveryError::new("c".into(), "splat".into()),
+        ];
+        let response = Ok(CallResponse::ScanLibrary(ScanSummary::new(0, errs, 1)));
+        let res = handle_dispatch_result(response, &PathBuf::from("/some/root"), &counter);
+        assert!(res.is_ok(), "summary errors are recorded, not propagated");
+        assert_eq!(
+            counter.load(Ordering::Relaxed),
+            3,
+            "counter must be incremented by summary.errors.len()"
+        );
+    }
+
+    #[test]
+    fn handle_wrong_callresponse_variant_is_hard_error() {
+        let counter = Arc::new(AtomicU64::new(0));
+        // Orchestrate variant is wrong for a ScanLibrary dispatch.
+        let response = Ok(CallResponse::Orchestrate(
+            voom_domain::orchestration::OrchestrationResult::new(vec![], vec![], false),
+        ));
+        let res = handle_dispatch_result(response, &PathBuf::from("/some/root"), &counter);
+        let err = res.expect_err("wrong variant must be hard error");
+        assert!(
+            err.to_string().contains("wrong CallResponse variant"),
+            "error message must name the failure mode; got: {err}"
+        );
+        assert_eq!(
+            counter.load(Ordering::Relaxed),
+            0,
+            "counter must not be touched on wrong-variant error"
+        );
+    }
+
+    #[test]
+    fn handle_dispatch_err_is_propagated_with_path_context() {
+        let counter = Arc::new(AtomicU64::new(0));
+        let err = voom_domain::errors::VoomError::plugin("discovery", "boom");
+        let res = handle_dispatch_result(Err(err), &PathBuf::from("/some/root"), &counter);
+        let err = res.expect_err("dispatch Err must propagate");
+        let chain = format!("{err:#}");
+        assert!(
+            chain.contains("filesystem scan failed for /some/root"),
+            "error chain must include path context; got: {chain}"
+        );
+    }
+}

--- a/crates/voom-cli/src/commands/mod.rs
+++ b/crates/voom-cli/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod bug_report;
 pub mod completions;
 pub mod config;
 pub mod db;
+pub(crate) mod discovery_dispatch;
 pub mod env;
 pub mod estimate;
 pub mod events;

--- a/crates/voom-cli/src/commands/process/pipeline_streaming.rs
+++ b/crates/voom-cli/src/commands/process/pipeline_streaming.rs
@@ -293,8 +293,6 @@ fn spawn_discovery_stage(
     let paths = paths.to_vec();
 
     tokio::task::spawn_blocking(move || -> Result<()> {
-        let discovery = voom_discovery::DiscoveryPlugin::new();
-
         let run_scan = || -> Result<()> {
             for path in &paths {
                 if token.is_cancelled() {
@@ -333,34 +331,28 @@ fn spawn_discovery_stage(
                     );
                 }));
 
-                let token_inner = token.clone();
-                let tx_inner = tx_disc.clone();
-                let on_event: voom_discovery::EventSink = Box::new(move |event| {
-                    if token_inner.is_cancelled() {
-                        return;
-                    }
-                    // blocking_send applies natural backpressure: when the
-                    // ingest channel is full this blocks the rayon worker
-                    // until the ingest stage drains.
-                    let _ = tx_inner.blocking_send(event);
-                });
-
-                let started = std::time::Instant::now();
-                discovery
-                    .scan_streaming(&options, on_event)
+                // Route through the kernel so the discovery plugin handles the
+                // scan via `Plugin::on_call`. The plugin uses `blocking_send`
+                // on `sink` (backpressure), checks `cancel` between items, and
+                // — on a successful scan — emits a `RootWalkCompletedEvent` on
+                // `root_done` carrying our `scan_session`. The dispatcher in
+                // the ingest stage consumes those events to open the per-root
+                // gate when `execute_during_discovery` is on.
+                let call = voom_domain::call::Call::ScanLibrary {
+                    uri: format!("file://{}", path.display()),
+                    options,
+                    scan_session,
+                    sink: tx_disc.clone(),
+                    root_done: tx_root_done.clone(),
+                    cancel: token.clone(),
+                };
+                let query = voom_domain::capabilities::CapabilityQuery::Sharded {
+                    kind: "discover".into(),
+                    key: "file".into(),
+                };
+                kernel
+                    .dispatch_to_capability(query, call)
                     .with_context(|| format!("filesystem scan failed for {}", path.display()))?;
-
-                // Emit RootWalkCompleted so the dispatcher can open the gate
-                // and drain the holding buffer for this root. Only send when
-                // the channel exists (i.e. execute_during_discovery is on).
-                if let Some(tx) = tx_root_done.as_ref() {
-                    let elapsed_ms =
-                        u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
-                    let evt = RootWalkCompletedEvent::new(path.clone(), scan_session, elapsed_ms);
-                    if let Err(e) = tx.blocking_send(evt) {
-                        tracing::warn!(error = %e, "tx_root_done dropped; ingest dispatcher gone");
-                    }
-                }
             }
             Ok(())
         };
@@ -719,7 +711,18 @@ mod tests {
         config.max_workers = 2;
         config.worker_prefix = "test".into();
         let pool = Arc::new(WorkerPool::new(queue, config, token));
-        let kernel = Arc::new(voom_kernel::Kernel::new());
+        // The streaming pipeline routes discovery through
+        // `Kernel::dispatch_to_capability(Sharded { kind: "discover", key:
+        // "file" }, …)`, so the discovery plugin must be registered for the
+        // capability resolver to find a handler.
+        let mut kernel = voom_kernel::Kernel::new();
+        kernel
+            .register_plugin(
+                Arc::new(voom_discovery::DiscoveryPlugin::for_bootstrap()),
+                10,
+            )
+            .expect("register discovery");
+        let kernel = Arc::new(kernel);
         (pool, store, kernel)
     }
 

--- a/crates/voom-cli/src/commands/process/pipeline_streaming.rs
+++ b/crates/voom-cli/src/commands/process/pipeline_streaming.rs
@@ -1086,4 +1086,136 @@ mod tests {
             .count();
         assert_eq!(successes, 200, "expected all 200 jobs to succeed");
     }
+
+    /// Regression test for Codex round-3 finding #2 (PR #420).
+    ///
+    /// A discovery plugin that emits files on the sink but never sends to
+    /// `root_done` must make the process pipeline fail closed, not silently
+    /// drop the held items. Native discovery always sends root_done on
+    /// success; this test exercises the "broken plugin" path.
+    #[tokio::test]
+    async fn process_pipeline_fails_closed_when_discovery_omits_root_done() {
+        use std::sync::OnceLock;
+        use voom_domain::call::{Call, CallResponse, ScanSummary};
+        use voom_domain::capabilities::Capability;
+        use voom_kernel::Plugin;
+
+        // Custom discovery plugin: emits one FileDiscoveredEvent to the
+        // sink, then returns Ok WITHOUT sending RootWalkCompletedEvent
+        // to root_done. This is the contract violation Task 4 catches.
+        struct OmitsRootDonePlugin;
+
+        impl Plugin for OmitsRootDonePlugin {
+            fn name(&self) -> &'static str {
+                "test-omits-root-done"
+            }
+
+            fn version(&self) -> &'static str {
+                "0.0.0-test"
+            }
+
+            voom_kernel::plugin_cargo_metadata!();
+
+            fn capabilities(&self) -> &[Capability] {
+                static CAPS: OnceLock<Vec<Capability>> = OnceLock::new();
+                CAPS.get_or_init(|| {
+                    vec![Capability::Discover {
+                        schemes: vec!["file".into()],
+                    }]
+                })
+                .as_slice()
+            }
+
+            fn on_call(&self, call: &Call) -> voom_domain::errors::Result<CallResponse> {
+                let Call::ScanLibrary {
+                    options,
+                    sink,
+                    root_done: _intentionally_unused,
+                    cancel,
+                    ..
+                } = call
+                else {
+                    return Err(voom_domain::errors::VoomError::plugin(
+                        self.name(),
+                        "unexpected Call variant",
+                    ));
+                };
+
+                // Emit one fake file on the sink. content_hash = None so
+                // the ingest task's no-hash branch is taken. The path
+                // falls under options.root so root_for_path() returns
+                // Some — that's what puts the item in the holding buffer
+                // (gate is closed because we never send root_done).
+                if !cancel.is_cancelled() {
+                    let event = voom_domain::events::FileDiscoveredEvent::new(
+                        options.root.join("fake.mkv"),
+                        42,
+                        None,
+                    );
+                    let _ = sink.blocking_send(event);
+                }
+
+                // Return Ok WITHOUT sending root_done. This is the
+                // contract violation.
+                Ok(CallResponse::ScanLibrary(ScanSummary::new(1, vec![], 1)))
+            }
+        }
+
+        // Build a kernel with ONLY the broken plugin claiming
+        // discover/file. The real DiscoveryPlugin is not registered, so
+        // dispatch routes to ours. We can't use `make_pool` here because
+        // it always registers the real discovery plugin and Sharded
+        // capability keys must be unique.
+        let mut kernel = voom_kernel::Kernel::new();
+        kernel
+            .register_plugin(Arc::new(OmitsRootDonePlugin), 10)
+            .expect("register test discovery plugin");
+        let kernel = Arc::new(kernel);
+
+        // Replicate the rest of `make_pool`'s scaffolding inline.
+        let token = CancellationToken::new();
+        let store: Arc<dyn StorageTrait> =
+            Arc::new(voom_domain::test_support::InMemoryStore::new());
+        let job_store: Arc<dyn voom_domain::storage::JobStorage> =
+            Arc::new(voom_domain::test_support::InMemoryStore::new());
+        let queue = Arc::new(JobQueue::new(job_store));
+        let mut config = WorkerPoolConfig::default();
+        config.max_workers = 2;
+        config.worker_prefix = "test".into();
+        let pool = Arc::new(WorkerPool::new(queue, config, token.clone()));
+
+        // execute_during_discovery = true exercises the holding-buffer
+        // path. Don't write any real fixtures — the fake plugin
+        // synthesizes a FileDiscoveredEvent referencing
+        // tmp.path().join("fake.mkv").
+        let tmp = TempDir::new().unwrap();
+        let mut args = make_test_args(vec![tmp.path().to_path_buf()]);
+        args.execute_during_discovery = true;
+
+        let outcome = run_streaming_pipeline(
+            &args,
+            &args.paths,
+            kernel,
+            store,
+            pool,
+            Arc::new(NoopReporter),
+            JobErrorStrategy::Continue,
+            HashSet::new(),
+            |_job| async { Ok(None) },
+            true, // quiet
+            true, // plan_only
+            token,
+            voom_domain::transition::ScanSessionId::new(),
+        )
+        .await;
+
+        let err = outcome
+            .err()
+            .expect("pipeline must fail closed when discovery omits RootWalkCompletedEvent");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("held") || msg.contains("RootWalkCompletedEvent"),
+            "error must name the failure mode (held items / missing root_done); got: {msg}"
+        );
+    }
 }

--- a/crates/voom-cli/src/commands/process/pipeline_streaming.rs
+++ b/crates/voom-cli/src/commands/process/pipeline_streaming.rs
@@ -350,9 +350,12 @@ fn spawn_discovery_stage(
                     kind: "discover".into(),
                     key: "file".into(),
                 };
-                kernel
-                    .dispatch_to_capability(query, call)
-                    .with_context(|| format!("filesystem scan failed for {}", path.display()))?;
+                let dispatch_result = kernel.dispatch_to_capability(query, call);
+                crate::commands::discovery_dispatch::handle_dispatch_result(
+                    dispatch_result,
+                    path,
+                    &discovery_errors,
+                )?;
             }
             Ok(())
         };

--- a/crates/voom-cli/src/commands/process/pipeline_streaming.rs
+++ b/crates/voom-cli/src/commands/process/pipeline_streaming.rs
@@ -604,11 +604,57 @@ fn spawn_ingest_stage(
         // Dropping tx_items signals "no more work" to the pool's enqueuer
         // (after the dispatcher is also done).
         if let Some(handle) = dispatcher_handle {
-            // Wait for the dispatcher to drain all buffered items before
-            // dropping tx_items. If cancelled, the holding buffer will still
-            // have items — just discard them (no SQL rows were created).
-            let _ = handle.await;
-            let _ = holding.drain_all(); // discard any leftover held items
+            // Wait for the dispatcher to finish. The dispatcher exits when
+            // its rx_root_done channel closes (all senders dropped — the
+            // discovery plugin's clone and the spawn_discovery_stage outer
+            // sender), or on cancellation. Propagate any JoinError (panic
+            // in the dispatcher) — silent swallowing would hide real bugs.
+            let dispatcher_result = handle.await;
+            if let Err(join_err) = dispatcher_result {
+                // Cancel the pipeline so workers exit promptly, then
+                // propagate the panic context.
+                token.cancel();
+                drop(tx_items);
+                return Err(anyhow::anyhow!(
+                    "root-walk dispatcher task panicked: {join_err}"
+                ));
+            }
+
+            // After dispatcher exit, check the holding buffer. Two cases:
+            //   (a) token cancelled — held items are meaningless because no
+            //       SQL rows were created for them yet; drop them.
+            //   (b) token NOT cancelled but holding is non-empty — discovery
+            //       returned Ok yet failed to emit RootWalkCompletedEvent for
+            //       every root that had files. The ingest dispatcher would
+            //       therefore never have opened those gates. Without this
+            //       check, the held items would be silently discarded, the
+            //       files would never be enqueued, and the run would finish
+            //       reporting success despite quietly dropping work.
+            //
+            // Codex's round-3 adversarial review (PR #420) flagged this
+            // exact path. Fail closed: emit an error naming the unprocessed
+            // count so the user can re-run.
+            let leftover = holding.drain_all();
+            if !token.is_cancelled() && !leftover.is_empty() {
+                tracing::error!(
+                    held_items = leftover.len(),
+                    "discovery dispatch returned Ok but did not emit \
+                     RootWalkCompletedEvent for every root with files; \
+                     {} item(s) were held and dropped",
+                    leftover.len()
+                );
+                token.cancel();
+                drop(tx_items);
+                return Err(anyhow::anyhow!(
+                    "process pipeline: {} discovered file(s) held against \
+                     un-opened root gates after discovery completed — likely \
+                     a discovery plugin that returned Ok without emitting \
+                     RootWalkCompletedEvent for every root. Re-run the \
+                     command; if the failure persists, the discovery plugin \
+                     is broken.",
+                    leftover.len()
+                ));
+            }
         }
         drop(tx_items);
 

--- a/crates/voom-cli/src/commands/scan/mod.rs
+++ b/crates/voom-cli/src/commands/scan/mod.rs
@@ -567,7 +567,18 @@ mod streaming_tests {
         let db_path = db_dir.path().join("voom.db");
         let store: Arc<dyn StorageTrait> =
             Arc::new(voom_sqlite_store::store::SqliteStore::open(&db_path).expect("open store"));
-        let kernel = Arc::new(voom_kernel::Kernel::new());
+        // The streaming pipeline routes discovery through
+        // `Kernel::dispatch_to_capability(Sharded { kind: "discover", key:
+        // "file" }, …)`, so the discovery plugin must be registered for the
+        // capability resolver to find a handler.
+        let mut kernel = voom_kernel::Kernel::new();
+        kernel
+            .register_plugin(
+                Arc::new(voom_discovery::DiscoveryPlugin::for_bootstrap()),
+                10,
+            )
+            .expect("register discovery");
+        let kernel = Arc::new(kernel);
         let media_dir = tempfile::tempdir().expect("temp media dir");
         Bed {
             _db_dir: db_dir,

--- a/crates/voom-cli/src/commands/scan/pipeline.rs
+++ b/crates/voom-cli/src/commands/scan/pipeline.rs
@@ -326,9 +326,12 @@ fn spawn_discovery_stage(
                     kind: "discover".into(),
                     key: "file".into(),
                 };
-                kernel
-                    .dispatch_to_capability(query, call)
-                    .with_context(|| format!("filesystem scan failed for {}", path.display()))?;
+                let dispatch_result = kernel.dispatch_to_capability(query, call);
+                crate::commands::discovery_dispatch::handle_dispatch_result(
+                    dispatch_result,
+                    path,
+                    &discovery_errors,
+                )?;
 
                 let dir_count = cumulative_discovered.load(Ordering::Relaxed) - pre;
                 processing_base.fetch_add(dir_count, Ordering::Relaxed);

--- a/crates/voom-cli/src/commands/scan/pipeline.rs
+++ b/crates/voom-cli/src/commands/scan/pipeline.rs
@@ -231,12 +231,15 @@ fn spawn_discovery_stage(
     let recursive = args.recursive;
     let paths = paths.to_vec();
     tokio::task::spawn_blocking(move || -> Result<u64> {
-        let discovery = voom_discovery::DiscoveryPlugin::new();
         let cumulative_discovered = Arc::new(AtomicU64::new(0));
         let processing_base = Arc::new(AtomicU64::new(0));
         // Local counter for discovery-time errors (open / hash / walk
         // failures). Returned via the JoinHandle's Ok value.
         let discovery_errors = Arc::new(AtomicU64::new(0));
+        // One scan-session id covers all paths in this scan run. The scan
+        // command doesn't use gate semantics or event_log correlation, but
+        // `Call::ScanLibrary` requires a session id.
+        let scan_session = voom_domain::transition::ScanSessionId::new();
 
         // Wrap the scan loop so we can inspect the result BEFORE dropping
         // tx_disc. On Err, we cancel the pipeline token first; that ensures
@@ -306,19 +309,25 @@ fn spawn_discovery_stage(
                     );
                 }));
 
-                let token_inner = token.clone();
-                let tx_inner = tx_disc.clone();
-                let on_event: voom_discovery::EventSink = Box::new(move |event| {
-                    if token_inner.is_cancelled() {
-                        return;
-                    }
-                    // blocking_send blocks the current rayon worker until the
-                    // ingest stage drains. This is the backpressure mechanism.
-                    let _ = tx_inner.blocking_send(event);
-                });
-
-                discovery
-                    .scan_streaming(&options, on_event)
+                // Route through the kernel so the discovery plugin handles the
+                // scan via `Plugin::on_call`. The plugin uses `blocking_send`
+                // on `sink` (backpressure) and checks `cancel` between items.
+                // We pass `root_done: None` — the scan command does not need
+                // per-root completion signalling.
+                let call = voom_domain::call::Call::ScanLibrary {
+                    uri: format!("file://{}", path.display()),
+                    options,
+                    scan_session,
+                    sink: tx_disc.clone(),
+                    root_done: None,
+                    cancel: token.clone(),
+                };
+                let query = voom_domain::capabilities::CapabilityQuery::Sharded {
+                    kind: "discover".into(),
+                    key: "file".into(),
+                };
+                kernel
+                    .dispatch_to_capability(query, call)
                     .with_context(|| format!("filesystem scan failed for {}", path.display()))?;
 
                 let dir_count = cumulative_discovered.load(Ordering::Relaxed) - pre;

--- a/crates/voom-cli/src/config.rs
+++ b/crates/voom-cli/src/config.rs
@@ -191,6 +191,32 @@ impl AppConfig {
             .and_then(voom_ffprobe_introspector::parser::AnimationDetectionMode::parse)
             .unwrap_or_default()
     }
+
+    /// Validate the loaded configuration. Returns `Err` with an actionable
+    /// message if the user has disabled a plugin that is required for core
+    /// commands.
+    ///
+    /// This catches the misconfiguration at startup with a clear error
+    /// rather than letting it surface as an opaque "no handler for
+    /// capability" failure deep inside a dispatch call.
+    pub fn validate(&self) -> Result<(), anyhow::Error> {
+        let disabled = &self.plugins.disabled_plugins;
+        let mut bad: Vec<&str> = REQUIRED_PLUGIN_NAMES
+            .iter()
+            .copied()
+            .filter(|req| disabled.iter().any(|d| d == *req))
+            .collect();
+        bad.sort();
+        if !bad.is_empty() {
+            anyhow::bail!(
+                "config: required plugin(s) {bad:?} are listed in disabled_plugins. \
+                 These plugins are required for the `scan` and `process` commands \
+                 after the plugin-contract rev-6 migration (#378). \
+                 Remove them from `disabled_plugins` in your config.toml."
+            );
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -312,6 +338,16 @@ pub const KNOWN_PLUGIN_NAMES: &[&str] = &[
     "report",
     "verifier",
 ];
+
+/// Plugins whose absence makes the `scan` or `process` commands non-functional.
+///
+/// After plugin contract rev 6 (issue #378), these commands route through
+/// `Kernel::dispatch_to_capability`, so the required capabilities must be
+/// claimed by a registered plugin. Disabling any of these via
+/// `disabled_plugins` in config.toml is an unrunnable configuration; we
+/// reject it at config load with an explicit error rather than failing at
+/// dispatch time with a less actionable "no handler" message.
+pub const REQUIRED_PLUGIN_NAMES: &[&str] = &["discovery"];
 
 /// Generate a default config.toml with all options commented out and documented.
 pub fn default_config_contents() -> String {
@@ -880,5 +916,64 @@ keep_last = 100000
         // See issue #194.
         assert_eq!(cfg.retention.event_log.keep_for_days, Some(60));
         assert_eq!(cfg.retention.event_log.keep_last, Some(500_000));
+    }
+
+    #[test]
+    fn validate_accepts_default_config() {
+        let config = AppConfig::default();
+        assert!(config.validate().is_ok(), "default config must validate");
+    }
+
+    #[test]
+    fn validate_accepts_disabling_optional_plugins() {
+        let mut config = AppConfig::default();
+        config.plugins.disabled_plugins = vec!["mkvtoolnix-executor".into(), "web-server".into()];
+        assert!(
+            config.validate().is_ok(),
+            "optional plugins may be disabled"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_discovery_in_disabled_plugins() {
+        let mut config = AppConfig::default();
+        config.plugins.disabled_plugins = vec!["discovery".into()];
+        let err = config
+            .validate()
+            .expect_err("discovery in disabled_plugins must fail");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("discovery"),
+            "error must name the offending plugin; got: {msg}"
+        );
+        assert!(
+            msg.contains("disabled_plugins"),
+            "error must point at the config key; got: {msg}"
+        );
+        assert!(
+            msg.contains("scan") || msg.contains("process"),
+            "error must explain which commands break; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_lists_all_required_plugins_disabled() {
+        // If REQUIRED_PLUGIN_NAMES grows, the message should mention every one
+        // the user has disabled — not just the first.
+        let mut config = AppConfig::default();
+        config.plugins.disabled_plugins = REQUIRED_PLUGIN_NAMES
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect();
+        let err = config
+            .validate()
+            .expect_err("required plugin disabled must fail");
+        let msg = format!("{err}");
+        for required in REQUIRED_PLUGIN_NAMES {
+            assert!(
+                msg.contains(required),
+                "error must mention required plugin '{required}'; got: {msg}"
+            );
+        }
     }
 }

--- a/crates/voom-cli/src/config.rs
+++ b/crates/voom-cli/src/config.rs
@@ -373,8 +373,9 @@ pub fn default_config_contents() -> String {
 # wasm_dir = "{data_dir_str}/plugins/wasm"
 
 # List of plugin names to disable at startup.
-# Valid names: sqlite-store, tool-detector, discovery,
+# Optional plugins (safe to disable): sqlite-store, tool-detector,
 #   mkvtoolnix-executor, ffmpeg-executor, backup-manager, job-manager
+# Required plugins (cannot be disabled): discovery
 # disabled_plugins = ["mkvtoolnix-executor"]
 
 # Default policy file applied when no --policy or --policy-map flag is given.

--- a/crates/voom-cli/tests/plugin_stats_e2e.rs
+++ b/crates/voom-cli/tests/plugin_stats_e2e.rs
@@ -86,14 +86,17 @@ async fn scan_populates_plugin_stats_table() {
         "plugin_stats rollup should have at least one row after a scan; got zero"
     );
 
-    // Direct SQL assertion that a specific named plugin appears in the table.
-    // The dispatcher records the *subscriber's* plugin_id, not the publisher's
-    // (see `Bus::publish_recursive` in voom-kernel/src/bus.rs). Discovery is a
-    // pure publisher (`handles()` returns false for every event — see
-    // `DiscoveryPlugin::test_handles_no_events`), so it never appears in
-    // `plugin_stats`. We assert on `sqlite-store` instead, which subscribes to
-    // every event for persistence and is therefore the canonical reliable
-    // subscriber on any scan run.
+    // Direct SQL assertions that specific named plugins appear in the table.
+    //
+    // `sqlite-store` is a bus subscriber: `Bus::publish_recursive` records the
+    // *subscriber's* plugin_id on every event it handles, so a single scan
+    // produces many `sqlite-store` rows. This invariant predates Phase 3.
+    //
+    // `discovery` is a capability-dispatched plugin: after Phase 3 (#378), the
+    // CLI scan command issues one `Call::ScanLibrary` per root through
+    // `Kernel::dispatch_to_capability`, which records a `PluginStatRecord` for
+    // the resolved plugin (see `voom-kernel/src/lib.rs` ~lines 497-505). So at
+    // least one `discovery` row must appear after any successful scan.
     let db_path = env.db_path();
     let conn = rusqlite::Connection::open(&db_path)
         .unwrap_or_else(|e| panic!("open {}: {e}", db_path.display()));
@@ -107,6 +110,20 @@ async fn scan_populates_plugin_stats_table() {
     assert!(
         store_count > 0,
         "expected at least one sqlite-store row in plugin_stats"
+    );
+
+    let discovery_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM plugin_stats WHERE plugin_id = 'discovery'",
+            [],
+            |r| r.get(0),
+        )
+        .expect("count discovery rows");
+    assert!(
+        discovery_count > 0,
+        "expected at least one 'discovery' row in plugin_stats after a scan; the CLI dispatches \
+         ScanLibrary through Kernel::dispatch_to_capability which records the resolved plugin id \
+         (#378 Phase 3)"
     );
 }
 

--- a/plugins/discovery/Cargo.toml
+++ b/plugins/discovery/Cargo.toml
@@ -20,6 +20,7 @@ xxhash-rust = { workspace = true }
 tracing = { workspace = true }
 chrono = { workspace = true }
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 unicode-normalization = "0.1"
 
 [features]
@@ -33,6 +34,5 @@ workspace = true
 [dev-dependencies]
 tempfile = { workspace = true }
 tokio = { workspace = true }
-tokio-util = { workspace = true }
 voom-domain = { workspace = true }
 voom-kernel = { workspace = true }

--- a/plugins/discovery/src/lib.rs
+++ b/plugins/discovery/src/lib.rs
@@ -28,6 +28,18 @@ pub struct DiscoveryPlugin {
 }
 
 impl DiscoveryPlugin {
+    /// Bootstrap-only constructor — the canonical public entry point.
+    ///
+    /// After Phase 3, all discovery work flows through
+    /// `Kernel::dispatch_to_capability(Discover, Call::ScanLibrary)`.
+    /// Constructing a `DiscoveryPlugin` instance directly is legitimate only
+    /// at kernel-bootstrap registration time; tests inside this crate use
+    /// `new()` for in-crate test setup.
+    #[must_use]
+    pub fn for_bootstrap() -> Self {
+        Self::new()
+    }
+
     #[must_use]
     pub fn new() -> Self {
         Self {

--- a/plugins/discovery/src/lib.rs
+++ b/plugins/discovery/src/lib.rs
@@ -4,15 +4,12 @@ pub mod scanner;
 #[cfg(feature = "test-hooks")]
 pub mod test_hooks;
 
-pub use scanner::EventSink;
 pub use scanner::hash_file;
 pub use scanner::normalize_path;
-pub use scanner::scan_directory_streaming;
 
 use voom_domain::call::{Call, CallResponse, ScanSummary};
 use voom_domain::capabilities::Capability;
-use voom_domain::errors::Result;
-use voom_domain::events::{FileDiscoveredEvent, RootWalkCompletedEvent};
+use voom_domain::events::RootWalkCompletedEvent;
 pub use voom_domain::scan::{
     ErrorCallback, FingerprintLookup, MutationSnapshotLoader, ScanOptions, ScanProgress,
 };
@@ -41,7 +38,7 @@ impl DiscoveryPlugin {
     }
 
     #[must_use]
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             capabilities: vec![Capability::Discover {
                 schemes: vec!["file".into()],
@@ -49,24 +46,14 @@ impl DiscoveryPlugin {
         }
     }
 
-    /// Scan a directory for media files and return discovery events.
-    pub fn scan(&self, options: &ScanOptions) -> Result<Vec<FileDiscoveredEvent>> {
-        scanner::scan_directory(options)
-    }
-
-    /// Streaming scan. See [`scanner::scan_directory_streaming`].
-    pub fn scan_streaming(
+    /// Test-only synchronous scan helper. Production code goes through
+    /// `Plugin::on_call(Call::ScanLibrary)`.
+    #[cfg(test)]
+    pub(crate) fn scan(
         &self,
         options: &ScanOptions,
-        on_event: scanner::EventSink,
-    ) -> Result<()> {
-        scanner::scan_directory_streaming(options, on_event)
-    }
-}
-
-impl Default for DiscoveryPlugin {
-    fn default() -> Self {
-        Self::new()
+    ) -> voom_domain::errors::Result<Vec<voom_domain::events::FileDiscoveredEvent>> {
+        scanner::scan_directory(options)
     }
 }
 
@@ -175,7 +162,7 @@ impl Plugin for DiscoveryPlugin {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use voom_domain::events::Event;
+    use voom_domain::events::{Event, FileDiscoveredEvent};
 
     #[test]
     fn test_plugin_metadata() {

--- a/plugins/discovery/src/lib.rs
+++ b/plugins/discovery/src/lib.rs
@@ -132,9 +132,19 @@ impl Plugin for DiscoveryPlugin {
 
         match scan_result {
             Ok(()) => {
-                // Send the root-walk-completed signal *only* after a successful
-                // scan, mirroring the Call::ScanLibrary doc contract.
-                if let Some(done) = root_done {
+                // Send the root-walk-completed signal only after a successful
+                // *and uncancelled* scan, mirroring the Call::ScanLibrary doc
+                // contract. The scanner may have returned Ok before observing
+                // the cancel — that's a race window for tiny libraries — but
+                // a cancelled walk is not a "completed" walk for callers using
+                // root_done (e.g. the gate dispatcher in the process pipeline,
+                // which would otherwise open the gate for incomplete data).
+                if cancel.is_cancelled() {
+                    tracing::debug!(
+                        root = %options.root.display(),
+                        "scan returned Ok but cancel was observed post-scan; suppressing RootWalkCompletedEvent"
+                    );
+                } else if let Some(done) = root_done {
                     if let Err(e) = done.try_send(RootWalkCompletedEvent::new(
                         options.root.clone(),
                         *scan_session,
@@ -662,6 +672,53 @@ mod tests {
         assert!(
             rx_root.try_recv().is_err(),
             "no second root event for a single Call"
+        );
+    }
+
+    #[test]
+    fn on_call_suppresses_root_done_when_cancelled_even_if_scan_returned_ok() {
+        use tokio::sync::mpsc;
+        use tokio_util::sync::CancellationToken;
+        use voom_domain::call::Call;
+        use voom_domain::events::{FileDiscoveredEvent, RootWalkCompletedEvent};
+
+        // Tiny library — only one file, so the scanner is overwhelmingly likely
+        // to return Ok before the pre-cancellation below would have caused
+        // any worker to bail.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("only.mkv"), b"x").unwrap();
+
+        let (sink, _rx) = mpsc::channel::<FileDiscoveredEvent>(8);
+        let (root_done_tx, mut root_done_rx) = mpsc::channel::<RootWalkCompletedEvent>(1);
+
+        let cancel = CancellationToken::new();
+        // Cancel before on_call. The scanner will likely still return Ok for
+        // such a tiny library — but the plugin must observe the cancelled token
+        // post-scan and skip the root_done emission.
+        cancel.cancel();
+
+        let mut options = ScanOptions::new(dir.path());
+        options.hash_files = false;
+
+        let call = Call::ScanLibrary {
+            uri: format!("file://{}", dir.path().display()),
+            options,
+            scan_session: voom_domain::transition::ScanSessionId::new(),
+            sink,
+            root_done: Some(root_done_tx),
+            cancel,
+        };
+
+        let plugin = DiscoveryPlugin::new();
+        let response = plugin.on_call(&call);
+
+        // The scanner may or may not have returned Ok depending on timing.
+        // We don't assert on the response — only on the root_done invariant.
+        let _ = response;
+
+        assert!(
+            root_done_rx.try_recv().is_err(),
+            "RootWalkCompletedEvent must NOT be emitted on a cancelled scan, regardless of scan_result"
         );
     }
 }

--- a/plugins/discovery/src/lib.rs
+++ b/plugins/discovery/src/lib.rs
@@ -126,7 +126,7 @@ impl Plugin for DiscoveryPlugin {
             }
         });
 
-        let scan_result = scanner::scan_directory_streaming(options, on_event);
+        let scan_result = scanner::scan_directory_streaming(options, cancel, on_event);
 
         let duration_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
 

--- a/plugins/discovery/src/lib.rs
+++ b/plugins/discovery/src/lib.rs
@@ -516,4 +516,165 @@ mod tests {
         let events = plugin.scan(&opts).unwrap();
         assert_eq!(events.len(), extensions.len());
     }
+
+    #[test]
+    fn on_call_backpressures_when_sink_is_saturated() {
+        use std::time::Duration;
+        use tokio::sync::mpsc;
+        use tokio_util::sync::CancellationToken;
+        use voom_domain::call::{Call, CallResponse};
+        use voom_domain::events::FileDiscoveredEvent;
+
+        // Three files, but a bounded channel of capacity 1.
+        let dir = tempfile::tempdir().unwrap();
+        for i in 0..3 {
+            std::fs::write(dir.path().join(format!("f{i}.mkv")), b"x").unwrap();
+        }
+
+        let (sink, mut rx) = mpsc::channel::<FileDiscoveredEvent>(1);
+        let cancel = CancellationToken::new();
+        let mut options = ScanOptions::new(dir.path());
+        options.hash_files = false;
+        let call = Call::ScanLibrary {
+            uri: format!("file://{}", dir.path().display()),
+            options,
+            scan_session: voom_domain::transition::ScanSessionId::new(),
+            sink,
+            root_done: None,
+            cancel,
+        };
+
+        let plugin = DiscoveryPlugin::new();
+
+        // Run on_call on a separate thread so we can drain at our pace from the
+        // test thread. on_call is synchronous and will block on blocking_send
+        // when the sink saturates.
+        let handle = std::thread::spawn(move || plugin.on_call(&call));
+
+        // Give the plugin a moment to start.
+        std::thread::sleep(Duration::from_millis(100));
+
+        // Drain the events as they arrive. The plugin's blocking_send will
+        // unblock as we drain; eventually the scan completes.
+        let mut total = 0;
+        while let Some(_e) = rx.blocking_recv() {
+            total += 1;
+            if total >= 3 {
+                break;
+            }
+        }
+
+        // Plugin should have completed. join() returns the CallResponse.
+        let response = handle.join().unwrap().expect("on_call");
+        match response {
+            CallResponse::ScanLibrary(summary) => assert_eq!(summary.file_count, 3),
+            other => panic!("wrong variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn on_call_respects_mid_scan_cancellation() {
+        use tokio::sync::mpsc;
+        use tokio_util::sync::CancellationToken;
+        use voom_domain::call::Call;
+        use voom_domain::events::FileDiscoveredEvent;
+
+        // Many files; we cancel after a few are emitted.
+        let dir = tempfile::tempdir().unwrap();
+        for i in 0..50 {
+            std::fs::write(dir.path().join(format!("f{i:03}.mkv")), b"x").unwrap();
+        }
+
+        let (sink, mut rx) = mpsc::channel::<FileDiscoveredEvent>(8);
+        let cancel = CancellationToken::new();
+        let mut options = ScanOptions::new(dir.path());
+        options.hash_files = false;
+        let call = Call::ScanLibrary {
+            uri: format!("file://{}", dir.path().display()),
+            options,
+            scan_session: voom_domain::transition::ScanSessionId::new(),
+            sink,
+            root_done: None,
+            cancel: cancel.clone(),
+        };
+
+        let plugin = DiscoveryPlugin::new();
+        let handle = std::thread::spawn(move || plugin.on_call(&call));
+
+        // Drain a few events, then cancel.
+        let mut drained = 0;
+        while drained < 3 {
+            if rx.blocking_recv().is_some() {
+                drained += 1;
+            } else {
+                // Scan finished before we got 3 events — unlikely with 50 files,
+                // but bail gracefully so the test doesn't hang.
+                break;
+            }
+        }
+        cancel.cancel();
+
+        // Drain whatever's still buffered or trickles in until the sender closes.
+        while let Some(_e) = rx.blocking_recv() {
+            drained += 1;
+        }
+
+        // The plugin should have returned. Cancel is not an error condition,
+        // so on_call returns Ok with whatever events made it through.
+        let _response = handle
+            .join()
+            .unwrap()
+            .expect("on_call (cancel is not an error)");
+
+        // The interesting invariant: cancellation actually stopped the scan
+        // before all 50 files were emitted.
+        assert!(
+            drained < 50,
+            "cancellation should stop the scan before emitting all 50 files (got {drained})"
+        );
+    }
+
+    #[test]
+    fn on_call_emits_one_root_done_per_call() {
+        use tokio::sync::mpsc;
+        use tokio_util::sync::CancellationToken;
+        use voom_domain::call::Call;
+        use voom_domain::events::{FileDiscoveredEvent, RootWalkCompletedEvent};
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.mkv"), b"x").unwrap();
+        std::fs::write(dir.path().join("b.mkv"), b"x").unwrap();
+
+        let (sink, mut rx) = mpsc::channel::<FileDiscoveredEvent>(16);
+        let (root_done, mut rx_root) = mpsc::channel::<RootWalkCompletedEvent>(8);
+        let cancel = CancellationToken::new();
+        let mut options = ScanOptions::new(dir.path());
+        options.hash_files = false;
+
+        let call = Call::ScanLibrary {
+            uri: format!("file://{}", dir.path().display()),
+            options,
+            scan_session: voom_domain::transition::ScanSessionId::new(),
+            sink,
+            root_done: Some(root_done),
+            cancel,
+        };
+
+        let plugin = DiscoveryPlugin::new();
+        let _response = plugin.on_call(&call).expect("on_call");
+
+        // Drain files.
+        let mut file_count = 0;
+        while let Ok(_e) = rx.try_recv() {
+            file_count += 1;
+        }
+        assert_eq!(file_count, 2);
+
+        // Exactly one RootWalkCompletedEvent.
+        let _root1 = rx_root.try_recv().expect("one root event");
+        assert!(
+            rx_root.try_recv().is_err(),
+            "no second root event for a single Call"
+        );
+    }
 }

--- a/plugins/discovery/src/lib.rs
+++ b/plugins/discovery/src/lib.rs
@@ -9,7 +9,7 @@ pub use scanner::hash_file;
 pub use scanner::normalize_path;
 pub use scanner::scan_directory_streaming;
 
-use voom_domain::call::{Call, CallResponse, DiscoveryError, ScanSummary};
+use voom_domain::call::{Call, CallResponse, ScanSummary};
 use voom_domain::capabilities::Capability;
 use voom_domain::errors::Result;
 use voom_domain::events::{FileDiscoveredEvent, RootWalkCompletedEvent};
@@ -92,44 +92,37 @@ impl Plugin for DiscoveryPlugin {
             ));
         };
 
-        // Shared counters / error list — populated from inside the rayon
-        // worker callback.
+        // Shared counter — populated from inside the rayon worker callback.
         let file_count = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
-        let errors: std::sync::Arc<std::sync::Mutex<Vec<DiscoveryError>>> =
-            std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
 
         let count_clone = file_count.clone();
         let sink_clone = sink.clone();
-        let errors_clone = errors.clone();
         let cancel_clone = cancel.clone();
 
         let started = std::time::Instant::now();
 
         // The scanner is synchronous and rayon-parallel. Forward each
-        // FileDiscoveredEvent into the caller's tokio mpsc via `try_send`.
-        // If the channel is full we record a DiscoveryError rather than
-        // blocking the scanner thread; Phase 3 will replace this with a
-        // proper async pump that respects back-pressure.
+        // FileDiscoveredEvent into the caller's tokio mpsc via `blocking_send`.
+        // `blocking_send` applies natural backpressure: when the receiver is
+        // full, the rayon worker blocks until drain. A `SendError` here means
+        // the receiver was dropped — caller went away, safe to swallow; the
+        // next `cancel_clone.is_cancelled()` check will short-circuit any
+        // remaining work.
         let on_event: scanner::EventSink = Box::new(move |event| {
             if cancel_clone.is_cancelled() {
                 return;
             }
-            let path_display = event.path.display().to_string();
-            match sink_clone.try_send(event) {
+            match sink_clone.blocking_send(event) {
                 Ok(()) => {
                     count_clone.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 }
-                Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
-                    if let Ok(mut errs) = errors_clone.lock() {
-                        errs.push(DiscoveryError::new(
-                            path_display,
-                            "scan sink full; dropping event (caller draining too slowly)".into(),
-                        ));
-                    }
-                }
-                Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                Err(_send_error) => {
                     // Receiver dropped — caller no longer cares. Stop counting,
-                    // let the scanner finish naturally.
+                    // let the scanner finish naturally; the next cancel check
+                    // will short-circuit remaining work.
+                    tracing::debug!(
+                        "scan sink receiver dropped; remaining events will be discarded"
+                    );
                 }
             }
         });
@@ -143,28 +136,21 @@ impl Plugin for DiscoveryPlugin {
                 // Send the root-walk-completed signal *only* after a successful
                 // scan, mirroring the Call::ScanLibrary doc contract.
                 if let Some(done) = root_done {
-                    let _ = done.try_send(RootWalkCompletedEvent::new(
+                    if let Err(e) = done.try_send(RootWalkCompletedEvent::new(
                         options.root.clone(),
                         *scan_session,
                         duration_ms,
-                    ));
-                }
-                let collected_errors = match errors.lock() {
-                    Ok(guard) => guard.clone(),
-                    Err(poisoned) => {
-                        // A scanner worker panicked while holding the lock.
-                        // Surface the loss explicitly rather than returning an
-                        // empty error list (which would look like a clean run
-                        // to the caller).
+                    )) {
                         tracing::warn!(
-                            "scan error list mutex poisoned; partial error data discarded"
+                            error = %e,
+                            root = %options.root.display(),
+                            "failed to deliver RootWalkCompletedEvent",
                         );
-                        poisoned.into_inner().clone()
                     }
-                };
+                }
                 let summary = ScanSummary::new(
                     file_count.load(std::sync::atomic::Ordering::Relaxed),
-                    collected_errors,
+                    vec![],
                     1,
                 );
                 Ok(CallResponse::ScanLibrary(summary))
@@ -414,6 +400,89 @@ mod tests {
             reused.load(Ordering::Relaxed),
             0,
             "HashReused must not fire when mtime is newer than last_seen"
+        );
+    }
+
+    #[test]
+    fn on_call_scan_library_emits_events_to_sink() {
+        use tokio::sync::mpsc;
+        use tokio_util::sync::CancellationToken;
+        use voom_domain::transition::ScanSessionId;
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("video.mkv"), b"fake mkv data").unwrap();
+        std::fs::write(dir.path().join("audio.mp4"), b"fake mp4 data").unwrap();
+        std::fs::write(dir.path().join("readme.txt"), b"not media").unwrap();
+
+        let (sink, mut rx) = mpsc::channel::<FileDiscoveredEvent>(16);
+        let (root_done_tx, mut root_done_rx) = mpsc::channel::<RootWalkCompletedEvent>(1);
+        let cancel = CancellationToken::new();
+        let scan_session = ScanSessionId::new();
+
+        let call = Call::ScanLibrary {
+            uri: format!("file://{}", dir.path().display()),
+            options: ScanOptions::new(dir.path()),
+            scan_session,
+            sink,
+            root_done: Some(root_done_tx),
+            cancel,
+        };
+
+        let plugin = DiscoveryPlugin::new();
+        let response = plugin.on_call(&call).expect("on_call should succeed");
+
+        // Drain the events synchronously: on_call returned, so the rayon
+        // workers have all finished pushing into the channel.
+        let mut received = Vec::new();
+        while let Ok(event) = rx.try_recv() {
+            received.push(event);
+        }
+        assert_eq!(received.len(), 2, "should receive 2 media events");
+
+        // root_done must be emitted exactly once, carrying the caller's session id.
+        let root_done_event = root_done_rx
+            .try_recv()
+            .expect("RootWalkCompletedEvent must be emitted on success");
+        assert_eq!(root_done_event.session, scan_session);
+        assert!(
+            root_done_rx.try_recv().is_err(),
+            "exactly one RootWalkCompletedEvent expected"
+        );
+
+        let CallResponse::ScanLibrary(summary) = response else {
+            panic!("expected CallResponse::ScanLibrary");
+        };
+        assert_eq!(summary.file_count, 2);
+        assert_eq!(summary.roots_scanned, 1);
+        assert!(summary.errors.is_empty(), "errors should be empty");
+    }
+
+    #[test]
+    fn on_call_does_not_emit_root_done_when_scan_fails() {
+        use tokio::sync::mpsc;
+        use tokio_util::sync::CancellationToken;
+        use voom_domain::transition::ScanSessionId;
+
+        let (sink, _rx) = mpsc::channel::<FileDiscoveredEvent>(16);
+        let (root_done_tx, mut root_done_rx) = mpsc::channel::<RootWalkCompletedEvent>(1);
+        let cancel = CancellationToken::new();
+        let scan_session = ScanSessionId::new();
+
+        let call = Call::ScanLibrary {
+            uri: "file:///definitely/does/not/exist/scratch/scan".into(),
+            options: ScanOptions::new("/definitely/does/not/exist/scratch/scan"),
+            scan_session,
+            sink,
+            root_done: Some(root_done_tx),
+            cancel,
+        };
+
+        let plugin = DiscoveryPlugin::new();
+        let result = plugin.on_call(&call);
+        assert!(result.is_err(), "scanning a missing path must return Err");
+        assert!(
+            root_done_rx.try_recv().is_err(),
+            "RootWalkCompletedEvent must NOT be emitted on scan failure"
         );
     }
 

--- a/plugins/discovery/src/scanner.rs
+++ b/plugins/discovery/src/scanner.rs
@@ -279,13 +279,13 @@ fn report_walk_errors(options: &ScanOptions, walk_errors: &[DiscoveryWalkError])
 /// and must be `Send + Sync`. Implementations that need ordering or
 /// serialization (e.g. an mpsc sender that returns errors) should handle
 /// it themselves.
-pub type EventSink = Box<dyn Fn(FileDiscoveredEvent) + Send + Sync>;
+pub(crate) type EventSink = Box<dyn Fn(FileDiscoveredEvent) + Send + Sync>;
 
 /// Streaming variant of [`scan_directory`]. Emits each `FileDiscoveredEvent`
 /// via `on_event` as soon as its content hash is computed, rather than
 /// collecting into a `Vec`. Order is rayon-dependent — callers that need a
 /// deterministic order should sort downstream.
-pub fn scan_directory_streaming(options: &ScanOptions, on_event: EventSink) -> Result<()> {
+pub(crate) fn scan_directory_streaming(options: &ScanOptions, on_event: EventSink) -> Result<()> {
     if !options.root.exists() {
         return Err(VoomError::Io(std::io::Error::new(
             std::io::ErrorKind::NotFound,
@@ -359,10 +359,12 @@ pub fn scan_directory_streaming(options: &ScanOptions, on_event: EventSink) -> R
     Ok(())
 }
 
-/// Scan a directory for media files. Returns all discovered events in
-/// deterministic path order. Kept for callers (e.g. `voom process`) that
-/// expect a fully-collected list.
-pub fn scan_directory(options: &ScanOptions) -> Result<Vec<FileDiscoveredEvent>> {
+/// Test-only synchronous scan helper that collects all events in
+/// deterministic path order. Production code goes through
+/// `DiscoveryPlugin::on_call(Call::ScanLibrary)` which uses the streaming
+/// variant directly.
+#[cfg(test)]
+pub(crate) fn scan_directory(options: &ScanOptions) -> Result<Vec<FileDiscoveredEvent>> {
     let collected: Arc<Mutex<Vec<FileDiscoveredEvent>>> = Arc::new(Mutex::new(Vec::new()));
     let collected_clone = collected.clone();
     scan_directory_streaming(

--- a/plugins/discovery/src/scanner.rs
+++ b/plugins/discovery/src/scanner.rs
@@ -183,6 +183,7 @@ fn hash_file_full(file: &mut fs::File) -> Result<String> {
 fn walk_media_files(
     options: &ScanOptions,
     snapshot: Option<&SessionMutationSnapshot>,
+    cancel: &tokio_util::sync::CancellationToken,
 ) -> (Vec<(PathBuf, u64)>, usize, Vec<DiscoveryWalkError>) {
     #[cfg(feature = "test-hooks")]
     if let Some(delay) = crate::test_hooks::delay_for(&options.root) {
@@ -199,6 +200,12 @@ fn walk_media_files(
     let mut orphaned_temp_count: usize = 0;
     let mut walk_errors = Vec::new();
     for entry_result in walker {
+        if cancel.is_cancelled() {
+            // Caller cancelled; stop enumerating. Anything we've already
+            // collected is fine to return — the caller (the plugin's on_call)
+            // is responsible for suppressing root_done on cancellation.
+            break;
+        }
         let entry = match entry_result {
             Ok(entry) => entry,
             Err(err) => {
@@ -301,7 +308,12 @@ pub(crate) fn scan_directory_streaming(options: &ScanOptions, on_event: EventSin
         None
     };
 
-    let (media_paths, _orphaned, walk_errors) = walk_media_files(options, snapshot.as_ref());
+    // TEMP (Task 2 replaces this with a function parameter): use a
+    // never-cancelled token at the call site so this task compiles in
+    // isolation. Task 2 threads the caller's CancellationToken through.
+    let scan_cancel = tokio_util::sync::CancellationToken::new();
+    let (media_paths, _orphaned, walk_errors) =
+        walk_media_files(options, snapshot.as_ref(), &scan_cancel);
     report_walk_errors(options, &walk_errors);
 
     tracing::info!(
@@ -765,5 +777,31 @@ mod tests {
         assert_eq!(events.len(), 2);
         // Existing API guarantees deterministic path ordering.
         assert!(events[0].path < events[1].path);
+    }
+
+    #[test]
+    fn walk_media_files_observes_cancellation() {
+        use tokio_util::sync::CancellationToken;
+
+        let dir = tempfile::tempdir().unwrap();
+        // Many files — without cancellation the walk would discover all 50.
+        for i in 0..50 {
+            std::fs::write(dir.path().join(format!("f{i:03}.mkv")), b"x").unwrap();
+        }
+
+        let options = ScanOptions::new(dir.path());
+        let cancel = CancellationToken::new();
+        cancel.cancel(); // Pre-cancel so the walk bails on the very first observable check.
+
+        let (paths, _orphans, _walk_errors) = walk_media_files(&options, None, &cancel);
+
+        // The walker may have already enumerated some entries before the first
+        // check, but the invariant is "fewer than all 50" — cancellation actually
+        // stops work.
+        assert!(
+            paths.len() < 50,
+            "cancellation should stop the walk before discovering all 50 files (got {})",
+            paths.len()
+        );
     }
 }

--- a/plugins/discovery/src/scanner.rs
+++ b/plugins/discovery/src/scanner.rs
@@ -292,7 +292,11 @@ pub(crate) type EventSink = Box<dyn Fn(FileDiscoveredEvent) + Send + Sync>;
 /// via `on_event` as soon as its content hash is computed, rather than
 /// collecting into a `Vec`. Order is rayon-dependent — callers that need a
 /// deterministic order should sort downstream.
-pub(crate) fn scan_directory_streaming(options: &ScanOptions, on_event: EventSink) -> Result<()> {
+pub(crate) fn scan_directory_streaming(
+    options: &ScanOptions,
+    cancel: &tokio_util::sync::CancellationToken,
+    on_event: EventSink,
+) -> Result<()> {
     if !options.root.exists() {
         return Err(VoomError::Io(std::io::Error::new(
             std::io::ErrorKind::NotFound,
@@ -308,12 +312,8 @@ pub(crate) fn scan_directory_streaming(options: &ScanOptions, on_event: EventSin
         None
     };
 
-    // TEMP (Task 2 replaces this with a function parameter): use a
-    // never-cancelled token at the call site so this task compiles in
-    // isolation. Task 2 threads the caller's CancellationToken through.
-    let scan_cancel = tokio_util::sync::CancellationToken::new();
     let (media_paths, _orphaned, walk_errors) =
-        walk_media_files(options, snapshot.as_ref(), &scan_cancel);
+        walk_media_files(options, snapshot.as_ref(), cancel);
     report_walk_errors(options, &walk_errors);
 
     tracing::info!(
@@ -327,6 +327,13 @@ pub(crate) fn scan_directory_streaming(options: &ScanOptions, on_event: EventSin
     let fd_sem = Arc::new(FdSemaphore::new(MAX_CONCURRENT_FDS));
 
     let process_file = |(path, walk_size): &(PathBuf, u64)| {
+        if cancel.is_cancelled() {
+            // Caller cancelled; skip this file. Other workers will hit the
+            // same check on their next file. We don't release any per-file
+            // resources here because we haven't acquired any yet (the FD
+            // guard hasn't been built).
+            return;
+        }
         let _guard = fd_sem.guard();
         let result = build_event(
             path,
@@ -379,8 +386,10 @@ pub(crate) fn scan_directory_streaming(options: &ScanOptions, on_event: EventSin
 pub(crate) fn scan_directory(options: &ScanOptions) -> Result<Vec<FileDiscoveredEvent>> {
     let collected: Arc<Mutex<Vec<FileDiscoveredEvent>>> = Arc::new(Mutex::new(Vec::new()));
     let collected_clone = collected.clone();
+    let cancel = tokio_util::sync::CancellationToken::new();
     scan_directory_streaming(
         options,
+        &cancel,
         Box::new(move |event| {
             collected_clone
                 .lock()
@@ -724,8 +733,10 @@ mod tests {
         let emitted_clone = emitted.clone();
 
         let options = ScanOptions::new(dir.path());
+        let cancel = tokio_util::sync::CancellationToken::new();
         scan_directory_streaming(
             &options,
+            &cancel,
             Box::new(move |event| {
                 emitted_clone.lock().unwrap().push(event);
             }),
@@ -762,7 +773,8 @@ mod tests {
         }));
 
         // Sanity: with a healthy directory, no errors fire.
-        scan_directory_streaming(&options, Box::new(|_| {})).unwrap();
+        let cancel = tokio_util::sync::CancellationToken::new();
+        scan_directory_streaming(&options, &cancel, Box::new(|_| {})).unwrap();
         assert_eq!(errors.load(Ordering::Relaxed), 0);
     }
 
@@ -802,6 +814,47 @@ mod tests {
             paths.len() < 50,
             "cancellation should stop the walk before discovering all 50 files (got {})",
             paths.len()
+        );
+    }
+
+    #[test]
+    fn scan_directory_streaming_observes_cancellation_during_hashing() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use tokio_util::sync::CancellationToken;
+
+        // Many small files; hashing each is fast, so the test relies on
+        // bulk cancellation, not racing a slow hash.
+        let dir = tempfile::tempdir().unwrap();
+        for i in 0..50 {
+            std::fs::write(dir.path().join(format!("f{i:03}.mkv")), b"x").unwrap();
+        }
+
+        let emitted = Arc::new(AtomicUsize::new(0));
+        let emitted_clone = emitted.clone();
+
+        let mut options = ScanOptions::new(dir.path());
+        options.hash_files = true; // exercise the hashing path
+
+        let cancel = CancellationToken::new();
+        cancel.cancel(); // pre-cancel so workers observe it immediately
+
+        let result = scan_directory_streaming(
+            &options,
+            &cancel,
+            Box::new(move |_event| {
+                emitted_clone.fetch_add(1, Ordering::Relaxed);
+            }),
+        );
+
+        // The function returns Ok even on cancellation — cancellation is not an
+        // error condition for the scanner. The invariant we test is: fewer than
+        // all 50 files emitted, because workers observed the token.
+        assert!(result.is_ok(), "scanner returns Ok on cancellation");
+        assert!(
+            emitted.load(Ordering::Relaxed) < 50,
+            "cancellation should stop workers before emitting all 50 events (got {})",
+            emitted.load(Ordering::Relaxed)
         );
     }
 }

--- a/plugins/discovery/tests/aborts_when_snapshot_load_fails.rs
+++ b/plugins/discovery/tests/aborts_when_snapshot_load_fails.rs
@@ -2,10 +2,16 @@
 //! must not proceed. Discovery must not silently fall through to "no
 //! exclusions" because that re-introduces the rediscovery race.
 
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
-use voom_discovery::{ScanOptions, SessionMutationSnapshot, scan_directory_streaming};
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use voom_discovery::{DiscoveryPlugin, ScanOptions, SessionMutationSnapshot};
+use voom_domain::call::Call;
 use voom_domain::errors::{StorageErrorKind, VoomError};
+use voom_domain::events::{FileDiscoveredEvent, RootWalkCompletedEvent};
+use voom_domain::transition::ScanSessionId;
+use voom_kernel::Plugin;
 
 #[test]
 fn scanner_aborts_when_snapshot_loader_errors() {
@@ -21,17 +27,35 @@ fn scanner_aborts_when_snapshot_loader_errors() {
         })
     }));
 
-    let emitted = Arc::new(Mutex::new(Vec::new()));
-    let sink = {
-        let emitted = emitted.clone();
-        Box::new(move |fd| emitted.lock().unwrap().push(fd))
+    let (sink, mut rx) = mpsc::channel::<FileDiscoveredEvent>(16);
+    let (root_done_tx, mut root_done_rx) = mpsc::channel::<RootWalkCompletedEvent>(1);
+    let cancel = CancellationToken::new();
+
+    let call = Call::ScanLibrary {
+        uri: format!("file://{}", tmp.path().display()),
+        options: opts,
+        scan_session: ScanSessionId::new(),
+        sink,
+        root_done: Some(root_done_tx),
+        cancel,
     };
-    let res = scan_directory_streaming(&opts, sink);
+
+    let plugin = DiscoveryPlugin::for_bootstrap();
+    let res = plugin.on_call(&call);
 
     assert!(res.is_err(), "scan must fail when snapshot load fails");
+
+    // No events must have been emitted from an aborted scan.
+    let mut emitted = 0;
+    while rx.try_recv().is_ok() {
+        emitted += 1;
+    }
+    assert_eq!(emitted, 0, "no events must be emitted from an aborted scan");
+
+    // root_done must NOT fire on failure.
     assert!(
-        emitted.lock().unwrap().is_empty(),
-        "no events must be emitted from an aborted scan"
+        root_done_rx.try_recv().is_err(),
+        "RootWalkCompletedEvent must NOT be emitted on scan failure",
     );
 }
 

--- a/plugins/discovery/tests/dispatch_scan_library.rs
+++ b/plugins/discovery/tests/dispatch_scan_library.rs
@@ -38,7 +38,7 @@ fn dispatch_scan_library_streams_through_real_discovery_plugin() {
 
     let mut kernel = Kernel::new();
     kernel
-        .register_plugin(Arc::new(DiscoveryPlugin::new()), 10)
+        .register_plugin(Arc::new(DiscoveryPlugin::for_bootstrap()), 10)
         .expect("register discovery");
     let kernel = Arc::new(kernel);
 
@@ -111,7 +111,7 @@ fn dispatch_scan_library_rejects_other_call_variants() {
     // an error rather than silently succeeding.
     let mut kernel = Kernel::new();
     kernel
-        .register_plugin(Arc::new(DiscoveryPlugin::new()), 10)
+        .register_plugin(Arc::new(DiscoveryPlugin::for_bootstrap()), 10)
         .expect("register discovery");
 
     let call = Call::Orchestrate {


### PR DESCRIPTION
## Summary

Phase 3 of 6 in the plugin-contract rev-6 series for issue #378. Migrates `DiscoveryPlugin` to be invoked exclusively through `Kernel::dispatch_to_capability`, removing the public direct-scan APIs at the type level so there is no second door.

**Prerequisite:** Phase 1 (#409, #410) merged. Phase 2 (#418) merged. Phase 3 is independent of Phase 2 for native discovery; CI inherits the wasm32-wasip2 toolchain setup wired in Phase 2.

### What ships

- `DiscoveryPlugin::on_call` handles `Call::ScanLibrary` end-to-end. It bridges the Call's `sink` / `root_done` / `cancel` / `options` into the existing `scan_directory_streaming` callback API, using `blocking_send` for natural backpressure. `RootWalkCompletedEvent` is emitted only after a successful **and uncancelled** scan and carries the caller's `scan_session`.
- CLI scan and process pipelines (`scan/pipeline.rs`, `process/pipeline_streaming.rs`) now dispatch one `Call::ScanLibrary` per root through `kernel.dispatch_to_capability(CapabilityQuery::Sharded { kind: "discover", key: "file" }, …)`. The inline `on_event` closures and inline `RootWalkCompletedEvent` emission are gone — that logic now lives once, inside the plugin. The response is unwrapped through a `discovery_dispatch::handle_dispatch_result` helper that hard-errors on wrong `CallResponse` variants and folds `ScanSummary.errors` into `discovery_errors`.
- `DiscoveryPlugin::new`, `scan`, and `scan_streaming` are narrowed to `pub(crate)` (or deleted where they had zero callers). `impl Default for DiscoveryPlugin` is removed. `for_bootstrap()` is the sole public construction site. External code is *physically* unable to bypass the kernel.
- Cooperative cancellation is now threaded into the scanner itself: `walk_media_files` checks the token between walkdir iterations; the rayon worker closure inside `scan_directory_streaming` checks before each file's hash. The plugin's `on_call` also checks the token post-scan to suppress `RootWalkCompletedEvent` even when the scanner happened to finish before observing the cancel.
- `AppConfig::validate()` rejects `disabled_plugins` entries that name required plugins (currently `discovery`) at config-load time with an actionable error — before any plugin registration runs. The generated `config.toml` template now distinguishes optional from required plugins. Without this, a user with `disabled_plugins = ["discovery"]` would have hit an opaque "no handler for capability" error on the first dispatch.
- The process pipeline's ingest task fails closed when its holding buffer is non-empty after discovery completes uncancelled — catching a discovery plugin that returns `Ok` without emitting `RootWalkCompletedEvent` for every root. Dispatcher task panics now propagate instead of being silently swallowed via `let _ = handle.await`.

### Tests added

Phase 3 proper:
- **backpressure** — bounded sink (capacity 1) with three files; `blocking_send` must backpressure rather than drop.
- **mid-scan cancellation** — cancel mid-scan with 50 files; plugin must observe the token and exit before emitting all.
- **per-root completion** — exactly one `RootWalkCompletedEvent` per `Call::ScanLibrary`.
- **scan-failure regression** — when `scan_directory_streaming` returns `Err`, no `RootWalkCompletedEvent` is emitted.
- **#378 acceptance** — after a real `voom scan`, `plugin_stats` contains a `discovery` row.
- `aborts_when_snapshot_load_fails` rewritten through `Plugin::on_call(Call::ScanLibrary)`.

Round-1 review fixes (Codex adversarial review pass 1):
- **scanner-level cancellation** — `walk_media_files_observes_cancellation` and `scan_directory_streaming_observes_cancellation_during_hashing` pin that the walker and the rayon workers each bail on a pre-cancelled token.
- **race-window cancellation** — `on_call_suppresses_root_done_when_cancelled_even_if_scan_returned_ok` pins that the plugin's post-scan check suppresses `root_done` even when the scanner returned `Ok` before observing the cancel.
- **dispatch response handling** — four unit tests in `discovery_dispatch.rs` covering `Ok` with empty errors, `Ok` with summary errors folded into counter, wrong `CallResponse` variant rejected as hard error, dispatch `Err` propagated with path context.

Round-2 review fixes (Codex adversarial review pass 3):
- **required-plugin validation** — `validate_rejects_discovery_in_disabled_plugins`, `validate_accepts_default_config`, `validate_accepts_disabling_optional_plugins`, `validate_lists_all_required_plugins_disabled`, plus `bootstrap_fails_when_discovery_is_disabled` integration test.
- **fail-closed on held items** — `process_pipeline_fails_closed_when_discovery_omits_root_done` uses a custom in-test plugin that claims `Capability::Discover { schemes: ["file"] }`, emits a file, and returns `Ok` without sending `root_done`; asserts the pipeline returns `Err` naming the failure mode. This is the regression test Codex's round-3 review explicitly asked for.

### Architectural invariants (verified)

- Zero external callers of `voom_discovery::DiscoveryPlugin::new` (compile-time enforced).
- Zero external callers of `voom_discovery::DiscoveryPlugin::scan_streaming` and `voom_discovery::scan_directory_streaming` (compile-time enforced).
- `DiscoveryPlugin::for_bootstrap` is called from exactly six sites: production bootstrap, two test-bed helpers, and three integration tests in `plugins/discovery/tests/`.
- Cancellation is cooperative at three layers (walker, rayon worker, post-scan `root_done` gate); pre-cancelling the token measurably shortens a 50-file scan.
- Discovery dispatch responses are validated: wrong-variant returns a hard error; `summary.errors` are folded into `discovery_errors`.
- Bootstrap fails fast on `disabled_plugins = ["discovery"]` with an actionable error before any plugin runs.
- Process pipeline fails closed when held items remain post-discovery without cancellation — a broken plugin can no longer silently drop work.

### What does NOT ship

- Evaluator / Orchestrator migrations — Phases 4 and 5.
- Documentation reverts and final acceptance e2e — Phase 6.
- Stale doc-comment references to `scan_streaming` in `process/pipeline_streaming.rs` (lines 4 and 76) and a test comment at line 963 — Phase 6 cleanup.

## Commits

Phase 3:
1. `feat(discovery): implement Plugin::on_call for Call::ScanLibrary; gate root_done on success`
2. `refactor(discovery): add for_bootstrap constructor; bootstrap uses it`
3. `refactor(cli): scan/pipeline.rs uses Kernel::dispatch_to_capability for discovery`
4. `refactor(cli): process pipeline uses Kernel::dispatch_to_capability for discovery`
5. `test(discovery): on_call backpressure, cancellation, and root_done ordering`
6. `test(cli): discovery row appears in plugin_stats after scan`
7. `refactor(discovery): narrow new/scan/scan_streaming to pub(crate)`

Round-1 review fixes:
8. `fix(discovery): walk_media_files observes CancellationToken`
9. `fix(discovery): scan_directory_streaming honors caller's CancellationToken`
10. `fix(discovery): suppress RootWalkCompletedEvent on cancellation`
11. `feat(cli): add discovery_dispatch::handle_dispatch_result helper`
12. `refactor(cli): scan/pipeline.rs uses discovery_dispatch helper`
13. `refactor(cli): process pipeline uses discovery_dispatch helper`

Round-2 review fixes:
14. `feat(cli): AppConfig::validate rejects disabled required plugins`
15. `feat(cli): bootstrap validates config before plugin registration`
16. `docs(cli): config.toml template no longer lists 'discovery' as disableable`
17. `fix(cli): process pipeline fails closed on held items + dispatcher panic`
18. `test(cli): regression test for discovery plugin that omits root_done`

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (77 suites, 2729 tests, 0 failures)
- [x] `cargo test -p voom-cli --features functional -- --test-threads=4` (12 suites, 741 tests, 0 failures)
- [x] Both Codex round-3 named regression tests present and passing.
- [x] Invariant greps: zero external callers of the narrowed APIs.

Refs #378.