### PR TITLE
Plugin contract rev 6 (#378) — Phase 5: phase-orchestrator promotion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3977,6 +3977,7 @@ name = "voom-phase-orchestrator"
 version = "0.1.0"
 dependencies = [
  "insta",
+ "serde_json",
  "tracing",
  "voom-domain",
  "voom-dsl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3980,6 +3980,7 @@ dependencies = [
  "tracing",
  "voom-domain",
  "voom-dsl",
+ "voom-kernel",
  "voom-policy-evaluator",
 ]
 

--- a/crates/voom-cli/src/app.rs
+++ b/crates/voom-cli/src/app.rs
@@ -51,6 +51,11 @@ const PRIORITY_CAPABILITY_COLLECTOR: i32 = 35;
 // matters for in-process consumers within the same dispatch, and the policy
 // evaluator caches independently.
 const PRIORITY_POLICY_EVALUATOR: i32 = 36;
+// Phase orchestrator — Exclusive single-handler plugin (claims
+// Capability::OrchestratePhases). Stateless: subscribes to no events, so the
+// priority value is only used by the unused bus-dispatch ordering. Slotted
+// next to the evaluator (37) for natural grouping (PR #378 / Phase 5).
+const PRIORITY_PHASE_ORCHESTRATOR: i32 = 37;
 // Backup manager dispatches before executors (30 < 39/40) so the source
 // file is backed up before any executor mutates it.
 const PRIORITY_BACKUP_MANAGER: i32 = 30;
@@ -276,6 +281,16 @@ pub fn bootstrap_kernel_with_store(config: &AppConfig) -> Result<BootstrapResult
         voom_policy_evaluator::PolicyEvaluatorPlugin::for_bootstrap(),
         PRIORITY_POLICY_EVALUATOR,
         "policy evaluator"
+    );
+
+    // Phase orchestrator — claims Capability::OrchestratePhases. Stateless:
+    // on_call routes Call::Orchestrate to the existing free-function
+    // orchestrate(plans) surface (PR #378 / Phase 5).
+    register_if_enabled!(
+        "phase-orchestrator",
+        voom_phase_orchestrator::PhaseOrchestratorPlugin::for_bootstrap(),
+        PRIORITY_PHASE_ORCHESTRATOR,
+        "phase orchestrator"
     );
 
     // Executor — mkvtoolnix (MKV metadata, track removal/reorder, convert-to-MKV)

