### PR TITLE
fix: preserve ffmpeg stderr for diagnostics

### DIFF
--- a/crates/voom-domain/src/events.rs
+++ b/crates/voom-domain/src/events.rs
@@ -1238,6 +1238,7 @@ mod tests {
             command: "ffmpeg -i /test.mkv out.mkv".into(),
             exit_code: Some(1),
             stderr_tail: "Error opening input".into(),
+            stderr_full: Some("full stderr: Error opening input".into()),
             duration_ms: 1234,
         });
 
@@ -1247,6 +1248,10 @@ mod tests {
         let detail = restored.execution_detail.unwrap();
         assert_eq!(detail.exit_code, Some(1));
         assert_eq!(detail.stderr_tail, "Error opening input");
+        assert_eq!(
+            detail.stderr_full.as_deref(),
+            Some("full stderr: Error opening input")
+        );
         assert_eq!(detail.duration_ms, 1234);
     }
 

--- a/crates/voom-domain/src/plan.rs
+++ b/crates/voom-domain/src/plan.rs
@@ -1297,6 +1297,12 @@ pub struct ExecutionDetail {
     /// Last N non-empty lines of stderr. Populated on failure and on
     /// mkvmerge warnings (exit code 1). Empty on clean success.
     pub stderr_tail: String,
+    /// Full stderr captured from a failed executor invocation.
+    ///
+    /// This is intentionally optional so existing persisted plan results and
+    /// non-ffmpeg executors can continue to provide only `stderr_tail`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stderr_full: Option<String>,
     /// Wall-clock execution time in milliseconds.
     pub duration_ms: u64,
 }
@@ -1401,6 +1407,24 @@ mod tests {
         assert_eq!(deserialized.policy_name, "default");
         assert_eq!(deserialized.actions.len(), 1);
         assert_eq!(deserialized.actions[0].operation, OperationType::SetDefault);
+    }
+
+    #[test]
+    fn execution_detail_deserializes_legacy_json_without_stderr_full() {
+        let json = r#"{
+            "command": "ffmpeg -i in.mkv out.mkv",
+            "exit_code": 1,
+            "stderr_tail": "Conversion failed",
+            "duration_ms": 42
+        }"#;
+
+        let detail: ExecutionDetail = serde_json::from_str(json).unwrap();
+
+        assert_eq!(detail.command, "ffmpeg -i in.mkv out.mkv");
+        assert_eq!(detail.exit_code, Some(1));
+        assert_eq!(detail.stderr_tail, "Conversion failed");
+        assert_eq!(detail.stderr_full, None);
+        assert_eq!(detail.duration_ms, 42);
     }
 
     #[test]

--- a/crates/voom-wit/src/convert.rs
+++ b/crates/voom-wit/src/convert.rs
@@ -549,6 +549,7 @@ mod tests {
             command: "handbrake --input movie.mkv".to_string(),
             exit_code: Some(0),
             stderr_tail: String::new(),
+            stderr_full: Some("complete diagnostic stream".to_string()),
             duration_ms: 25,
         };
         let mut result = EventResult::plan_succeeded("executor", None);
@@ -559,7 +560,12 @@ mod tests {
 
         assert!(restored.claimed);
         assert_eq!(restored.execution_error, None);
-        assert_eq!(restored.execution_detail.unwrap().command, detail.command);
+        let restored_detail = restored.execution_detail.as_ref().unwrap();
+        assert_eq!(restored_detail.command, detail.command);
+        assert_eq!(restored_detail.exit_code, detail.exit_code);
+        assert_eq!(restored_detail.stderr_tail, detail.stderr_tail);
+        assert_eq!(restored_detail.stderr_full, detail.stderr_full);
+        assert_eq!(restored_detail.duration_ms, detail.duration_ms);
     }
 
     #[test]

--- a/plugins/ffmpeg-executor/src/executor.rs
+++ b/plugins/ffmpeg-executor/src/executor.rs
@@ -193,6 +193,7 @@ fn execute_plan_with_runners(
                 command: command_str,
                 exit_code: Some(0),
                 stderr_tail: String::new(),
+                stderr_full: None,
                 duration_ms,
             };
             let action_results = actions
