### PR TITLE
Plugin contract rev-6 (#378) — Phase 6: docs reconciliation + acceptance e2e

### DIFF
--- a/crates/voom-cli/tests/plugin_stats_e2e.rs
+++ b/crates/voom-cli/tests/plugin_stats_e2e.rs
@@ -494,15 +494,20 @@ async fn event_log_contains_no_call_payloads_after_process() {
         );
     }
 
-    // `event_type LIKE 'call.%'` is the generic invariant; specific Call
-    // variant payload patterns would rot the moment a new Call variant
-    // landed without updating the test.
+    // Two regression classes to catch, both kept generic so a new `Call`
+    // variant never silently bypasses the guard:
+    //   1. event_type LIKE 'call.%' — a plugin re-emits a Call as an event.
+    //   2. payload LIKE '%"call.%'  — a Call's debug-format string leaks
+    //      into the payload of any legitimate event (e.g. a PluginError
+    //      that includes the Call in its message).
     let db_path = env.db_path();
     let conn = rusqlite::Connection::open(&db_path)
         .unwrap_or_else(|e| panic!("open {}: {e}", db_path.display()));
     let call_event_count: i64 = conn
         .query_row(
-            "SELECT COUNT(*) FROM event_log WHERE event_type LIKE 'call.%'",
+            "SELECT COUNT(*) FROM event_log
+             WHERE event_type LIKE 'call.%'
+                OR payload LIKE '%\"call.%'",
             [],
             |row| row.get(0),
         )

--- a/crates/voom-cli/tests/plugin_stats_e2e.rs
+++ b/crates/voom-cli/tests/plugin_stats_e2e.rs
@@ -378,3 +378,130 @@ async fn process_dry_run_populates_policy_evaluator_stats_row() {
          (#378 Phase 4). Got {evaluator_count} rows."
     );
 }
+
+// ─── Phase 6 acceptance: full kernel-registered coverage ─────────────────────
+
+/// Copy the bundled `distorted.mkv` fixture (a real, ffprobe-readable Matroska
+/// file under 16 KiB) into the given destination. Used by Phase 6 acceptance
+/// tests that need introspection to succeed so the dry-run pipeline reaches
+/// `kernel_invoke::orchestrate` and produces a `phase-orchestrator` row.
+fn copy_real_mkv_fixture(dest: &std::path::Path) {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let src = std::path::Path::new(manifest_dir)
+        .join("../../plugins/ffmpeg-executor/tests/fixtures/vmaf/distorted.mkv");
+    let src = src
+        .canonicalize()
+        .unwrap_or_else(|e| panic!("canonicalize {}: {e}", src.display()));
+    std::fs::copy(&src, dest).unwrap_or_else(|e| {
+        panic!(
+            "copy real mkv fixture {} -> {}: {e}",
+            src.display(),
+            dest.display()
+        )
+    });
+}
+
+/// After rev-6, every kernel-registered plugin invoked by `voom process`
+/// produces at least one `plugin_stats` row. This pins the closed coverage
+/// gap (#378) so it can't quietly re-open: `discovery`, `policy-evaluator`,
+/// and `phase-orchestrator` all flow through `dispatch_to_capability`, which
+/// records one `PluginStatRecord` per call. The `phase-orchestrator` row in
+/// particular requires introspection to succeed (it only subscribes to no
+/// events, so its only entry point is `on_call(Call::Orchestrate)`), so the
+/// test uses the bundled real-Matroska fixture rather than synthetic bytes.
+#[tokio::test]
+async fn process_records_stats_rows_for_discovery_evaluator_orchestrator() {
+    let _lock = TEST_LOCK.lock().await;
+    let mut env = TestEnv::new().await;
+
+    env.set_policy(
+        r#"policy "phase6-coverage-fixture" {
+            phase init { container mkv }
+        }"#,
+    );
+    copy_real_mkv_fixture(&env.root().join("clip.mkv"));
+
+    let policy_path = env
+        .policy_path()
+        .to_str()
+        .expect("utf-8 policy path")
+        .to_string();
+    let root = env.root().to_str().expect("utf-8 root").to_string();
+
+    let _outcome = env
+        .run_process(&[&root, "--policy", &policy_path, "--dry-run", "--no-backup"])
+        .await;
+
+    // Allow the SqliteStatsSink writer thread to flush batched rows.
+    tokio::time::sleep(Duration::from_millis(2000)).await;
+
+    let db_path = env.db_path();
+    let conn = rusqlite::Connection::open(&db_path)
+        .unwrap_or_else(|e| panic!("open {}: {e}", db_path.display()));
+    let names_seen: Vec<String> = conn
+        .prepare("SELECT DISTINCT plugin_id FROM plugin_stats")
+        .expect("prepare distinct plugin_id query")
+        .query_map([], |row| row.get(0))
+        .expect("execute distinct plugin_id query")
+        .map(|r| r.expect("read plugin_id row"))
+        .collect();
+
+    for required in ["discovery", "policy-evaluator", "phase-orchestrator"] {
+        assert!(
+            names_seen.iter().any(|n| n == required),
+            "plugin_stats must include row for {required} after `voom process`; \
+             saw plugin_ids: {names_seen:?} (#378 Phase 6)"
+        );
+    }
+}
+
+/// Call dispatches are RPC, not broadcast — they must not show up in
+/// `event_log`. This guards against an accidental `kernel.dispatch()`
+/// emission from inside a plugin's `on_call` path: the kernel maps `Call`
+/// variants to `call.<variant>` strings only as a debug formatting aid, and
+/// none of those strings should ever survive into `event_log`.
+#[tokio::test]
+async fn event_log_contains_no_call_payloads_after_process() {
+    let _lock = TEST_LOCK.lock().await;
+    let mut env = TestEnv::new().await;
+
+    env.set_policy(
+        r#"policy "phase6-event-log-fixture" {
+            phase init { container mkv }
+        }"#,
+    );
+    env.write_media("clip.mkv", 32);
+
+    let policy_path = env
+        .policy_path()
+        .to_str()
+        .expect("utf-8 policy path")
+        .to_string();
+    let root = env.root().to_str().expect("utf-8 root").to_string();
+
+    let _outcome = env
+        .run_process(&[&root, "--policy", &policy_path, "--dry-run", "--no-backup"])
+        .await;
+
+    tokio::time::sleep(Duration::from_millis(2000)).await;
+
+    let db_path = env.db_path();
+    let conn = rusqlite::Connection::open(&db_path)
+        .unwrap_or_else(|e| panic!("open {}: {e}", db_path.display()));
+    let call_event_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM event_log
+             WHERE event_type LIKE 'call.%'
+                OR payload LIKE '%\"call.evaluate_policy\"%'
+                OR payload LIKE '%\"call.orchestrate\"%'
+                OR payload LIKE '%\"call.scan_library\"%'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("count call-shaped event_log rows");
+    assert_eq!(
+        call_event_count, 0,
+        "Call dispatches must never appear in event_log; found \
+         {call_event_count} call-shaped rows (#378 Phase 6)"
+    );
+}