--- a/crates/voom-cli/src/commands/plugin.rs
+++ b/crates/voom-cli/src/commands/plugin.rs
@@ -179,30 +179,64 @@ fn disable(name: &str) -> Result<()> {
 /// Shared implementation for enable/disable: validates the plugin name, checks
 /// current state, mutates the disabled list, and saves the config.
 fn set_plugin_enabled(name: &str, enabled: bool) -> Result<()> {
+    let mut config = config::load_config()?;
+    let changed = apply_plugin_enable_change(&mut config, name, enabled)?;
+
+    let state_style = if enabled {
+        style("enabled").green()
+    } else {
+        style("disabled").yellow()
+    };
+
+    if !changed {
+        println!(
+            "Plugin \"{}\" is already {}.",
+            style(name).cyan(),
+            state_style
+        );
+        return Ok(());
+    }
+
+    config::save_config(&config)?;
+    println!(
+        "{} Plugin \"{}\" has been {}.",
+        style("OK").bold().green(),
+        style(name).cyan(),
+        state_style
+    );
+    Ok(())
+}
+
+/// Apply an enable/disable transition to an in-memory config.
+///
+/// Returns `true` if the config was modified and needs to be saved. Returns
+/// `false` if the plugin was already in the requested state (no-op).
+///
+/// Rejects:
+/// - Unknown plugin names (not in `KNOWN_PLUGIN_NAMES`).
+/// - Attempts to disable a plugin in `REQUIRED_PLUGIN_NAMES`. Required
+///   plugins are gated at the CLI boundary so users never reach the cryptic
+///   bootstrap-time validation error from `AppConfig::validate`.
+fn apply_plugin_enable_change(
+    config: &mut config::AppConfig,
+    name: &str,
+    enabled: bool,
+) -> Result<bool> {
     if !config::KNOWN_PLUGIN_NAMES.contains(&name) {
         let known = config::KNOWN_PLUGIN_NAMES.join(", ");
         bail!("Unknown plugin \"{name}\". Known plugins: {known}");
     }
-
-    let mut config = config::load_config()?;
-    let is_disabled = config.plugins.disabled_plugins.iter().any(|d| d == name);
-
-    if enabled && !is_disabled {
-        println!(
-            "Plugin \"{}\" is already {}.",
-            style(name).cyan(),
-            style("enabled").green()
+    if !enabled && config::REQUIRED_PLUGIN_NAMES.contains(&name) {
+        let required = config::REQUIRED_PLUGIN_NAMES.join(", ");
+        bail!(
+            "Cannot disable required plugin \"{name}\". \
+             Required plugins (the scan/process commands fail to bootstrap without them): {required}."
         );
-        return Ok(());
     }
 
-    if !enabled && is_disabled {
-        println!(
-            "Plugin \"{}\" is already {}.",
-            style(name).cyan(),
-            style("disabled").yellow()
-        );
-        return Ok(());
+    let is_disabled = config.plugins.disabled_plugins.iter().any(|d| d == name);
+    if enabled != is_disabled {
+        return Ok(false);
     }
 
     if enabled {
@@ -210,24 +244,7 @@ fn set_plugin_enabled(name: &str, enabled: bool) -> Result<()> {
     } else {
         config.plugins.disabled_plugins.push(name.to_string());
     }
-    config::save_config(&config)?;
-
-    if enabled {
-        println!(
-            "{} Plugin \"{}\" has been {}.",
-            style("OK").bold().green(),
-            style(name).cyan(),
-            style("enabled").green()
-        );
-    } else {
-        println!(
-            "{} Plugin \"{}\" has been {}.",
-            style("OK").bold().green(),
-            style(name).cyan(),
-            style("disabled").yellow()
-        );
-    }
-    Ok(())
+    Ok(true)
 }
 
 fn install(path: &std::path::Path) -> Result<()> {
@@ -368,5 +385,43 @@ mod tests {
         // Verify that enable/disable check against KNOWN_PLUGIN_NAMES
         assert!(config::KNOWN_PLUGIN_NAMES.contains(&"sqlite-store"));
         assert!(!config::KNOWN_PLUGIN_NAMES.contains(&"nonexistent-plugin"));
+    }
+
+    #[test]
+    fn cannot_disable_required_plugins_via_cli() {
+        // For every name in REQUIRED_PLUGIN_NAMES, attempting to disable it
+        // must fail with an actionable error message naming the plugin.
+        // This guards the CLI boundary so users never reach the cryptic
+        // bootstrap-time config-validation failure.
+        for name in config::REQUIRED_PLUGIN_NAMES {
+            let mut cfg = config::AppConfig::default();
+            let err = apply_plugin_enable_change(&mut cfg, name, false)
+                .expect_err(&format!("disable of required plugin {name} must fail"));
+            let msg = err.to_string();
+            assert!(
+                msg.contains("Cannot disable required plugin"),
+                "error must explain why disable was rejected; got: {msg}"
+            );
+            assert!(
+                msg.contains(name),
+                "error must name the rejected plugin {name}; got: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn enabling_required_plugin_still_succeeds() {
+        // Idempotent: enabling a required plugin from its default state
+        // (enabled) is a no-op success. Confirms the rejection gate is
+        // bounded to the disable direction.
+        for name in config::REQUIRED_PLUGIN_NAMES {
+            let mut cfg = config::AppConfig::default();
+            let changed = apply_plugin_enable_change(&mut cfg, name, true)
+                .unwrap_or_else(|e| panic!("enable of required plugin {name} should succeed: {e}"));
+            assert!(
+                !changed,
+                "enabling an already-enabled required plugin must be a no-op"
+            );
+        }
     }
 }

--- a/crates/voom-cli/src/commands/process/pipeline.rs
+++ b/crates/voom-cli/src/commands/process/pipeline.rs
@@ -1352,6 +1352,156 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn execute_path_produces_phase_orchestrator_stats_row_on_success() {
+        // The happy path: a real `process_single_file_execute` invocation
+        // against a file that the policy skips (no executor needed, inner
+        // returns Ok) must still produce exactly one phase-orchestrator
+        // plugin_stats row from the wrapper's finalization call. This is
+        // the production-code-path complement to the dispatch-boundary
+        // test in phase_orchestrator_parity::
+        // dispatch_to_capability_produces_phase_orchestrator_stats_row.
+        use std::sync::Mutex;
+        use voom_domain::plugin_stats::{PluginInvocationOutcome, PluginStatRecord};
+        use voom_kernel::stats_sink::StatsSink;
+
+        #[derive(Default)]
+        struct RecordingSink(Mutex<Vec<PluginStatRecord>>);
+        impl StatsSink for RecordingSink {
+            fn record(&self, record: PluginStatRecord) {
+                self.0.lock().unwrap().push(record);
+            }
+        }
+
+        // Policy with `skip when video.codec == "hevc"` against an hevc file
+        // produces a single plan with skip_reason set. The execute pipeline
+        // dispatches a PlanCreated + PlanSkipped pair (no executor needed)
+        // and the inner returns Ok cleanly. The wrapper then unconditionally
+        // invokes the orchestrator, which is the row we are asserting on.
+        let policy = r#"policy "test" {
+                phase transcode-video {
+                    skip when video.codec == "hevc"
+                    transcode video to hevc
+                }
+            }"#;
+        let fixture = process_tests::TestFixture::with_policy(policy);
+        let path = fixture.dir_path().join("movie.mkv");
+        let mut file = MediaFile::new(path)
+            .with_container(Container::Mkv)
+            .with_tracks(vec![Track::new(0, TrackType::Video, "hevc".into())]);
+        file.duration = 120.0;
+        file.tracks[0].width = Some(1920);
+        file.tracks[0].height = Some(1080);
+        let compiled = voom_dsl::compile_policy(policy).unwrap();
+
+        let sink: Arc<RecordingSink> = Arc::new(RecordingSink::default());
+        let mut kernel = voom_kernel::Kernel::new();
+        kernel.set_stats_sink(sink.clone() as Arc<dyn StatsSink>);
+        register_policy_evaluator(&mut kernel);
+        register_phase_orchestrator(&mut kernel);
+        let ctx = fixture.make_ctx(
+            Arc::new(kernel),
+            Arc::new(voom_domain::test_support::InMemoryStore::new()),
+        );
+
+        let result = process_single_file_execute(&file, &compiled, &ctx).await;
+        assert!(
+            result.is_ok(),
+            "execute path returned an error on success scenario: {result:?}"
+        );
+
+        let records = sink.0.lock().unwrap();
+        let orch_rows: Vec<&PluginStatRecord> = records
+            .iter()
+            .filter(|r| r.plugin_id == "phase-orchestrator")
+            .collect();
+        assert_eq!(
+            orch_rows.len(),
+            1,
+            "expected exactly 1 phase-orchestrator row after success execute; \
+             got {} of {} total: {:?}",
+            orch_rows.len(),
+            records.len(),
+            *records
+        );
+        assert!(
+            matches!(orch_rows[0].outcome, PluginInvocationOutcome::Ok),
+            "expected outcome Ok, got {:?}",
+            orch_rows[0].outcome
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_path_produces_orchestrator_row_even_when_inner_returns_err() {
+        // rev-3 critical regression test: when the inner returns Err (e.g.,
+        // executor failure), the wrapper MUST STILL invoke the orchestrator.
+        // If this assertion fails, the wrapper's finalization isn't running
+        // on the Err path — rev-2 finding #2 has regressed.
+        use std::sync::Mutex;
+        use voom_domain::plugin_stats::{PluginInvocationOutcome, PluginStatRecord};
+        use voom_kernel::stats_sink::StatsSink;
+
+        #[derive(Default)]
+        struct RecordingSink(Mutex<Vec<PluginStatRecord>>);
+        impl StatsSink for RecordingSink {
+            fn record(&self, record: PluginStatRecord) {
+                self.0.lock().unwrap().push(record);
+            }
+        }
+
+        let policy = global_hw_policy();
+        let fixture = process_tests::TestFixture::with_policy(policy);
+        let path = fixture.dir_path().join("movie.mkv");
+        let file = h264_file(path);
+        let compiled = voom_dsl::compile_policy(policy).unwrap();
+
+        let sink: Arc<RecordingSink> = Arc::new(RecordingSink::default());
+        let mut kernel = voom_kernel::Kernel::new();
+        kernel.set_stats_sink(sink.clone() as Arc<dyn StatsSink>);
+        register_policy_evaluator(&mut kernel);
+        register_phase_orchestrator(&mut kernel);
+        // FailingExecutor mirrors the existing
+        // failed_executable_plan_returns_file_job_error test fixture: it
+        // returns plan_failed for every PlanCreated event, which makes
+        // process_single_file_execute_inner return Err via the
+        // "executable plan(s) failed" branch.
+        kernel
+            .register_plugin(Arc::new(FailingExecutor), 50)
+            .unwrap();
+        let ctx = fixture.make_ctx(
+            Arc::new(kernel),
+            Arc::new(voom_domain::test_support::InMemoryStore::new()),
+        );
+
+        let result = process_single_file_execute(&file, &compiled, &ctx).await;
+        assert!(
+            result.is_err(),
+            "expected Err from failing executor; got {result:?}"
+        );
+
+        let records = sink.0.lock().unwrap();
+        let orch_rows: Vec<&PluginStatRecord> = records
+            .iter()
+            .filter(|r| r.plugin_id == "phase-orchestrator")
+            .collect();
+        assert_eq!(
+            orch_rows.len(),
+            1,
+            "expected 1 phase-orchestrator row even after inner Err; \
+             got {} of {} total. If this is 0, the wrapper's finalization isn't \
+             running on the Err path — rev-2 finding #2 has regressed. Rows: {:?}",
+            orch_rows.len(),
+            records.len(),
+            *records
+        );
+        assert!(
+            matches!(orch_rows[0].outcome, PluginInvocationOutcome::Ok),
+            "the orchestrator dispatch itself should succeed even when the \
+             execute path returns Err; got outcome {:?}",
+            orch_rows[0].outcome
+        );
+    }
+
+    #[tokio::test]
     async fn process_pipeline_respects_plan_limiter() {
         let policy = nvenc_policy();
         let fixture = process_tests::TestFixture::with_policy(policy);

--- a/crates/voom-cli/src/commands/process/pipeline.rs
+++ b/crates/voom-cli/src/commands/process/pipeline.rs
@@ -708,6 +708,8 @@ fn preserve_persisted_file_identity(
 /// Policy evaluation now flows through `kernel_invoke::evaluate` so the
 /// kernel's `dispatch_to_capability` instrumentation records a
 /// `plugin_stats` row for each dry-run invocation (#378 Phase 4).
+/// Phase orchestration now flows through `kernel_invoke::orchestrate` as
+/// well (#378 Phase 5).
 fn orchestrate_plans(
     kernel: &voom_kernel::Kernel,
     compiled: &voom_dsl::CompiledPolicy,
@@ -724,7 +726,8 @@ fn orchestrate_plans(
         Some(capabilities.clone()),
     )
     .map_err(|e| format!("evaluate dispatch failed (dry-run): {e:#}"))?;
-    Ok(voom_phase_orchestrator::orchestrate(result.plans))
+    crate::kernel_invoke::orchestrate(kernel, result.plans, compiled.name.clone())
+        .map_err(|e| format!("orchestrate dispatch failed (dry-run): {e:#}"))
 }
 
 /// Determine the file path after plan execution.
@@ -933,6 +936,24 @@ mod tests {
             .expect("register PolicyEvaluatorPlugin for dispatch_to_capability");
     }
 
+    /// Test-only helper: register the phase-orchestrator plugin on a fresh kernel
+    /// so `Kernel::dispatch_to_capability(Exclusive { kind: "orchestrate_phases" }, ...)`
+    /// resolves. Mirrors the bootstrap registration at `app.rs::PRIORITY_PHASE_ORCHESTRATOR`
+    /// — keep the priority in sync if that constant ever changes.
+    fn register_phase_orchestrator(kernel: &mut voom_kernel::Kernel) {
+        let plugin_ctx =
+            voom_kernel::PluginContext::new(serde_json::json!({}), std::env::temp_dir());
+        kernel
+            .init_and_register(
+                std::sync::Arc::new(
+                    voom_phase_orchestrator::PhaseOrchestratorPlugin::for_bootstrap(),
+                ),
+                37,
+                &plugin_ctx,
+            )
+            .expect("register PhaseOrchestratorPlugin for dispatch_to_capability");
+    }
+
     struct RecordingExecutor {
         entered_tx: mpsc::Sender<()>,
     }
@@ -1128,6 +1149,7 @@ mod tests {
         let store = Arc::new(voom_domain::test_support::InMemoryStore::new());
         let mut kernel = voom_kernel::Kernel::new();
         register_policy_evaluator(&mut kernel);
+        register_phase_orchestrator(&mut kernel);
         let ctx = fixture.make_ctx(Arc::new(kernel), store.clone());
         let path = fixture.dir_path().join("movie.mkv");
         let mut file = h264_file(path);
@@ -1257,6 +1279,7 @@ mod tests {
 
         let mut kernel = voom_kernel::Kernel::new();
         register_policy_evaluator(&mut kernel);
+        register_phase_orchestrator(&mut kernel);
         kernel
             .register_plugin(Arc::new(FailingExecutor), 50)
             .unwrap();
@@ -1299,6 +1322,7 @@ mod tests {
         let (entered_tx, entered_rx) = mpsc::channel();
         let mut kernel = voom_kernel::Kernel::new();
         register_policy_evaluator(&mut kernel);
+        register_phase_orchestrator(&mut kernel);
         kernel
             .register_plugin(Arc::new(RecordingExecutor { entered_tx }), 50)
             .unwrap();
@@ -1353,6 +1377,7 @@ mod tests {
         let (entered_tx, entered_rx) = mpsc::channel();
         let mut kernel = voom_kernel::Kernel::new();
         register_policy_evaluator(&mut kernel);
+        register_phase_orchestrator(&mut kernel);
         kernel
             .register_plugin(Arc::new(RecordingExecutor { entered_tx }), 50)
             .unwrap();
@@ -1402,6 +1427,7 @@ mod tests {
         let (entered_tx, entered_rx) = mpsc::channel();
         let mut kernel = voom_kernel::Kernel::new();
         register_policy_evaluator(&mut kernel);
+        register_phase_orchestrator(&mut kernel);
         kernel
             .register_plugin(Arc::new(RecordingExecutor { entered_tx }), 50)
             .unwrap();

--- a/crates/voom-cli/src/commands/process/pipeline.rs
+++ b/crates/voom-cli/src/commands/process/pipeline.rs
@@ -226,10 +226,56 @@ fn include_in_plan_only_output(plan: &voom_domain::plan::Plan) -> bool {
 ///
 /// After each phase executes successfully, the file is re-introspected so
 /// that subsequent phases see the updated path, container, and tracks.
+/// Real execution: evaluate → execute → re-introspect per phase.
+///
+/// Splits responsibilities between an inner async fn that runs the per-phase
+/// execution loop and this outer wrapper that always finalizes the file with
+/// a `phase-orchestrator` Call dispatch. The orchestrator dispatch is
+/// non-fatal (logged on error, never propagated): observability must not turn
+/// successful file mutations into errors for the caller (PR #378 / Phase 5).
 async fn process_single_file_execute(
     file: &voom_domain::media::MediaFile,
     compiled: &voom_dsl::CompiledPolicy,
     ctx: &ProcessContext<'_>,
+) -> std::result::Result<Option<serde_json::Value>, String> {
+    let mut all_plans: Vec<voom_domain::plan::Plan> = Vec::new();
+    let inner_result = process_single_file_execute_inner(file, compiled, ctx, &mut all_plans).await;
+    // Always invoke the orchestrator after the inner returns — Ok, Err via ?,
+    // or explicit return. This is the kernel-instrumented call that produces
+    // the phase-orchestrator plugin_stats row for every file processed.
+    // Non-fatal: orchestrator dispatch errors are logged, not propagated.
+    invoke_orchestrator_observability(ctx, compiled, all_plans);
+    inner_result
+}
+
+/// Non-fatal finalization: invoke the orchestrator for stats attribution +
+/// per-file orchestration boundary. Errors from the kernel dispatch are
+/// logged via `tracing::warn!` and not propagated — this call's role is
+/// observability, and a missing-handler / wrong-response / panicking-plugin
+/// failure should never turn a successful file mutation into an error for
+/// the caller. `verify_registration_invariants` at bootstrap (Phase 1)
+/// already prevents "no handler for OrchestratePhases" since the capability
+/// is Exclusive; the runtime non-propagation is defense in depth.
+fn invoke_orchestrator_observability(
+    ctx: &ProcessContext<'_>,
+    compiled: &voom_dsl::CompiledPolicy,
+    all_plans: Vec<voom_domain::plan::Plan>,
+) {
+    if let Err(e) = crate::kernel_invoke::orchestrate(&ctx.kernel, all_plans, compiled.name.clone())
+    {
+        tracing::warn!(
+            policy = %compiled.name,
+            error = %e,
+            "phase-orchestrator dispatch failed at end-of-file; plugin_stats row may be missing for this file"
+        );
+    }
+}
+
+async fn process_single_file_execute_inner(
+    file: &voom_domain::media::MediaFile,
+    compiled: &voom_dsl::CompiledPolicy,
+    ctx: &ProcessContext<'_>,
+    all_plans: &mut Vec<voom_domain::plan::Plan>,
 ) -> std::result::Result<Option<serde_json::Value>, String> {
     let file_path_str = file.path.display().to_string();
     let keep_backups = compiled.config.keep_backups;
@@ -268,6 +314,7 @@ async fn process_single_file_execute(
         let mut plan = plan
             .with_session_id(ctx.counters.session_id)
             .with_scan_session(ctx.scan_session);
+        all_plans.push(plan.clone());
 
         plans_evaluated += 1;
 

--- a/crates/voom-cli/src/config.rs
+++ b/crates/voom-cli/src/config.rs
@@ -336,6 +336,7 @@ pub const KNOWN_PLUGIN_NAMES: &[&str] = &[
     "backup-manager",
     "job-manager",
     "policy-evaluator",
+    "phase-orchestrator",
     "report",
     "verifier",
 ];
@@ -348,7 +349,7 @@ pub const KNOWN_PLUGIN_NAMES: &[&str] = &[
 /// `disabled_plugins` in config.toml is an unrunnable configuration; we
 /// reject it at config load with an explicit error rather than failing at
 /// dispatch time with a less actionable "no handler" message.
-pub const REQUIRED_PLUGIN_NAMES: &[&str] = &["discovery", "policy-evaluator"];
+pub const REQUIRED_PLUGIN_NAMES: &[&str] = &["discovery", "policy-evaluator", "phase-orchestrator"];
 
 /// Generate a default config.toml with all options commented out and documented.
 pub fn default_config_contents() -> String {
@@ -634,7 +635,7 @@ mod tests {
 
     #[test]
     fn test_known_plugin_names_count() {
-        assert_eq!(KNOWN_PLUGIN_NAMES.len(), 14);
+        assert_eq!(KNOWN_PLUGIN_NAMES.len(), 15);
     }
 
     #[test]

--- a/crates/voom-cli/src/config.rs
+++ b/crates/voom-cli/src/config.rs
@@ -355,6 +355,7 @@ pub const REQUIRED_PLUGIN_NAMES: &[&str] = &["discovery", "policy-evaluator", "p
 pub fn default_config_contents() -> String {
     let data_dir = default_data_dir();
     let data_dir_str = data_dir.display();
+    let required_list = REQUIRED_PLUGIN_NAMES.join(", ");
 
     format!(
         r#"# VOOM configuration file
@@ -377,7 +378,7 @@ pub fn default_config_contents() -> String {
 # List of plugin names to disable at startup.
 # Optional plugins (safe to disable): sqlite-store, tool-detector,
 #   mkvtoolnix-executor, ffmpeg-executor, backup-manager, job-manager
-# Required plugins (cannot be disabled): discovery
+# Required plugins (cannot be disabled): {required_list}
 # disabled_plugins = ["mkvtoolnix-executor"]
 
 # Default policy file applied when no --policy or --policy-map flag is given.
@@ -704,6 +705,25 @@ mod tests {
         assert!(contents.contains("[retention.event_log]"));
         assert!(contents.contains("[retention.file_transitions]"));
         assert!(contents.contains("[retention.plugin_stats]"));
+    }
+
+    #[test]
+    fn default_config_contents_lists_every_required_plugin() {
+        // The template's "Required plugins" comment must be derived from
+        // REQUIRED_PLUGIN_NAMES so it can never go stale when the
+        // required-list grows. Iterating the constant in the assertion
+        // guarantees the comment updates in lockstep with the constant.
+        let contents = default_config_contents();
+        let required_line = contents
+            .lines()
+            .find(|l| l.contains("Required plugins (cannot be disabled)"))
+            .expect("template must label the required-plugin list explicitly");
+        for name in REQUIRED_PLUGIN_NAMES {
+            assert!(
+                required_line.contains(name),
+                "required-plugin comment must mention {name}; got: {required_line}"
+            );
+        }
     }
 
     // ── load_config with temp files ──────────────────────────

--- a/crates/voom-cli/src/kernel_invoke.rs
+++ b/crates/voom-cli/src/kernel_invoke.rs
@@ -84,6 +84,45 @@ pub fn evaluate(
     }
 }
 
+/// Dispatch phase orchestration through the kernel's
+/// `Capability::OrchestratePhases` handler (the `PhaseOrchestratorPlugin`
+/// registered at bootstrap).
+///
+/// Records one row in `plugin_stats` per call (kernel-instrumented at the
+/// Call boundary). Use this from CLI runtime paths so every orchestration is
+/// host-measured.
+///
+/// `policy_name` is included in the Call payload per spec (useful for stats
+/// attribution and future cross-cutting features); the current orchestrator
+/// implementation doesn't read it.
+///
+/// # Errors
+/// - Capability not claimed (bootstrap bug): error names the missing capability.
+/// - Plugin returned the wrong `CallResponse` variant: hard error naming the
+///   variant returned. Cannot happen with the in-tree `PhaseOrchestratorPlugin`
+///   but is checked because a future WASM plugin could violate this.
+/// - Plugin's `on_call` returned `Err`: propagated.
+/// - Plugin panicked: caught at the kernel boundary, returned as `Err`.
+pub fn orchestrate(
+    kernel: &Kernel,
+    plans: Vec<voom_domain::plan::Plan>,
+    policy_name: String,
+) -> Result<voom_phase_orchestrator::OrchestrationResult> {
+    let call = Call::Orchestrate { plans, policy_name };
+    let query = CapabilityQuery::Exclusive {
+        kind: Capability::OrchestratePhases.kind().to_string(),
+    };
+    let response = kernel
+        .dispatch_to_capability(query, call)
+        .map_err(anyhow::Error::new)?;
+    match response {
+        CallResponse::Orchestrate(result) => Ok(result),
+        other => Err(anyhow!(
+            "orchestrate dispatch returned wrong CallResponse variant: {other:?}"
+        )),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -169,6 +208,59 @@ mod tests {
         assert!(
             chain.contains("EvaluatePolicy")
                 || chain.contains("evaluate_policy")
+                || chain.contains("no handler"),
+            "error must name the missing capability or 'no handler'; got: {chain}"
+        );
+    }
+
+    fn kernel_with_orchestrator() -> voom_kernel::Kernel {
+        let mut kernel = voom_kernel::Kernel::new();
+        let ctx = voom_kernel::PluginContext::new(serde_json::json!({}), std::env::temp_dir());
+        kernel
+            .init_and_register(
+                std::sync::Arc::new(
+                    voom_phase_orchestrator::PhaseOrchestratorPlugin::for_bootstrap(),
+                ),
+                37,
+                &ctx,
+            )
+            .expect("init_and_register phase-orchestrator");
+        kernel
+    }
+
+    #[test]
+    fn orchestrate_returns_result_for_single_phase_policy() {
+        let kernel = kernel_with_orchestrator();
+        let policy =
+            voom_dsl::compile_policy(r#"policy "demo" { phase init { container mkv } }"#).unwrap();
+        let file = voom_domain::media::MediaFile::new(std::path::PathBuf::from("/movies/test.mkv"));
+        let plans = voom_policy_evaluator::evaluator::evaluate(&policy, &file).plans;
+
+        let result =
+            orchestrate(&kernel, plans, "demo".into()).expect("orchestrate should succeed");
+        assert_eq!(result.plans.len(), 1);
+        assert_eq!(result.plans[0].phase_name, "init");
+    }
+
+    #[test]
+    fn orchestrate_with_empty_plans_returns_empty_result() {
+        let kernel = kernel_with_orchestrator();
+        let result =
+            orchestrate(&kernel, vec![], "demo".into()).expect("orchestrate should succeed");
+        assert!(result.plans.is_empty());
+        assert!(result.phase_results.is_empty());
+        assert!(!result.file_modified);
+    }
+
+    #[test]
+    fn orchestrate_without_orchestrator_registered_is_hard_error() {
+        let kernel = voom_kernel::Kernel::new();
+        let err = orchestrate(&kernel, vec![], "demo".into())
+            .expect_err("dispatch without a handler must fail");
+        let chain = format!("{err:#}");
+        assert!(
+            chain.contains("OrchestratePhases")
+                || chain.contains("orchestrate_phases")
                 || chain.contains("no handler"),
             "error must name the missing capability or 'no handler'; got: {chain}"
         );

--- a/crates/voom-cli/tests/phase_orchestrator_parity.rs
+++ b/crates/voom-cli/tests/phase_orchestrator_parity.rs
@@ -1,0 +1,131 @@
+//! Parity tests: kernel-routed orchestration must produce bit-identical
+//! OrchestrationResults vs. direct library calls.
+//!
+//! Uses `serde_json::Value` equality on the full result struct —
+//! OrchestrationResult is serde-derived (Phase 1), so this catches any
+//! field-level divergence including phase_results, outcomes, skip_reasons,
+//! and file_modified.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use voom_domain::media::{Container, MediaFile, Track, TrackType};
+use voom_dsl::compile_policy;
+use voom_kernel::{Kernel, PluginContext};
+
+fn test_file() -> MediaFile {
+    let mut file = MediaFile::new(PathBuf::from("/media/Movie.mkv"));
+    file.container = Container::Mkv;
+    file.tracks = vec![
+        {
+            let mut t = Track::new(0, TrackType::Video, "hevc".into());
+            t.width = Some(1920);
+            t.height = Some(1080);
+            t
+        },
+        {
+            let mut t = Track::new(1, TrackType::AudioMain, "aac".into());
+            t.language = "eng".into();
+            t.channels = Some(2);
+            t.is_default = true;
+            t
+        },
+    ];
+    file
+}
+
+fn kernel_with_orchestrator() -> Kernel {
+    let mut kernel = Kernel::new();
+    let ctx = PluginContext::new(serde_json::json!({}), std::env::temp_dir());
+    kernel
+        .init_and_register(
+            Arc::new(voom_phase_orchestrator::PhaseOrchestratorPlugin::for_bootstrap()),
+            37,
+            &ctx,
+        )
+        .expect("register orchestrator");
+    kernel
+}
+
+fn assert_orchestration_results_equal(
+    direct: &voom_phase_orchestrator::OrchestrationResult,
+    routed: &voom_phase_orchestrator::OrchestrationResult,
+) {
+    let direct_v = serde_json::to_value(direct).expect("serialize direct");
+    let routed_v = serde_json::to_value(routed).expect("serialize routed");
+    assert_eq!(
+        direct_v, routed_v,
+        "kernel-routed OrchestrationResult differs from direct call:\n  direct: {direct_v}\n  routed: {routed_v}"
+    );
+}
+
+#[test]
+fn parity_simple_single_phase() {
+    let kernel = kernel_with_orchestrator();
+    let policy =
+        compile_policy(r#"policy "demo" { phase init { container mkv } }"#).expect("compile");
+    let file = test_file();
+    let plans = voom_policy_evaluator::evaluator::evaluate(&policy, &file).plans;
+
+    let direct = voom_phase_orchestrator::orchestrate(plans.clone());
+
+    let routed = voom_cli::kernel_invoke::orchestrate(&kernel, plans, "demo".into())
+        .expect("kernel orchestrate");
+
+    assert_orchestration_results_equal(&direct, &routed);
+}
+
+#[test]
+fn parity_multi_phase_with_skip_and_depends() {
+    // Exercise the orchestrate() state machine: dependencies, skip-when, and
+    // run-if interact to produce a non-trivial PhaseResult sequence. If the
+    // plugin path drops any of those state transitions, the JSON comparison
+    // will surface the divergence.
+    let kernel = kernel_with_orchestrator();
+    let policy = compile_policy(
+        r#"policy "demo" {
+            phase containerize { container mkv }
+            phase normalize {
+                depends_on: [containerize]
+                keep audio where lang in [eng]
+            }
+            phase already_hevc {
+                depends_on: [normalize]
+                skip when video.codec == "hevc"
+                transcode video to hevc { crf: 20 }
+            }
+        }"#,
+    )
+    .expect("compile");
+    let file = test_file(); // hevc — already_hevc skips
+    let plans = voom_policy_evaluator::evaluator::evaluate(&policy, &file).plans;
+
+    let direct = voom_phase_orchestrator::orchestrate(plans.clone());
+
+    let routed = voom_cli::kernel_invoke::orchestrate(&kernel, plans, "demo".into())
+        .expect("kernel orchestrate");
+
+    assert_orchestration_results_equal(&direct, &routed);
+
+    // Bonus sanity assertion to confirm the test is exercising the skip path —
+    // if the policy ever stops triggering the skip branch, the parity test
+    // silently becomes weaker.
+    assert_eq!(
+        routed.phase_results[2].outcome,
+        voom_domain::plan::PhaseOutcome::Skipped,
+        "already_hevc must be skipped for this parity test to exercise the skip path"
+    );
+}
+
+#[test]
+fn parity_empty_plans() {
+    // Edge case: empty plan list. The free function returns an
+    // OrchestrationResult with no phase results and file_modified=false;
+    // the plugin path must match exactly.
+    let kernel = kernel_with_orchestrator();
+    let direct = voom_phase_orchestrator::orchestrate(vec![]);
+    let routed = voom_cli::kernel_invoke::orchestrate(&kernel, vec![], "empty".into())
+        .expect("kernel orchestrate");
+
+    assert_orchestration_results_equal(&direct, &routed);
+}

--- a/crates/voom-cli/tests/phase_orchestrator_parity.rs
+++ b/crates/voom-cli/tests/phase_orchestrator_parity.rs
@@ -129,3 +129,41 @@ fn parity_empty_plans() {
 
     assert_orchestration_results_equal(&direct, &routed);
 }
+
+#[test]
+fn dispatch_to_capability_produces_phase_orchestrator_stats_row() {
+    // The spec's #378 acceptance criterion at the dispatch-boundary level:
+    // calling Kernel::dispatch_to_capability with Capability::OrchestratePhases
+    // (via kernel_invoke::orchestrate) must produce exactly one PluginStatRecord
+    // attributed to "phase-orchestrator" with outcome Ok. Phase 6 codifies the
+    // full voom-process e2e; this test catches regressions in the dispatch
+    // instrumentation itself for the orchestrator capability.
+    use std::sync::Mutex;
+    use voom_domain::plugin_stats::{PluginInvocationOutcome, PluginStatRecord};
+    use voom_kernel::stats_sink::StatsSink;
+
+    #[derive(Default)]
+    struct RecordingSink(Mutex<Vec<PluginStatRecord>>);
+    impl StatsSink for RecordingSink {
+        fn record(&self, record: PluginStatRecord) {
+            self.0.lock().unwrap().push(record);
+        }
+    }
+
+    let sink: Arc<RecordingSink> = Arc::new(RecordingSink::default());
+    let kernel = kernel_with_orchestrator();
+    kernel.set_stats_sink(sink.clone() as Arc<dyn StatsSink>);
+
+    voom_cli::kernel_invoke::orchestrate(&kernel, vec![], "demo".into())
+        .expect("kernel orchestrate");
+
+    let records = sink.0.lock().unwrap();
+    assert_eq!(records.len(), 1, "exactly one stats row per dispatch");
+    assert_eq!(records[0].plugin_id, "phase-orchestrator");
+    assert_eq!(records[0].event_type, "call.orchestrate");
+    assert!(
+        matches!(records[0].outcome, PluginInvocationOutcome::Ok),
+        "successful dispatch must record Ok outcome; got {:?}",
+        records[0].outcome
+    );
+}

--- a/plugins/phase-orchestrator/Cargo.toml
+++ b/plugins/phase-orchestrator/Cargo.toml
@@ -22,5 +22,6 @@ workspace = true
 
 [dev-dependencies]
 insta = { workspace = true }
+serde_json = { workspace = true }
 voom-dsl = { workspace = true }
 voom-policy-evaluator = { workspace = true }

--- a/plugins/phase-orchestrator/Cargo.toml
+++ b/plugins/phase-orchestrator/Cargo.toml
@@ -14,6 +14,7 @@ description = "Phase orchestration plugin for VOOM — sequences policy phases w
 [dependencies]
 voom-domain = { workspace = true }
 voom-dsl = { workspace = true }
+voom-kernel = { workspace = true }
 tracing = { workspace = true }
 
 [lints]

--- a/plugins/phase-orchestrator/src/lib.rs
+++ b/plugins/phase-orchestrator/src/lib.rs
@@ -9,6 +9,10 @@ pub use voom_domain::orchestration::OrchestrationResult;
 use voom_domain::plan::{PhaseOutcome, PhaseResult, Plan};
 use voom_dsl::compiled::{CompiledPolicy, ErrorStrategy};
 
+pub mod plugin;
+
+pub use plugin::PhaseOrchestratorPlugin;
+
 /// Produce phase outcomes from pre-evaluated plans, computing skip/completion
 /// state and dry-run summary.
 ///

--- a/plugins/phase-orchestrator/src/plugin.rs
+++ b/plugins/phase-orchestrator/src/plugin.rs
@@ -17,15 +17,25 @@ use voom_domain::errors::{Result, VoomError};
 use voom_kernel::Plugin;
 
 /// Kernel-registered plugin that exposes `voom-phase-orchestrator` via Call dispatch.
-#[non_exhaustive]
 pub struct PhaseOrchestratorPlugin {
     capabilities: Vec<Capability>,
 }
 
 impl PhaseOrchestratorPlugin {
-    /// Bootstrap-only constructor.
+    /// Bootstrap-only constructor — the canonical public entry point.
+    ///
+    /// All runtime orchestrator invocations flow through
+    /// `Kernel::dispatch_to_capability(Exclusive(OrchestratePhases), Call::Orchestrate)`.
+    /// Constructing a `PhaseOrchestratorPlugin` directly is legitimate only at
+    /// kernel-bootstrap registration time and inside in-crate tests
+    /// (via the `pub(crate) fn new()` companion).
     #[must_use]
     pub fn for_bootstrap() -> Self {
+        Self::new()
+    }
+
+    #[must_use]
+    pub(crate) fn new() -> Self {
         Self {
             capabilities: vec![Capability::OrchestratePhases],
         }
@@ -33,10 +43,11 @@ impl PhaseOrchestratorPlugin {
 }
 
 impl Plugin for PhaseOrchestratorPlugin {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "phase-orchestrator"
     }
-    fn version(&self) -> &str {
+
+    fn version(&self) -> &'static str {
         env!("CARGO_PKG_VERSION")
     }
 
@@ -59,8 +70,11 @@ impl Plugin for PhaseOrchestratorPlugin {
         } = call
         else {
             return Err(VoomError::plugin(
-                "phase-orchestrator",
-                format!("phase-orchestrator only handles Call::Orchestrate, got {call:?}"),
+                self.name(),
+                format!(
+                    "PhaseOrchestratorPlugin only handles Call::Orchestrate, got {:?}",
+                    std::mem::discriminant(call)
+                ),
             ));
         };
 

--- a/plugins/phase-orchestrator/src/plugin.rs
+++ b/plugins/phase-orchestrator/src/plugin.rs
@@ -87,3 +87,144 @@ impl Plugin for PhaseOrchestratorPlugin {
         Ok(CallResponse::Orchestrate(result))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use voom_domain::media::{Container, MediaFile, Track, TrackType};
+    use voom_domain::plan::PhaseOutcome;
+
+    fn test_file() -> MediaFile {
+        let mut file = MediaFile::new(PathBuf::from("/media/Movie.mkv"));
+        file.container = Container::Mkv;
+        file.tracks = vec![{
+            let mut t = Track::new(0, TrackType::Video, "hevc".into());
+            t.width = Some(1920);
+            t.height = Some(1080);
+            t
+        }];
+        file
+    }
+
+    fn eval(policy: &voom_dsl::CompiledPolicy, file: &MediaFile) -> Vec<voom_domain::plan::Plan> {
+        voom_policy_evaluator::evaluator::evaluate(policy, file).plans
+    }
+
+    #[test]
+    fn on_call_orchestrate_delegates_to_free_function() {
+        let plugin = PhaseOrchestratorPlugin::new();
+        let policy =
+            voom_dsl::compile_policy(r#"policy "demo" { phase init { container mkv } }"#).unwrap();
+        let file = test_file();
+        let plans = eval(&policy, &file);
+
+        let direct = crate::orchestrate(plans.clone());
+
+        let call = Call::Orchestrate {
+            plans: plans.clone(),
+            policy_name: "demo".into(),
+        };
+        let response = plugin.on_call(&call).expect("on_call ok");
+
+        match response {
+            CallResponse::Orchestrate(routed) => {
+                // Full-struct equality via serde — OrchestrationResult is
+                // Serialize per Phase 1, so this comparison catches every
+                // field-level divergence including phase_results, outcomes,
+                // skip reasons, and file_modified.
+                let direct_v = serde_json::to_value(&direct).expect("serialize direct");
+                let routed_v = serde_json::to_value(&routed).expect("serialize routed");
+                assert_eq!(
+                    direct_v, routed_v,
+                    "kernel-routed OrchestrationResult differs from direct call"
+                );
+            }
+            _ => panic!("wrong CallResponse variant"),
+        }
+    }
+
+    #[test]
+    fn on_call_preserves_phase_outcomes() {
+        // Multi-phase policy where outcomes reliably reflect orchestrate() logic
+        // (skip vs. pending vs. completed). Confirm the routed plugin path
+        // produces identical outcomes.
+        let plugin = PhaseOrchestratorPlugin::new();
+        let policy = voom_dsl::compile_policy(
+            r#"policy "demo" {
+                phase first { container mkv }
+                phase second {
+                    depends_on: [first]
+                    skip when video.codec == "hevc"
+                    transcode video to hevc { crf: 20 }
+                }
+            }"#,
+        )
+        .unwrap();
+        let file = test_file(); // hevc — second phase should be skipped
+        let plans = eval(&policy, &file);
+
+        let call = Call::Orchestrate {
+            plans,
+            policy_name: "demo".into(),
+        };
+        let response = plugin.on_call(&call).expect("on_call ok");
+        let CallResponse::Orchestrate(result) = response else {
+            panic!("wrong variant");
+        };
+
+        assert_eq!(result.phase_results.len(), 2);
+        assert_eq!(
+            result.phase_results[1].outcome,
+            PhaseOutcome::Skipped,
+            "second phase should be Skipped (video already hevc)"
+        );
+    }
+
+    #[test]
+    fn on_call_rejects_non_orchestrate_call_variants() {
+        let plugin = PhaseOrchestratorPlugin::new();
+        let policy =
+            voom_dsl::compile_policy(r#"policy "demo" { phase init { container mkv } }"#).unwrap();
+        let file = test_file();
+        let call = Call::EvaluatePolicy {
+            policy: Box::new(policy),
+            file: Box::new(file),
+            phase: None,
+            phase_outputs: None,
+            phase_outcomes: None,
+            capabilities_override: None,
+        };
+        let err = plugin.on_call(&call).unwrap_err();
+        assert!(
+            err.to_string().contains("only handles Call::Orchestrate"),
+            "error message should name the expected variant; got: {err}"
+        );
+    }
+
+    #[test]
+    fn handles_returns_false_for_all_events() {
+        let plugin = PhaseOrchestratorPlugin::new();
+        assert!(!plugin.handles(voom_domain::events::Event::FILE_DISCOVERED));
+        assert!(!plugin.handles(voom_domain::events::Event::FILE_INTROSPECTED));
+        assert!(!plugin.handles(voom_domain::events::Event::EXECUTOR_CAPABILITIES));
+        assert!(!plugin.handles(voom_domain::events::Event::PLAN_CREATED));
+        assert!(!plugin.handles("any-arbitrary-string"));
+    }
+
+    #[test]
+    fn on_call_with_empty_plans_is_well_defined() {
+        let plugin = PhaseOrchestratorPlugin::new();
+        let call = Call::Orchestrate {
+            plans: vec![],
+            policy_name: "empty".into(),
+        };
+        let response = plugin.on_call(&call).expect("on_call ok");
+        let CallResponse::Orchestrate(result) = response else {
+            panic!("wrong variant");
+        };
+        assert!(result.plans.is_empty());
+        assert!(result.phase_results.is_empty());
+        assert!(!result.file_modified);
+    }
+}

--- a/plugins/phase-orchestrator/src/plugin.rs
+++ b/plugins/phase-orchestrator/src/plugin.rs
@@ -1,0 +1,75 @@
+//! Kernel-registered plugin wrapper for the phase orchestrator.
+//!
+//! The free functions in `lib.rs` (`orchestrate`, `format_dry_run`,
+//! `needs_execution`, `phase_error_strategy`) remain the canonical library
+//! API — they stay `pub`. `PhaseOrchestratorPlugin` is an *additional* entry
+//! path that exposes the orchestrator through the kernel's
+//! `dispatch_to_capability(Capability::OrchestratePhases, Call::Orchestrate)`
+//! route, which is how the CLI invokes orchestration after Phase 5.
+//!
+//! The plugin is stateless: it subscribes to no events and has no internal
+//! cache. Every `on_call` invocation delegates directly to the
+//! `orchestrate(plans)` free function.
+
+use voom_domain::call::{Call, CallResponse};
+use voom_domain::capabilities::Capability;
+use voom_domain::errors::{Result, VoomError};
+use voom_kernel::Plugin;
+
+/// Kernel-registered plugin that exposes `voom-phase-orchestrator` via Call dispatch.
+#[non_exhaustive]
+pub struct PhaseOrchestratorPlugin {
+    capabilities: Vec<Capability>,
+}
+
+impl PhaseOrchestratorPlugin {
+    /// Bootstrap-only constructor.
+    #[must_use]
+    pub fn for_bootstrap() -> Self {
+        Self {
+            capabilities: vec![Capability::OrchestratePhases],
+        }
+    }
+}
+
+impl Plugin for PhaseOrchestratorPlugin {
+    fn name(&self) -> &str {
+        "phase-orchestrator"
+    }
+    fn version(&self) -> &str {
+        env!("CARGO_PKG_VERSION")
+    }
+
+    voom_kernel::plugin_cargo_metadata!();
+
+    fn capabilities(&self) -> &[Capability] {
+        &self.capabilities
+    }
+
+    fn handles(&self, _event_type: &str) -> bool {
+        // PhaseOrchestratorPlugin is stateless; it does not subscribe to any
+        // events. Its only entry point is on_call(Call::Orchestrate).
+        false
+    }
+
+    fn on_call(&self, call: &Call) -> Result<CallResponse> {
+        let Call::Orchestrate {
+            plans,
+            policy_name: _,
+        } = call
+        else {
+            return Err(VoomError::plugin(
+                "phase-orchestrator",
+                format!("phase-orchestrator only handles Call::Orchestrate, got {call:?}"),
+            ));
+        };
+
+        // Delegate to the existing pub free function. The plugin is purely a
+        // dispatch surface; the orchestration logic remains in lib.rs.
+        // `policy_name` is accepted as part of the Call payload (per spec)
+        // but not currently read — it's pass-through metadata for stats
+        // attribution and potential future cross-cutting use.
+        let result = crate::orchestrate(plans.clone());
+        Ok(CallResponse::Orchestrate(result))
+    }
+}


### PR DESCRIPTION
## Summary

Promote `voom-phase-orchestrator` to a kernel-registered plugin per the contract
revision in
[`docs/superpowers/specs/2026-05-14-plugin-stats-self-reporting-design.md`](../docs/superpowers/specs/2026-05-14-plugin-stats-self-reporting-design.md).

Phase 5 of 6. Prerequisites: Phases 1 and 4 merged. Independent of Phases 2 and 3.

### What ships

- New `PhaseOrchestratorPlugin` claiming `Capability::OrchestratePhases` (Exclusive).
- Stateless plugin: `handles()` returns `false` for every event type. The only entry point is `on_call(Call::Orchestrate)`, which delegates to the existing `pub fn orchestrate(plans)` free function and wraps the result in `CallResponse::Orchestrate`.
- **No events emitted from `on_call`** — the CLI's existing `dispatch.rs` `PlanCreated` orchestration is preserved verbatim.
- **All four free functions stay `pub`** (`orchestrate`, `format_dry_run`, `needs_execution`, `phase_error_strategy`). The plugin is purely additive surface.
- New `voom_cli::kernel_invoke::orchestrate` helper.
- **Two CLI call sites migrated:**
  - Task 5a — the inner `voom_phase_orchestrator::orchestrate(plans)` call inside the dry-run helper `orchestrate_plans` at `process/pipeline.rs`. The helper signature (kernel param + `Result` return) was already in place from Phase 4.
  - Task 5b — `process_single_file_execute` split into an outer wrapper and an inner async fn. The wrapper invokes `kernel_invoke::orchestrate(...)` **after** the inner returns, regardless of how the inner returned (success, `Err` via `?`, or explicit return). The orchestrator dispatch is non-fatal (logs on error via `tracing::warn!`, never propagates) so an observability failure can never turn successful file mutations into a hard error. This closes the `plugin_stats` coverage gap for normal `voom process` runs AND ensures every exit path — including the existing `?` early-returns inside the per-phase loop — produces a stats row.
- `REQUIRED_PLUGIN_NAMES` extended with `"phase-orchestrator"`; `KNOWN_PLUGIN_NAMES` count bumped from 14 to 15.
- New `PRIORITY_PHASE_ORCHESTRATOR = 37` in `app.rs`, slotted next to `PRIORITY_POLICY_EVALUATOR = 36` for natural grouping (priority is decorative since the plugin subscribes to no events).
- Parity tests: kernel-routed orchestration == direct library call, full-struct `serde_json::Value` equality, three policy shapes (single-phase, multi-phase with skip-and-depends, empty plans).
- Dispatch-boundary stats coverage test (Task 6b): `dispatch_to_capability(OrchestratePhases, ...)` via `kernel_invoke::orchestrate` produces exactly one `PluginStatRecord` attributed to `phase-orchestrator` with outcome `Ok`.
- Execute-path integration tests (Task 6c): two `tokio` integration tests against `process_single_file_execute` — one for the success path (skip-when policy, inner returns `Ok`), one that drives an inner-Err exit via `FailingExecutor` (regression test for rev-2 Finding 2: `?`-bypass).
- Plugin tests pin `handles()` returning false for all events and `on_call` rejecting non-Orchestrate variants.

### What does NOT ship

- Documentation reverts and full acceptance e2e — Phase 6.
- A `orchestrate_with_outcomes` variant that consumes the execute path's actual per-phase execution outcomes — explicit follow-up issue (would require either domain-type extension `PhaseOutcome::Failed` or a separate execution-outcome map alongside `PhaseOutcome`). Out of scope here because the spec's #378 acceptance only requires the stats row, and the current call's pre-execution semantics are accurate for what they encode (see the Execute-path semantics caveat in the plan's Architecture section).
- Anything from Phases 2 or 3 (independent).

### Notes

- `policy_name` is included in `Call::Orchestrate { plans, policy_name }` per spec but not currently read by the orchestrator. It's pass-through metadata for stats attribution and future cross-cutting features.
- `needs_execution`, `format_dry_run`, and `phase_error_strategy` are inspectors over `OrchestrationResult` / `CompiledPolicy` — pure functions, not dispatch paths. They stay on the direct library API for the same reason the offline `policy explain` / `policy diff` commands kept their direct evaluator calls in Phase 4.
- Execute-path orchestrator invocation always runs after the inner returns, so failed files also produce a stats row.
- `event_type` recorded for orchestrator dispatches is `"call.orchestrate"` (kernel's `call_kind_str` maps `Call::Orchestrate` to that; consistent with Phase 4's `"call.evaluate_policy"` for `Call::EvaluatePolicy`).

## Test plan

- [x] `cargo test --workspace` (all suites pass)
- [x] `cargo test -p voom-cli --features functional -- --test-threads=4` (128-test functional suite passes)
- [x] `cargo test -p voom-cli --test phase_orchestrator_parity` (3 parity tests + dispatch-boundary stats test, 4 total)
- [x] `cargo test -p voom-cli --lib execute_path_produces` (2 execute-path integration tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] Plan* dispatch behavior unchanged (no Plan* events emitted from the orchestrator plugin).
- [x] Four `pub` free functions still public in `plugins/phase-orchestrator/src/lib.rs`.
- [x] PhaseOrchestratorPlugin registered at bootstrap with `PRIORITY_PHASE_ORCHESTRATOR = 37`.
- [x] Zero remaining direct `voom_phase_orchestrator::orchestrate(` calls in `pipeline.rs` (verified by `grep`).
- [x] Orchestrator dispatch errors in the execute path are logged via `tracing::warn!`, not propagated to caller.

Refs #378.