@@ -215,6 +216,7 @@ fn execute_plan_with_runners(
                 "ffmpeg failed"
             );
             let tail = voom_process::stderr_tail(&output.stderr, STDERR_TAIL_LINES);
+            let stderr_full = crate::capture_stderr_full(&output.stderr);
             let display_tail = if tail.is_empty() {
                 "(no output)"
             } else {
@@ -228,6 +230,7 @@ fn execute_plan_with_runners(
                 command: command_str,
                 exit_code: output.status.code(),
                 stderr_tail: tail,
+                stderr_full: Some(stderr_full),
                 duration_ms,
             };
             let action_results = vec![
@@ -1020,9 +1023,34 @@ mod tests {
         }
     }
 
+    struct FailingProcessRunner {
+        stderr: Vec<u8>,
+    }
+
+    impl ProcessRunner for FailingProcessRunner {
+        fn run(
+            &self,
+            _tool: &str,
+            _args: &[String],
+            _timeout: Duration,
+            _env_vars: &[(&str, &str)],
+        ) -> Result<Output> {
+            Ok(Output {
+                status: failure_status(),
+                stdout: Vec::new(),
+                stderr: self.stderr.clone(),
+            })
+        }
+    }
+
     #[cfg(unix)]
     fn success_status() -> ExitStatus {
         ExitStatus::from_raw(0)
+    }
+
+    #[cfg(unix)]
+    fn failure_status() -> ExitStatus {
+        ExitStatus::from_raw(1 << 8)
     }
 
     fn command_output_path(tool: &str, args: &[String]) -> Option<PathBuf> {
@@ -1257,6 +1285,42 @@ mod tests {
 
         let outcome = &prepared.outcomes[0];
         assert_eq!(outcome.target_vmaf, Some(88));
+    }
+
+    #[test]
+    fn ffmpeg_failures_preserve_full_stderr_alongside_tail() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let source_path = tmp.path().join("source.mp4");
+        fs::write(&source_path, b"input video").unwrap();
+
+        let mut plan = video_plan(TranscodeSettings::default());
+        plan.file.path = source_path;
+        let full_stderr = (0..=24)
+            .map(|i| format!("ffmpeg diagnostic line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let runner = FailingProcessRunner {
+            stderr: full_stderr.clone().into_bytes(),
+        };
+
+        let execution = execute_plan_with_runners(
+            &plan,
+            &HwAccelConfig::new(),
+            &SuccessfulVmafRunner,
+            &runner,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(execution.action_results.len(), 1);
+        assert!(!execution.action_results[0].success);
+        let detail = execution.action_results[0]
+            .execution_detail
+            .as_ref()
+            .expect("failed ffmpeg result should include execution detail");
+        assert_eq!(detail.stderr_full.as_deref(), Some(full_stderr.as_str()));
+        assert!(!detail.stderr_tail.contains("diagnostic line 0"));
+        assert!(detail.stderr_tail.contains("diagnostic line 24"));
     }
 
     #[test]

--- a/plugins/ffmpeg-executor/src/lib.rs
+++ b/plugins/ffmpeg-executor/src/lib.rs
@@ -50,6 +50,17 @@ struct FfmpegExecutorConfig {
 }
 
 const DEFAULT_NVENC_MAX_PARALLEL_PER_GPU: usize = 2;
+pub(crate) const STDERR_FULL_MAX_BYTES: usize = 1024 * 1024;
+
+pub(crate) fn capture_stderr_full(stderr: &[u8]) -> String {
+    if stderr.len() <= STDERR_FULL_MAX_BYTES {
+        return String::from_utf8_lossy(stderr).into_owned();
+    }
+
+    let mut captured = String::from_utf8_lossy(&stderr[..STDERR_FULL_MAX_BYTES]).into_owned();
+    captured.push_str("\n...[stderr truncated after 1048576 bytes]");
+    captured
+}
 
 fn positive_or_default(value: Option<usize>, default: usize) -> usize {
     match value {
@@ -430,6 +441,7 @@ impl FfmpegExecutorPlugin {
                     command: command_str,
                     exit_code: Some(0),
                     stderr_tail: String::new(),
+                    stderr_full: None,
                     duration_ms,
                 };
                 Ok(vec![
@@ -440,6 +452,7 @@ impl FfmpegExecutorPlugin {
             Ok(o) => {
                 let _ = std::fs::remove_file(&temp_path);
                 let tail = voom_process::stderr_tail(&o.stderr, 20);
+                let stderr_full = capture_stderr_full(&o.stderr);
                 let display_tail = if tail.is_empty() {
                     "(no output)"
                 } else {
@@ -455,6 +468,7 @@ impl FfmpegExecutorPlugin {
                     command: command_str,
                     exit_code: o.status.code(),
                     stderr_tail: tail,
+                    stderr_full: Some(stderr_full),
                     duration_ms,
                 };
                 Ok(vec![
@@ -722,6 +736,18 @@ mod tests {
         let mut plan = Plan::new(file, "test", "process");
         plan.actions = actions;
         plan
+    }
+
+    #[test]
+    fn capture_stderr_full_keeps_head_and_caps_size() {
+        let mut stderr = vec![b'a'; STDERR_FULL_MAX_BYTES + 32];
+        stderr[0..8].copy_from_slice(b"ROOT_OOM");
+
+        let captured = capture_stderr_full(&stderr);
+
+        assert!(captured.starts_with("ROOT_OOM"));
+        assert!(captured.contains("stderr truncated after 1048576 bytes"));
+        assert!(!captured.ends_with(&"a".repeat(32)));
     }
 
     #[test]

--- a/plugins/mkvtoolnix-executor/src/lib.rs
+++ b/plugins/mkvtoolnix-executor/src/lib.rs
@@ -368,6 +368,7 @@ impl MkvtoolnixExecutorPlugin {
                     exit_code: o.status.code(),
                     // exit code 1 = mkvmerge warnings; capture stderr for diagnostics
                     stderr_tail: voom_process::stderr_tail(&o.stderr, 20),
+                    stderr_full: None,
                     duration_ms,
                 };
                 Ok(vec![
@@ -392,6 +393,7 @@ impl MkvtoolnixExecutorPlugin {
                     command: command_str,
                     exit_code: o.status.code(),
                     stderr_tail: tail,
+                    stderr_full: None,
                     duration_ms,
                 };
                 Ok(vec![

--- a/plugins/mkvtoolnix-executor/src/merge.rs
+++ b/plugins/mkvtoolnix-executor/src/merge.rs
@@ -101,6 +101,7 @@ pub fn execute_merge_actions(
             exit_code: output.status.code(),
             // exit code 1 = mkvmerge warnings; capture stderr for diagnostics
             stderr_tail: voom_process::stderr_tail(&output.stderr, 20),
+            stderr_full: None,
             duration_ms,
         };
         Ok(actions
@@ -127,6 +128,7 @@ pub fn execute_merge_actions(
             command: command_str,
             exit_code: output.status.code(),
             stderr_tail: tail,
+            stderr_full: None,
             duration_ms,
         };
         Ok(vec![

--- a/plugins/sqlite-store/src/store/plan_storage.rs
+++ b/plugins/sqlite-store/src/store/plan_storage.rs
@@ -438,6 +438,7 @@ mod tests {
             command: "ffmpeg -i in.mkv out.mkv".into(),
             exit_code: Some(1),
             stderr_tail: "codec not supported".into(),
+            stderr_full: Some("full stderr with codec not supported".into()),
             duration_ms: 1_234,
         };
         store
@@ -450,6 +451,10 @@ mod tests {
         assert_eq!(parsed["error"], "transcode failed");
         assert_eq!(parsed["detail"]["exit_code"], 1);
         assert_eq!(parsed["detail"]["duration_ms"], 1_234);
+        assert_eq!(
+            parsed["detail"]["stderr_full"],
+            "full stderr with codec not supported"
+        );
     }
 
     #[test]

--- a/scripts/e2e-policy-audit/lib/failure-clusters.py
+++ b/scripts/e2e-policy-audit/lib/failure-clusters.py
@@ -45,7 +45,7 @@ def text_for_result(raw: str) -> tuple[dict[str, Any], str]:
     detail = parsed.get("detail") or {}
     parts = [
         str(parsed.get("error") or ""),
-        str(detail.get("stderr_tail") or ""),
+        str(detail.get("stderr_full") or detail.get("stderr_tail") or ""),
         str(detail.get("command") or ""),
     ]
     return parsed, "\n".join(parts)

--- a/scripts/e2e-policy-audit/tests/test.sh
+++ b/scripts/e2e-policy-audit/tests/test.sh
@@ -571,7 +571,7 @@ run_failure_clusters_test() {
 
   cat >"${actual}/failed-plans.tsv" <<'EOF'
 plan_id	file_id	phase	result
-plan-1	file-1	transcode-video	{"detail":{"exit_code":187,"command":"ffmpeg -i '/lib/show/S01E01.mkv' out.mkv","stderr_tail":"cuCtxCreate failed -> CUDA_ERROR_OUT_OF_MEMORY: out of memory"},"error":"ffmpeg exited with exit status: 187"}
+plan-1	file-1	transcode-video	{"detail":{"exit_code":187,"command":"ffmpeg -i '/lib/show/S01E01.mkv' out.mkv","stderr_tail":"Conversion failed","stderr_full":"cuCtxCreate failed -> CUDA_ERROR_OUT_OF_MEMORY: out of memory\nConversion failed"},"error":"ffmpeg exited with exit status: 187"}
 plan-2	file-2	transcode-video	{"detail":null,"error":"storage error: failed to insert transcode outcome: FOREIGN KEY constraint failed"}
 EOF
 
@@ -595,7 +595,7 @@ EOF
 
   cat >"${actual}/expected-clusters.tsv" <<'EOF'
 phase	signature	exit_code	container	video_codec	count	top_resolution	sample_path	sample_plan_id	sample_error
-transcode-video	cuda-context-oom	187	mkv	h264	1	1920x1080	/lib/show/S01E01.mkv	plan-1	ffmpeg exited with exit status: 187 | cuCtxCreate failed -> CUDA_ERROR_OUT_OF_MEMORY: out of memory
+transcode-video	cuda-context-oom	187	mkv	h264	1	1920x1080	/lib/show/S01E01.mkv	plan-1	ffmpeg exited with exit status: 187 | cuCtxCreate failed -> CUDA_ERROR_OUT_OF_MEMORY: out of memory | Conversion failed
 transcode-video	storage-fk-transcode-outcome		mkv	mpeg4	1	640x480	/lib/show/S01E02.mkv	plan-2	storage error: failed to insert transcode outcome: FOREIGN KEY constraint failed
 EOF
 


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary

- Add an optional `stderr_full` field to execution details so failed ffmpeg runs can retain the head of stderr alongside the existing compact `stderr_tail`.
- Cap stored full stderr at 1 MiB with a truncation marker, preserving the early root-cause lines while avoiding unbounded persisted results.
- Teach `failure-clusters.py` to prefer `stderr_full` when classifying failed plan results, while keeping legacy `stderr_tail` fallback behavior.

Fixes #397

## Testing

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p voom-domain execution_detail_deserializes_legacy_json_without_stderr_full -- --nocapture`
- `cargo test -p voom-domain test_plan_failed_with_execution_detail_roundtrip -- --nocapture`
- `cargo test -p voom-wit test_event_result_roundtrip_preserves_execution_lifecycle_fields -- --nocapture`
- `cargo test -p voom-sqlite-store update_plan_error_with_detail -- --nocapture`
- `cargo test -p voom-ffmpeg-executor capture_stderr_full_keeps_head_and_caps_size -- --nocapture`
- `cargo test -p voom-ffmpeg-executor ffmpeg_failures_preserve_full_stderr_alongside_tail -- --nocapture`
- `cargo check -p voom-mkvtoolnix-executor -p voom-ffmpeg-executor -p voom-sqlite-store -p voom-wit -p voom-domain`
- Focused `failure-clusters.py` fixture run verifying `stderr_full` drives `cuda-context-oom` classification while legacy/null detail fallback still works.

Note: I also tried `scripts/e2e-policy-audit/tests/test.sh`, but this local macOS environment uses Python 3.9.6 and the broader script exits earlier in an existing helper (`env-check-timeline.py`) on `str | None` annotations. The focused failure-clusters fixture above covers the changed classifier behavior.
