### PR TITLE
scripts: add e2e tier 4 observability

### DIFF
--- a/scripts/e2e-policy-audit/README.md
+++ b/scripts/e2e-policy-audit/README.md
@@ -30,10 +30,22 @@ All flags have defaults (see `run.sh --help`):
 | `--probe-workers` | `8` | Parallelism for `ffprobe` sweep |
 | `--no-build` | (off) | Skip `cargo build --release` |
 | `--no-web` | (off) | Skip the `voom serve` smoke-test |
-| `--no-probe` | (off) | Skip the independent `ffprobe` sweep (DB-only diffs) |
+| `--no-probe` | (off) | Skip the independent `ffprobe` sweep and ffprobe-backed metadata diffs |
 
-After a failed run, inspect `diffs/failure-clusters.md` first. To materialize a
-small library containing representative problem files:
+### Long-run sidecar intervals
+
+The long-run sidecars default to issue #402's production cadence:
+
+| Variable | Default | Meaning |
+|---|---:|---|
+| `VOOM_E2E_DMON_INTERVAL_SECONDS` | `30` | GPU power/clock/utilization sample interval |
+| `VOOM_E2E_DB_CHECKPOINT_INTERVAL_SECONDS` | `21600` | DB checkpoint interval, six hours |
+| `VOOM_E2E_WATCHDOG_INTERVAL_SECONDS` | `600` | Jobs-list poll interval |
+| `VOOM_E2E_WATCHDOG_STUCK_POLLS` | `12` | Consecutive unchanged polls before `USR1` |
+
+After a failed run, inspect `summary.md` first. For failed-plan runs,
+`diffs/failure-clusters.md` groups representative problem files; to materialize
+a small library containing them:
 
 ```bash
 ~/voom-e2e-runs/<run>/repro/copy-repro-set.sh /tmp/voom-repro-library
@@ -68,6 +80,7 @@ BUILD=target/release/voom POLICY=/path/to/policy.voom ~/voom-e2e-runs/<run>/repr
 ├── pre/, post/                   library snapshots (find manifest + ffprobe NDJSON + DB NDJSON)
 │   └── voom-db-tables/           raw SQLite export (per-table TSV) post-scan / post-process
 ├── runtime/                      5-minute host state samples during voom process
+│   └── nvidia-dmon.csv           nvidia-smi dmon power/clock/utilization timeseries
 ├── env/                          tool versions, GPU state, policy copy, redacted config
 │   ├── version.json              structured VOOM build/version metadata
 │   ├── journal.log               host journal captured after voom process
@@ -76,8 +89,10 @@ BUILD=target/release/voom POLICY=/path/to/policy.voom ~/voom-e2e-runs/<run>/repr
 │   └── rpm-recently-changed.txt  recently changed installed RPMs
 ├── logs/                         one file per CLI invocation, plus *.rc exit-code sidecars
 │   ├── plugin-errors/            compact repeated plugin.error signature logs
-│   └── env-check/                hourly voom env check snapshots during process
+│   ├── env-check/                hourly voom env check snapshots during process
+│   └── watchdog.log              forward-progress watchdog polls and timeout reason
 ├── db-export/                    raw SQLite tables (post-process; consumed by build-summary)
+│   └── checkpoint-NNNN/          periodic raw SQLite table exports during process
 ├── reports/                      voom report --all, files, plans, jobs, events
 │   ├── scan.json                 structured `voom scan --format json` summary
 │   ├── process.json              structured `voom process --format json` summary
@@ -92,6 +107,7 @@ BUILD=target/release/voom POLICY=/path/to/policy.voom ~/voom-e2e-runs/<run>/repr
 │   └── copy-repro-set.sh         copy representative problem files to a small library
 ├── web-smoke/                    statuses + body samples + content assertions
 ├── diffs/
+│   ├── db-growth.tsv             row count per exported table at each checkpoint
 │   ├── plugin-error-summary.md   repeated plugin.error signatures by plugin
 │   ├── plan-preview-vs-executed.tsv/.md  planned vs executed phase/action/skip diff
 │   ├── deprecations.md           `warning:` lines from logs/*.log

--- a/scripts/e2e-policy-audit/lib/build-summary.sh
+++ b/scripts/e2e-policy-audit/lib/build-summary.sh
@@ -104,6 +104,11 @@ elif [[ -f "${jobs_report}" ]]; then
   fi
 fi
 
+watchdog_rc="${run}/logs/watchdog.log.rc"
+if [[ -f "${watchdog_rc}" ]] && [[ "$(cat "${watchdog_rc}")" == "2" ]]; then
+  note_fail "forward-progress watchdog detected no job-state change"
+fi
+
 # Per-phase plan summary from db-export/plans.tsv.
 phase_summary="${run}/diffs/phase-summary.tsv"
 failed_plans="${run}/diffs/failed-plans.tsv"
@@ -313,7 +318,11 @@ fi
   link_artifact_if_exists "reports/env-check.json"
   link_artifact_if_exists "env/version.json"
   link_artifact_if_exists "logs/plugin-errors/"
+  link_artifact_if_exists "logs/watchdog.log"
   link_artifact_if_exists "runtime/"
+  link_artifact_if_exists "runtime/nvidia-dmon.csv"
+  link_artifact_if_exists "diffs/db-growth.tsv"
+  link_artifact_if_exists "db-export/checkpoint-0001/"
   link_artifact_if_exists "env/journal.log"
   link_artifact_if_exists "env/dmesg.log"
   link_artifact_if_exists "env/dnf-history.txt"

--- a/scripts/e2e-policy-audit/lib/db-checkpoint-sampler.sh
+++ b/scripts/e2e-policy-audit/lib/db-checkpoint-sampler.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Periodically exports DB checkpoints and row-count growth while voom process runs.
+# Usage: db-checkpoint-sampler.sh <run-dir> <db-path> [interval-seconds]
+set -euo pipefail
+
+run_dir="${1:?run dir required}"
+db_path="${2:?db path required}"
+interval="${3:-21600}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+growth="${run_dir}/diffs/db-growth.tsv"
+checkpoint_root="${run_dir}/db-export"
+tables=(files tracks jobs plans file_transitions bad_files discovered_files)
+
+mkdir -p "${checkpoint_root}" "${run_dir}/diffs"
+
+if [[ ! -f "${growth}" ]]; then
+    printf 'checkpoint\ttable\trows\n' >"${growth}"
+fi
+
+sample_index=0
+active_pid=""
+active_uses_group=0
+sleep_pid=""
+
+cleanup() {
+    if [[ -n "${active_pid}" ]]; then
+        if ((active_uses_group)); then
+            kill -- "-${active_pid}" 2>/dev/null || true
+        else
+            kill "${active_pid}" 2>/dev/null || true
+        fi
+        wait "${active_pid}" 2>/dev/null || true
+        active_pid=""
+        active_uses_group=0
+    fi
+    if [[ -n "${sleep_pid}" ]]; then
+        kill "${sleep_pid}" 2>/dev/null || true
+        wait "${sleep_pid}" 2>/dev/null || true
+        sleep_pid=""
+    fi
+}
+
+terminate() {
+    cleanup
+    exit 0
+}
+
+trap terminate INT TERM
+trap cleanup EXIT
+
+start_active_command() {
+    if command -v setsid >/dev/null 2>&1; then
+        setsid "$@" &
+        active_uses_group=1
+    else
+        "$@" &
+        active_uses_group=0
+    fi
+    active_pid="$!"
+}
+
+write_growth_rows() {
+    local checkpoint="$1"
+    local db="$2"
+    local table count count_file rc
+    for table in "${tables[@]}"; do
+        count_file=$(mktemp "${run_dir}/diffs/db-count.XXXXXX")
+        start_active_command sqlite3 "${db}" "SELECT COUNT(*) FROM ${table};" >"${count_file}" 2>/dev/null
+        if wait "${active_pid}"; then
+            rc=0
+        else
+            rc="$?"
+        fi
+        active_pid=""
+        active_uses_group=0
+        if [[ "${rc}" -eq 0 ]]; then
+            count=$(cat "${count_file}")
+        else
+            count=0
+        fi
+        rm -f "${count_file}"
+        printf '%s\t%s\t%s\n' "${checkpoint}" "${table}" "${count}" >>"${growth}"
+    done
+}
+
+while true; do
+    sample_index=$((sample_index + 1))
+    checkpoint="$(printf 'checkpoint-%04d' "${sample_index}")"
+    out_dir="${checkpoint_root}/${checkpoint}"
+    if [[ -r "${db_path}" ]]; then
+        mkdir -p "${out_dir}"
+        start_active_command "${script_dir}/db-export.sh" "${db_path}" "${out_dir}" >"${out_dir}/db-export.log" 2>&1
+        if wait "${active_pid}"; then
+            export_rc=0
+        else
+            export_rc="$?"
+        fi
+        active_pid=""
+        active_uses_group=0
+        if [[ "${export_rc}" -ne 0 ]]; then
+            touch "${out_dir}/EXPORT_FAILED"
+            printf '%s\t%s\t%s\n' "${checkpoint}" "__db_export_failed__" "0" >>"${growth}"
+        fi
+        write_growth_rows "${checkpoint}" "${db_path}"
+    else
+        printf '%s\t%s\t%s\n' "${checkpoint}" "__db_unreadable__" "0" >>"${growth}"
+    fi
+
+    if [[ "${VOOM_E2E_CHECKPOINT_TEST_ONCE:-0}" == "1" ]]; then
+        exit 0
+    fi
+
+    sleep "${interval}" &
+    sleep_pid="$!"
+    wait "${sleep_pid}"
+    sleep_pid=""
+done

--- a/scripts/e2e-policy-audit/lib/nvidia-dmon-sampler.sh
+++ b/scripts/e2e-policy-audit/lib/nvidia-dmon-sampler.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Captures nvidia-smi dmon output during voom process.
+# Usage: nvidia-dmon-sampler.sh <run-dir> [interval-seconds]
+set -euo pipefail
+
+run_dir="${1:?run dir required}"
+interval="${2:-30}"
+out="${run_dir}/runtime/nvidia-dmon.csv"
+mkdir -p "$(dirname "${out}")"
+
+if ! command -v nvidia-smi >/dev/null 2>&1; then
+    {
+        printf '# nvidia-smi not found\n'
+        printf '# timestamp: %s\n' "$(date -Iseconds)"
+    } >"${out}"
+    exit 0
+fi
+
+exec nvidia-smi dmon -s pcu -d "${interval}" -o DT >"${out}"

--- a/scripts/e2e-policy-audit/lib/progress-watchdog.sh
+++ b/scripts/e2e-policy-audit/lib/progress-watchdog.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Watches voom jobs list for forward progress while voom process runs.
+# Usage: progress-watchdog.sh <run-dir> <voom-bin> <target-pid> <target-uses-group:0|1> [interval] [stuck-polls]
+set -euo pipefail
+
+run_dir="${1:?run dir required}"
+voom_bin="${2:?voom bin required}"
+target_pid="${3:?target pid required}"
+target_uses_group="${4:?target uses group required}"
+interval="${5:-600}"
+stuck_limit="${6:-12}"
+log="${run_dir}/logs/watchdog.log"
+rc_file="${run_dir}/logs/watchdog.log.rc"
+mkdir -p "${run_dir}/logs"
+
+last_signature=""
+stuck_count=0
+poll_count=0
+sleep_pid=""
+
+cleanup() {
+    if [[ -n "${sleep_pid}" ]]; then
+        kill "${sleep_pid}" 2>/dev/null || true
+        wait "${sleep_pid}" 2>/dev/null || true
+        sleep_pid=""
+    fi
+}
+
+record_status() {
+    local rc="$1"
+    if [[ "${rc}" == "0" && -f "${rc_file}" && "$(cat "${rc_file}")" == "2" ]]; then
+        return 0
+    fi
+    printf '%s\n' "${rc}" >"${rc_file}"
+}
+
+finish() {
+    local rc="$1"
+    record_status "${rc}"
+    exit 0
+}
+
+target_is_live() {
+    if ((target_uses_group)); then
+        kill -0 "-${target_pid}" 2>/dev/null
+    else
+        kill -0 "${target_pid}" 2>/dev/null
+    fi
+}
+
+signal_target() {
+    kill -USR1 "${target_pid}" 2>/dev/null || true
+}
+
+trap 'cleanup; finish 0' INT TERM
+trap cleanup EXIT
+
+{
+    printf 'started: %s\n' "$(date -Iseconds)"
+    printf 'target_pid: %s\n' "${target_pid}"
+    printf 'interval_seconds: %s\n' "${interval}"
+    printf 'stuck_polls: %s\n' "${stuck_limit}"
+} >>"${log}"
+
+while target_is_live; do
+    poll_count=$((poll_count + 1))
+    sig=$("${voom_bin}" jobs list 2>/dev/null | sha256sum | awk '{print $1}' || true)
+    if [[ -n "${last_signature}" && "${sig}" == "${last_signature}" ]]; then
+        stuck_count=$((stuck_count + 1))
+    else
+        stuck_count=0
+    fi
+    last_signature="${sig}"
+
+    printf '%s\tpoll=%s\tstuck=%s\tsignature=%s\n' \
+        "$(date -Iseconds)" "${poll_count}" "${stuck_count}" "${sig}" >>"${log}"
+
+    if ((stuck_count >= stuck_limit)); then
+        printf 'WATCHDOG: no job-state change after %s unchanged poll(s)\n' "${stuck_count}" >>"${log}"
+        record_status 2
+        signal_target
+        finish 2
+    fi
+
+    if [[ -n "${VOOM_E2E_WATCHDOG_TEST_MAX_POLLS:-}" ]] &&
+        ((poll_count >= VOOM_E2E_WATCHDOG_TEST_MAX_POLLS)); then
+        finish 0
+    fi
+
+    sleep "${interval}" &
+    sleep_pid="$!"
+    wait "${sleep_pid}"
+    sleep_pid=""
+done
+
+finish 0

--- a/scripts/e2e-policy-audit/run.sh
+++ b/scripts/e2e-policy-audit/run.sh
@@ -113,8 +113,14 @@ json_run() {
 
 runtime_sampler_pid=""
 env_check_sampler_pid=""
+nvidia_dmon_pid=""
+db_checkpoint_sampler_pid=""
+progress_watchdog_pid=""
 runtime_sampler_uses_group=0
 env_check_sampler_uses_group=0
+nvidia_dmon_uses_group=0
+db_checkpoint_sampler_uses_group=0
+progress_watchdog_uses_group=0
 active_process_pid=""
 active_process_uses_group=0
 
@@ -183,6 +189,18 @@ stop_process_samplers() {
     stop_process_tree "${env_check_sampler_pid}" "${env_check_sampler_uses_group}"
     env_check_sampler_pid=""
     env_check_sampler_uses_group=0
+
+    stop_process_tree "${nvidia_dmon_pid}" "${nvidia_dmon_uses_group}"
+    nvidia_dmon_pid=""
+    nvidia_dmon_uses_group=0
+
+    stop_process_tree "${db_checkpoint_sampler_pid}" "${db_checkpoint_sampler_uses_group}"
+    db_checkpoint_sampler_pid=""
+    db_checkpoint_sampler_uses_group=0
+
+    stop_process_tree "${progress_watchdog_pid}" "${progress_watchdog_uses_group}"
+    progress_watchdog_pid=""
+    progress_watchdog_uses_group=0
 }
 
 start_process_samplers() {
@@ -198,6 +216,25 @@ start_process_samplers() {
         env_check_sampler_uses_group=0
     fi
     env_check_sampler_pid=$!
+    if start_background_session \
+        "${lib_dir}/nvidia-dmon-sampler.sh" \
+        "${run_dir}" \
+        "${VOOM_E2E_DMON_INTERVAL_SECONDS:-30}"; then
+        nvidia_dmon_uses_group=1
+    else
+        nvidia_dmon_uses_group=0
+    fi
+    nvidia_dmon_pid=$!
+    if start_background_session \
+        "${lib_dir}/db-checkpoint-sampler.sh" \
+        "${run_dir}" \
+        "${db_path}" \
+        "${VOOM_E2E_DB_CHECKPOINT_INTERVAL_SECONDS:-21600}"; then
+        db_checkpoint_sampler_uses_group=1
+    else
+        db_checkpoint_sampler_uses_group=0
+    fi
+    db_checkpoint_sampler_pid=$!
 }
 
 forward_process_signal() {
@@ -226,6 +263,20 @@ run_process_command() {
         active_process_uses_group=0
     fi >"${run_dir}/reports/process.json" 2>"${run_dir}/logs/process.log"
     active_process_pid=$!
+
+    if start_background_session \
+        "${lib_dir}/progress-watchdog.sh" \
+        "${run_dir}" \
+        "${voom_bin}" \
+        "${active_process_pid}" \
+        "${active_process_uses_group}" \
+        "${VOOM_E2E_WATCHDOG_INTERVAL_SECONDS:-600}" \
+        "${VOOM_E2E_WATCHDOG_STUCK_POLLS:-12}"; then
+        progress_watchdog_uses_group=1
+    else
+        progress_watchdog_uses_group=0
+    fi
+    progress_watchdog_pid=$!
 
     trap 'stop_process_samplers' EXIT
     trap 'forward_process_signal INT 130' INT

--- a/scripts/e2e-policy-audit/tests/test.sh
+++ b/scripts/e2e-policy-audit/tests/test.sh
@@ -177,6 +177,36 @@ EOF
 
 run_summary_jobs_json_straggler_test
 
+run_summary_watchdog_timeout_test() {
+  local actual summary
+  actual=$(mktemp -d)
+  trap 'rm -R "${actual}"' EXIT
+
+  mkdir -p "${actual}/logs" "${actual}/reports" "${actual}/db-export" "${actual}/diffs"
+  for log_name in env-check policy-validate scan; do
+    printf '0\n' >"${actual}/logs/${log_name}.log.rc"
+  done
+  printf '2\n' >"${actual}/logs/watchdog.log.rc"
+  cat >"${actual}/diffs/files-summary.md" <<'EOF'
+# Snapshot Diff Summary
+
+Disappeared paths: 0
+Missing backup post-run: 0
+EOF
+
+  "lib/build-summary.sh" "${actual}" 0 0
+  summary="${actual}/summary.md"
+  if ! grep -Fq "FAIL: forward-progress watchdog detected no job-state change" "${summary}"; then
+    echo "FAIL: watchdog timeout did not fail summary" >&2
+    fail=1
+  fi
+
+  rm -R "${actual}"
+  trap - EXIT
+}
+
+run_summary_watchdog_timeout_test
+
 run_summary_deprecation_gate_test() {
   local actual
   local summary
@@ -336,6 +366,110 @@ EOF
 }
 
 run_deprecations_test
+
+run_progress_watchdog_timeout_test() {
+  local actual fake_voom sleep_pid
+  actual=$(mktemp -d)
+  fake_voom="${actual}/voom"
+  cleanup_progress_watchdog_timeout_test() {
+    if [[ -n "${sleep_pid:-}" ]]; then
+      kill "${sleep_pid}" 2>/dev/null || true
+      wait "${sleep_pid}" 2>/dev/null || true
+      sleep_pid=""
+    fi
+    if [[ -n "${actual:-}" && -d "${actual}" ]]; then
+      rm -R "${actual}"
+    fi
+  }
+  trap cleanup_progress_watchdog_timeout_test EXIT
+
+  cat >"${fake_voom}" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "jobs" && "$2" == "list" ]]; then
+  printf 'job-1 running\n'
+  exit 0
+fi
+exit 2
+EOF
+  chmod +x "${fake_voom}"
+
+  sleep 30 &
+  sleep_pid=$!
+  VOOM_E2E_WATCHDOG_TEST_MAX_POLLS=3 \
+    "lib/progress-watchdog.sh" "${actual}" "${fake_voom}" "${sleep_pid}" 0 1 1
+
+  kill "${sleep_pid}" 2>/dev/null || true
+  wait "${sleep_pid}" 2>/dev/null || true
+  sleep_pid=""
+
+  if ! grep -Fq "WATCHDOG: no job-state change" "${actual}/logs/watchdog.log"; then
+    echo "FAIL: watchdog did not log timeout" >&2
+    fail=1
+  fi
+  if [[ "$(cat "${actual}/logs/watchdog.log.rc")" != "2" ]]; then
+    echo "FAIL: watchdog timeout rc should be 2" >&2
+    fail=1
+  fi
+
+  cleanup_progress_watchdog_timeout_test
+  trap - EXIT
+}
+
+run_progress_watchdog_timeout_test
+
+run_db_checkpoint_growth_test() {
+  local actual db expected_files
+  actual=$(mktemp -d)
+  db="${actual}/voom.db"
+  expected_files="${actual}/expected-files.tsv"
+  trap 'rm -R "${actual}"' EXIT
+
+  sqlite3 "${db}" <<'SQL'
+CREATE TABLE files(id TEXT PRIMARY KEY, path TEXT);
+CREATE TABLE tracks(id TEXT PRIMARY KEY, file_id TEXT);
+CREATE TABLE jobs(id TEXT PRIMARY KEY, status TEXT);
+CREATE TABLE plans(id TEXT PRIMARY KEY, file_id TEXT);
+CREATE TABLE file_transitions(id TEXT PRIMARY KEY);
+CREATE TABLE bad_files(id TEXT PRIMARY KEY);
+CREATE TABLE discovered_files(id TEXT PRIMARY KEY);
+INSERT INTO files VALUES ('file-1', '/lib/a.mkv');
+INSERT INTO jobs VALUES ('job-1', 'running');
+SQL
+
+  VOOM_E2E_CHECKPOINT_TEST_ONCE=1 \
+    "lib/db-checkpoint-sampler.sh" "${actual}" "${db}" 999
+
+  test -f "${actual}/db-export/checkpoint-0001/files.tsv" || {
+    echo "FAIL: checkpoint files.tsv missing" >&2
+    fail=1
+  }
+  cat >"${expected_files}" <<'EOF'
+id	path
+file-1	/lib/a.mkv
+EOF
+  assert_match "${actual}/db-export/checkpoint-0001/files.tsv" "${expected_files}"
+  test -f "${actual}/db-export/checkpoint-0001/EXPORT_FAILED" || {
+    echo "FAIL: checkpoint EXPORT_FAILED marker missing" >&2
+    fail=1
+  }
+  if ! grep -Fq $'checkpoint\ttable\trows' "${actual}/diffs/db-growth.tsv"; then
+    echo "FAIL: db-growth.tsv missing header" >&2
+    fail=1
+  fi
+  if ! grep -Fq $'checkpoint-0001\t__db_export_failed__\t0' "${actual}/diffs/db-growth.tsv"; then
+    echo "FAIL: db-growth.tsv missing export failure row" >&2
+    fail=1
+  fi
+  if ! grep -Fq $'checkpoint-0001\tfiles\t1' "${actual}/diffs/db-growth.tsv"; then
+    echo "FAIL: db-growth.tsv missing files row count" >&2
+    fail=1
+  fi
+
+  rm -R "${actual}"
+  trap - EXIT
+}
+
+run_db_checkpoint_growth_test
 
 run_summary_web_smoke_fail_then_sse_warn_test() {
   local actual


### PR DESCRIPTION
## Summary
- add GPU `nvidia-smi dmon` timeseries capture for e2e policy audit runs
- add periodic DB checkpoint exports with row-count growth tracking
- add a forward-progress watchdog that marks stalled runs and signals `voom` to flush

## Test Plan
- [x] `scripts/e2e-policy-audit/tests/test.sh`
- [x] `bash -n scripts/e2e-policy-audit/lib/nvidia-dmon-sampler.sh scripts/e2e-policy-audit/lib/db-checkpoint-sampler.sh scripts/e2e-policy-audit/lib/progress-watchdog.sh scripts/e2e-policy-audit/run.sh scripts/e2e-policy-audit/lib/build-summary.sh`

Closes issue #402 