### PR TITLE
Phase 4 — policy evaluator promotion (#378)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4000,6 +4000,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "insta",
+ "parking_lot",
  "proptest",
  "serde",
  "serde_json",
@@ -4007,6 +4008,7 @@ dependencies = [
  "uuid",
  "voom-domain",
  "voom-dsl",
+ "voom-kernel",
 ]
 
 [[package]]

--- a/crates/voom-cli/src/app.rs
+++ b/crates/voom-cli/src/app.rs
@@ -45,6 +45,12 @@ const PRIORITY_STORAGE: i32 = 38;
 // the collector before any subsequent event reaches the executors.
 // (Lower priority = earlier dispatch — see voom_kernel::EventBus::subscribe_plugin.)
 const PRIORITY_CAPABILITY_COLLECTOR: i32 = 35;
+// Policy evaluator — dispatches AFTER capability-collector (35 < 36) so any
+// EXECUTOR_CAPABILITIES event has already populated the collector. Both
+// plugins subscribe to that event; the relative order between 35 and 36 only
+// matters for in-process consumers within the same dispatch, and the policy
+// evaluator caches independently.
+const PRIORITY_POLICY_EVALUATOR: i32 = 36;
 // Backup manager dispatches before executors (30 < 39/40) so the source
 // file is backed up before any executor mutates it.
 const PRIORITY_BACKUP_MANAGER: i32 = 30;
@@ -260,6 +266,17 @@ pub fn bootstrap_kernel_with_store(config: &AppConfig) -> Result<BootstrapResult
             )
             .context("Failed to initialize and register capability collector")?
     };