--- a/crates/voom-cli/tests/plugin_stats_e2e.rs
+++ b/crates/voom-cli/tests/plugin_stats_e2e.rs
@@ -460,6 +460,15 @@ async fn process_records_stats_rows_for_discovery_evaluator_orchestrator() {
 /// emission from inside a plugin's `on_call` path: the kernel maps `Call`
 /// variants to `call.<variant>` strings only as a debug formatting aid, and
 /// none of those strings should ever survive into `event_log`.
+///
+/// The test uses the real Matroska fixture and asserts on
+/// `outcome.result.is_ok()` plus the presence of `policy-evaluator` and
+/// `phase-orchestrator` rows in `plugin_stats` BEFORE checking `event_log`.
+/// Those preconditions are not decoration — they prove the calls actually
+/// ran during this run. A previous version of this test used synthetic
+/// bytes that failed ffprobe before evaluator/orchestrator were ever
+/// dispatched, which made the absence assertion vacuous (Codex adversarial
+/// review).
 #[tokio::test]
 async fn event_log_contains_no_call_payloads_after_process() {
     let _lock = TEST_LOCK.lock().await;
@@ -470,7 +479,7 @@ async fn event_log_contains_no_call_payloads_after_process() {
             phase init { container mkv }
         }"#,
     );
-    env.write_media("clip.mkv", 32);
+    copy_real_mkv_fixture(&env.root().join("clip.mkv"));
 
     let policy_path = env
         .policy_path()
@@ -479,15 +488,41 @@ async fn event_log_contains_no_call_payloads_after_process() {
         .to_string();
     let root = env.root().to_str().expect("utf-8 root").to_string();
 
-    let _outcome = env
+    let outcome = env
         .run_process(&[&root, "--policy", &policy_path, "--dry-run", "--no-backup"])
         .await;
+    outcome.result.as_ref().unwrap_or_else(|e| {
+        panic!(
+            "voom process must succeed so evaluator and orchestrator are actually \
+             dispatched; otherwise the event_log absence assertion below is vacuous: {e:#}"
+        )
+    });
 
     tokio::time::sleep(Duration::from_millis(2000)).await;
 
     let db_path = env.db_path();
     let conn = rusqlite::Connection::open(&db_path)
         .unwrap_or_else(|e| panic!("open {}: {e}", db_path.display()));
+
+    // Precondition: prove the Call paths we're guarding actually ran during
+    // this run. Without these rows, the event_log absence assertion below
+    // would still pass on a regression that re-emits Calls as events,
+    // because the regression simply wouldn't be exercised.
+    let names_seen: Vec<String> = conn
+        .prepare("SELECT DISTINCT plugin_id FROM plugin_stats")
+        .expect("prepare distinct plugin_id query")
+        .query_map([], |row| row.get(0))
+        .expect("execute distinct plugin_id query")
+        .map(|r| r.expect("read plugin_id row"))
+        .collect();
+    for required in ["policy-evaluator", "phase-orchestrator"] {
+        assert!(
+            names_seen.iter().any(|n| n == required),
+            "precondition: this guard test is meaningful only if the {required} \
+             Call actually ran; saw plugin_ids: {names_seen:?}"
+        );
+    }
+
     let call_event_count: i64 = conn
         .query_row(
             "SELECT COUNT(*) FROM event_log

--- a/crates/voom-cli/tests/plugin_stats_e2e.rs
+++ b/crates/voom-cli/tests/plugin_stats_e2e.rs
@@ -17,7 +17,7 @@ use voom_domain::plugin_stats::PluginStatsFilter;
 use voom_domain::storage::PluginStatsStorage;
 use voom_sqlite_store::store::SqliteStore;
 
-use common::{EnvOverride, TestEnv};
+use common::{EnvOverride, ProcessOutcome, TestEnv};
 
 // All tests in this file manipulate `XDG_CONFIG_HOME` via std::env::set_var.
 // That is not safe to do concurrently. Serialize with this mutex.
@@ -382,9 +382,10 @@ async fn process_dry_run_populates_policy_evaluator_stats_row() {
 // ─── Phase 6 acceptance: full kernel-registered coverage ─────────────────────
 
 /// Copy the bundled `distorted.mkv` fixture (a real, ffprobe-readable Matroska
-/// file under 16 KiB) into the given destination. Used by Phase 6 acceptance
-/// tests that need introspection to succeed so the dry-run pipeline reaches
-/// `kernel_invoke::orchestrate` and produces a `phase-orchestrator` row.
+/// file under 16 KiB) into the given destination. Synthetic bytes fail
+/// ffprobe, which short-circuits the process pipeline before evaluator and
+/// orchestrator Calls are dispatched — so any Phase 6 test that needs those
+/// Calls to actually run must seed with a real Matroska file.
 fn copy_real_mkv_fixture(dest: &std::path::Path) {
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let src = std::path::Path::new(manifest_dir)
@@ -401,96 +402,73 @@ fn copy_real_mkv_fixture(dest: &std::path::Path) {
     });
 }
 
+/// Drive a `voom process --dry-run --no-backup` against a single-phase policy
+/// seeded with the real Matroska fixture. Returns the full `ProcessOutcome`
+/// so callers can assert on `result` when their invariant requires the run
+/// to have succeeded.
+async fn run_phase6_dry_run(env: &mut TestEnv, policy_name: &str) -> ProcessOutcome {
+    env.set_policy(&format!(
+        r#"policy "{policy_name}" {{ phase init {{ container mkv }} }}"#
+    ));
+    copy_real_mkv_fixture(&env.root().join("clip.mkv"));
+    let policy_path = env
+        .policy_path()
+        .to_str()
+        .expect("utf-8 policy path")
+        .to_string();
+    let root = env.root().to_str().expect("utf-8 root").to_string();
+    env.run_process(&[&root, "--policy", &policy_path, "--dry-run", "--no-backup"])
+        .await
+}
+
+/// Read the set of distinct `plugin_id` values currently in `plugin_stats`
+/// via the storage trait (the same query path the file's first test uses).
+fn distinct_plugin_ids(env: &TestEnv) -> Vec<String> {
+    let filter = PluginStatsFilter::new(None, None, None);
+    open_store(env)
+        .rollup_plugin_stats(&filter)
+        .expect("rollup_plugin_stats")
+        .into_iter()
+        .map(|r| r.plugin_id)
+        .collect()
+}
+
 /// After rev-6, every kernel-registered plugin invoked by `voom process`
-/// produces at least one `plugin_stats` row. This pins the closed coverage
-/// gap (#378) so it can't quietly re-open: `discovery`, `policy-evaluator`,
-/// and `phase-orchestrator` all flow through `dispatch_to_capability`, which
-/// records one `PluginStatRecord` per call. The `phase-orchestrator` row in
-/// particular requires introspection to succeed (it only subscribes to no
-/// events, so its only entry point is `on_call(Call::Orchestrate)`), so the
-/// test uses the bundled real-Matroska fixture rather than synthetic bytes.
+/// produces at least one `plugin_stats` row. The `phase-orchestrator` row in
+/// particular requires introspection to succeed (its only entry point is
+/// `on_call(Call::Orchestrate)`), so the test seeds with the real Matroska
+/// fixture rather than synthetic bytes.
 #[tokio::test]
 async fn process_records_stats_rows_for_discovery_evaluator_orchestrator() {
     let _lock = TEST_LOCK.lock().await;
     let mut env = TestEnv::new().await;
 
-    env.set_policy(
-        r#"policy "phase6-coverage-fixture" {
-            phase init { container mkv }
-        }"#,
-    );
-    copy_real_mkv_fixture(&env.root().join("clip.mkv"));
+    let _outcome = run_phase6_dry_run(&mut env, "phase6-coverage-fixture").await;
 
-    let policy_path = env
-        .policy_path()
-        .to_str()
-        .expect("utf-8 policy path")
-        .to_string();
-    let root = env.root().to_str().expect("utf-8 root").to_string();
-
-    let _outcome = env
-        .run_process(&[&root, "--policy", &policy_path, "--dry-run", "--no-backup"])
-        .await;
-
-    // Allow the SqliteStatsSink writer thread to flush batched rows.
     tokio::time::sleep(Duration::from_millis(2000)).await;
 
-    let db_path = env.db_path();
-    let conn = rusqlite::Connection::open(&db_path)
-        .unwrap_or_else(|e| panic!("open {}: {e}", db_path.display()));
-    let names_seen: Vec<String> = conn
-        .prepare("SELECT DISTINCT plugin_id FROM plugin_stats")
-        .expect("prepare distinct plugin_id query")
-        .query_map([], |row| row.get(0))
-        .expect("execute distinct plugin_id query")
-        .map(|r| r.expect("read plugin_id row"))
-        .collect();
-
-    for required in ["discovery", "policy-evaluator", "phase-orchestrator"] {
+    let names_seen = distinct_plugin_ids(&env);
+    for required in voom_cli::config::REQUIRED_PLUGIN_NAMES {
         assert!(
             names_seen.iter().any(|n| n == required),
             "plugin_stats must include row for {required} after `voom process`; \
-             saw plugin_ids: {names_seen:?} (#378 Phase 6)"
+             saw plugin_ids: {names_seen:?}"
         );
     }
 }
 
-/// Call dispatches are RPC, not broadcast — they must not show up in
-/// `event_log`. This guards against an accidental `kernel.dispatch()`
-/// emission from inside a plugin's `on_call` path: the kernel maps `Call`
-/// variants to `call.<variant>` strings only as a debug formatting aid, and
-/// none of those strings should ever survive into `event_log`.
-///
-/// The test uses the real Matroska fixture and asserts on
-/// `outcome.result.is_ok()` plus the presence of `policy-evaluator` and
-/// `phase-orchestrator` rows in `plugin_stats` BEFORE checking `event_log`.
-/// Those preconditions are not decoration — they prove the calls actually
-/// ran during this run. A previous version of this test used synthetic
-/// bytes that failed ffprobe before evaluator/orchestrator were ever
-/// dispatched, which made the absence assertion vacuous (Codex adversarial
-/// review).
+/// Call dispatches are RPC, not broadcast — they must not appear in
+/// `event_log`. The test asserts that `policy-evaluator` and
+/// `phase-orchestrator` rows are present in `plugin_stats` first, so the
+/// absence assertion below is meaningful: a regression that re-emits Calls
+/// as events would otherwise produce a vacuous pass on a fixture that
+/// short-circuited before those Calls ran.
 #[tokio::test]
 async fn event_log_contains_no_call_payloads_after_process() {
     let _lock = TEST_LOCK.lock().await;
     let mut env = TestEnv::new().await;
 
-    env.set_policy(
-        r#"policy "phase6-event-log-fixture" {
-            phase init { container mkv }
-        }"#,
-    );
-    copy_real_mkv_fixture(&env.root().join("clip.mkv"));
-
-    let policy_path = env
-        .policy_path()
-        .to_str()
-        .expect("utf-8 policy path")
-        .to_string();
-    let root = env.root().to_str().expect("utf-8 root").to_string();
-
-    let outcome = env
-        .run_process(&[&root, "--policy", &policy_path, "--dry-run", "--no-backup"])
-        .await;
+    let outcome = run_phase6_dry_run(&mut env, "phase6-event-log-fixture").await;
     outcome.result.as_ref().unwrap_or_else(|e| {
         panic!(
             "voom process must succeed so evaluator and orchestrator are actually \
@@ -500,22 +478,15 @@ async fn event_log_contains_no_call_payloads_after_process() {
 
     tokio::time::sleep(Duration::from_millis(2000)).await;
 
-    let db_path = env.db_path();
-    let conn = rusqlite::Connection::open(&db_path)
-        .unwrap_or_else(|e| panic!("open {}: {e}", db_path.display()));
-
-    // Precondition: prove the Call paths we're guarding actually ran during
-    // this run. Without these rows, the event_log absence assertion below
-    // would still pass on a regression that re-emits Calls as events,
-    // because the regression simply wouldn't be exercised.
-    let names_seen: Vec<String> = conn
-        .prepare("SELECT DISTINCT plugin_id FROM plugin_stats")
-        .expect("prepare distinct plugin_id query")
-        .query_map([], |row| row.get(0))
-        .expect("execute distinct plugin_id query")
-        .map(|r| r.expect("read plugin_id row"))
-        .collect();
-    for required in ["policy-evaluator", "phase-orchestrator"] {
+    // Precondition: prove the Call paths we're guarding actually ran. Without
+    // these rows, the event_log absence check would pass even on a regression
+    // that re-emits Calls as events, because the regression wouldn't be
+    // exercised.
+    let names_seen = distinct_plugin_ids(&env);
+    for required in voom_cli::config::REQUIRED_PLUGIN_NAMES
+        .iter()
+        .filter(|n| **n != "discovery")
+    {
         assert!(
             names_seen.iter().any(|n| n == required),
             "precondition: this guard test is meaningful only if the {required} \
@@ -523,13 +494,15 @@ async fn event_log_contains_no_call_payloads_after_process() {
         );
     }
 
+    // `event_type LIKE 'call.%'` is the generic invariant; specific Call
+    // variant payload patterns would rot the moment a new Call variant
+    // landed without updating the test.
+    let db_path = env.db_path();
+    let conn = rusqlite::Connection::open(&db_path)
+        .unwrap_or_else(|e| panic!("open {}: {e}", db_path.display()));
     let call_event_count: i64 = conn
         .query_row(
-            "SELECT COUNT(*) FROM event_log
-             WHERE event_type LIKE 'call.%'
-                OR payload LIKE '%\"call.evaluate_policy\"%'
-                OR payload LIKE '%\"call.orchestrate\"%'
-                OR payload LIKE '%\"call.scan_library\"%'",
+            "SELECT COUNT(*) FROM event_log WHERE event_type LIKE 'call.%'",
             [],
             |row| row.get(0),
         )
@@ -537,6 +510,6 @@ async fn event_log_contains_no_call_payloads_after_process() {
     assert_eq!(
         call_event_count, 0,
         "Call dispatches must never appear in event_log; found \
-         {call_event_count} call-shaped rows (#378 Phase 6)"
+         {call_event_count} call-shaped rows"
     );
 }

--- a/crates/voom-plugin-sdk/README.md
+++ b/crates/voom-plugin-sdk/README.md
@@ -7,26 +7,32 @@ language with a WIT-capable toolchain). Covers the rev-6 plugin contract
 ## Implementing `on_call`
 
 `Plugin::on_call` handles unary and streaming RPCs the kernel routes to
-your plugin via `dispatch_to_capability`. The `Call` enum is
-`#[non_exhaustive]`; match the variants you handle and reject the rest
-with an explicit error:
+your plugin via `dispatch_to_capability`. The trait takes `&Call` (the
+kernel keeps ownership for stats accounting) and returns
+`voom_domain::errors::Result<CallResponse>`. The `Call` enum is
+`#[non_exhaustive]`; match the variant you handle with a `let ... else`
+guard and reject the rest with an explicit error:
 
 ```rust
 use voom_domain::call::{Call, CallResponse};
+use voom_domain::errors::{Result, VoomError};
 
 impl Plugin for MyEvaluator {
-    fn on_call(&self, call: Call) -> anyhow::Result<CallResponse> {
-        match call {
-            Call::EvaluatePolicy { policy, file, .. } => {
-                let result = self.evaluate(*policy, *file)?;
-                Ok(CallResponse::EvaluatePolicy(result))
-            }
-            other => anyhow::bail!(
-                "{} does not handle {:?}",
+    fn on_call(&self, call: &Call) -> Result<CallResponse> {
+        let Call::EvaluatePolicy { policy, file, .. } = call else {
+            return Err(VoomError::plugin(
                 self.name(),
-                other
-            ),
-        }
+                format!(
+                    "{} only handles Call::EvaluatePolicy, got {:?}",
+                    self.name(),
+                    std::mem::discriminant(call)
+                ),
+            ));
+        };
+        // `policy` and `file` are `&Box<...>` — deref coercion lets them
+        // flow into helpers that take `&CompiledPolicy` / `&MediaFile`.
+        let result = self.evaluate(policy, file)?;
+        Ok(CallResponse::EvaluatePolicy(result))
     }
 }
 ```
@@ -34,14 +40,27 @@ impl Plugin for MyEvaluator {
 ## Claiming a capability
 
 Return one or more `Capability` values from `Plugin::capabilities()`.
-Each capability has a resolution discipline (`Exclusive`, `Sharded`, or
-`Shared`); claiming an Exclusive capability that another plugin already
-claims is a registration error.
+The trait returns `&[Capability]`, so plugins typically store the claim
+list in a field set up by `new()`. Each capability has a resolution
+discipline (`Exclusive`, `Sharded`, or `Shared`); claiming an Exclusive
+capability that another plugin already claims is a registration error.
 
 ```rust
+pub struct MyEvaluator {
+    capabilities: Vec<Capability>,
+}
+
+impl MyEvaluator {
+    pub fn new() -> Self {
+        Self {
+            capabilities: vec![Capability::EvaluatePolicy],   // Exclusive
+        }
+    }
+}
+
 impl Plugin for MyEvaluator {
-    fn capabilities(&self) -> Vec<Capability> {
-        vec![Capability::EvaluatePolicy]   // Exclusive
+    fn capabilities(&self) -> &[Capability] {
+        &self.capabilities
     }
 }
 ```
@@ -53,27 +72,40 @@ and register your own.
 
 ## Streaming Calls
 
-A streaming Call is a `Call` variant whose payload contains an
-`mpsc::Sender<T>`. The plugin sends items through the sender while
-running; the host consumes from the matching receiver. Backpressure is
-the channel's natural backpressure — a saturated consumer blocks the
+A streaming Call is a `Call` variant whose payload contains a
+`tokio::sync::mpsc::Sender<T>`. The plugin sends items through the sender
+while running; the host consumes from the matching receiver. Backpressure
+is the channel's natural backpressure — a saturated consumer blocks the
 plugin's `blocking_send`.
 
+Because `on_call` receives `&Call`, the destructured fields are
+references: `sink: &Sender<...>`, `cancel: &CancellationToken`, and
+`root_done: &Option<Sender<...>>`. Calling `sink.blocking_send(...)` and
+`cancel.is_cancelled()` works directly through the references.
+
 ```rust
-Call::ScanLibrary {
+let Call::ScanLibrary {
     uri,
     options,
-    scan_session,
-    sink,           // mpsc::Sender<FileDiscoveredEvent>
-    root_done,
-    cancel,         // CancellationToken — observe between sends
-} => {
-    for entry in walk(&uri, &options) {
-        if cancel.is_cancelled() { break; }
-        sink.blocking_send(make_event(entry))?;
-    }
-    Ok(CallResponse::ScanLibrary(summary))
+    sink,           // &mpsc::Sender<FileDiscoveredEvent>
+    root_done,      // &Option<mpsc::Sender<RootWalkCompletedEvent>>
+    cancel,         // &CancellationToken — observe between sends
+    ..
+} = call else {
+    return Err(VoomError::plugin(self.name(), "expected ScanLibrary"));
+};
+for entry in walk(uri, options) {
+    if cancel.is_cancelled() { break; }
+    sink.blocking_send(make_event(entry))
+        .map_err(|e| VoomError::plugin(self.name(), e.to_string()))?;
 }
+// `root_done` is optional; emit a completion event through it if the
+// host wired one up (e.g. so the per-root execution gate can open).
+if let Some(_rd) = root_done {
+    // build the appropriate RootWalkCompletedEvent for your scan and
+    // send it through `_rd.blocking_send(...)`.
+}
+Ok(CallResponse::ScanLibrary(summary))
 ```
 
 WASM plugins use the host import `emit-call-item` (defined in

--- a/crates/voom-plugin-sdk/README.md
+++ b/crates/voom-plugin-sdk/README.md
@@ -80,42 +80,74 @@ cancellation via `cancel.is_cancelled()`. See `docs/architecture.md`
 `Cargo.toml` dependencies: `voom-plugin-sdk`, `wit-bindgen`. WIT files
 live in `crates/voom-wit/wit/`.
 
-WASM plugins do not implement `voom_kernel::Plugin`. They implement the
-WIT-generated `Guest` trait and decode/encode the WASM-safe mirror of
-`Call` (`WasmCall`) at the `on-call` boundary. `WasmCall` omits the
-non-serde fields (`sink`, `root_done`, `cancel`) — those are host-only;
-streaming emission goes through host imports.
+WASM plugins do not implement `voom_kernel::Plugin`. They expose three
+free functions — `get_info`, `handles`, `on_event`, and (for plugins
+that claim a Call-handling capability) an `on_call` — and the
+SDK-driven `wit_bindgen::generate!` + `export!` wiring connects them to
+the WIT `Guest` exports. The shape that matches the in-tree
+`wasm-plugins/example-metadata` and `wasm-plugins/radarr-metadata`
+templates:
 
 ```rust
 use voom_plugin_sdk::{
-    WasmCall, CallResponse,
-    decode_call, encode_response,
+    Capability, Event, HostFunctions, OnEventResult, PluginInfoData,
+    WasmCall, CallResponse, decode_call, encode_response,
 };
 
-wit_bindgen::generate!({
-    world: "voom-plugin",
-    path: "path/to/voom-wit/wit",
-});
-
-struct MyPlugin;
-
-impl Guest for MyPlugin {
-    fn on_call(call_bytes: Vec<u8>) -> Result<Vec<u8>, String> {
-        let call = decode_call(&call_bytes)?;
-        let response = match call {
-            WasmCall::EvaluatePolicy { policy, file, .. } => {
-                let result = evaluate(&policy, &file)
-                    .map_err(|e| e.to_string())?;
-                CallResponse::EvaluatePolicy(result)
-            }
-            other => return Err(format!("unhandled WasmCall: {other:?}")),
-        };
-        encode_response(&response)
-    }
+// Identity + capability claim. Capabilities are the same
+// `voom_domain::capabilities::Capability` enum the native side uses,
+// re-exported from voom-plugin-sdk.
+pub fn get_info() -> PluginInfoData {
+    PluginInfoData::new(
+        "my-plugin",
+        "0.1.0",
+        vec![Capability::EnrichMetadata { source: "my-plugin".into() }],
+    )
+    .with_description("Example metadata enrichment plugin")
+    .with_license("MIT")
 }
 
-export!(MyPlugin);
+pub fn handles(event_type: &str) -> bool {
+    event_type == Event::FILE_INTROSPECTED
+}
+
+pub fn on_event(
+    event_type: &str,
+    payload: &[u8],
+    host: &dyn HostFunctions,
+) -> Option<OnEventResult> {
+    // ... see wasm-plugins/example-metadata for a worked example.
+    let _ = (event_type, payload, host);
+    None
+}
 ```
+
+### Handling Calls in WASM
+
+For plugins that claim a Call-handling capability, decode the host-supplied
+bytes into the WASM-safe mirror `WasmCall`, do the work, then encode the
+`CallResponse`. `WasmCall` omits the non-serde fields (`sink`, `root_done`,
+`cancel`) — those are host-only; streaming emission goes through host
+imports (see below).
+
+```rust
+pub fn on_call(call_bytes: &[u8]) -> Result<Vec<u8>, String> {
+    let call = decode_call(call_bytes)?;
+    let response = match call {
+        WasmCall::EvaluatePolicy { policy, file, .. } => {
+            let result = evaluate(&policy, &file)
+                .map_err(|e| e.to_string())?;
+            CallResponse::EvaluatePolicy(result)
+        }
+        other => return Err(format!("unhandled WasmCall: {other:?}")),
+    };
+    encode_response(&response)
+}
+```
+
+The `wit_bindgen::generate!` + `export!` block that wires `get_info`,
+`handles`, `on_event`, and `on_call` to the WIT `Guest` exports is the
+final step; see the example plugin sources for the boilerplate.
 
 ### Streaming Calls (WASM)
 
@@ -142,11 +174,14 @@ The underlying WIT contract — `on-call`, `emit-call-item`,
 
 ## Capabilities
 
-Both tiers claim capabilities via the same `voom_domain::capabilities::Capability`
-enum:
+Both tiers claim capabilities via the same
+`voom_domain::capabilities::Capability` enum (re-exported from
+`voom_plugin_sdk` for WASM authors):
 
 - **Native** — return them from `Plugin::capabilities() -> &[Capability]`.
-- **WASM** — list them in the `PluginInfo` returned by `Guest::get_info()`.
+- **WASM** — pass them as the third argument to `PluginInfoData::new`
+  inside your `get_info()` free function (the SDK forwards them through
+  the WIT `plugin-info.capabilities` field).
 
 Each capability has a resolution discipline
 (`voom_domain::capability_resolution::CapabilityResolution`): `Exclusive`

--- a/crates/voom-plugin-sdk/README.md
+++ b/crates/voom-plugin-sdk/README.md
@@ -1,54 +1,35 @@
 # voom-plugin-sdk
 
-SDK for authoring VOOM plugins — both native (Rust) and WASM (any
-language with a WIT-capable toolchain). Covers the rev-6 plugin contract
-(#378).
+Helpers for authoring VOOM **WASM** plugins. This crate intentionally
+does not depend on `voom-kernel` — it ships only the types, ABI helpers,
+and host shims a `wasm32-wasip1` guest needs.
 
-## Implementing `on_call`
+VOOM also supports **native** plugins (Rust crates compiled into the
+binary that implement `voom_kernel::Plugin` directly). Native plugins
+do not use this SDK; they depend on `voom-kernel` and `voom-domain`
+instead. See the "Native plugins" section below for the contract surface
+and `docs/plugin-development.md` for the full walkthrough.
 
-`Plugin::on_call` handles unary and streaming RPCs the kernel routes to
-your plugin via `dispatch_to_capability`. The trait takes `&Call` (the
-kernel keeps ownership for stats accounting) and returns
-`voom_domain::errors::Result<CallResponse>`. The `Call` enum is
-`#[non_exhaustive]`; match the variant you handle with a `let ... else`
-guard and reject the rest with an explicit error:
+Both tiers participate in the same rev-6 plugin contract (#378):
+capability claims, unary and streaming Calls routed via
+`Kernel::dispatch_to_capability`, and instrumented `plugin_stats`
+records.
+
+## Native plugins (compiled into the binary)
+
+`Cargo.toml` dependencies: `voom-kernel`, `voom-domain`. Not
+`voom-plugin-sdk`.
+
+Plugins implement `voom_kernel::Plugin` and override `on_call` to handle
+unary or streaming Calls the kernel routes via
+`Kernel::dispatch_to_capability`:
 
 ```rust
 use voom_domain::call::{Call, CallResponse};
+use voom_domain::capabilities::Capability;
 use voom_domain::errors::{Result, VoomError};
+use voom_kernel::Plugin;
 
-impl Plugin for MyEvaluator {
-    fn on_call(&self, call: &Call) -> Result<CallResponse> {
-        let Call::EvaluatePolicy { policy, file, .. } = call else {
-            return Err(VoomError::plugin(
-                self.name(),
-                format!(
-                    "{} only handles Call::EvaluatePolicy, got {:?}",
-                    self.name(),
-                    std::mem::discriminant(call)
-                ),
-            ));
-        };
-        // `policy` and `file` are `&Box<...>` — deref coercion lets them
-        // flow into helpers that take `&CompiledPolicy` / `&MediaFile`.
-        let result = self.evaluate(policy, file)?;
-        Ok(CallResponse::EvaluatePolicy(result))
-    }
-}
-```
-
-## Claiming a capability
-
-Return one or more `Capability` values from `Plugin::capabilities()`.
-The trait returns `&[Capability]`, so plugins typically store the claim
-list in a field set up by `new()`. Each capability has a resolution
-discipline (`Exclusive`, `Sharded`, or `Competing` — see
-`voom_domain::capability_resolution::CapabilityResolution`); claiming an
-Exclusive capability that another plugin already claims is a
-registration error, and claiming a Sharded capability whose shard key
-collides with an existing claim is likewise rejected.
-
-```rust
 pub struct MyEvaluator {
     capabilities: Vec<Capability>,
 }
@@ -56,68 +37,128 @@ pub struct MyEvaluator {
 impl MyEvaluator {
     pub fn new() -> Self {
         Self {
-            capabilities: vec![Capability::EvaluatePolicy],   // Exclusive
+            capabilities: vec![Capability::EvaluatePolicy], // Exclusive
         }
     }
 }
 
 impl Plugin for MyEvaluator {
-    fn capabilities(&self) -> &[Capability] {
-        &self.capabilities
+    fn name(&self) -> &str { "my-evaluator" }
+    fn version(&self) -> &str { "0.1.0" }
+    fn capabilities(&self) -> &[Capability] { &self.capabilities }
+
+    fn on_call(&self, call: &Call) -> Result<CallResponse> {
+        let Call::EvaluatePolicy { policy, file, .. } = call else {
+            return Err(VoomError::plugin(
+                self.name(),
+                format!(
+                    "{} only handles Call::EvaluatePolicy, got {:?}",
+                    self.name(),
+                    std::mem::discriminant(call),
+                ),
+            ));
+        };
+        // `policy` and `file` are `&Box<...>`; deref coercion lets them
+        // flow into helpers that take `&CompiledPolicy` / `&MediaFile`.
+        let result = self.evaluate(policy, file)?;
+        Ok(CallResponse::EvaluatePolicy(result))
     }
 }
 ```
 
-The kernel routes `Call::EvaluatePolicy` to the single plugin claiming
-`Capability::EvaluatePolicy`. To take over the capability in a custom
-build, disable the default plugin via `disabled_plugins` in `config.toml`
-and register your own.
+### Streaming Calls (native)
 
-## Streaming Calls
+Streaming-Call variants of `Call` (e.g. `Call::ScanLibrary`) carry a
+`tokio::sync::mpsc::Sender<T>` plus a `CancellationToken`. Because
+`on_call` takes `&Call`, the destructured fields are references; the
+plugin emits items through `sink.blocking_send(...)` and observes
+cancellation via `cancel.is_cancelled()`. See `docs/architecture.md`
+("Communication primitives — Events vs Calls") for a full example.
 
-A streaming Call is a `Call` variant whose payload contains a
-`tokio::sync::mpsc::Sender<T>`. The plugin sends items through the sender
-while running; the host consumes from the matching receiver. Backpressure
-is the channel's natural backpressure — a saturated consumer blocks the
-plugin's `blocking_send`.
+## WASM plugins
 
-Because `on_call` receives `&Call`, the destructured fields are
-references: `sink: &Sender<...>`, `cancel: &CancellationToken`, and
-`root_done: &Option<Sender<...>>`. Calling `sink.blocking_send(...)` and
-`cancel.is_cancelled()` works directly through the references.
+`Cargo.toml` dependencies: `voom-plugin-sdk`, `wit-bindgen`. WIT files
+live in `crates/voom-wit/wit/`.
+
+WASM plugins do not implement `voom_kernel::Plugin`. They implement the
+WIT-generated `Guest` trait and decode/encode the WASM-safe mirror of
+`Call` (`WasmCall`) at the `on-call` boundary. `WasmCall` omits the
+non-serde fields (`sink`, `root_done`, `cancel`) — those are host-only;
+streaming emission goes through host imports.
 
 ```rust
-let Call::ScanLibrary {
-    uri,
-    options,
-    sink,           // &mpsc::Sender<FileDiscoveredEvent>
-    root_done,      // &Option<mpsc::Sender<RootWalkCompletedEvent>>
-    cancel,         // &CancellationToken — observe between sends
-    ..
-} = call else {
-    return Err(VoomError::plugin(self.name(), "expected ScanLibrary"));
+use voom_plugin_sdk::{
+    WasmCall, CallResponse,
+    decode_call, encode_response,
 };
-for entry in walk(uri, options) {
-    if cancel.is_cancelled() { break; }
-    sink.blocking_send(make_event(entry))
-        .map_err(|e| VoomError::plugin(self.name(), e.to_string()))?;
+
+wit_bindgen::generate!({
+    world: "voom-plugin",
+    path: "path/to/voom-wit/wit",
+});
+
+struct MyPlugin;
+
+impl Guest for MyPlugin {
+    fn on_call(call_bytes: Vec<u8>) -> Result<Vec<u8>, String> {
+        let call = decode_call(&call_bytes)?;
+        let response = match call {
+            WasmCall::EvaluatePolicy { policy, file, .. } => {
+                let result = evaluate(&policy, &file)
+                    .map_err(|e| e.to_string())?;
+                CallResponse::EvaluatePolicy(result)
+            }
+            other => return Err(format!("unhandled WasmCall: {other:?}")),
+        };
+        encode_response(&response)
+    }
 }
-// `root_done` is optional; emit a completion event through it if the
-// host wired one up (e.g. so the per-root execution gate can open).
-if let Some(_rd) = root_done {
-    // build the appropriate RootWalkCompletedEvent for your scan and
-    // send it through `_rd.blocking_send(...)`.
-}
-Ok(CallResponse::ScanLibrary(summary))
+
+export!(MyPlugin);
 ```
 
-WASM plugins use the host import `emit-call-item` (defined in
-`crates/voom-wit/wit/host.wit`) to push items; cancellation is observed
-via `call-is-cancelled`.
+### Streaming Calls (WASM)
+
+For streaming variants (`WasmCall::ScanLibrary` today), emit items
+through host imports rather than `mpsc::Sender` fields. The SDK exposes
+typed wrappers:
+
+```rust
+use voom_plugin_sdk::{emit_file_discovered, is_cancelled};
+use voom_plugin_sdk::host::HostFunctions;
+
+fn scan(host: &dyn HostFunctions, uri: &str) -> Result<(), String> {
+    for entry in walk(uri) {
+        if is_cancelled(host) { break; }
+        emit_file_discovered(host, &entry.into())?;
+    }
+    Ok(())
+}
+```
+
+The underlying WIT contract — `on-call`, `emit-call-item`,
+`emit-root-walk-completed`, `call-is-cancelled` — is defined in
+`crates/voom-wit/wit/host.wit` and `crates/voom-wit/wit/plugin.wit`.
+
+## Capabilities
+
+Both tiers claim capabilities via the same `voom_domain::capabilities::Capability`
+enum:
+
+- **Native** — return them from `Plugin::capabilities() -> &[Capability]`.
+- **WASM** — list them in the `PluginInfo` returned by `Guest::get_info()`.
+
+Each capability has a resolution discipline
+(`voom_domain::capability_resolution::CapabilityResolution`): `Exclusive`
+(at most one claimant), `Sharded` (disjoint per-key claimants), or
+`Competing` (kernel picks at dispatch time by priority). Claiming an
+Exclusive capability that another plugin already claims is a
+registration error; Sharded capabilities reject colliding shard keys.
 
 ## See also
 
-- `docs/architecture.md` — Communication primitives & Capability-based
-  routing.
+- `docs/plugin-development.md` — full two-tier authoring walkthrough.
+- `docs/architecture.md` — communication primitives, capability-based
+  routing, and stats-sink instrumentation.
 - `docs/superpowers/specs/2026-05-14-plugin-stats-self-reporting-design.md`
-  — design rationale.
+  — rev-6 design rationale.

--- a/crates/voom-plugin-sdk/README.md
+++ b/crates/voom-plugin-sdk/README.md
@@ -1,0 +1,88 @@
+# voom-plugin-sdk
+
+SDK for authoring VOOM plugins — both native (Rust) and WASM (any
+language with a WIT-capable toolchain). Covers the rev-6 plugin contract
+(#378).
+
+## Implementing `on_call`
+
+`Plugin::on_call` handles unary and streaming RPCs the kernel routes to
+your plugin via `dispatch_to_capability`. The `Call` enum is
+`#[non_exhaustive]`; match the variants you handle and reject the rest
+with an explicit error:
+
+```rust
+use voom_domain::call::{Call, CallResponse};
+
+impl Plugin for MyEvaluator {
+    fn on_call(&self, call: Call) -> anyhow::Result<CallResponse> {
+        match call {
+            Call::EvaluatePolicy { policy, file, .. } => {
+                let result = self.evaluate(*policy, *file)?;
+                Ok(CallResponse::EvaluatePolicy(result))
+            }
+            other => anyhow::bail!(
+                "{} does not handle {:?}",
+                self.name(),
+                other
+            ),
+        }
+    }
+}
+```
+
+## Claiming a capability
+
+Return one or more `Capability` values from `Plugin::capabilities()`.
+Each capability has a resolution discipline (`Exclusive`, `Sharded`, or
+`Shared`); claiming an Exclusive capability that another plugin already
+claims is a registration error.
+
+```rust
+impl Plugin for MyEvaluator {
+    fn capabilities(&self) -> Vec<Capability> {
+        vec![Capability::EvaluatePolicy]   // Exclusive
+    }
+}
+```
+
+The kernel routes `Call::EvaluatePolicy` to the single plugin claiming
+`Capability::EvaluatePolicy`. To take over the capability in a custom
+build, disable the default plugin via `disabled_plugins` in `config.toml`
+and register your own.
+
+## Streaming Calls
+
+A streaming Call is a `Call` variant whose payload contains an
+`mpsc::Sender<T>`. The plugin sends items through the sender while
+running; the host consumes from the matching receiver. Backpressure is
+the channel's natural backpressure — a saturated consumer blocks the
+plugin's `blocking_send`.
+
+```rust
+Call::ScanLibrary {
+    uri,
+    options,
+    scan_session,
+    sink,           // mpsc::Sender<FileDiscoveredEvent>
+    root_done,
+    cancel,         // CancellationToken — observe between sends
+} => {
+    for entry in walk(&uri, &options) {
+        if cancel.is_cancelled() { break; }
+        sink.blocking_send(make_event(entry))?;
+    }
+    Ok(CallResponse::ScanLibrary(summary))
+}
+```
+
+WASM plugins use the host import `emit-call-item` (defined in
+`crates/voom-wit/wit/host.wit`) to push items; cancellation is observed
+via `call-is-cancelled`.
+
+## See also
+
+- `docs/architecture.md` — Communication primitives & Capability-based
+  routing.
+- `docs/superpowers/specs/2026-05-14-plugin-stats-self-reporting-design.md`
+  — design rationale.

--- a/crates/voom-plugin-sdk/README.md
+++ b/crates/voom-plugin-sdk/README.md
@@ -80,74 +80,84 @@ cancellation via `cancel.is_cancelled()`. See `docs/architecture.md`
 `Cargo.toml` dependencies: `voom-plugin-sdk`, `wit-bindgen`. WIT files
 live in `crates/voom-wit/wit/`.
 
-WASM plugins do not implement `voom_kernel::Plugin`. They expose three
-free functions — `get_info`, `handles`, `on_event`, and (for plugins
-that claim a Call-handling capability) an `on_call` — and the
-SDK-driven `wit_bindgen::generate!` + `export!` wiring connects them to
-the WIT `Guest` exports. The shape that matches the in-tree
-`wasm-plugins/example-metadata` and `wasm-plugins/radarr-metadata`
-templates:
+WASM plugins do not implement `voom_kernel::Plugin`. They implement the
+WIT-generated `Guest` trait — `wit_bindgen::generate!` produces it from
+`crates/voom-wit/wit/plugin.wit` — and `export!(YourType)` wires that
+impl to the WIT exports the host loads. There is no free-function
+shortcut; `wit_bindgen` only exports methods on a type that implements
+`Guest`. (The in-tree `wasm-plugins/*` crates are stub sketches that
+demonstrate the SDK helper types but do not include the
+`wit_bindgen::generate!` / `export!` lines and so do not produce loadable
+`.wasm` artifacts as-is.)
+
+The `Guest` trait has four methods that map directly to the WIT
+contract:
+
+| WIT export                                  | Guest method   | Returns |
+| ------------------------------------------- | -------------- | --- |
+| `get-info: func() -> plugin-info`           | `get_info`     | the WIT-generated `PluginInfo` record |
+| `handles: func(event-type) -> bool`         | `handles`      | `bool` |
+| `on-event: func(event-data) -> option<...>` | `on_event`     | `Option<EventResult>` |
+| `on-call: func(list<u8>) -> result<...>`    | `on_call`      | `Result<Vec<u8>, String>` |
+
+A minimal implementation that uses SDK helpers for the Call boundary:
 
 ```rust
 use voom_plugin_sdk::{
-    Capability, Event, HostFunctions, OnEventResult, PluginInfoData,
     WasmCall, CallResponse, decode_call, encode_response,
 };
 
-// Identity + capability claim. Capabilities are the same
-// `voom_domain::capabilities::Capability` enum the native side uses,
-// re-exported from voom-plugin-sdk.
-pub fn get_info() -> PluginInfoData {
-    PluginInfoData::new(
-        "my-plugin",
-        "0.1.0",
-        vec![Capability::EnrichMetadata { source: "my-plugin".into() }],
-    )
-    .with_description("Example metadata enrichment plugin")
-    .with_license("MIT")
-}
+wit_bindgen::generate!({
+    world: "voom-plugin",
+    path: "../../crates/voom-wit/wit",
+});
 
-pub fn handles(event_type: &str) -> bool {
-    event_type == Event::FILE_INTROSPECTED
-}
+struct MyPlugin;
 
-pub fn on_event(
-    event_type: &str,
-    payload: &[u8],
-    host: &dyn HostFunctions,
-) -> Option<OnEventResult> {
-    // ... see wasm-plugins/example-metadata for a worked example.
-    let _ = (event_type, payload, host);
-    None
-}
-```
-
-### Handling Calls in WASM
-
-For plugins that claim a Call-handling capability, decode the host-supplied
-bytes into the WASM-safe mirror `WasmCall`, do the work, then encode the
-`CallResponse`. `WasmCall` omits the non-serde fields (`sink`, `root_done`,
-`cancel`) — those are host-only; streaming emission goes through host
-imports (see below).
-
-```rust
-pub fn on_call(call_bytes: &[u8]) -> Result<Vec<u8>, String> {
-    let call = decode_call(call_bytes)?;
-    let response = match call {
-        WasmCall::EvaluatePolicy { policy, file, .. } => {
-            let result = evaluate(&policy, &file)
-                .map_err(|e| e.to_string())?;
-            CallResponse::EvaluatePolicy(result)
+impl Guest for MyPlugin {
+    // get-info: build the WIT-generated PluginInfo record directly.
+    // `Capability` here is the WIT-generated enum (kebab-case names),
+    // not voom_domain::capabilities::Capability.
+    fn get_info() -> PluginInfo {
+        PluginInfo {
+            name: "my-plugin".into(),
+            version: "0.1.0".into(),
+            description: Some("Example".into()),
+            author: None,
+            license: Some("MIT".into()),
+            homepage: None,
+            capabilities: vec![Capability::EvaluatePolicy],
         }
-        other => return Err(format!("unhandled WasmCall: {other:?}")),
-    };
-    encode_response(&response)
+    }
+
+    fn handles(_event_type: String) -> bool { false }
+
+    fn on_event(_event: EventData) -> Option<EventResult> { None }
+
+    // on-call: decode the host bytes into a typed WasmCall, do the work,
+    // encode the CallResponse. WasmCall omits the non-serde fields
+    // (sink, root_done, cancel) — those are host-only.
+    fn on_call(call_bytes: Vec<u8>) -> Result<Vec<u8>, String> {
+        let call = decode_call(&call_bytes)?;
+        let response = match call {
+            WasmCall::EvaluatePolicy { policy, file, .. } => {
+                let result = evaluate(&policy, &file)
+                    .map_err(|e| e.to_string())?;
+                CallResponse::EvaluatePolicy(result)
+            }
+            other => return Err(format!("unhandled WasmCall: {other:?}")),
+        };
+        encode_response(&response)
+    }
 }
+
+export!(MyPlugin);
 ```
 
-The `wit_bindgen::generate!` + `export!` block that wires `get_info`,
-`handles`, `on_event`, and `on_call` to the WIT `Guest` exports is the
-final step; see the example plugin sources for the boilerplate.
+`PluginInfoData` (re-exported from `voom_plugin_sdk::types`) is an
+optional convenience builder you can use inside `get_info()` to assemble
+a `PluginInfo` field-by-field — it is **not** itself the type
+`Guest::get_info` returns.
 
 ### Streaming Calls (WASM)
 
@@ -174,14 +184,19 @@ The underlying WIT contract — `on-call`, `emit-call-item`,
 
 ## Capabilities
 
-Both tiers claim capabilities via the same
-`voom_domain::capabilities::Capability` enum (re-exported from
-`voom_plugin_sdk` for WASM authors):
+Both tiers claim capabilities, but the enum used differs by tier:
 
-- **Native** — return them from `Plugin::capabilities() -> &[Capability]`.
-- **WASM** — pass them as the third argument to `PluginInfoData::new`
-  inside your `get_info()` free function (the SDK forwards them through
-  the WIT `plugin-info.capabilities` field).
+- **Native** — return `&[voom_domain::capabilities::Capability]` from
+  `Plugin::capabilities()`.
+- **WASM** — list `Capability` values (the WIT-generated variant, with
+  kebab-case variant names — `evaluate-policy`, `orchestrate-phases`,
+  `enrich-metadata(...)`, etc., defined in
+  `crates/voom-wit/wit/plugin.wit`) inside the `PluginInfo` returned by
+  `Guest::get_info()`.
+
+The host translates the WIT enum into the domain enum when it loads the
+plugin, so a WASM plugin claiming `Capability::EvaluatePolicy` collides
+with the same claim from a native plugin during registry validation.
 
 Each capability has a resolution discipline
 (`voom_domain::capability_resolution::CapabilityResolution`): `Exclusive`

--- a/crates/voom-plugin-sdk/README.md
+++ b/crates/voom-plugin-sdk/README.md
@@ -42,8 +42,11 @@ impl Plugin for MyEvaluator {
 Return one or more `Capability` values from `Plugin::capabilities()`.
 The trait returns `&[Capability]`, so plugins typically store the claim
 list in a field set up by `new()`. Each capability has a resolution
-discipline (`Exclusive`, `Sharded`, or `Shared`); claiming an Exclusive
-capability that another plugin already claims is a registration error.
+discipline (`Exclusive`, `Sharded`, or `Competing` — see
+`voom_domain::capability_resolution::CapabilityResolution`); claiming an
+Exclusive capability that another plugin already claims is a
+registration error, and claiming a Sharded capability whose shard key
+collides with an existing claim is likewise rejected.
 
 ```rust
 pub struct MyEvaluator {

--- a/crates/voom-plugin-sdk/README.md
+++ b/crates/voom-plugin-sdk/README.md
@@ -107,7 +107,9 @@ author = "Me"
 license = "MIT"
 homepage = "https://example.com/my-plugin"
 
-# Events the plugin subscribes to (drives Plugin::handles in the host).
+# Events the plugin subscribes to. The host uses this list (not the
+# WASM module's WIT handles export) to decide which events to forward
+# into the module's on-event entry point.
 handles_events = ["file.introspected"]
 
 # Capability claims (drives Plugin::capabilities → routing for Calls).
@@ -146,14 +148,16 @@ sketches that demonstrate the SDK helper types but do not include the
 `wit_bindgen::generate!` / `export!` lines and so do not produce
 loadable `.wasm` artifacts as-is.)
 
-The `Guest` trait has four methods that map to the WIT contract:
+The `Guest` trait has four methods that map to the WIT contract. Only
+two are invoked by the kernel today; the other two exist in the contract
+but are satisfied entirely by the manifest TOML:
 
 | WIT export                                  | Guest method   | What the host does with the return |
 | ------------------------------------------- | -------------- | --- |
-| `get-info: func() -> plugin-info`           | `get_info`     | not invoked by the kernel today; capabilities come from the manifest |
-| `handles: func(event-type) -> bool`         | `handles`      | per-event filter for `on-event` dispatch |
-| `on-event: func(event-data) -> option<...>` | `on_event`     | event payload + optional produced events |
-| `on-call: func(list<u8>) -> result<...>`    | `on_call`      | MessagePack-encoded `CallResponse` or error string |
+| `get-info: func() -> plugin-info`           | `get_info`     | not invoked; identity and capabilities come from the manifest |
+| `handles: func(event-type) -> bool`         | `handles`      | not invoked; the per-event filter is `manifest.handles_events` |
+| `on-event: func(event-data) -> option<...>` | `on_event`     | called for each event the manifest opted into; returns optional produced events |
+| `on-call: func(list<u8>) -> result<...>`    | `on_call`      | called when the kernel routes a Call to this plugin; returns MessagePack `CallResponse` bytes or error string |
 
 A minimal implementation that uses SDK helpers for the Call boundary:
 
@@ -185,6 +189,8 @@ impl Guest for MyPlugin {
         }
     }
 
+    // handles is also unused by the kernel today; the per-event filter
+    // is `manifest.handles_events`. Returning false here is harmless.
     fn handles(_event_type: String) -> bool { false }
 
     fn on_event(_event: EventData) -> Option<EventResult> { None }

--- a/crates/voom-plugin-sdk/README.md
+++ b/crates/voom-plugin-sdk/README.md
@@ -77,28 +77,83 @@ cancellation via `cancel.is_cancelled()`. See `docs/architecture.md`
 
 ## WASM plugins
 
-`Cargo.toml` dependencies: `voom-plugin-sdk`, `wit-bindgen`. WIT files
-live in `crates/voom-wit/wit/`.
+WASM plugins ship two artifacts side by side:
 
-WASM plugins do not implement `voom_kernel::Plugin`. They implement the
-WIT-generated `Guest` trait — `wit_bindgen::generate!` produces it from
-`crates/voom-wit/wit/plugin.wit` — and `export!(YourType)` wires that
-impl to the WIT exports the host loads. There is no free-function
-shortcut; `wit_bindgen` only exports methods on a type that implements
-`Guest`. (The in-tree `wasm-plugins/*` crates are stub sketches that
-demonstrate the SDK helper types but do not include the
-`wit_bindgen::generate!` / `export!` lines and so do not produce loadable
-`.wasm` artifacts as-is.)
+1. A compiled component (`my-plugin.wasm`) built with `wit-bindgen` against
+   the WIT files at `crates/voom-wit/wit/`.
+2. A manifest TOML (`my-plugin.toml`) that declares the plugin's identity,
+   capability claims, subscribed events, and sandbox grants.
 
-The `Guest` trait has four methods that map directly to the WIT
-contract:
+The host loads identity and capabilities **from the manifest, not from
+any function exported by the WASM module.** `Plugin::name()` and
+`Plugin::capabilities()` on the loaded `WasmPlugin` return the manifest's
+values verbatim (`crates/voom-kernel/src/loader.rs`); the kernel does
+not invoke `Guest::get_info` to read capabilities. If your manifest is
+missing or its capability list is wrong, your plugin will not be routed
+the corresponding Calls regardless of what its WIT exports say.
 
-| WIT export                                  | Guest method   | Returns |
+### Manifest TOML
+
+The manifest sits alongside the `.wasm` file (`<plugin-name>.toml`).
+Capability variants are the same `voom_domain::capabilities::Capability`
+enum the native side uses; serde renders them as TOML tables under
+`[[capabilities]]`:
+
+```toml
+name = "my-plugin"
+version = "0.1.0"
+description = "Example metadata enrichment plugin"
+author = "Me"
+license = "MIT"
+homepage = "https://example.com/my-plugin"
+
+# Events the plugin subscribes to (drives Plugin::handles in the host).
+handles_events = ["file.introspected"]
+
+# Capability claims (drives Plugin::capabilities → routing for Calls).
+[[capabilities]]
+[capabilities.EnrichMetadata]
+source = "my-plugin"
+
+# Optional sandbox grants.
+allowed_domains = ["api.example.com"]
+
+# Optional priority (lower = runs first; defaults to 70).
+priority = 70
+
+# Optional: pin the SDK protocol version (currently 1).
+protocol_version = 1
+```
+
+Unit-variant capabilities (`EvaluatePolicy`, `OrchestratePhases`,
+`DetectTools`, `ManageJobs`, `ServeHttp`, `Backup`, `Transcribe`,
+`Synthesize`) use the empty-table form `EvaluatePolicy = {}`. Variants
+that carry data (`Discover { schemes }`, `Introspect { formats }`,
+`Execute { operations, formats }`, `Store { backend }`,
+`EnrichMetadata { source }`) use the nested-table form shown above. See
+`docs/plugin-development.md` and the existing `wasm-plugins/*`
+manifests for worked examples.
+
+### WIT exports (the `.wasm` side)
+
+`Cargo.toml` dependencies: `voom-plugin-sdk`, `wit-bindgen`. The runtime
+contract is the WIT-generated `Guest` trait — `wit_bindgen::generate!`
+produces it from `crates/voom-wit/wit/plugin.wit` — and `export!(YourType)`
+wires the impl to the WIT exports the host loads. There is no
+free-function shortcut; `wit_bindgen` only exports methods on a type
+that implements `Guest`. (The in-tree `wasm-plugins/*` crates are stub
+sketches that demonstrate the SDK helper types but do not include the
+`wit_bindgen::generate!` / `export!` lines and so do not produce
+loadable `.wasm` artifacts as-is.)
+
+The `Guest` trait has four methods that map to the WIT contract:
+
+| WIT export                                  | Guest method   | What the host does with the return |
 | ------------------------------------------- | -------------- | --- |
-| `get-info: func() -> plugin-info`           | `get_info`     | the WIT-generated `PluginInfo` record |
-| `handles: func(event-type) -> bool`         | `handles`      | `bool` |
-| `on-event: func(event-data) -> option<...>` | `on_event`     | `Option<EventResult>` |
-| `on-call: func(list<u8>) -> result<...>`    | `on_call`      | `Result<Vec<u8>, String>` |
+| `get-info: func() -> plugin-info`           | `get_info`     | not invoked by the kernel today; capabilities come from the manifest |
+| `handles: func(event-type) -> bool`         | `handles`      | per-event filter for `on-event` dispatch |
+| `on-event: func(event-data) -> option<...>` | `on_event`     | event payload + optional produced events |
+| `on-call: func(list<u8>) -> result<...>`    | `on_call`      | MessagePack-encoded `CallResponse` or error string |
 
 A minimal implementation that uses SDK helpers for the Call boundary:
 
@@ -115,18 +170,18 @@ wit_bindgen::generate!({
 struct MyPlugin;
 
 impl Guest for MyPlugin {
-    // get-info: build the WIT-generated PluginInfo record directly.
-    // `Capability` here is the WIT-generated enum (kebab-case names),
-    // not voom_domain::capabilities::Capability.
+    // get-info is part of the WIT contract; the kernel does not call it
+    // today (capabilities come from the manifest). Returning a minimal
+    // PluginInfo satisfies the trait without claiming anything extra.
     fn get_info() -> PluginInfo {
         PluginInfo {
             name: "my-plugin".into(),
             version: "0.1.0".into(),
-            description: Some("Example".into()),
+            description: None,
             author: None,
-            license: Some("MIT".into()),
+            license: None,
             homepage: None,
-            capabilities: vec![Capability::EvaluatePolicy],
+            capabilities: vec![],
         }
     }
 
@@ -154,11 +209,6 @@ impl Guest for MyPlugin {
 export!(MyPlugin);
 ```
 
-`PluginInfoData` (re-exported from `voom_plugin_sdk::types`) is an
-optional convenience builder you can use inside `get_info()` to assemble
-a `PluginInfo` field-by-field — it is **not** itself the type
-`Guest::get_info` returns.
-
 ### Streaming Calls (WASM)
 
 For streaming variants (`WasmCall::ScanLibrary` today), emit items
@@ -184,19 +234,19 @@ The underlying WIT contract — `on-call`, `emit-call-item`,
 
 ## Capabilities
 
-Both tiers claim capabilities, but the enum used differs by tier:
+Both tiers claim capabilities against the same
+`voom_domain::capabilities::Capability` enum, but declare them through
+different mechanisms:
 
-- **Native** — return `&[voom_domain::capabilities::Capability]` from
-  `Plugin::capabilities()`.
-- **WASM** — list `Capability` values (the WIT-generated variant, with
-  kebab-case variant names — `evaluate-policy`, `orchestrate-phases`,
-  `enrich-metadata(...)`, etc., defined in
-  `crates/voom-wit/wit/plugin.wit`) inside the `PluginInfo` returned by
-  `Guest::get_info()`.
+- **Native** — return `&[Capability]` from `Plugin::capabilities()`.
+- **WASM** — list them under `[[capabilities]]` in the manifest TOML.
+  The kernel loads the manifest at plugin-load time and uses those
+  values as the plugin's capability set. Anything declared in
+  `Guest::get_info` is ignored for routing today.
 
-The host translates the WIT enum into the domain enum when it loads the
-plugin, so a WASM plugin claiming `Capability::EvaluatePolicy` collides
-with the same claim from a native plugin during registry validation.
+Because both tiers feed the same `Capability` enum into the registry, a
+WASM plugin claiming `Capability::EvaluatePolicy` collides with the
+same claim from a native plugin during registration.
 
 Each capability has a resolution discipline
 (`voom_domain::capability_resolution::CapabilityResolution`): `Exclusive`

--- a/docs/INITIAL_DESIGN.md
+++ b/docs/INITIAL_DESIGN.md
@@ -1597,3 +1597,22 @@ voom
 | **Plan** | Execution plan: list of actions to perform on a file. Produced by evaluator, consumed by executors. |
 | **Phase** | Named stage in a policy pipeline. Phases execute sequentially with optional skip/dependency conditions. |
 | **Event** | Typed enum variant published to the event bus. Plugins subscribe by event type string. |
+
+---
+
+## 16. Addendum — Plugin contract rev-6 (#378)
+
+The original design (sections 1–15 above) described two plugin tiers:
+kernel-registered plugins invoked via `Plugin::on_event` and library-only
+crates the CLI called directly. The rev-6 contract collapses this
+distinction. All former library-only crates (`discovery`,
+`policy-evaluator`, `phase-orchestrator`) are now kernel-registered and
+invoked via `Kernel::dispatch_to_capability`. The kernel exposes three
+communication primitives — event broadcast, unary Call, streaming Call —
+and times every invocation through the shared stats sink.
+
+The full design rationale, including `Call` / `CallResponse` shape,
+capability resolution discipline, and the WASM `on-call` ABI, lives in
+`docs/superpowers/specs/2026-05-14-plugin-stats-self-reporting-design.md`.
+See `docs/architecture.md` ("Communication primitives — Events vs Calls"
+and "Capability-based routing") for the runtime view.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,10 +29,10 @@ VOOM (Video Orchestration Operations Manager) is a policy-driven video library m
 │   MKVToolNix ───── FFmpeg ──────────── Backup                  │
 │   Job Manager ──── Introspection ───── Bus Tracer              │
 │   Health ───────── Capabilities ────── Report                  │
+│   Phase Orchestrator ── Policy Evaluator                       │
 │                                                                │
-│     Native Plugins — Library-Only (called directly by CLI)     │
+│     Native Plugins — Library-Only (started by `serve` command) │
 │                                                                │
-│   Evaluator ────── Orchestrator                                │
 │   Web Server                                                   │
 ├────────────────────────────────────────────────────────────────┤
 │            WASM Plugins (loaded at runtime via wasmtime)       │
@@ -124,7 +124,7 @@ pub trait Plugin: Send + Sync {
 }
 ```
 
-Plugins that participate in event-driven coordination override `handles()` and `on_event()`. Library-only plugins (policy-evaluator, phase-orchestrator, web-server) are called directly by the CLI and are not registered with the kernel — they don't participate in event dispatch.
+Plugins that participate in event-driven coordination override `handles()` and `on_event()`. Plugins that handle capability-routed RPCs override `on_call()` and return the relevant `Capability` from `capabilities()` — see [Communication primitives — Events vs Calls](#communication-primitives--events-vs-calls) and [Capability-based routing](#capability-based-routing) below. The `web-server` is the remaining library-only plugin: it is started by `voom serve` and is not registered with the kernel during one-shot CLI runs.
 
 The ffprobe-introspector is both kernel-registered (subscribes to `FileDiscovered` to enqueue introspection jobs) and called directly by the CLI (for deterministic progress reporting). The bus-tracer is a development tool that logs events to a file with configurable glob-pattern filtering.
 
@@ -175,7 +175,7 @@ pub enum Capability {
 }
 ```
 
-Capabilities are used for plugin registration and discovery. Currently, executor routing uses priority-ordered event dispatch: when a `PlanCreated` event is published, the first executor that claims it (via `EventResult.claimed`) handles the plan. Capability-based routing is planned for a future sprint; the registry currently uses name-based lookup only.
+Capabilities are used for plugin registration and discovery. Currently, executor routing uses priority-ordered event dispatch: when a `PlanCreated` event is published, the first executor that claims it (via `EventResult.claimed`) handles the plan. Capability-based routing is now first-class for unary and streaming RPCs — see [Capability-based routing](#capability-based-routing) below. Executor selection for `PlanCreated` still uses priority-ordered event dispatch; converting the executors to capability-routed `on_call` is tracked separately.
 
 ## Event Bus
 
@@ -206,44 +206,119 @@ Events are published to all subscribed plugins, ordered by priority (lower = run
 
 ### Bus dispatcher instrumentation
 
-Every plugin invocation is timed by the dispatcher and forwarded to a
-`StatsSink` (issue #92). The default sink (`NoopStatsSink`) discards records;
-the CLI wires `SqliteStatsSink` to persist to the `plugin_stats` table.
-Records carry `plugin_id`, `event_type`, `started_at`, `duration_ms`, and an
-`outcome` of `ok` / `skipped` / `err{category}` / `panic`. Records are
+Every plugin invocation that flows through the kernel — whether the kernel
+calls `Plugin::on_event` (event subscribers) or `Plugin::on_call` (unary and
+streaming RPCs routed via `dispatch_to_capability`) — is timed and recorded as
+one `PluginStatRecord`. The stats sink is kernel-internal; plugins have no
+write API. Outcomes are classified `Ok` / `Err` / `Panic`. Coverage is
+complete: pure publishers like `discovery` are now kernel-registered plugins
+whose work happens inside `on_call(Call::ScanLibrary)`, and offline callees
+like `policy-evaluator` and `phase-orchestrator` are kernel-registered with
+`on_call(Call::EvaluatePolicy)` and `on_call(Call::Orchestrate)`
+respectively. The default sink (`NoopStatsSink`) discards records; the CLI
+wires `SqliteStatsSink` to persist to the `plugin_stats` table. Records are
 written in background batches and dropped if the bounded channel overflows —
 the bus must not block.
 
-#### Coverage: subscribers only
+### Communication primitives — Events vs Calls
 
-The dispatcher instruments only plugins that subscribe to events
-through the bus — its instrumentation point is the
-`Plugin::on_event(...)` invocation. Two distinct kinds of code emit
-events but never enter that path, and their absence from
-`plugin_stats` is for two different reasons:
+The kernel supports three primitives, each suited to a different interaction
+shape:
 
-- **Kernel-registered no-subscriber plugins.** `discovery` is a
-  registered plugin whose `handles()` returns `false` for every event,
-  so the dispatcher never calls `on_event` on it. It emits
-  `FileDiscovered` events via `kernel.dispatch(...)` from within its
-  own scan loop. This is the textbook "publisher-only plugin" case:
-  the work *is* a plugin invocation, just not one the dispatcher
-  observes.
-- **Library-only callees.** `phase-orchestrator` and `policy-evaluator`
-  are not registered with the kernel at all (see
-  [Two-Tier Plugin Model](#two-tier-plugin-model)). The CLI calls them
-  directly; the corresponding `PlanCreated` / `PlanExecuting` /
-  `PlanCompleted` events are dispatched by the CLI's `PlanDispatcher`,
-  not by the libraries themselves. There is no plugin invocation to
-  attribute time to.
+**Event broadcast (pub/sub).** Plugins emit events via
+`kernel.dispatch(Event::*)`. Every subscriber receives a copy in priority
+order. The event author does not know — and cannot influence — who handles
+it. Best for one-to-many notifications (`FileDiscovered`, `PlanCompleted`,
+`JobStarted`). Subscribers implement `Plugin::on_event` and declare interest
+via `Plugin::handles`.
 
-For end-to-end visibility across both kinds of gap, use the
-Deliverable-2 (Prometheus `/metrics`) and Deliverable-3
-(OpenTelemetry) exporters that #92 builds toward. Issue #378 records
-the decision to leave Deliverable 1 scoped to dispatcher-observed
-subscribers; a future host-API issue can revisit a plugin
-self-reporting primitive if `discovery`-class coverage gaps become a
-measured operational pain point.
+**Unary Call.** A request-response RPC dispatched to whichever plugin claims
+the matching `Capability`. The caller gets exactly one `CallResponse` (or an
+error). Best for "I need *the* policy evaluator to evaluate this file":
+
+```rust
+let response = kernel.dispatch_to_capability(
+    CapabilityQuery::Single(Capability::EvaluatePolicy),
+    Call::EvaluatePolicy {
+        policy: Box::new(compiled),
+        file: Box::new(media_file),
+        phase: None,
+        phase_outputs: None,
+        phase_outcomes: None,
+        capabilities_override: None,
+    },
+)?;
+let CallResponse::EvaluatePolicy(eval_result) = response else { unreachable!() };
+```
+
+Implemented in the plugin via `on_call`:
+
+```rust
+impl Plugin for PolicyEvaluatorPlugin {
+    fn on_call(&self, call: Call) -> Result<CallResponse> {
+        match call {
+            Call::EvaluatePolicy { policy, file, .. } => {
+                let result = self.evaluate(*policy, *file)?;
+                Ok(CallResponse::EvaluatePolicy(result))
+            }
+            other => bail!("policy-evaluator does not handle {:?}", call_kind(&other)),
+        }
+    }
+}
+```
+
+**Streaming Call.** A long-lived RPC that emits items through a host-provided
+`mpsc::Sender` while running. Best when the producer's output is unbounded or
+the consumer wants backpressure (`Call::ScanLibrary` streams
+`FileDiscoveredEvent`s through `sink: mpsc::Sender<FileDiscoveredEvent>` so a
+saturated CLI consumer blocks the plugin's `blocking_send`). Cancellation
+flows the opposite direction via `CancellationToken`. WASM plugins use
+`emit-call-item` (host import) to enqueue items.
+
+**Why three?** Event broadcast loses the response. Unary Call doesn't fit
+producers whose output is the work. Streaming Call adds the per-item channel
+without the breadth-first cost of broadcast.
+
+### Capability-based routing
+
+`Kernel::dispatch_to_capability(query, call)` resolves the routing target at
+call time rather than baking handler identity into the caller:
+
+```rust
+pub fn dispatch_to_capability(
+    &self,
+    query: CapabilityQuery,
+    call: Call,
+) -> Result<CallResponse>
+```
+
+Each `Capability` variant declares its resolution discipline via
+`Capability::resolution()`:
+
+- **Exclusive** — at most one registered plugin may claim it. Registration
+  fails with a duplicate-claim error if two plugins both declare the same
+  Exclusive capability. Used by `EvaluatePolicy`, `OrchestratePhases`, and
+  `ScanLibrary`. The kernel routes the call to the single claimant.
+- **Sharded** — multiple plugins claim disjoint shards (e.g. one executor per
+  codec family). The kernel routes on a shard key the caller supplies.
+- **Shared** — any plugin may claim; the caller picks one explicitly (rare;
+  reserved for future use).
+
+A plugin claims a capability by returning it from `Plugin::capabilities()`:
+
+```rust
+impl Plugin for PhaseOrchestratorPlugin {
+    fn capabilities(&self) -> Vec<Capability> {
+        vec![Capability::OrchestratePhases]
+    }
+}
+```
+
+The kernel enforces uniqueness at `Registry::register` and surfaces
+violations as an actionable error with the colliding plugin names.
+`Registry::get_typed::<P>()` is available for the rare case where a caller
+wants the concrete plugin handle rather than a routed call (used internally
+by some test fixtures).
 
 ### Retention invariants
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -237,8 +237,11 @@ the matching `Capability`. The caller gets exactly one `CallResponse` (or an
 error). Best for "I need *the* policy evaluator to evaluate this file":
 
 ```rust
+let query = CapabilityQuery::Exclusive {
+    kind: Capability::EvaluatePolicy.kind().to_string(),
+};
 let response = kernel.dispatch_to_capability(
-    CapabilityQuery::Single(Capability::EvaluatePolicy),
+    query,
     Call::EvaluatePolicy {
         policy: Box::new(compiled),
         file: Box::new(media_file),
@@ -251,18 +254,24 @@ let response = kernel.dispatch_to_capability(
 let CallResponse::EvaluatePolicy(eval_result) = response else { unreachable!() };
 ```
 
-Implemented in the plugin via `on_call`:
+Implemented in the plugin via `on_call`. `Plugin::on_call` takes `&Call`, so
+the destructured variant fields are references; deref coercion lets them flow
+into functions that take `&CompiledPolicy` / `&MediaFile`:
 
 ```rust
 impl Plugin for PolicyEvaluatorPlugin {
-    fn on_call(&self, call: Call) -> Result<CallResponse> {
-        match call {
-            Call::EvaluatePolicy { policy, file, .. } => {
-                let result = self.evaluate(*policy, *file)?;
-                Ok(CallResponse::EvaluatePolicy(result))
-            }
-            other => bail!("policy-evaluator does not handle {:?}", call_kind(&other)),
-        }
+    fn on_call(&self, call: &Call) -> voom_domain::errors::Result<CallResponse> {
+        let Call::EvaluatePolicy { policy, file, .. } = call else {
+            return Err(VoomError::plugin(
+                self.name(),
+                format!(
+                    "PolicyEvaluatorPlugin only handles Call::EvaluatePolicy, got {:?}",
+                    std::mem::discriminant(call)
+                ),
+            ));
+        };
+        let result = self.evaluate(policy, file)?;
+        Ok(CallResponse::EvaluatePolicy(result))
     }
 }
 ```
@@ -304,12 +313,18 @@ Each `Capability` variant declares its resolution discipline via
 - **Shared** — any plugin may claim; the caller picks one explicitly (rare;
   reserved for future use).
 
-A plugin claims a capability by returning it from `Plugin::capabilities()`:
+A plugin claims one or more capabilities by returning them from
+`Plugin::capabilities()`. The trait returns `&[Capability]`, so plugins
+typically store the claim list in a field set up by `new()`:
 
 ```rust
+pub struct PhaseOrchestratorPlugin {
+    capabilities: Vec<Capability>,
+}
+
 impl Plugin for PhaseOrchestratorPlugin {
-    fn capabilities(&self) -> Vec<Capability> {
-        vec![Capability::OrchestratePhases]
+    fn capabilities(&self) -> &[Capability] {
+        &self.capabilities
     }
 }
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -308,10 +308,13 @@ Each `Capability` variant declares its resolution discipline via
   fails with a duplicate-claim error if two plugins both declare the same
   Exclusive capability. Used by `EvaluatePolicy`, `OrchestratePhases`, and
   `ScanLibrary`. The kernel routes the call to the single claimant.
-- **Sharded** — multiple plugins claim disjoint shards (e.g. one executor per
-  codec family). The kernel routes on a shard key the caller supplies.
-- **Shared** — any plugin may claim; the caller picks one explicitly (rare;
-  reserved for future use).
+- **Sharded** — multiple plugins claim disjoint shards (e.g. one Discover
+  plugin per URI scheme). Registration fails if a new claim collides on
+  the same shard key. The kernel routes on a shard key the caller supplies.
+- **Competing** — multiple plugins may claim the same capability without a
+  uniqueness check; the kernel picks one at dispatch time using priority
+  ordering (the same model used by the legacy `EventResult.claimed`
+  executor path).
 
 A plugin claims one or more capabilities by returning them from
 `Plugin::capabilities()`. The trait returns `&[Capability]`, so plugins

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -404,24 +404,12 @@ Stats are persisted to the `plugin_stats` SQLite table with retention managed
 by the same `[retention.plugin_stats]` config section as other tables (PR #170).
 Defaults: keep for 30 days, keep last 100,000 rows.
 
-**Note (coverage):** Only plugins that *subscribe* to events appear in
-the rollup. Two kinds of code are missing for distinct reasons:
-
-- `discovery` is a kernel-registered plugin that publishes
-  `FileDiscovered` but does not subscribe to anything, so the
-  dispatcher never observes it.
-- `phase-orchestrator` and `policy-evaluator` are not plugins at all —
-  they are library-only crates the CLI calls directly. The
-  corresponding `Plan*` events come from the CLI's `PlanDispatcher`,
-  not from those crates.
-
-This is an intentional design boundary for Deliverable 1 of #92; see
-[Bus dispatcher instrumentation — Coverage: subscribers only][arch] in
-the architecture docs for the rationale and the path to full coverage
-via Prometheus / OpenTelemetry (Deliverables 2 and 3). Tracked as
-follow-up #378.
-
-[arch]: ../docs/architecture.md#coverage-subscribers-only
+**Coverage:** Every kernel-registered plugin appears in the rollup after the
+plugin contract rev-6 migration (#378). Both event subscribers (timed via
+`on_event`) and unary/streaming RPC handlers (timed via `on_call`) feed the
+same kernel-owned stats sink, so `discovery`, `policy-evaluator`, and
+`phase-orchestrator` all show rows after a representative `voom scan` or
+`voom process` run.
 
 ---
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -407,9 +407,18 @@ Defaults: keep for 30 days, keep last 100,000 rows.
 **Coverage:** Every kernel-registered plugin appears in the rollup after the
 plugin contract rev-6 migration (#378). Both event subscribers (timed via
 `on_event`) and unary/streaming RPC handlers (timed via `on_call`) feed the
-same kernel-owned stats sink, so `discovery`, `policy-evaluator`, and
-`phase-orchestrator` all show rows after a representative `voom scan` or
-`voom process` run.
+same kernel-owned stats sink. Which plugin_ids appear after a given run
+depends on which Calls that command dispatches:
+
+- `voom scan` dispatches `Call::ScanLibrary`, producing rows for
+  `discovery` plus any subscriber that observes scan-time events (e.g.
+  `sqlite-store`). It does **not** invoke the evaluator or orchestrator,
+  so those rows will be absent.
+- `voom process` against a file that introspects successfully additionally
+  dispatches `Call::EvaluatePolicy` and `Call::Orchestrate`, producing
+  rows for `policy-evaluator` and `phase-orchestrator`. Files that fail
+  introspection short-circuit before those Calls, so their per-file
+  contribution to the rollup will lack evaluator and orchestrator rows.
 
 ---
 

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -563,10 +563,20 @@ mod tests {
         file
     }
 
+    // There is no `test_handles` here: the kernel never invokes
+    // Guest::handles for WASM plugins. The per-event filter is the
+    // manifest's `handles_events` list. Test what your on_event
+    // actually does with each event type instead.
+
     #[test]
-    fn test_handles() {
-        assert!(handles("file.introspected"));
-        assert!(!handles("plan.created"));
+    fn test_on_event_ignores_unsubscribed_event_type() {
+        let event = Event::PlanCreated(/* …minimal fixture… */);
+        let payload = serialize_event(&event).unwrap();
+        let result = MyWasmPlugin::on_event(EventData {
+            event_type: event.event_type().to_string(),
+            payload,
+        });
+        assert!(result.is_none(), "plan.created is not in handles_events");
     }
 
     #[test]
@@ -761,7 +771,7 @@ For the WASM boundary, capabilities are encoded as colon-separated strings:
 
 5. **Test without WASM** — Write your plugin logic as regular Rust functions and test them with standard `#[test]`. Only the WIT bindings require the WASM target.
 
-6. **Keep manifests accurate** — The manifest's `handles_events` must match what your `handles()` function returns. The manifest is read before the plugin is loaded.
+6. **Keep manifests accurate** — For WASM plugins, the manifest's `handles_events` is what the host uses to filter event dispatch (the WIT `handles` export is not invoked). List every event type your `on_event` actually consumes; an event missing from `handles_events` will never reach your plugin. For native plugins, the kernel calls `Plugin::handles` directly, so the trait method is authoritative.
 
 7. **WASM plugins are sandboxed** — You cannot access the filesystem, network, or environment directly. All external access goes through host functions.
 

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -391,6 +391,16 @@ interface host {
 
 ### Implementation
 
+> **Capability and identity routing for WASM plugins comes from the
+> manifest TOML, not from `Guest::get_info`.** The kernel loads
+> `name`, `version`, the capability claim list, and the
+> `handles_events` filter from the `<plugin-name>.toml` file that
+> sits beside the `.wasm` artifact (`crates/voom-kernel/src/loader.rs`).
+> `Guest::get_info` and `Guest::handles` are part of the WIT contract
+> but the kernel does not call them today — they exist for forward
+> compatibility. Keep the manifest as your source of truth; treat the
+> `PluginInfo` returned from `get_info` as a stub.
+
 **`src/lib.rs`:**
 
 ```rust
@@ -405,24 +415,24 @@ wit_bindgen::generate!({
 struct MyWasmPlugin;
 
 impl Guest for MyWasmPlugin {
+    // The kernel does not invoke `get_info`. Identity and capabilities
+    // are loaded from the manifest TOML below. Return a minimal stub.
     fn get_info() -> PluginInfo {
         PluginInfo {
             name: "my-wasm-plugin".to_string(),
             version: "0.1.0".to_string(),
-            description: Some("My custom metadata enrichment plugin".to_string()),
+            description: None,
             author: None,
-            license: Some("MIT".to_string()),
+            license: None,
             homepage: None,
-            capabilities: vec![
-                Capability::EnrichMetadata(EnrichCap {
-                    source: "my-source".to_string(),
-                }),
-            ],
+            capabilities: vec![],
         }
     }
 
-    fn handles(event_type: String) -> bool {
-        event_type == "file.introspected"
+    // Not invoked by the kernel today — the per-event filter is
+    // `manifest.handles_events`. Returning false here is harmless.
+    fn handles(_event_type: String) -> bool {
+        false
     }
 
     fn on_event(event: EventData) -> Option<EventResult> {


### PR DESCRIPTION
## Summary

Phase 6 of the plugin-contract rev-6 migration (#378). Final reconciliation pass: retires the pre-rev-6 docs that captured the closed coverage gap, replaces the "capability routing is planned for a future sprint" placeholder, and pins the new end-to-end behavior in `plugin_stats_e2e.rs`.

Spec: `docs/superpowers/specs/2026-05-14-plugin-stats-self-reporting-design.md` (Phase 6 + Documentation updates).

## What's in the diff

### Docs

- **`docs/architecture.md`** — `policy-evaluator` and `phase-orchestrator` moved into the kernel-registered layer-diagram block. The "planned for a future sprint" placeholder is replaced with a forward reference to the new "Capability-based routing" subsection. The "Bus dispatcher instrumentation" intro now covers both `on_event` and `on_call` paths. The obsolete "Coverage: subscribers only" subsection is deleted. Two new tutorial subsections added: "Communication primitives — Events vs Calls" and "Capability-based routing", with code examples drawn from the in-tree policy-evaluator and phase-orchestrator plugins.
- **`docs/cli-reference.md`** — 18-line subscribers-only caveat replaced with per-command coverage bullets: `voom scan` covers `discovery`; `voom process` (against a successfully-introspected file) additionally covers `policy-evaluator` and `phase-orchestrator`.
- **`docs/INITIAL_DESIGN.md`** — appended §16 addendum pointing at the rev-6 spec and the new architecture subsections.
- **`docs/plugin-development.md`** — `Guest::get_info` and `Guest::handles` reconciled with how the kernel actually loads WASM plugins: identity, capabilities, and the per-event filter come from the manifest TOML (`crates/voom-kernel/src/loader.rs:70, :473`); the WIT exports are not invoked. The example shrinks to a minimal stub and the "Keep manifests accurate" best-practice splits its advice by tier.
- **`crates/voom-plugin-sdk/README.md`** — new two-tier guide. Native section uses `voom-kernel` + `voom-domain` with the full `Plugin`/`on_call` shape. WASM section opens by stating the two-artifact model (`.wasm` + `.toml`) and that the manifest is the source of truth for identity and capabilities; shows the shippable `impl Guest` + `wit_bindgen::generate!` + `export!` path that the in-tree `wasm-plugins/*` stub crates do not currently include. Streaming-Call helpers (`emit_file_discovered`, `is_cancelled`) covered without ever referencing `mpsc::Sender` on the WASM side.

### Tests

- **`crates/voom-cli/tests/plugin_stats_e2e.rs`** — two new functional acceptance tests:
  - `process_records_stats_rows_for_discovery_evaluator_orchestrator` — iterates `voom_cli::config::REQUIRED_PLUGIN_NAMES` against `plugin_stats` after a real-fixture dry-run, ensuring all three rev-6 plugins record rows.
  - `event_log_contains_no_call_payloads_after_process` — asserts both regression classes are absent from `event_log` with generic predicates that don't rot on new `Call` variants: `event_type LIKE 'call.%'` plus `payload LIKE '%"call.%'`. Asserts `outcome.result.is_ok()` and the presence of evaluator+orchestrator `plugin_stats` rows as preconditions so the absence check is never vacuous.

  Shared helpers: `copy_real_mkv_fixture` (synthetic bytes fail ffprobe and short-circuit the pipeline before evaluator/orchestrator dispatch), `run_phase6_dry_run`, and `distinct_plugin_ids` (via `PluginStatsStorage::rollup_plugin_stats`, matching the file's first test).

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo test -p voom-cli --features functional --test plugin_stats_e2e` — 7/7 pass
- [x] `cargo test --workspace --exclude voom-cli` green
- [x] No remaining `"Coverage: subscribers only"`, `"planned for a future sprint"`, or hardcoded plugin-name triple in the new tests

## Notes

- No production-code changes. No new dependencies.
- Closes the rev-6 migration (#378).

🤖 Generated with [Claude Code](https://claude.com/claude-code)