+
+    // Policy evaluator — claims Capability::EvaluatePolicy. Subscribes to
+    // EXECUTOR_CAPABILITIES so the cached snapshot stays current; on_call
+    // routes Call::EvaluatePolicy to the existing free-function evaluator
+    // surface (PR #378 / Phase 4).
+    register_if_enabled!(
+        "policy-evaluator",
+        voom_policy_evaluator::PolicyEvaluatorPlugin::for_bootstrap(),
+        PRIORITY_POLICY_EVALUATOR,
+        "policy evaluator"
+    );
 
     // Executor — mkvtoolnix (MKV metadata, track removal/reorder, convert-to-MKV)
     register_if_enabled!(
@@ -532,6 +549,33 @@ mod tests {
         assert!(
             msg.contains("discovery"),
             "error must name discovery; got: {msg}"
+        );
+        assert!(
+            msg.contains("disabled_plugins") || msg.contains("required"),
+            "error must explain the cause; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn bootstrap_fails_when_policy_evaluator_is_disabled() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = AppConfig {
+            data_dir: dir.path().to_path_buf(),
+            plugins: crate::config::PluginsConfig {
+                disabled_plugins: vec!["policy-evaluator".into()],
+                ..crate::config::PluginsConfig::default()
+            },
+            ..AppConfig::default()
+        };
+
+        let err = match bootstrap_kernel_with_store(&config) {
+            Ok(_) => panic!("bootstrap must fail when policy-evaluator is disabled"),
+            Err(e) => e,
+        };
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("policy-evaluator"),
+            "error must name policy-evaluator; got: {msg}"
         );
         assert!(
             msg.contains("disabled_plugins") || msg.contains("required"),

--- a/crates/voom-cli/src/commands/process/pipeline.rs
+++ b/crates/voom-cli/src/commands/process/pipeline.rs
@@ -127,15 +127,14 @@ pub(super) async fn process_single_file(
 /// Dry-run / plan-only: evaluate all phases up front against the original file.
 ///
 /// Signature mirrors `process_single_file_execute` so that `process_single_file`
-/// can dispatch either without casting — the `Result` wrapper is required even
-/// though the dry-run path never produces an error.
-#[allow(clippy::unnecessary_wraps)]
+/// can dispatch either without casting. The `Result` propagates errors from
+/// `kernel_invoke::evaluate` dispatch.
 fn process_single_file_dry_run(
     file: &voom_domain::media::MediaFile,
     compiled: &voom_dsl::CompiledPolicy,
     ctx: &ProcessContext<'_>,
 ) -> std::result::Result<Option<serde_json::Value>, String> {
-    let mut result = orchestrate_plans(compiled, file, ctx.capabilities);
+    let mut result = orchestrate_plans(&ctx.kernel, compiled, file, ctx.capabilities)?;
     annotate_disk_space_violations(&mut result, file);
 
     collect_safeguard_violations(file, &result, ctx);
@@ -705,14 +704,27 @@ fn preserve_persisted_file_identity(
 ///
 /// NOTE: This function does NOT dispatch `PlanCreated` events. Dispatching
 /// here would trigger executor plugins during dry-run mode.
+///
+/// Policy evaluation now flows through `kernel_invoke::evaluate` so the
+/// kernel's `dispatch_to_capability` instrumentation records a
+/// `plugin_stats` row for each dry-run invocation (#378 Phase 4).
 fn orchestrate_plans(
+    kernel: &voom_kernel::Kernel,
     compiled: &voom_dsl::CompiledPolicy,
     file: &voom_domain::media::MediaFile,
     capabilities: &voom_domain::CapabilityMap,
-) -> voom_phase_orchestrator::OrchestrationResult {
-    let plans =
-        voom_policy_evaluator::evaluate_with_capabilities(compiled, file, capabilities).plans;
-    voom_phase_orchestrator::orchestrate(plans)
+) -> std::result::Result<voom_phase_orchestrator::OrchestrationResult, String> {
+    let result = crate::kernel_invoke::evaluate(
+        kernel,
+        compiled.clone(),
+        file.clone(),
+        None,
+        None,
+        None,
+        Some(capabilities.clone()),
+    )
+    .map_err(|e| format!("evaluate dispatch failed (dry-run): {e:#}"))?;
+    Ok(voom_phase_orchestrator::orchestrate(result.plans))
 }
 
 /// Determine the file path after plan execution.

--- a/crates/voom-cli/src/commands/process/pipeline.rs
+++ b/crates/voom-cli/src/commands/process/pipeline.rs
@@ -253,13 +253,17 @@ async fn process_single_file_execute(
             break;
         }
 
-        let Some(plan) = voom_policy_evaluator::evaluate_single_phase_with_hints(
-            phase_name,
-            compiled,
-            &current_file,
-            &phase_outcomes,
-            ctx.capabilities,
-        ) else {
+        let result = crate::kernel_invoke::evaluate(
+            &ctx.kernel,
+            compiled.clone(),
+            current_file.clone(),
+            Some(phase_name.clone()),
+            None,
+            Some(phase_outcomes.clone()),
+            Some(ctx.capabilities.clone()),
+        )
+        .map_err(|e| format!("evaluate dispatch failed for phase {phase_name}: {e:#}"))?;
+        let Some(plan) = result.plans.into_iter().next() else {
             continue;
         };
         let mut plan = plan
@@ -901,6 +905,22 @@ mod tests {
     use super::super::tests as process_tests;
     use super::*;
 
+    /// Test-only helper: register the policy-evaluator plugin on a fresh kernel
+    /// so `Kernel::dispatch_to_capability(Exclusive { kind: "evaluate_policy" }, ...)`
+    /// resolves. Mirrors the bootstrap registration at `app.rs::PRIORITY_POLICY_EVALUATOR`
+    /// — keep the priority in sync if that constant ever changes.
+    fn register_policy_evaluator(kernel: &mut voom_kernel::Kernel) {
+        let plugin_ctx =
+            voom_kernel::PluginContext::new(serde_json::json!({}), std::env::temp_dir());
+        kernel
+            .init_and_register(
+                std::sync::Arc::new(voom_policy_evaluator::PolicyEvaluatorPlugin::for_bootstrap()),
+                36,
+                &plugin_ctx,
+            )
+            .expect("register PolicyEvaluatorPlugin for dispatch_to_capability");
+    }
+
     struct RecordingExecutor {
         entered_tx: mpsc::Sender<()>,
     }
@@ -1094,7 +1114,9 @@ mod tests {
     async fn auto_crop_detection_persists_and_updates_plan_file() {
         let fixture = process_tests::TestFixture::with_policy(global_hw_policy());
         let store = Arc::new(voom_domain::test_support::InMemoryStore::new());
-        let ctx = fixture.make_ctx(Arc::new(voom_kernel::Kernel::new()), store.clone());
+        let mut kernel = voom_kernel::Kernel::new();
+        register_policy_evaluator(&mut kernel);
+        let ctx = fixture.make_ctx(Arc::new(kernel), store.clone());
         let path = fixture.dir_path().join("movie.mkv");
         let mut file = h264_file(path);
         let mut plan = crop_plan(file.clone(), CropSettings::auto());
@@ -1222,6 +1244,7 @@ mod tests {
         let compiled = voom_dsl::compile_policy(policy).unwrap();
 
         let mut kernel = voom_kernel::Kernel::new();
+        register_policy_evaluator(&mut kernel);
         kernel
             .register_plugin(Arc::new(FailingExecutor), 50)
             .unwrap();
@@ -1263,6 +1286,7 @@ mod tests {
 
         let (entered_tx, entered_rx) = mpsc::channel();
         let mut kernel = voom_kernel::Kernel::new();
+        register_policy_evaluator(&mut kernel);
         kernel
             .register_plugin(Arc::new(RecordingExecutor { entered_tx }), 50)
             .unwrap();
@@ -1316,6 +1340,7 @@ mod tests {
 
         let (entered_tx, entered_rx) = mpsc::channel();
         let mut kernel = voom_kernel::Kernel::new();
+        register_policy_evaluator(&mut kernel);
         kernel
             .register_plugin(Arc::new(RecordingExecutor { entered_tx }), 50)
             .unwrap();
@@ -1364,6 +1389,7 @@ mod tests {
 
         let (entered_tx, entered_rx) = mpsc::channel();
         let mut kernel = voom_kernel::Kernel::new();
+        register_policy_evaluator(&mut kernel);
         kernel
             .register_plugin(Arc::new(RecordingExecutor { entered_tx }), 50)
             .unwrap();

--- a/crates/voom-cli/src/config.rs
+++ b/crates/voom-cli/src/config.rs
@@ -335,6 +335,7 @@ pub const KNOWN_PLUGIN_NAMES: &[&str] = &[
     "ffmpeg-executor",
     "backup-manager",
     "job-manager",
+    "policy-evaluator",
     "report",
     "verifier",
 ];
@@ -347,7 +348,7 @@ pub const KNOWN_PLUGIN_NAMES: &[&str] = &[
 /// `disabled_plugins` in config.toml is an unrunnable configuration; we
 /// reject it at config load with an explicit error rather than failing at
 /// dispatch time with a less actionable "no handler" message.
-pub const REQUIRED_PLUGIN_NAMES: &[&str] = &["discovery"];
+pub const REQUIRED_PLUGIN_NAMES: &[&str] = &["discovery", "policy-evaluator"];
 
 /// Generate a default config.toml with all options commented out and documented.
 pub fn default_config_contents() -> String {
@@ -633,7 +634,7 @@ mod tests {
 
     #[test]
     fn test_known_plugin_names_count() {
-        assert_eq!(KNOWN_PLUGIN_NAMES.len(), 13);
+        assert_eq!(KNOWN_PLUGIN_NAMES.len(), 14);
     }
 
     #[test]

--- a/crates/voom-cli/src/kernel_invoke.rs
+++ b/crates/voom-cli/src/kernel_invoke.rs
@@ -1,0 +1,176 @@
+//! Typed helpers wrapping `Kernel::dispatch_to_capability` for the CLI's
+//! runtime evaluator/orchestrator/scan call sites.
+//!
+//! Each helper builds the matching `Call`, dispatches via the kernel,
+//! validates the `CallResponse` variant, and returns the unwrapped inner
+//! result. Wrong response variants and dispatch errors are turned into
+//! actionable `anyhow::Error`s so the CLI can fail closed with context.
+//!
+//! This module is purely additive: callers may keep using the free
+//! `voom_policy_evaluator::*` functions for code paths that do not have a
+//! kernel handle (e.g. `voom policy test`, `voom policy diff`, integration
+//! tests of pure plan shapes).
+
+use std::collections::HashMap;
+
+use anyhow::{anyhow, Result};
+
+use voom_domain::call::{Call, CallResponse};
+use voom_domain::capabilities::{Capability, CapabilityQuery};
+use voom_domain::capability_map::CapabilityMap;
+use voom_domain::evaluation::{EvaluationOutcome, EvaluationResult};
+use voom_domain::media::MediaFile;
+use voom_domain::plan::PhaseOutput;
+use voom_dsl::compiled::CompiledPolicy;
+use voom_kernel::Kernel;
+
+/// Dispatch a policy evaluation through the kernel's `Capability::EvaluatePolicy`
+/// handler (the `PolicyEvaluatorPlugin` registered at bootstrap).
+///
+/// Records one row in `plugin_stats` per call (kernel-instrumented at the
+/// Call boundary). Use this from CLI runtime paths so every evaluation is
+/// host-measured.
+///
+/// `phase`: if `Some(name)`, the evaluator runs the single named phase;
+/// `None` evaluates every phase in policy order.
+///
+/// `phase_outputs`: optional `HashMap<phase_name, PhaseOutput>` used by the
+/// `evaluate_*_with_phase_outputs` codepath for cross-phase field lookups.
+///
+/// `phase_outcomes`: optional per-phase outcomes used by single-phase
+/// evaluation to evaluate `skip_when` / `run_if` / `depends_on` conditions.
+///
+/// `capabilities_override`: if `Some`, used verbatim. If `None`, the plugin
+/// consults its cached snapshot populated from `Event::ExecutorCapabilities`.
+///
+/// # Errors
+/// - Capability not claimed (bootstrap bug): error names the missing capability.
+/// - Plugin returned the wrong `CallResponse` variant: hard error naming the
+///   variant returned. Cannot happen with the in-tree `PolicyEvaluatorPlugin`
+///   but is checked because a future WASM plugin could violate this.
+/// - Plugin's `on_call` returned `Err`: propagated.
+/// - Plugin panicked: caught at the kernel boundary, returned as `Err`.
+pub fn evaluate(
+    kernel: &Kernel,
+    policy: CompiledPolicy,
+    file: MediaFile,
+    phase: Option<String>,
+    phase_outputs: Option<HashMap<String, PhaseOutput>>,
+    phase_outcomes: Option<HashMap<String, EvaluationOutcome>>,
+    capabilities_override: Option<CapabilityMap>,
+) -> Result<EvaluationResult> {
+    let call = Call::EvaluatePolicy {
+        policy: Box::new(policy),
+        file: Box::new(file),
+        phase,
+        phase_outputs,
+        phase_outcomes,
+        capabilities_override,
+    };
+    // String-typed kind, derived from `Capability::kind()`, so the canonical
+    // wire token ("evaluate_policy") flows through the domain enum rather
+    // than being duplicated as a literal.
+    let query = CapabilityQuery::Exclusive {
+        kind: Capability::EvaluatePolicy.kind().to_string(),
+    };
+    let response = kernel
+        .dispatch_to_capability(query, call)
+        .map_err(anyhow::Error::new)?;
+    match response {
+        CallResponse::EvaluatePolicy(result) => Ok(result),
+        other => Err(anyhow!(
+            "evaluate dispatch returned wrong CallResponse variant: {other:?}"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+    use voom_policy_evaluator::PolicyEvaluatorPlugin;
+
+    fn kernel_with_evaluator() -> Kernel {
+        let mut kernel = Kernel::new();
+        let ctx = voom_kernel::PluginContext::new(serde_json::json!({}), std::env::temp_dir());
+        kernel
+            .init_and_register(Arc::new(PolicyEvaluatorPlugin::for_bootstrap()), 36, &ctx)
+            .expect("init_and_register policy-evaluator");
+        kernel
+    }
+
+    #[test]
+    fn evaluate_returns_one_plan_for_one_phase_policy() {
+        let kernel = kernel_with_evaluator();
+        let policy =
+            voom_dsl::compile_policy(r#"policy "demo" { phase init { container mkv } }"#).unwrap();
+        let file = MediaFile::new(PathBuf::from("/movies/test.mkv"));
+
+        let result = evaluate(&kernel, policy, file, None, None, None, None)
+            .expect("evaluate should succeed");
+        assert_eq!(result.plans.len(), 1);
+        assert_eq!(result.plans[0].phase_name, "init");
+    }
+
+    #[test]
+    fn evaluate_single_phase_present_returns_one_plan() {
+        let kernel = kernel_with_evaluator();
+        let policy = voom_dsl::compile_policy(
+            r#"policy "demo" { phase a { container mkv } phase b { container mkv } }"#,
+        )
+        .unwrap();
+        let file = MediaFile::new(PathBuf::from("/movies/test.mkv"));
+
+        let result = evaluate(
+            &kernel,
+            policy,
+            file,
+            Some("b".into()),
+            None,
+            Some(HashMap::new()),
+            None,
+        )
+        .expect("evaluate should succeed");
+        assert_eq!(result.plans.len(), 1);
+        assert_eq!(result.plans[0].phase_name, "b");
+    }
+
+    #[test]
+    fn evaluate_single_phase_missing_returns_zero_plans() {
+        let kernel = kernel_with_evaluator();
+        let policy =
+            voom_dsl::compile_policy(r#"policy "demo" { phase init { container mkv } }"#).unwrap();
+        let file = MediaFile::new(PathBuf::from("/movies/test.mkv"));
+
+        let result = evaluate(
+            &kernel,
+            policy,
+            file,
+            Some("does-not-exist".into()),
+            None,
+            Some(HashMap::new()),
+            None,
+        )
+        .expect("evaluate should succeed even when phase is missing");
+        assert!(result.plans.is_empty());
+    }
+
+    #[test]
+    fn evaluate_without_evaluator_registered_is_hard_error() {
+        let kernel = Kernel::new();
+        let policy =
+            voom_dsl::compile_policy(r#"policy "demo" { phase init { container mkv } }"#).unwrap();
+        let file = MediaFile::new(PathBuf::from("/movies/test.mkv"));
+
+        let err = evaluate(&kernel, policy, file, None, None, None, None)
+            .expect_err("dispatch without a handler must fail");
+        let chain = format!("{err:#}");
+        assert!(
+            chain.contains("EvaluatePolicy")
+                || chain.contains("evaluate_policy")
+                || chain.contains("no handler"),
+            "error must name the missing capability or 'no handler'; got: {chain}"
+        );
+    }
+}

--- a/crates/voom-cli/src/kernel_invoke.rs
+++ b/crates/voom-cli/src/kernel_invoke.rs
@@ -13,7 +13,7 @@
 
 use std::collections::HashMap;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 
 use voom_domain::call::{Call, CallResponse};
 use voom_domain::capabilities::{Capability, CapabilityQuery};

--- a/crates/voom-cli/src/lib.rs
+++ b/crates/voom-cli/src/lib.rs
@@ -9,6 +9,7 @@ pub mod cli;
 pub mod commands;
 pub mod config;
 pub mod introspect;
+pub mod kernel_invoke;
 pub mod lock;
 pub mod output;
 pub mod paths;

--- a/crates/voom-cli/tests/plugin_stats_e2e.rs
+++ b/crates/voom-cli/tests/plugin_stats_e2e.rs
@@ -320,3 +320,67 @@ async fn estimate_calibrate_does_not_mutate_database() {
          {baseline_cost_model_samples}, now {after_cost_model_samples}"
     );
 }
+
+// ─── Phase 4: process-path stats coverage ────────────────────────────────────
+
+/// A `voom process --dry-run` must record at least one `policy-evaluator` row
+/// in `plugin_stats`. `--dry-run` exercises the full process pipeline up to
+/// (but not including) executor mutation, so the per-phase `kernel_invoke::evaluate`
+/// call site fires and the kernel's dispatch_to_capability instrumentation
+/// writes a `plugin_stats` row whose `plugin_id = "policy-evaluator"`.
+///
+/// This is the regression that protects the spec acceptance criterion
+/// "`plugin_stats` contains rows for `discovery`, `policy-evaluator`, and
+/// `phase-orchestrator` after a `voom process` run" (#378).
+#[tokio::test]
+async fn process_dry_run_populates_policy_evaluator_stats_row() {
+    let _lock = TEST_LOCK.lock().await;
+    let mut env = TestEnv::new().await;
+
+    // A one-phase policy that evaluates against any container — keeps the
+    // evaluator's work non-trivial without depending on real ffprobe output.
+    env.set_policy(
+        r#"policy "phase4-stats-fixture" {
+            phase init { container mkv }
+        }"#,
+    );
+    env.write_media("a.mkv", 32);
+
+    let policy_path = env
+        .policy_path()
+        .to_str()
+        .expect("utf-8 policy path")
+        .to_string();
+    let root = env.root().to_str().expect("utf-8 root").to_string();
+
+    let _outcome = env
+        .run_process(&[
+            &root,
+            "--policy",
+            &policy_path,
+            "--dry-run",
+            "--no-backup",
+        ])
+        .await;
+
+    // Allow the SqliteStatsSink writer thread to flush batched rows.
+    tokio::time::sleep(Duration::from_millis(2000)).await;
+
+    let db_path = env.db_path();
+    let conn = rusqlite::Connection::open(&db_path)
+        .unwrap_or_else(|e| panic!("open {}: {e}", db_path.display()));
+    let evaluator_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM plugin_stats WHERE plugin_id = 'policy-evaluator'",
+            [],
+            |r| r.get(0),
+        )
+        .expect("count policy-evaluator rows");
+    assert!(
+        evaluator_count > 0,
+        "expected at least one 'policy-evaluator' row in plugin_stats after a \
+         dry-run process; the CLI dispatches Call::EvaluatePolicy through \
+         Kernel::dispatch_to_capability which records the resolved plugin id \
+         (#378 Phase 4). Got {evaluator_count} rows."
+    );
+}

--- a/crates/voom-cli/tests/plugin_stats_e2e.rs
+++ b/crates/voom-cli/tests/plugin_stats_e2e.rs
@@ -354,13 +354,7 @@ async fn process_dry_run_populates_policy_evaluator_stats_row() {
     let root = env.root().to_str().expect("utf-8 root").to_string();
 
     let _outcome = env
-        .run_process(&[
-            &root,
-            "--policy",
-            &policy_path,
-            "--dry-run",
-            "--no-backup",
-        ])
+        .run_process(&[&root, "--policy", &policy_path, "--dry-run", "--no-backup"])
         .await;
 
     // Allow the SqliteStatsSink writer thread to flush batched rows.

--- a/plugins/policy-evaluator/Cargo.toml
+++ b/plugins/policy-evaluator/Cargo.toml
@@ -19,6 +19,8 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 chrono = { workspace = true }
 uuid = { workspace = true }
+voom-kernel = { workspace = true }
+parking_lot = { workspace = true }
 
 [lints]
 workspace = true

--- a/plugins/policy-evaluator/src/lib.rs
+++ b/plugins/policy-evaluator/src/lib.rs
@@ -8,6 +8,9 @@ pub mod condition;
 pub mod container_compat;
 pub mod evaluator;
 pub mod filter;
+pub mod plugin;
+
+pub use plugin::PolicyEvaluatorPlugin;
 
 use std::collections::HashMap;
 

--- a/plugins/policy-evaluator/src/plugin.rs
+++ b/plugins/policy-evaluator/src/plugin.rs
@@ -67,6 +67,95 @@ impl Plugin for PolicyEvaluatorPlugin {
         }
         Ok(None)
     }
+
+    fn on_call(
+        &self,
+        call: &voom_domain::call::Call,
+    ) -> voom_domain::errors::Result<voom_domain::call::CallResponse> {
+        use voom_domain::call::{Call, CallResponse};
+
+        let Call::EvaluatePolicy {
+            policy,
+            file,
+            phase,
+            phase_outputs,
+            phase_outcomes,
+            capabilities_override,
+        } = call
+        else {
+            return Err(voom_domain::errors::VoomError::plugin(
+                self.name(),
+                format!(
+                    "PolicyEvaluatorPlugin only handles Call::EvaluatePolicy, got {:?}",
+                    std::mem::discriminant(call)
+                ),
+            ));
+        };
+
+        // Resolve capability snapshot: override takes precedence; otherwise the
+        // cached snapshot populated by on_event. The lock is released before
+        // any evaluator work runs.
+        let caps = capabilities_override
+            .clone()
+            .unwrap_or_else(|| self.cache.read().clone());
+
+        let result = match (phase.as_deref(), phase_outputs.as_ref()) {
+            (None, None) => {
+                // Full policy, no cross-phase lookup. The high-level wrapper
+                // already includes apply_capability_hints.
+                crate::evaluate_with_capabilities(policy, file, &caps)
+            }
+            (None, Some(outputs)) => {
+                // Full policy WITH cross-phase lookup. Build the closure-based
+                // lookup, evaluate, then apply hints.
+                let lookup_fn: Box<crate::condition::PhaseOutputLookup<'_>> =
+                    Box::new(|phase_name: &str| outputs.get(phase_name).cloned());
+                let mut res = crate::evaluator::evaluate_with_phase_outputs(
+                    policy,
+                    file,
+                    Some(&caps),
+                    Some(&*lookup_fn),
+                );
+                crate::evaluator::apply_capability_hints(&mut res.plans, &caps);
+                res
+            }
+            (Some(phase_name), None) => {
+                // Single phase, no cross-phase lookup.
+                // `evaluate_single_phase_with_hints` calls
+                // `apply_capability_hints` internally.
+                let outcomes = phase_outcomes.clone().unwrap_or_default();
+                let plan = crate::evaluate_single_phase_with_hints(
+                    phase_name, policy, file, &outcomes, &caps,
+                );
+                voom_domain::evaluation::EvaluationResult::new(
+                    plan.map(|p| vec![p]).unwrap_or_default(),
+                )
+            }
+            (Some(phase_name), Some(outputs)) => {
+                // Single phase WITH cross-phase lookup. Build lookup, evaluate,
+                // apply hints to the (single) plan.
+                let lookup_fn: Box<crate::condition::PhaseOutputLookup<'_>> =
+                    Box::new(|phase_name: &str| outputs.get(phase_name).cloned());
+                let outcomes = phase_outcomes.clone().unwrap_or_default();
+                let mut plan = crate::evaluator::evaluate_single_phase_with_phase_outputs(
+                    phase_name,
+                    policy,
+                    file,
+                    &outcomes,
+                    Some(&caps),
+                    Some(&*lookup_fn),
+                );
+                if let Some(p) = plan.as_mut() {
+                    crate::evaluator::apply_capability_hints(std::slice::from_mut(p), &caps);
+                }
+                voom_domain::evaluation::EvaluationResult::new(
+                    plan.map(|p| vec![p]).unwrap_or_default(),
+                )
+            }
+        };
+
+        Ok(CallResponse::EvaluatePolicy(result))
+    }
 }
 
 #[cfg(test)]
@@ -109,5 +198,286 @@ mod tests {
         assert!(!snapshot.is_empty(), "cache must be populated after event");
         assert!(snapshot.has_encoder("libx264"));
         assert!(snapshot.has_format("matroska"));
+    }
+
+    #[test]
+    fn on_call_wrong_variant_returns_plugin_error() {
+        let plugin = PolicyEvaluatorPlugin::new();
+        let call = voom_domain::call::Call::Orchestrate {
+            plans: vec![],
+            policy_name: "demo".into(),
+        };
+        let err = plugin
+            .on_call(&call)
+            .expect_err("Orchestrate is not handled by policy-evaluator");
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("PolicyEvaluatorPlugin") || msg.contains("policy-evaluator"),
+            "error must name the plugin; got: {msg}"
+        );
+        assert!(
+            msg.contains("EvaluatePolicy"),
+            "error must say which variant it expected; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn on_call_full_policy_no_phase_outputs_uses_evaluate_with_capabilities() {
+        use std::path::PathBuf;
+        use voom_domain::call::{Call, CallResponse};
+        use voom_domain::media::MediaFile;
+
+        let plugin = PolicyEvaluatorPlugin::new();
+        let policy =
+            voom_dsl::compile_policy(r#"policy "demo" { phase init { container mkv } }"#).unwrap();
+        let file = MediaFile::new(PathBuf::from("/movies/test.mkv"));
+
+        let call = Call::EvaluatePolicy {
+            policy: Box::new(policy),
+            file: Box::new(file),
+            phase: None,
+            phase_outputs: None,
+            phase_outcomes: None,
+            capabilities_override: None,
+        };
+
+        let response = plugin.on_call(&call).expect("on_call should succeed");
+        let CallResponse::EvaluatePolicy(result) = response else {
+            panic!("expected EvaluatePolicy response; got {response:?}");
+        };
+        assert_eq!(result.plans.len(), 1, "init phase produces one plan");
+        assert_eq!(result.plans[0].phase_name, "init");
+    }
+
+    #[test]
+    fn on_call_single_phase_returns_zero_or_one_plan() {
+        use std::collections::HashMap;
+        use std::path::PathBuf;
+        use voom_domain::call::{Call, CallResponse};
+        use voom_domain::media::MediaFile;
+
+        let plugin = PolicyEvaluatorPlugin::new();
+        let policy = voom_dsl::compile_policy(
+            r#"policy "demo" {
+                phase one { container mkv }
+                phase two { keep audio where lang in [eng] }
+            }"#,
+        )
+        .unwrap();
+        let file = MediaFile::new(PathBuf::from("/movies/test.mkv"));
+
+        // Phase "one" exists — one plan returned.
+        let call_present = Call::EvaluatePolicy {
+            policy: Box::new(policy.clone()),
+            file: Box::new(file.clone()),
+            phase: Some("one".into()),
+            phase_outputs: None,
+            phase_outcomes: Some(HashMap::new()),
+            capabilities_override: None,
+        };
+        let CallResponse::EvaluatePolicy(present) = plugin.on_call(&call_present).unwrap() else {
+            panic!("expected EvaluatePolicy");
+        };
+        assert_eq!(present.plans.len(), 1);
+        assert_eq!(present.plans[0].phase_name, "one");
+
+        // Phase "missing" does not exist — zero plans returned (Option::None
+        // surfaces as an empty Vec so CLI callers can use plans.first()).
+        let call_missing = Call::EvaluatePolicy {
+            policy: Box::new(policy),
+            file: Box::new(file),
+            phase: Some("missing".into()),
+            phase_outputs: None,
+            phase_outcomes: Some(HashMap::new()),
+            capabilities_override: None,
+        };
+        let CallResponse::EvaluatePolicy(missing) = plugin.on_call(&call_missing).unwrap() else {
+            panic!("expected EvaluatePolicy");
+        };
+        assert!(
+            missing.plans.is_empty(),
+            "missing phase must surface as empty plans, not error"
+        );
+    }
+
+    #[test]
+    fn on_call_full_policy_with_phase_outputs_routes_through_lookup() {
+        use std::collections::HashMap;
+        use std::path::PathBuf;
+        use voom_domain::call::{Call, CallResponse};
+        use voom_domain::media::MediaFile;
+
+        let plugin = PolicyEvaluatorPlugin::new();
+        let policy = voom_dsl::compile_policy(
+            r#"policy "demo" {
+                phase a { container mkv }
+                phase b { keep audio where lang in [eng] }
+            }"#,
+        )
+        .unwrap();
+        let file = MediaFile::new(PathBuf::from("/movies/test.mkv"));
+
+        let call = Call::EvaluatePolicy {
+            policy: Box::new(policy),
+            file: Box::new(file),
+            phase: None,
+            // Empty map is fine — the goal is to exercise the routing arm
+            // (boxed PhaseOutputLookup construction + apply_capability_hints).
+            phase_outputs: Some(HashMap::new()),
+            phase_outcomes: None,
+            capabilities_override: None,
+        };
+
+        let CallResponse::EvaluatePolicy(result) = plugin.on_call(&call).expect("on_call") else {
+            panic!("expected EvaluatePolicy");
+        };
+        assert_eq!(result.plans.len(), 2);
+        // Phase order is determined by the DSL compiler's topological sort,
+        // which is not the source order when phases have no `depends_on`. Just
+        // assert that both phases were evaluated — the routing arm wraps the
+        // result and applies hints regardless of order.
+        let mut phase_names: Vec<&str> =
+            result.plans.iter().map(|p| p.phase_name.as_str()).collect();
+        phase_names.sort_unstable();
+        assert_eq!(phase_names, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn on_call_single_phase_with_phase_outputs_routes_through_lookup() {
+        use std::collections::HashMap;
+        use std::path::PathBuf;
+        use voom_domain::call::{Call, CallResponse};
+        use voom_domain::media::MediaFile;
+
+        let plugin = PolicyEvaluatorPlugin::new();
+        let policy = voom_dsl::compile_policy(
+            r#"policy "demo" {
+                phase target { container mkv }
+            }"#,
+        )
+        .unwrap();
+        let file = MediaFile::new(PathBuf::from("/movies/test.mkv"));
+
+        let call = Call::EvaluatePolicy {
+            policy: Box::new(policy),
+            file: Box::new(file),
+            phase: Some("target".into()),
+            phase_outputs: Some(HashMap::new()),
+            phase_outcomes: Some(HashMap::new()),
+            capabilities_override: None,
+        };
+
+        let CallResponse::EvaluatePolicy(result) = plugin.on_call(&call).expect("on_call") else {
+            panic!("expected EvaluatePolicy");
+        };
+        assert_eq!(result.plans.len(), 1);
+        assert_eq!(result.plans[0].phase_name, "target");
+    }
+
+    #[test]
+    fn on_call_prefers_capabilities_override_over_cached_snapshot() {
+        use std::path::PathBuf;
+        use voom_domain::call::{Call, CallResponse};
+        use voom_domain::capability_map::CapabilityMap;
+        use voom_domain::events::{CodecCapabilities, Event, ExecutorCapabilitiesEvent};
+        use voom_domain::media::MediaFile;
+
+        let plugin = PolicyEvaluatorPlugin::new();
+        // Seed cache with a registered executor that lists NO encoders. The
+        // map is non-empty (so apply_capability_hints will run) but no executor
+        // can encode h264 — yielding warnings and no executor_hint.
+        plugin
+            .on_event(&Event::ExecutorCapabilities(
+                ExecutorCapabilitiesEvent::new(
+                    "ffmpeg-executor",
+                    CodecCapabilities::new(vec![], vec![]),
+                    vec![],
+                    vec![],
+                ),
+            ))
+            .unwrap();
+
+        let mut override_map = CapabilityMap::new();
+        // `encoders_for` matches encoder names against the policy's codec
+        // identifier verbatim, so the encoders list must contain "h264"
+        // (the wire name used in the policy), not the ffmpeg library alias.
+        override_map.register(ExecutorCapabilitiesEvent::new(
+            "ffmpeg-executor",
+            CodecCapabilities::new(vec!["h264".into()], vec!["h264".into()]),
+            vec!["matroska".into()],
+            vec![],
+        ));
+
+        let policy = voom_dsl::compile_policy(
+            r#"policy "demo" {
+                phase tc {
+                    transcode video to h264 { crf: 20 }
+                }
+            }"#,
+        )
+        .unwrap();
+        let mut file = MediaFile::new(PathBuf::from("/movies/test.mkv"));
+        file.container = voom_domain::media::Container::Mkv;
+        let mut video =
+            voom_domain::media::Track::new(0, voom_domain::media::TrackType::Video, "hevc".into());
+        video.width = Some(1920);
+        video.height = Some(1080);
+        file.tracks = vec![video];
+
+        let with_override = Call::EvaluatePolicy {
+            policy: Box::new(policy.clone()),
+            file: Box::new(file.clone()),
+            phase: None,
+            phase_outputs: None,
+            phase_outcomes: None,
+            capabilities_override: Some(override_map),
+        };
+        let without_override = Call::EvaluatePolicy {
+            policy: Box::new(policy),
+            file: Box::new(file),
+            phase: None,
+            phase_outputs: None,
+            phase_outcomes: None,
+            capabilities_override: None,
+        };
+
+        let CallResponse::EvaluatePolicy(with_caps) = plugin.on_call(&with_override).unwrap()
+        else {
+            panic!()
+        };
+        let CallResponse::EvaluatePolicy(without_caps) = plugin.on_call(&without_override).unwrap()
+        else {
+            panic!()
+        };
+
+        // `apply_capability_hints` mutates `plan.executor_hint` (the hint is
+        // attached to the Plan, not to individual PlannedActions). With the
+        // override map ffmpeg-executor is the sole h264 encoder, so the hint
+        // is set; without the override no executor advertises h264, so the
+        // hint is None.
+        let with_hints: Vec<_> = with_caps
+            .plans
+            .iter()
+            .map(|p| p.executor_hint.clone())
+            .collect();
+        let without_hints: Vec<_> = without_caps
+            .plans
+            .iter()
+            .map(|p| p.executor_hint.clone())
+            .collect();
+        assert_ne!(
+            with_hints, without_hints,
+            "override map must yield different hints than empty cache; with={with_hints:?} without={without_hints:?}"
+        );
+        assert_eq!(
+            with_hints,
+            vec![Some("ffmpeg-executor".to_string())],
+            "override map should pin the plan to ffmpeg-executor"
+        );
+        assert_eq!(
+            without_hints,
+            vec![None],
+            "cached snapshot with no encoders should leave executor_hint unset"
+        );
     }
 }

--- a/plugins/policy-evaluator/src/plugin.rs
+++ b/plugins/policy-evaluator/src/plugin.rs
@@ -1,0 +1,113 @@
+//! Policy evaluator plugin: claims `Capability::EvaluatePolicy` and routes
+//! `Call::EvaluatePolicy` to the existing free-function evaluator surface.
+//!
+//! The plugin subscribes to `Event::EXECUTOR_CAPABILITIES` to keep a cached
+//! `CapabilityMap`, which `on_call` consults when no `capabilities_override`
+//! rides with the call. This mirrors today's capability-collector pattern
+//! while exposing a Call-handling capability the kernel can route to.
+
+use parking_lot::RwLock;
+
+use voom_domain::capabilities::Capability;
+use voom_domain::capability_map::CapabilityMap;
+use voom_domain::events::{Event, EventResult};
+use voom_kernel::Plugin;
+
+/// Policy evaluator plugin — claims `Capability::EvaluatePolicy` (Exclusive)
+/// and maintains a cached `CapabilityMap` from `ExecutorCapabilities` events.
+pub struct PolicyEvaluatorPlugin {
+    capabilities: Vec<Capability>,
+    cache: RwLock<CapabilityMap>,
+}
+
+impl PolicyEvaluatorPlugin {
+    /// Bootstrap-only constructor — the canonical public entry point.
+    ///
+    /// All runtime evaluator invocations flow through
+    /// `Kernel::dispatch_to_capability(Exclusive(EvaluatePolicy), Call::EvaluatePolicy)`.
+    /// Constructing a `PolicyEvaluatorPlugin` directly is legitimate only at
+    /// kernel-bootstrap registration time and inside in-crate tests
+    /// (via the `pub(crate) fn new()` companion).
+    #[must_use]
+    pub fn for_bootstrap() -> Self {
+        Self::new()
+    }
+
+    #[must_use]
+    pub(crate) fn new() -> Self {
+        Self {
+            capabilities: vec![Capability::EvaluatePolicy],
+            cache: RwLock::new(CapabilityMap::new()),
+        }
+    }
+}
+
+impl Plugin for PolicyEvaluatorPlugin {
+    fn name(&self) -> &'static str {
+        "policy-evaluator"
+    }
+
+    fn version(&self) -> &'static str {
+        env!("CARGO_PKG_VERSION")
+    }
+
+    voom_kernel::plugin_cargo_metadata!();
+
+    fn capabilities(&self) -> &[Capability] {
+        &self.capabilities
+    }
+
+    fn handles(&self, event_type: &str) -> bool {
+        event_type == Event::EXECUTOR_CAPABILITIES
+    }
+
+    fn on_event(&self, event: &Event) -> voom_domain::errors::Result<Option<EventResult>> {
+        if let Event::ExecutorCapabilities(caps) = event {
+            self.cache.write().register(caps.clone());
+        }
+        Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use voom_domain::events::{CodecCapabilities, ExecutorCapabilitiesEvent};
+
+    #[test]
+    fn claims_exclusive_evaluate_policy_capability() {
+        let plugin = PolicyEvaluatorPlugin::new();
+        assert_eq!(plugin.capabilities(), &[Capability::EvaluatePolicy]);
+        assert_eq!(
+            Capability::EvaluatePolicy.resolution(),
+            voom_domain::capability_resolution::CapabilityResolution::Exclusive,
+            "EvaluatePolicy must be Exclusive — second plugin claiming it fails at register"
+        );
+    }
+
+    #[test]
+    fn subscribes_only_to_executor_capabilities_events() {
+        let plugin = PolicyEvaluatorPlugin::new();
+        assert!(plugin.handles(Event::EXECUTOR_CAPABILITIES));
+        assert!(!plugin.handles(Event::FILE_DISCOVERED));
+        assert!(!plugin.handles(Event::PLAN_CREATED));
+    }
+
+    #[test]
+    fn on_event_populates_capability_cache() {
+        let plugin = PolicyEvaluatorPlugin::new();
+        let event = Event::ExecutorCapabilities(ExecutorCapabilitiesEvent::new(
+            "ffmpeg-executor",
+            CodecCapabilities::new(vec!["h264".into()], vec!["libx264".into(), "aac".into()]),
+            vec!["matroska".into()],
+            vec![],
+        ));
+
+        plugin.on_event(&event).expect("on_event should not fail");
+
+        let snapshot = plugin.cache.read().clone();
+        assert!(!snapshot.is_empty(), "cache must be populated after event");
+        assert!(snapshot.has_encoder("libx264"));
+        assert!(snapshot.has_format("matroska"));
+    }
+}

--- a/plugins/policy-evaluator/tests/dispatch_evaluate_policy.rs
+++ b/plugins/policy-evaluator/tests/dispatch_evaluate_policy.rs
@@ -1,0 +1,221 @@
+//! End-to-end parity test: dispatching `Call::EvaluatePolicy` through a real
+//! `Kernel` must produce the same `Plan`s as calling the free function
+//! `evaluate_with_capabilities` directly. Locks in the Phase 4 contract: the
+//! plugin is an instrumentation wrapper around the existing logic, not a
+//! divergent implementation.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use voom_domain::call::{Call, CallResponse};
+use voom_domain::capabilities::{Capability, CapabilityQuery};
+use voom_domain::capability_map::CapabilityMap;
+use voom_domain::events::{CodecCapabilities, ExecutorCapabilitiesEvent};
+use voom_domain::media::{Container, MediaFile, Track, TrackType};
+use voom_kernel::{Kernel, PluginContext};
+use voom_policy_evaluator::{PolicyEvaluatorPlugin, evaluate_with_capabilities};
+
+/// Strip per-evaluation, non-deterministic metadata (`id`, `evaluated_at`)
+/// from each plan's JSON form so two evaluations of the same `(policy, file)`
+/// can be compared for plan-content equality. The kernel dispatch path and
+/// the free-function path stamp their own UUIDs and timestamps; everything
+/// else must be byte-identical.
+///
+/// Strips only the top-level fields on each `Plan`; deliberately does NOT
+/// recurse, because nested types (e.g. `Plan.file: MediaFile`) carry their
+/// own `id` fields that are meaningful and must be compared, not erased.
+fn canonicalize_plans(plans_json: &serde_json::Value) -> serde_json::Value {
+    let mut owned = plans_json.clone();
+    if let Some(arr) = owned.as_array_mut() {
+        for plan in arr {
+            if let Some(obj) = plan.as_object_mut() {
+                obj.remove("id");
+                obj.remove("evaluated_at");
+            }
+        }
+    }
+    owned
+}
+
+fn fixture_file() -> MediaFile {
+    let mut file = MediaFile::new(PathBuf::from("/media/Movie.mkv"));
+    file.container = Container::Mkv;
+    let mut video = Track::new(0, TrackType::Video, "hevc".into());
+    video.width = Some(1920);
+    video.height = Some(1080);
+    let mut audio_eng = Track::new(1, TrackType::AudioMain, "ac3".into());
+    audio_eng.language = "eng".into();
+    audio_eng.channels = Some(6);
+    audio_eng.is_default = true;
+    let mut audio_jpn = Track::new(2, TrackType::AudioAlternate, "aac".into());
+    audio_jpn.language = "jpn".into();
+    audio_jpn.channels = Some(2);
+    let mut sub_eng = Track::new(3, TrackType::SubtitleMain, "srt".into());
+    sub_eng.language = "eng".into();
+    file.tracks = vec![video, audio_eng, audio_jpn, sub_eng];
+    file
+}
+
+fn fixture_caps() -> CapabilityMap {
+    let mut map = CapabilityMap::new();
+    map.register(ExecutorCapabilitiesEvent::new(
+        "ffmpeg-executor",
+        CodecCapabilities::new(
+            vec!["h264".into(), "hevc".into(), "aac".into()],
+            vec!["libx264".into(), "libx265".into(), "aac".into()],
+        ),
+        vec!["matroska".into(), "mp4".into()],
+        vec![],
+    ));
+    map
+}
+
+fn kernel_with_evaluator() -> Kernel {
+    let mut kernel = Kernel::new();
+    let ctx = PluginContext::new(serde_json::json!({}), std::env::temp_dir());
+    // Priority mirrors app.rs::PRIORITY_POLICY_EVALUATOR — keep in sync.
+    kernel
+        .init_and_register(Arc::new(PolicyEvaluatorPlugin::for_bootstrap()), 36, &ctx)
+        .expect("init_and_register policy-evaluator");
+    kernel
+}
+
+#[test]
+fn dispatch_produces_same_plans_as_direct_call_for_simple_policy() {
+    let policy = voom_dsl::compile_policy(
+        r#"policy "demo" {
+            phase containerize { container mkv }
+            phase normalize {
+                depends_on: [containerize]
+                keep audio where lang in [eng]
+            }
+        }"#,
+    )
+    .unwrap();
+    let file = fixture_file();
+    let caps = fixture_caps();
+
+    let direct = evaluate_with_capabilities(&policy, &file, &caps);
+
+    let kernel = kernel_with_evaluator();
+    let call = Call::EvaluatePolicy {
+        policy: Box::new(policy),
+        file: Box::new(file),
+        phase: None,
+        phase_outputs: None,
+        phase_outcomes: None,
+        capabilities_override: Some(caps),
+    };
+    let response = kernel
+        .dispatch_to_capability(
+            CapabilityQuery::Exclusive {
+                kind: Capability::EvaluatePolicy.kind().to_string(),
+            },
+            call,
+        )
+        .expect("dispatch should succeed");
+    let CallResponse::EvaluatePolicy(via_dispatch) = response else {
+        panic!("expected EvaluatePolicy response; got {response:?}");
+    };
+
+    let direct_json = canonicalize_plans(&serde_json::to_value(&direct.plans).unwrap());
+    let dispatch_json = canonicalize_plans(&serde_json::to_value(&via_dispatch.plans).unwrap());
+    assert_eq!(
+        direct_json, dispatch_json,
+        "free-function and dispatch paths must produce identical plans"
+    );
+}
+
+#[test]
+fn dispatch_produces_same_plans_as_direct_call_for_transcode_policy() {
+    let policy = voom_dsl::compile_policy(
+        r#"policy "demo" {
+            phase tc {
+                transcode video to h264 { crf: 20 }
+            }
+        }"#,
+    )
+    .unwrap();
+    let file = fixture_file();
+    let caps = fixture_caps();
+
+    let direct = evaluate_with_capabilities(&policy, &file, &caps);
+
+    let kernel = kernel_with_evaluator();
+    let call = Call::EvaluatePolicy {
+        policy: Box::new(policy),
+        file: Box::new(file),
+        phase: None,
+        phase_outputs: None,
+        phase_outcomes: None,
+        capabilities_override: Some(caps),
+    };
+    let CallResponse::EvaluatePolicy(via_dispatch) = kernel
+        .dispatch_to_capability(
+            CapabilityQuery::Exclusive {
+                kind: Capability::EvaluatePolicy.kind().to_string(),
+            },
+            call,
+        )
+        .unwrap()
+    else {
+        panic!("expected EvaluatePolicy response");
+    };
+
+    let direct_json = canonicalize_plans(&serde_json::to_value(&direct.plans).unwrap());
+    let dispatch_json = canonicalize_plans(&serde_json::to_value(&via_dispatch.plans).unwrap());
+    assert_eq!(direct_json, dispatch_json);
+}
+
+#[test]
+fn dispatch_records_plugin_stats_row_for_each_call() {
+    use std::sync::Mutex;
+    use voom_domain::plugin_stats::PluginStatRecord;
+    use voom_kernel::stats_sink::StatsSink;
+
+    #[derive(Default)]
+    struct RecordingSink(Mutex<Vec<PluginStatRecord>>);
+    impl StatsSink for RecordingSink {
+        fn record(&self, record: PluginStatRecord) {
+            self.0.lock().unwrap().push(record);
+        }
+    }
+
+    let sink: Arc<RecordingSink> = Arc::new(RecordingSink::default());
+    let kernel = kernel_with_evaluator();
+    kernel.set_stats_sink(sink.clone() as Arc<dyn StatsSink>);
+
+    let policy =
+        voom_dsl::compile_policy(r#"policy "demo" { phase init { container mkv } }"#).unwrap();
+    let file = fixture_file();
+    let call = Call::EvaluatePolicy {
+        policy: Box::new(policy),
+        file: Box::new(file),
+        phase: None,
+        phase_outputs: None,
+        phase_outcomes: None,
+        capabilities_override: None,
+    };
+
+    kernel
+        .dispatch_to_capability(
+            CapabilityQuery::Exclusive {
+                kind: Capability::EvaluatePolicy.kind().to_string(),
+            },
+            call,
+        )
+        .unwrap();
+
+    let records = sink.0.lock().unwrap();
+    assert_eq!(records.len(), 1, "exactly one stats row per dispatch");
+    assert_eq!(records[0].plugin_id, "policy-evaluator");
+    assert_eq!(records[0].event_type, "call.evaluate_policy");
+    assert!(
+        matches!(
+            records[0].outcome,
+            voom_domain::plugin_stats::PluginInvocationOutcome::Ok
+        ),
+        "successful dispatch must record Ok outcome; got {:?}",
+        records[0].outcome
+    );
+}


### PR DESCRIPTION
## Summary

Phase 4 of plugin-contract rev 6 ([#378](https://github.com/randomparity/voom/issues/378)). Promotes the policy evaluator from a library-only crate to a kernel-registered `PolicyEvaluatorPlugin` that claims `Capability::EvaluatePolicy` (Exclusive) and routes `Call::EvaluatePolicy` to the existing free-function evaluator surface. The CLI's two runtime evaluator call sites (`pipeline.rs:256` per-phase, `pipeline.rs:710` dry-run via `orchestrate_plans`) now dispatch through `Kernel::dispatch_to_capability` via a new `kernel_invoke::evaluate` helper, so every evaluation produces a row in `plugin_stats`.

### Changes
- **`PolicyEvaluatorPlugin`** with cached `CapabilityMap` populated by `Event::ExecutorCapabilities` (mirrors `capability-collector`)
- **`crates/voom-cli/src/kernel_invoke.rs`** — new module exposing one helper: `evaluate(...) -> Result<EvaluationResult>` wrapping `Kernel::dispatch_to_capability(CapabilityQuery::Exclusive { kind: ... }, Call::EvaluatePolicy { ... })`
- **Bootstrap** registers the plugin at priority 36 (after `capability-collector` at 35)
- **`KNOWN_PLUGIN_NAMES`** and **`REQUIRED_PLUGIN_NAMES`** updated to include `policy-evaluator`; disabling it now fails config validation
- **Purely-additive surface** — the seven public free functions (`evaluate`, `evaluate_with_capabilities`, `evaluate_with_context`, `evaluate_with_phase_outputs`, `evaluate_single_phase`, `evaluate_single_phase_with_hints`, `evaluate_single_phase_with_phase_outputs`) plus `apply_capability_hints` and `EvaluationOutcome` stay `pub`; `policy test` / `policy diff` / `pipeline_integration.rs` unchanged
- **`on_call` emits no `Plan*` events**; CLI's `dispatch.rs` orchestration is preserved verbatim
- **Parity regression test** in `plugins/policy-evaluator/tests/dispatch_evaluate_policy.rs` pins free-function vs. dispatch-path plan equivalence and one-stats-row-per-call instrumentation

### TDD anchor
The first commit on this branch (`a627ff7e`) added a `voom process --dry-run` functional test that asserts a `policy-evaluator` row exists in `plugin_stats`. It was RED at commit time and turned GREEN after the dry-run migration in `e6124ecd`, validating the end-to-end pipeline.

### Spec reference
`docs/superpowers/specs/2026-05-14-plugin-stats-self-reporting-design.md` §6 (Policy evaluator) and §Rollout (Phase 4). All Phase-4 acceptance-criteria items are satisfied.

### Depends on
Phase 1 (PRs #409/#410) and Phase 3 (PR #420), both merged. Phase 2 (PR #418) is independent and not required. Phase 5 (phase-orchestrator promotion) is a sibling of this PR and lands separately.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` (clean)
- [x] `cargo test --workspace` — **2746 passed; 0 failed**
- [x] `cargo test -p voom-cli --features functional -- --test-threads=4` — **747 passed; 0 failed**
- [x] New tests:
  - `plugins/policy-evaluator/src/plugin.rs::tests` — 9 unit tests (capability claim, `on_event` cache, `on_call` routing across all four `(phase, phase_outputs)` arms, wrong-variant guard, override-vs-cache precedence)
  - `plugins/policy-evaluator/tests/dispatch_evaluate_policy.rs` — 3 integration tests (parity for simple + transcode policies; stats-row recording with correct `plugin_id`/`event_type`/`Ok` outcome)
  - `crates/voom-cli/src/kernel_invoke.rs::tests` — 4 unit tests
  - `crates/voom-cli/src/app.rs::bootstrap_fails_when_policy_evaluator_is_disabled`
  - `crates/voom-cli/tests/plugin_stats_e2e.rs::process_dry_run_populates_policy_evaluator_stats_row` (TDD anchor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)